### PR TITLE
Stop granting bind to every authenticated user for org-owned providers

### DIFF
--- a/docs/byo-providers.md
+++ b/docs/byo-providers.md
@@ -503,15 +503,22 @@ in URL paths.
   cannot keep a platform provider of the same name looking alive. Org providers
   therefore never set `HeartbeatRequired`, leaving readiness resting on endpoint
   validity. An org-scoped heartbeat path is future work.
-- **No hub-proxied UI or backend.** `/ui/providers/{name}` and
-  `/services/providers/{name}` resolve globally. An org provider that declares
-  `spec.ui.url` will not be proxied, and gets no default `iconURL` (the portal
-  falls back to its generic glyph). API-only org providers — the common case —
-  are unaffected: `EndpointsValid` now accepts an APIExport alone as "this
-  provider offers something", which opens no route since the proxies
-  independently 404 when the URLs are nil. Closing this is the subject of
-  [byo-provider-edge-transport.md](./byo-provider-edge-transport.md), whose
-  phase 2 routes both proxies over the edge tunnel.
+- **The provider UI is not portable; the backend is.** `/services/providers/{name}`
+  now resolves in the caller's Org and routes an org-owned provider over its edge
+  tunnel. `/ui/providers/{name}` does not: it still resolves platform-only, so an
+  Org self-hosting a provider that ships a micro-frontend gets the PLATFORM's
+  bundle while its own copy serves the API — wrong rather than broken, which is
+  the harder failure to notice.
+
+  This is not the same change as the backend one. The bundle is loaded with a
+  plain `<script src="/ui/providers/{name}/main.js">`
+  ([ProviderFrame.vue](../portal/src/pages/ProviderFrame.vue)), so the request
+  carries no `Authorization` header, and `BrowserIdentity` — the hub's only way
+  to name a caller — requires one. There is no identity on an asset GET to scope
+  by. Closing it needs either the portal fetching the bundle with credentials
+  and injecting it as a blob, or the Org encoded in the asset path so no
+  identity is needed. Both are portal-visible changes; neither is a proxy tweak.
+
 - **No edge-driven install.** The Org installs the chart itself with the returned
   kubeconfig. One-click install onto a chosen edge needs credential projection
   into the edge cluster (the agent's `Placement` plane ships no kcp credential
@@ -519,17 +526,29 @@ in URL paths.
   named, connected edge — see
   [byo-provider-edge-transport.md](./byo-provider-edge-transport.md) E-2 — so
   the target is known; only the credential projection is missing.
-- **The `bind` verb is not org-scoped.** The provider's own `init` runs
-  `provider-sdk/install`'s `ApplyBindGrant`, which grants `bind` on the APIExport
-  to the group `system:authenticated` — platform-wide. Discovery and the
-  hub-mediated Enable path are both org-scoped, but a user who learns another
-  Org's UUID can hand-craft an `APIBinding` in their own team workspace
-  referencing `root:faros:tenants:<otherOrg>:providers:<name>` and kcp's
-  admission will allow the bind. Closing this needs the per-Org bind ClusterRole
-  from [provider-scoping.md](./provider-scoping.md) P-3, which is unimplemented
-  for platform providers too — for them the platform admin is the gatekeeper at
-  onboard time, an argument that does not carry over to org-owned providers.
-  **This is the most important gap to close.**
+- **`bind` is no longer granted for org-owned providers, and P-3 is not what
+  closes it.** The provider's `init` used to grant `bind` on its APIExport to
+  `system:authenticated` in every provider workspace. For a platform provider
+  that is defensible — an admin vets it at onboard time. For an org-owned one
+  nobody vets anything, so it meant a member of ANY organization who learned
+  another Org's UUID could hand-craft an `APIBinding` and consume a provider
+  they were never offered.
+
+  `ApplyBindGrant` now resolves its own workspace from the `LogicalCluster` and,
+  under `root:faros:tenants:`, creates no grant and removes one an earlier
+  install left. Nothing supported breaks: every APIBinding faros creates comes
+  from the hub's Enable path, which runs as kcp-admin and needs no grant. What
+  stops working is writing an APIBinding by hand with kubectl, already outside
+  the hub-mediated model (O-10).
+
+  Note this is *not* provider-scoping.md's P-3, a per-Org `bind` ClusterRole.
+  That decision assumes a subject to bind — and there is none: the hub grants
+  workspace access per `User` (`ensureWorkspaceAdmin`), so kcp has no group
+  meaning "members of org X". Granting per member would need a reconciler
+  tracking membership across every org provider workspace. Refusing outright is
+  both simpler and tighter; P-3 should be revisited rather than implemented as
+  written.
+
 - **No `MaximalPermissionPolicy`.** An org provider's permission claims are
   capped only by what each consuming Workspace accepts at Enable. Same posture
   platform providers have today, but it is the thing to fix before any cross-org

--- a/provider-sdk/install/bindgrant_test.go
+++ b/provider-sdk/install/bindgrant_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package install
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// Which workspaces count as one organization's. A sibling of the tenants
+// container whose name merely starts with the same letters is not a tenant, and
+// treating it as one would silently drop a platform provider's grant.
+func TestIsOrgOwnedWorkspace(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{"root:faros:tenants:86b7f9e7:providers:infrastructure", true},
+		{"root:faros:tenants:86b7f9e7:providers:code", true},
+		{"root:faros:providers:infrastructure", false},
+		{"root:faros:system:providers", false},
+		{"root:faros", false},
+		{"", false},
+		{"root:faros:tenantsandthings:providers:x", false},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := isOrgOwnedWorkspace(tc.path); got != tc.want {
+				t.Errorf("isOrgOwnedWorkspace(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func bindGrantClient(t *testing.T, workspacePath string, seed ...*unstructured.Unstructured) dynamic.Interface {
+	t.Helper()
+	objs := []runtime.Object{}
+	if workspacePath != "" {
+		objs = append(objs, &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "core.kcp.io/v1alpha1",
+			"kind":       "LogicalCluster",
+			"metadata": map[string]any{
+				"name":        "cluster",
+				"annotations": map[string]any{"kcp.io/path": workspacePath},
+			},
+		}})
+	}
+	for _, o := range seed {
+		objs = append(objs, o)
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			logicalClusterGVR:     "LogicalClusterList",
+			clusterRoleGVR:        "ClusterRoleList",
+			clusterRoleBindingGVR: "ClusterRoleBindingList",
+		}, objs...)
+}
+
+func grantExists(t *testing.T, cl dynamic.Interface, name string) bool {
+	t.Helper()
+	_, err := cl.Resource(clusterRoleBindingGVR).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("get ClusterRoleBinding: %v", err)
+	}
+	return err == nil
+}
+
+// A platform provider is vetted by an admin at onboard time, so binding stays
+// open to any authenticated user — unchanged behaviour.
+func TestApplyBindGrantKeepsPlatformProvidersOpen(t *testing.T) {
+	cl := bindGrantClient(t, "root:faros:providers:code")
+
+	if err := ApplyBindGrant(context.Background(), cl, "code.providers.faros.sh"); err != nil {
+		t.Fatalf("ApplyBindGrant: %v", err)
+	}
+	if !grantExists(t, cl, "faros:providers:bind:code.providers.faros.sh") {
+		t.Error("platform provider lost its bind grant; tenants can no longer bind it by hand")
+	}
+}
+
+// Nobody vets an org-owned provider — an organization registers one itself — so
+// a grant to system:authenticated would let a member of ANY org bind it just by
+// learning that org's UUID.
+func TestApplyBindGrantSkipsOrgOwnedProviders(t *testing.T) {
+	cl := bindGrantClient(t, "root:faros:tenants:86b7f9e7:providers:code")
+
+	if err := ApplyBindGrant(context.Background(), cl, "code.providers.faros.sh"); err != nil {
+		t.Fatalf("ApplyBindGrant: %v", err)
+	}
+	if grantExists(t, cl, "faros:providers:bind:code.providers.faros.sh") {
+		t.Error("org-owned provider granted bind to system:authenticated — any org can bind it")
+	}
+}
+
+// Upgrading an org provider installed before this change has to close the hole,
+// not merely stop widening it.
+func TestApplyBindGrantRemovesAnInheritedGrant(t *testing.T) {
+	const roleName = "faros:providers:bind:code.providers.faros.sh"
+	existing := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRoleBinding",
+		"metadata":   map[string]any{"name": roleName},
+	}}
+	cl := bindGrantClient(t, "root:faros:tenants:86b7f9e7:providers:code", existing)
+
+	if !grantExists(t, cl, roleName) {
+		t.Fatal("seed failed")
+	}
+	if err := ApplyBindGrant(context.Background(), cl, "code.providers.faros.sh"); err != nil {
+		t.Fatalf("ApplyBindGrant: %v", err)
+	}
+	if grantExists(t, cl, roleName) {
+		t.Error("a grant from an earlier install survived the upgrade")
+	}
+}
+
+// An unresolvable workspace must not fall back to the widest grant.
+func TestApplyBindGrantFailsClosedWithoutAPath(t *testing.T) {
+	cl := bindGrantClient(t, "" /* no LogicalCluster */)
+
+	if err := ApplyBindGrant(context.Background(), cl, "code.providers.faros.sh"); err == nil {
+		t.Fatal("unresolvable workspace path did not error")
+	}
+	if grantExists(t, cl, "faros:providers:bind:code.providers.faros.sh") {
+		t.Error("a grant was created despite the workspace being unidentifiable")
+	}
+}

--- a/provider-sdk/install/install.go
+++ b/provider-sdk/install/install.go
@@ -409,13 +409,51 @@ func EnsureAPIExportEndpointSlice(ctx context.Context, cl dynamic.Interface, sli
 	return nil
 }
 
+// orgProviderWorkspacePrefix marks a provider workspace owned by one
+// organization rather than the platform:
+// root:faros:tenants:<orgUUID>:providers:<name>.
+const orgProviderWorkspacePrefix = "root:faros:tenants:"
+
+// isOrgOwnedWorkspace reports whether a workspace path belongs to a single
+// organization. Matching on the separator matters: a sibling of the tenants
+// container whose name merely starts with the same letters is not a tenant.
+func isOrgOwnedWorkspace(path string) bool {
+	return strings.HasPrefix(path, orgProviderWorkspacePrefix)
+}
+
 // ApplyBindGrant creates / updates the ClusterRole + ClusterRoleBinding in the
 // provider workspace that lets any authenticated faros user bind to the
 // provider's APIExport from their own workspace. Without it, kcp refuses
 // tenant-side APIBinding creates with 403. Subject is "system:authenticated":
 // the platform admin is the gatekeeper at onboard/install time.
+//
+// That gatekeeper argument does not carry over to an org-owned provider. Nobody
+// vets those — an organization registers one itself — so granting bind to every
+// authenticated user means a member of ANY organization who learns another
+// org's UUID can hand-craft an APIBinding in their own workspace and consume a
+// provider they were never offered. So for an org-owned workspace the grant is
+// not created, and one left by an earlier install is removed.
+//
+// Nothing supported breaks: every APIBinding faros creates comes from the hub's
+// Enable path, which runs as kcp-admin and needs no grant. What stops working
+// is hand-writing an APIBinding with kubectl, which for an Org workspace is
+// already outside the hub-mediated model (decision O-10).
 func ApplyBindGrant(ctx context.Context, cl dynamic.Interface, exportName string) error {
 	roleName := "faros:providers:bind:" + exportName
+
+	// Resolve from the LogicalCluster rather than a caller-supplied path:
+	// Options.WorkspacePath is deliberately empty in normal use, so that a
+	// provider chart is workspace-agnostic. This client is already scoped to
+	// the workspace being installed into, so it can just ask.
+	path, err := workspacePathOf(ctx, cl)
+	if err != nil {
+		// Fail closed. An unresolvable path must not default to the widest
+		// grant, and skipping costs only the unsupported kubectl path.
+		return fmt.Errorf("resolving workspace path for bind grant of %s: %w", exportName, err)
+	}
+	if isOrgOwnedWorkspace(path) {
+		return removeBindGrant(ctx, cl, roleName)
+	}
 	cr := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind":       "ClusterRole",
@@ -451,6 +489,38 @@ func ApplyBindGrant(ctx context.Context, cl dynamic.Interface, exportName string
 	}}
 	if err := applyUnstructured(ctx, cl, clusterRoleBindingGVR, crb); err != nil {
 		return fmt.Errorf("applying ClusterRoleBinding %s: %w", roleName, err)
+	}
+	return nil
+}
+
+// logicalClusterGVR is kcp's per-workspace singleton, named "cluster", whose
+// kcp.io/path annotation is the workspace's canonical path.
+var logicalClusterGVR = schema.GroupVersionResource{
+	Group: "core.kcp.io", Version: "v1alpha1", Resource: "logicalclusters",
+}
+
+// workspacePathOf returns the canonical path of the workspace cl is scoped to.
+func workspacePathOf(ctx context.Context, cl dynamic.Interface) (string, error) {
+	lc, err := cl.Resource(logicalClusterGVR).Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting LogicalCluster: %w", err)
+	}
+	path := lc.GetAnnotations()["kcp.io/path"]
+	if path == "" {
+		return "", fmt.Errorf("LogicalCluster carries no kcp.io/path annotation")
+	}
+	return path, nil
+}
+
+// removeBindGrant deletes a bind grant a previous install created, so that
+// upgrading an org-owned provider closes the hole rather than leaving it open
+// until someone notices. NotFound is success — the usual case.
+func removeBindGrant(ctx context.Context, cl dynamic.Interface, roleName string) error {
+	if err := cl.Resource(clusterRoleBindingGVR).Delete(ctx, roleName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("removing bind ClusterRoleBinding %s: %w", roleName, err)
+	}
+	if err := cl.Resource(clusterRoleGVR).Delete(ctx, roleName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("removing bind ClusterRole %s: %w", roleName, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Two of the three items from the BYO audit. The third turned out not to be the change I described, and this PR says why instead of shipping a guess.

## 1. `bind` was granted to `system:authenticated` — including for org providers

A provider's `init` granted `bind` on its APIExport to `system:authenticated` in **every** provider workspace. For a platform provider that is defensible: an admin vets it at onboard time and is the gatekeeper. For an org-owned one nobody vets anything — an organization registers its own — so it meant a member of **any** organization who learned another Org's UUID could hand-craft an `APIBinding` and consume a provider they were never offered.

`ApplyBindGrant` now resolves its own workspace from the `LogicalCluster`'s `kcp.io/path` and, under `root:faros:tenants:`, creates no grant and **removes one an earlier install left** — so upgrading closes the hole rather than merely stopping it from widening.

Resolution is read from the cluster rather than taken from `Options.WorkspacePath`, which is deliberately empty in normal use so provider charts stay workspace-agnostic. An unresolvable path is an error, not a fallback to the wide grant.

**Nothing supported breaks.** Every APIBinding faros creates comes from the hub's Enable path, which runs as kcp-admin and needs no grant — I checked, and nothing outside the hub creates APIBindings at all. What stops working is writing one by hand with `kubectl`, already outside the hub-mediated model (O-10).

### This is not P-3

`provider-scoping.md` P-3 proposes a per-Org `bind` ClusterRole. That assumes there is a subject to bind, and there isn't: the hub grants workspace access per `User` (`ensureWorkspaceAdmin`), so kcp has no group meaning "members of org X". Granting per member would need a reconciler tracking membership across every org provider workspace. Refusing outright is simpler and tighter, so the doc now says P-3 should be revisited rather than implemented as written.

## 2. A stale doc claim about what shipped

`byo-providers.md` said edge transport "routes **both** proxies over the edge tunnel". It routes one. The backend is org-scoped and edge-routed; the UI proxy is not.

## 3. The UI proxy is not a proxy tweak — correcting my own audit

I said org-scoping the UI proxy was "mechanically the same change as the backend". It is not. The micro-frontend loads via a plain `<script src="/ui/providers/{name}/main.js">`, so the request carries **no `Authorization` header** — and `BrowserIdentity`, the hub's only way to name a caller, requires one. There is no identity on an asset GET to scope by.

Closing it needs either the portal fetching the bundle with credentials and injecting it as a blob, or the Org encoded in the asset path so no identity is needed. Both are portal-visible changes and a design call, so the gap entry now states the constraint rather than implying a small fix.

## Verification

Main module and `provider-sdk` suites green; `make lint` clean.

Tests cover the platform path staying open, the org path being skipped, an inherited grant being removed, and an unresolvable workspace failing closed. Verified by mutation — neutering the org check makes two of them fail:

```
--- FAIL: TestApplyBindGrantSkipsOrgOwnedProviders
    org-owned provider granted bind to system:authenticated — any org can bind it
--- FAIL: TestApplyBindGrantRemovesAnInheritedGrant
    a grant from an earlier install survived the upgrade
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)