### PR TITLE
Improve App Studio model selection

### DIFF
--- a/providers/app-studio/api/llm_discovery.go
+++ b/providers/app-studio/api/llm_discovery.go
@@ -1,0 +1,358 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	projectLLMDiscoveryRequestMaxBytes  = 128 << 10
+	projectLLMDiscoveryResponseMaxBytes = 2 << 20
+	projectLLMDiscoveryTimeout          = 10 * time.Second
+	projectLLMDiscoveryMaxModels        = 1000
+)
+
+type DiscoverProjectLLMModelsRequest struct {
+	Provider        string `json:"provider,omitempty"`
+	BaseURL         string `json:"baseURL,omitempty"`
+	APIKey          string `json:"apiKey,omitempty"`
+	ExistingModelID string `json:"existingModelID,omitempty"`
+}
+
+type ProjectLLMDiscoveredModelView struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Compatibility string   `json:"compatibility"`
+	Capabilities  []string `json:"capabilities,omitempty"`
+}
+
+type ProjectLLMModelDiscoveryResponse struct {
+	Models []ProjectLLMDiscoveredModelView `json:"models"`
+	Source string                          `json:"source"`
+}
+
+type projectLLMDiscoveryUpstreamError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *projectLLMDiscoveryUpstreamError) Error() string { return e.Message }
+
+func newProjectLLMDiscoveryHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: projectLLMDiscoveryTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			// Never forward a workspace credential to a different location. Known
+			// provider endpoints do not require redirects, and custom gateways can
+			// expose their final API base URL explicitly.
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func (s *Server) discoverProjectLLMModels(w http.ResponseWriter, r *http.Request) {
+	c, _, ok := s.requireProjectClient(w, r)
+	if !ok {
+		return
+	}
+	var request DiscoverProjectLLMModelsRequest
+	if !decodeStrictJSONWithBodyLimit(w, r, &request, projectLLMDiscoveryRequestMaxBytes) {
+		return
+	}
+
+	settings := projectLLMSettings{
+		Provider: strings.TrimSpace(request.Provider),
+		BaseURL:  strings.TrimSpace(request.BaseURL),
+		APIKey:   strings.TrimSpace(request.APIKey),
+	}
+	if settings.Provider == "" {
+		settings.Provider = defaultProjectLLMProvider
+	}
+	if settings.BaseURL == "" {
+		if strings.EqualFold(settings.Provider, projectLLMProviderGoogle) {
+			settings.BaseURL = defaultProjectLLMGoogleBaseURL
+		} else {
+			settings.BaseURL = defaultProjectLLMBaseURL
+		}
+	}
+
+	baseURL, err := normalizeLLMBaseURL(settings.BaseURL)
+	if err != nil {
+		writeProjectError(w, err)
+		return
+	}
+	settings.BaseURL = baseURL
+	if err := validateProjectLLMBaseURL(settings.Provider, settings.BaseURL); err != nil {
+		writeProjectError(w, err)
+		return
+	}
+	if settings.APIKey == "" && strings.TrimSpace(request.ExistingModelID) != "" {
+		registry, err := readProjectLLMRegistry(r.Context(), c)
+		if err != nil {
+			writeProjectError(w, err)
+			return
+		}
+		stored, found := registry.model(request.ExistingModelID)
+		if !found {
+			writeStatus(w, http.StatusNotFound, "NotFound", "model configuration not found")
+			return
+		}
+		storedBaseURL, err := normalizeLLMBaseURL(stored.Settings.BaseURL)
+		if err != nil {
+			writeProjectError(w, err)
+			return
+		}
+		if !strings.EqualFold(strings.TrimSpace(settings.Provider), strings.TrimSpace(stored.Settings.Provider)) || settings.BaseURL != storedBaseURL {
+			writeProjectError(w, newValidationError("enter a credential before finding models from a changed provider or endpoint"))
+			return
+		}
+		settings.APIKey = strings.TrimSpace(stored.Settings.APIKey)
+	}
+	if settings.APIKey == "" {
+		writeProjectError(w, newValidationError("enter a credential before finding models"))
+		return
+	}
+	if err := validateProjectLLMAPIKey(settings.Provider, settings.APIKey); err != nil {
+		writeProjectError(w, err)
+		return
+	}
+	if strings.EqualFold(settings.Provider, projectLLMProviderGoogle) {
+		if _, serviceAccount, err := googleServiceAccountCredentialFromJSON(settings.APIKey); err != nil {
+			writeProjectError(w, err)
+			return
+		} else if serviceAccount {
+			writeProjectError(w, newValidationError("automatic model discovery is not available for Vertex AI service accounts yet; enter the model ID manually"))
+			return
+		}
+	}
+
+	client := s.llmDiscoveryHTTPClient
+	if client == nil {
+		client = newProjectLLMDiscoveryHTTPClient()
+	}
+	response, err := discoverProjectLLMModels(r.Context(), client, settings)
+	if err != nil {
+		var upstream *projectLLMDiscoveryUpstreamError
+		if errors.As(err, &upstream) {
+			writeStatus(w, http.StatusBadGateway, "BadGateway", upstream.Message)
+			return
+		}
+		writeStatus(w, http.StatusBadGateway, "BadGateway", "model discovery failed: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func discoverProjectLLMModels(ctx context.Context, client *http.Client, settings projectLLMSettings) (ProjectLLMModelDiscoveryResponse, error) {
+	if strings.EqualFold(settings.Provider, projectLLMProviderGoogle) {
+		models, err := discoverGoogleAIStudioModels(ctx, client, settings)
+		return ProjectLLMModelDiscoveryResponse{Models: models, Source: projectLLMProviderGoogle}, err
+	}
+	models, err := discoverOpenAICompatibleModels(ctx, client, settings)
+	return ProjectLLMModelDiscoveryResponse{Models: models, Source: defaultProjectLLMProvider}, err
+}
+
+func discoverOpenAICompatibleModels(ctx context.Context, client *http.Client, settings projectLLMSettings) ([]ProjectLLMDiscoveredModelView, error) {
+	endpoint, err := projectLLMDiscoveryEndpoint(settings.BaseURL, "models", nil)
+	if err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+strings.TrimSpace(settings.APIKey))
+
+	var payload struct {
+		Data []struct {
+			ID      string `json:"id"`
+			OwnedBy string `json:"owned_by"`
+		} `json:"data"`
+	}
+	if err := projectLLMDiscoveryJSON(client, request, &payload); err != nil {
+		return nil, err
+	}
+	models := make([]ProjectLLMDiscoveredModelView, 0, min(len(payload.Data), projectLLMDiscoveryMaxModels))
+	for _, item := range payload.Data {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			continue
+		}
+		models = append(models, projectLLMDiscoveredModel(id, id, defaultProjectLLMProvider, nil))
+		if len(models) >= projectLLMDiscoveryMaxModels {
+			break
+		}
+	}
+	return sortProjectLLMDiscoveredModels(models), nil
+}
+
+func discoverGoogleAIStudioModels(ctx context.Context, client *http.Client, settings projectLLMSettings) ([]ProjectLLMDiscoveredModelView, error) {
+	endpoint, err := projectLLMDiscoveryEndpoint(settings.BaseURL, "v1beta/models", url.Values{"pageSize": []string{"1000"}})
+	if err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("x-goog-api-key", strings.TrimSpace(settings.APIKey))
+
+	var payload struct {
+		Models []struct {
+			Name                       string   `json:"name"`
+			BaseModelID                string   `json:"baseModelId"`
+			DisplayName                string   `json:"displayName"`
+			SupportedGenerationMethods []string `json:"supportedGenerationMethods"`
+			SupportedActions           []string `json:"supportedActions"`
+		} `json:"models"`
+	}
+	if err := projectLLMDiscoveryJSON(client, request, &payload); err != nil {
+		return nil, err
+	}
+	models := make([]ProjectLLMDiscoveredModelView, 0, min(len(payload.Models), projectLLMDiscoveryMaxModels))
+	for _, item := range payload.Models {
+		id := strings.TrimPrefix(strings.TrimSpace(item.Name), "models/")
+		if strings.TrimSpace(item.BaseModelID) != "" {
+			id = strings.TrimSpace(item.BaseModelID)
+		}
+		if id == "" {
+			continue
+		}
+		capabilities := append([]string{}, item.SupportedGenerationMethods...)
+		capabilities = append(capabilities, item.SupportedActions...)
+		models = append(models, projectLLMDiscoveredModel(id, item.DisplayName, projectLLMProviderGoogle, capabilities))
+		if len(models) >= projectLLMDiscoveryMaxModels {
+			break
+		}
+	}
+	return sortProjectLLMDiscoveredModels(models), nil
+}
+
+func projectLLMDiscoveryJSON(client *http.Client, request *http.Request, target any) error {
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("request provider models: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return &projectLLMDiscoveryUpstreamError{
+			StatusCode: response.StatusCode,
+			Message:    fmt.Sprintf("provider model discovery returned %s; check the credential and endpoint", response.Status),
+		}
+	}
+	reader := io.LimitReader(response.Body, projectLLMDiscoveryResponseMaxBytes+1)
+	raw, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("read provider model response: %w", err)
+	}
+	if len(raw) > projectLLMDiscoveryResponseMaxBytes {
+		return errors.New("provider model response exceeded the 2 MiB limit")
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return errors.New("provider model discovery returned invalid JSON")
+	}
+	return nil
+}
+
+func projectLLMDiscoveryEndpoint(baseURL, suffix string, query url.Values) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", newValidationError("baseURL must be an absolute HTTP(S) URL")
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/" + strings.TrimLeft(suffix, "/")
+	u.RawPath = ""
+	u.RawQuery = query.Encode()
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+func projectLLMDiscoveredModel(id, name, provider string, capabilities []string) ProjectLLMDiscoveredModelView {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = id
+	}
+	compatibility := "available"
+	if projectLLMModelKnownUnsuitable(id, capabilities) {
+		compatibility = "unsuitable"
+	} else if projectAssistantCapabilitiesForModel(projectLLMSettings{Provider: provider, Model: id}).VisionToolResults {
+		compatibility = "recommended"
+	}
+	return ProjectLLMDiscoveredModelView{
+		ID:            id,
+		Name:          name,
+		Compatibility: compatibility,
+		Capabilities:  projectLLMDiscoveryCapabilities(capabilities),
+	}
+}
+
+func projectLLMModelKnownUnsuitable(id string, capabilities []string) bool {
+	for _, capability := range capabilities {
+		if strings.EqualFold(strings.TrimSpace(capability), "generateContent") {
+			return false
+		}
+	}
+	if len(capabilities) > 0 {
+		return true
+	}
+	normalized := strings.ToLower(strings.TrimSpace(id))
+	for _, prefix := range []string{"text-embedding", "embedding", "whisper", "tts", "dall-e", "gpt-image", "omni-moderation", "sora"} {
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func projectLLMDiscoveryCapabilities(values []string) []string {
+	seen := map[string]struct{}{}
+	capabilities := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		capabilities = append(capabilities, value)
+	}
+	sort.Strings(capabilities)
+	return capabilities
+}
+
+func sortProjectLLMDiscoveredModels(models []ProjectLLMDiscoveredModelView) []ProjectLLMDiscoveredModelView {
+	rank := map[string]int{"recommended": 0, "available": 1, "unsuitable": 2}
+	sort.SliceStable(models, func(i, j int) bool {
+		if rank[models[i].Compatibility] != rank[models[j].Compatibility] {
+			return rank[models[i].Compatibility] < rank[models[j].Compatibility]
+		}
+		return strings.ToLower(models[i].Name) < strings.ToLower(models[j].Name)
+	})
+	return models
+}

--- a/providers/app-studio/api/llm_discovery_test.go
+++ b/providers/app-studio/api/llm_discovery_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	asclient "github.com/faroshq/provider-app-studio/client"
+)
+
+func TestDiscoverProjectLLMModelsOpenAICompatible(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %q, want /v1/models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer workspace-key" {
+			t.Errorf("authorization = %q, want workspace credential", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"text-embedding-3-large"},{"id":"custom-chat"},{"id":"gpt-5.4"}]}`))
+	}))
+	defer upstream.Close()
+
+	response, err := discoverProjectLLMModels(t.Context(), upstream.Client(), projectLLMSettings{
+		Provider: defaultProjectLLMProvider,
+		BaseURL:  upstream.URL + "/v1",
+		APIKey:   "workspace-key",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Source != defaultProjectLLMProvider || len(response.Models) != 3 {
+		t.Fatalf("response = %#v, want three OpenAI-compatible models", response)
+	}
+	if response.Models[0].ID != "gpt-5.4" || response.Models[0].Compatibility != "recommended" {
+		t.Fatalf("first model = %#v, want recommended gpt-5.4", response.Models[0])
+	}
+	if response.Models[1].ID != "custom-chat" || response.Models[1].Compatibility != "available" {
+		t.Fatalf("second model = %#v, want available custom-chat", response.Models[1])
+	}
+	if response.Models[2].ID != "text-embedding-3-large" || response.Models[2].Compatibility != "unsuitable" {
+		t.Fatalf("third model = %#v, want unsuitable embedding model", response.Models[2])
+	}
+}
+
+func TestDiscoverProjectLLMModelsGoogleAIStudio(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1beta/models" || r.URL.Query().Get("pageSize") != "1000" {
+			t.Errorf("request URL = %q, want /v1beta/models?pageSize=1000", r.URL.String())
+		}
+		if got := r.Header.Get("x-goog-api-key"); got != "google-key" {
+			t.Errorf("x-goog-api-key = %q, want workspace credential", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[{"name":"models/gemini-2.5-pro","displayName":"Gemini 2.5 Pro","supportedGenerationMethods":["generateContent"]},{"name":"models/text-embedding-004","displayName":"Text Embedding 004","supportedGenerationMethods":["embedContent"]}]}`))
+	}))
+	defer upstream.Close()
+
+	response, err := discoverProjectLLMModels(t.Context(), upstream.Client(), projectLLMSettings{
+		Provider: projectLLMProviderGoogle,
+		BaseURL:  upstream.URL,
+		APIKey:   "google-key",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Source != projectLLMProviderGoogle || len(response.Models) != 2 {
+		t.Fatalf("response = %#v, want two Google models", response)
+	}
+	if response.Models[0].ID != "gemini-2.5-pro" || response.Models[0].Compatibility != "recommended" {
+		t.Fatalf("first model = %#v, want recommended Gemini model", response.Models[0])
+	}
+	if response.Models[1].ID != "text-embedding-004" || response.Models[1].Compatibility != "unsuitable" {
+		t.Fatalf("second model = %#v, want unsuitable embedding model", response.Models[1])
+	}
+}
+
+func TestDiscoverProjectLLMModelsHandlerReusesStoredCredential(t *testing.T) {
+	var receivedCredential string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCredential = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-5.4"}]}`))
+	}))
+	defer upstream.Close()
+
+	registry := projectLLMRegistry{Models: []projectLLMModelSettings{{
+		ID:   "gpt-high",
+		Name: "GPT High",
+		Settings: projectLLMSettings{
+			Provider: defaultProjectLLMProvider,
+			BaseURL:  upstream.URL,
+			Model:    "gpt-5.4",
+			APIKey:   "stored-workspace-key",
+		},
+	}}}
+	secret, err := projectLLMRegistrySecret(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: secret})
+	server := &Server{
+		projectClientFor:       func(identity) (*asclient.Client, error) { return client, nil },
+		llmDiscoveryHTTPClient: upstream.Client(),
+	}
+	request := projectLLMDiscoveryRequest(t, `{"provider":"openai-compatible","baseURL":"`+upstream.URL+`","existingModelID":"gpt-high"}`)
+	response := httptest.NewRecorder()
+
+	server.discoverProjectLLMModels(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", response.Code, response.Body.String())
+	}
+	if receivedCredential != "Bearer stored-workspace-key" {
+		t.Fatalf("authorization = %q, want stored workspace credential", receivedCredential)
+	}
+	var body ProjectLLMModelDiscoveryResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Models) != 1 || body.Models[0].ID != "gpt-5.4" {
+		t.Fatalf("response = %#v, want discovered model", body)
+	}
+}
+
+func TestDiscoverProjectLLMModelsHandlerRequiresCredential(t *testing.T) {
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{})
+	server := &Server{projectClientFor: func(identity) (*asclient.Client, error) { return client, nil }}
+	response := httptest.NewRecorder()
+
+	server.discoverProjectLLMModels(response, projectLLMDiscoveryRequest(t, `{"provider":"openai-compatible","baseURL":"https://api.openai.com/v1"}`))
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", response.Code, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "enter a credential before finding models") {
+		t.Fatalf("body = %q, want credential guidance", response.Body.String())
+	}
+}
+
+func TestDiscoverProjectLLMModelsHandlerDoesNotReuseCredentialForChangedEndpoint(t *testing.T) {
+	registry := projectLLMRegistry{Models: []projectLLMModelSettings{{
+		ID:   "gpt-high",
+		Name: "GPT High",
+		Settings: projectLLMSettings{
+			Provider: defaultProjectLLMProvider,
+			BaseURL:  "https://api.openai.com/v1",
+			Model:    "gpt-5.4",
+			APIKey:   "stored-workspace-key",
+		},
+	}}}
+	secret, err := projectLLMRegistrySecret(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{secret: secret})
+	server := &Server{projectClientFor: func(identity) (*asclient.Client, error) { return client, nil }}
+	response := httptest.NewRecorder()
+
+	server.discoverProjectLLMModels(response, projectLLMDiscoveryRequest(t, `{"provider":"openai-compatible","baseURL":"https://gateway.example/v1","existingModelID":"gpt-high"}`))
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", response.Code, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "changed provider or endpoint") {
+		t.Fatalf("body = %q, want changed-endpoint credential guidance", response.Body.String())
+	}
+}
+
+func projectLLMDiscoveryRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/api/projects/llm-settings/models/discover", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Faros-Tenant", "root:faros:tenants:org-a:workspace-a")
+	request.Header.Set("X-Faros-Cluster", "cluster-a")
+	return request
+}

--- a/providers/app-studio/api/llm_registry.go
+++ b/providers/app-studio/api/llm_registry.go
@@ -59,7 +59,7 @@ type CreateProjectLLMModelRequest struct {
 	Provider string `json:"provider,omitempty"`
 	BaseURL  string `json:"baseURL,omitempty"`
 	Model    string `json:"model"`
-	APIKey   string `json:"apiKey,omitempty"`
+	APIKey   string `json:"apiKey"`
 }
 
 type PatchProjectLLMModelRequest struct {
@@ -261,6 +261,37 @@ func normalizeProjectLLMModel(model *projectLLMModelSettings, runtime projectLLM
 	model.Settings.RetryBackoff = runtime.RetryBackoff
 	model.Settings.StreamIdleTimeout = runtime.StreamIdleTimeout
 	return normalizeProjectLLMSettings(&model.Settings)
+}
+
+func validateProjectLLMModelCredential(model projectLLMModelSettings) error {
+	if strings.TrimSpace(model.Settings.APIKey) == "" {
+		return newValidationError("a credential is required to connect this model")
+	}
+	return nil
+}
+
+func firstConfiguredProjectLLMModelID(models []projectLLMModelSettings) string {
+	var selected *projectLLMModelSettings
+	for _, model := range models {
+		if model.Archived || strings.TrimSpace(model.Settings.APIKey) == "" {
+			continue
+		}
+		if selected == nil || strings.ToLower(model.Name) < strings.ToLower(selected.Name) {
+			candidate := model
+			selected = &candidate
+		}
+	}
+	if selected == nil {
+		return ""
+	}
+	return selected.ID
+}
+
+func configuredProjectLLMDefaultModelID(registry projectLLMRegistry) string {
+	if model, found := registry.model(registry.DefaultModelID); found && strings.TrimSpace(model.Settings.APIKey) != "" {
+		return model.ID
+	}
+	return firstConfiguredProjectLLMModelID(registry.Models)
 }
 
 func readProjectLLMRegistry(ctx context.Context, c *asclient.Client) (projectLLMRegistry, error) {
@@ -477,10 +508,12 @@ func (s *Server) createProjectLLMModel(w http.ResponseWriter, r *http.Request) {
 		writeProjectError(w, err)
 		return
 	}
-	registry.Models = append(registry.Models, model)
-	if registry.DefaultModelID == "" {
-		registry.DefaultModelID = model.ID
+	if err := validateProjectLLMModelCredential(model); err != nil {
+		writeProjectError(w, err)
+		return
 	}
+	registry.Models = append(registry.Models, model)
+	registry.DefaultModelID = configuredProjectLLMDefaultModelID(registry)
 	if err := writeProjectLLMRegistry(r.Context(), c, registry); err != nil {
 		writeProjectError(w, err)
 		return
@@ -538,10 +571,15 @@ func (s *Server) patchProjectLLMModel(w http.ResponseWriter, r *http.Request) {
 		writeProjectError(w, err)
 		return
 	}
+	if err := validateProjectLLMModelCredential(model); err != nil {
+		writeProjectError(w, err)
+		return
+	}
 	registry.Models[index].Archived = true
 	model.RevisionID = uuid.NewString()
 	model.Archived = false
 	registry.Models = append(registry.Models, model)
+	registry.DefaultModelID = configuredProjectLLMDefaultModelID(registry)
 	if err := writeProjectLLMRegistry(r.Context(), c, registry); err != nil {
 		writeProjectError(w, err)
 		return
@@ -572,15 +610,7 @@ func (s *Server) deleteProjectLLMModel(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusNotFound, "NotFound", "model configuration not found")
 		return
 	}
-	if registry.DefaultModelID == id {
-		registry.DefaultModelID = ""
-		for _, model := range registry.Models {
-			if !model.Archived {
-				registry.DefaultModelID = model.ID
-				break
-			}
-		}
-	}
+	registry.DefaultModelID = configuredProjectLLMDefaultModelID(registry)
 	if err := writeProjectLLMRegistry(r.Context(), c, registry); err != nil {
 		writeProjectError(w, err)
 		return

--- a/providers/app-studio/api/llm_registry_test.go
+++ b/providers/app-studio/api/llm_registry_test.go
@@ -17,6 +17,9 @@ package api
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	asclient "github.com/faroshq/provider-app-studio/client"
@@ -72,6 +75,68 @@ func TestProjectLLMRegistryReadsLegacySingleModelSecret(t *testing.T) {
 	}
 	if registry.Models[0].Settings.Model != "legacy-model" || registry.Models[0].Settings.APIKey != "legacy-key" {
 		t.Fatalf("legacy model = %#v", registry.Models[0])
+	}
+}
+
+func TestProjectLLMRegistryRequiresCredentialForConnectedModels(t *testing.T) {
+	model := projectLLMModelSettings{
+		ID:   "gpt-high",
+		Name: "GPT High",
+		Settings: projectLLMSettings{
+			Provider: defaultProjectLLMProvider,
+			BaseURL:  "https://api.openai.com/v1",
+			Model:    "gpt-test",
+		},
+	}
+	if err := validateProjectLLMModelCredential(model); err == nil || err.Error() != "a credential is required to connect this model" {
+		t.Fatalf("missing credential error = %v", err)
+	}
+	model.Settings.APIKey = "workspace-secret"
+	if err := validateProjectLLMModelCredential(model); err != nil {
+		t.Fatalf("configured model rejected: %v", err)
+	}
+}
+
+func TestProjectLLMRegistryFallbackDefaultSkipsModelsWithoutCredentials(t *testing.T) {
+	models := []projectLLMModelSettings{
+		{ID: "deleted", Archived: true, Settings: projectLLMSettings{APIKey: "old-key"}},
+		{ID: "incomplete", Settings: projectLLMSettings{}},
+		{ID: "ready-z", Name: "Zulu", Settings: projectLLMSettings{APIKey: "ready-key"}},
+		{ID: "ready-a", Name: "Alpha", Settings: projectLLMSettings{APIKey: "ready-key"}},
+	}
+	if got := firstConfiguredProjectLLMModelID(models); got != "ready-a" {
+		t.Fatalf("fallback default = %q, want ready-a", got)
+	}
+	if got := firstConfiguredProjectLLMModelID(models[:2]); got != "" {
+		t.Fatalf("fallback default = %q, want empty when no configured model remains", got)
+	}
+	registry := projectLLMRegistry{DefaultModelID: "incomplete", Models: models}
+	if got := configuredProjectLLMDefaultModelID(registry); got != "ready-a" {
+		t.Fatalf("repaired default = %q, want ready-a", got)
+	}
+	registry.DefaultModelID = "ready-z"
+	if got := configuredProjectLLMDefaultModelID(registry); got != "ready-z" {
+		t.Fatalf("configured default = %q, want ready-z", got)
+	}
+}
+
+func TestCreateProjectLLMModelRejectsMissingCredential(t *testing.T) {
+	client := asclient.NewFromDynamic(projectSettingsDynamicClient{})
+	server := &Server{projectClientFor: func(identity) (*asclient.Client, error) { return client, nil }}
+	request := httptest.NewRequest(http.MethodPost, "/api/projects/llm-settings/models", strings.NewReader(
+		`{"name":"GPT High","provider":"openai-compatible","baseURL":"https://api.openai.com/v1","model":"gpt-test"}`,
+	))
+	request.Header.Set("X-Faros-Tenant", "root:faros:tenants:org-a:workspace-a")
+	request.Header.Set("X-Faros-Cluster", "cluster-a")
+	response := httptest.NewRecorder()
+
+	server.createProjectLLMModel(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusBadRequest, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "a credential is required to connect this model") {
+		t.Fatalf("body = %q, want actionable credential error", response.Body.String())
 	}
 }
 

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -74,12 +74,15 @@ type Server struct {
 	// projectClientFor is an optional test seam for handlers that need a
 	// workspace-scoped Project client without opening a GraphQL listener.
 	// Production leaves it nil and uses clientFor's caller-scoped GraphQL path.
-	projectClientFor     func(identity) (*asclient.Client, error)
-	assistantRunManager  *projectAssistantRunManager
-	assistantSupervisor  *projectAssistantSupervisor
-	runSandboxManager    *projectAssistantSandboxManager
-	runSandboxConfig     CodingSandboxConfig
-	runSandboxConfigured bool
+	projectClientFor func(identity) (*asclient.Client, error)
+	// llmDiscoveryHTTPClient is a narrow test seam for credential-scoped model
+	// catalog requests. Production uses a redirect-denying bounded client.
+	llmDiscoveryHTTPClient *http.Client
+	assistantRunManager    *projectAssistantRunManager
+	assistantSupervisor    *projectAssistantSupervisor
+	runSandboxManager      *projectAssistantSandboxManager
+	runSandboxConfig       CodingSandboxConfig
+	runSandboxConfigured   bool
 	// codingSandboxResolver resolves a caller's organization-scoped BYO
 	// provider binding. Nil is fail-closed. Platform force mode never calls it.
 	codingSandboxResolver  func(context.Context, identity, workspace.Scope) (CodingSandboxEligibility, error)
@@ -272,6 +275,7 @@ func (s *Server) Register(r *mux.Router) {
 	r.HandleFunc("/api/projects/import-repositories", s.listImportRepositories).Methods(http.MethodGet)
 	r.HandleFunc("/api/projects/llm-settings", s.getProjectLLMSettings).Methods(http.MethodGet)
 	r.HandleFunc("/api/projects/llm-settings", s.patchProjectLLMSettings).Methods(http.MethodPatch)
+	r.HandleFunc("/api/projects/llm-settings/models/discover", s.discoverProjectLLMModels).Methods(http.MethodPost)
 	r.HandleFunc("/api/projects/llm-settings/models", s.createProjectLLMModel).Methods(http.MethodPost)
 	r.HandleFunc("/api/projects/llm-settings/models/{model}", s.patchProjectLLMModel).Methods(http.MethodPatch)
 	r.HandleFunc("/api/projects/llm-settings/models/{model}", s.deleteProjectLLMModel).Methods(http.MethodDelete)

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -60,7 +60,16 @@ import {
   parseAssistantInterrupt,
   type ProjectAssistantInterruptView,
 } from './assistantInterrupt'
-import { validateLLMBaseURL } from './llmSettingsValidation'
+import {
+  hasLLMModelFormErrors,
+  validateLLMModelForm,
+  type LLMCredentialMode,
+} from './llmSettingsValidation'
+import {
+  inferLLMProviderPreset,
+  llmProviderSelection,
+  type LLMProviderPreset,
+} from './llmDiscovery'
 import AssistantActionLog from './AssistantActionLog.vue'
 import AssistantExecDetails from './AssistantExecDetails.vue'
 import {
@@ -279,6 +288,7 @@ import type {
   ProjectAssistantFollowUpQuestionOption,
   ProjectAssistantUIInterruptRequest,
   ProjectProviderBinding,
+  ProjectLLMDiscoveredModel,
   ProjectLLMSettings,
   ProjectMessage,
   ProjectPromotionReadiness,
@@ -400,7 +410,14 @@ interface WorkbenchLauncherItem {
   providerTool?: ProviderTool
 }
 
-type LLMCredentialMode = 'api-key' | 'service-account-json'
+interface LLMEditorSnapshot {
+  name: string
+  provider: string
+  credentialMode: LLMCredentialMode
+  baseURL: string
+  model: string
+  apiKey: string
+}
 type ProjectMessageViewStatus = 'interrupted'
 type ProjectAssistantComponentValue = ProjectAssistantUIComponent['component']
 interface ProjectAssistantSurface {
@@ -867,6 +884,7 @@ const llmName = ref('')
 const llmEditingModelID = ref<string | null>(null)
 const selectedLLMModelID = ref('')
 const llmProvider = ref(OPENAI_COMPATIBLE_PROVIDER)
+const llmProviderPreset = ref<LLMProviderPreset>('openai')
 const llmBaseURL = ref('https://api.openai.com/v1')
 const llmModel = ref(OPENAI_DEFAULT_MODEL)
 const llmApiKey = ref('')
@@ -875,10 +893,17 @@ const llmSaving = ref(false)
 const llmStatus = ref<string | null>(null)
 const llmActionError = ref<string | null>(null)
 const llmEditorOpen = ref(false)
+const llmEditorBaseline = ref<LLMEditorSnapshot | null>(null)
+const llmValidationAttempted = ref(false)
 const llmCreateRouteSession = ref(false)
 const llmSettingsLoading = ref(false)
 const llmSettingsError = ref<string | null>(null)
 let llmSettingsLoadSerial = 0
+const llmDiscoveredModels = ref<ProjectLLMDiscoveredModel[]>([])
+const llmDiscoveryLoading = ref(false)
+const llmDiscoveryError = ref<string | null>(null)
+const llmDiscoveryStatus = ref<string | null>(null)
+let llmDiscoverySerial = 0
 const messagesRef = ref<HTMLDivElement | null>(null)
 const expandedMessageTimestampID = ref<string | null>(null)
 const expandedAssistantProgressIDs = ref<Set<string>>(new Set())
@@ -1172,6 +1197,8 @@ function invalidateProjectContextState() {
   llmSaving.value = false
   llmEditorOpen.value = false
   llmEditingModelID.value = null
+  llmEditorBaseline.value = null
+  llmValidationAttempted.value = false
   selectedLLMModelID.value = ''
   providersLoading.value = false
   createReadinessLoading.value = false
@@ -1609,8 +1636,12 @@ const productionSummaryTarget = computed(() => {
   return previewURL || 'Project has no deployable preview URL yet.'
 })
 const isGoogleGeminiProvider = computed(() => llmProvider.value.trim().toLowerCase() === GOOGLE_AI_STUDIO_PROVIDER)
+const isCustomLLMProvider = computed(() => llmProviderPreset.value === 'custom')
 const isGoogleServiceAccountMode = computed(() =>
   isGoogleGeminiProvider.value && llmCredentialMode.value === 'service-account-json',
+)
+const llmCredentialRequired = computed(() =>
+  !llmEditingModelID.value || llmSettings.value?.models.find((saved) => saved.id === llmEditingModelID.value)?.configured === false,
 )
 const llmBaseURLPlaceholder = computed(() =>
   isGoogleServiceAccountMode.value ? GOOGLE_CLOUD_BASE_URL : isGoogleGeminiProvider.value ? GEMINI_BASE_URL : 'Base URL',
@@ -1619,13 +1650,55 @@ const llmApiKeyPlaceholder = computed(() =>
   isGoogleServiceAccountMode.value ? 'Service account JSON' : isGoogleGeminiProvider.value ? 'Gemini API key' : 'API key',
 )
 const llmApiKeyHint = computed(() =>
-  isGoogleServiceAccountMode.value
-    ? 'Paste the Google service-account JSON key. Faros exchanges it for a short-lived OAuth token.'
-    : isGoogleGeminiProvider.value
-      ? 'Paste a Gemini API key string, not an OAuth/JWT token.'
-      : '',
+  llmEditingModelID.value && !llmCredentialRequired.value && !llmApiKey.value.trim()
+    ? 'Leave blank to keep the current credential.'
+    : isGoogleServiceAccountMode.value
+      ? 'Paste the complete Google service-account JSON key. Faros exchanges it for a short-lived OAuth token.'
+      : isGoogleGeminiProvider.value
+        ? 'Paste a Gemini API key string, not an OAuth or JWT token.'
+        : 'Stored for this workspace and never returned to the browser.',
 )
-const llmBaseURLError = computed(() => validateLLMBaseURL(llmProvider.value, llmBaseURL.value))
+const llmProviderGuidance = computed(() =>
+  llmProviderPreset.value === 'openai'
+    ? 'Uses OpenAI’s standard API endpoint.'
+    : isGoogleGeminiProvider.value
+    ? 'Use a Gemini API key for Google AI Studio, or a service-account key for Vertex AI.'
+    : 'Use a provider or gateway that implements OpenAI Chat Completions and GET /models.',
+)
+const llmModelHint = computed(() =>
+  isGoogleServiceAccountMode.value
+    ? 'Use the exact Vertex AI model identifier, including its publisher prefix.'
+    : 'Use the exact model identifier shown by your provider.',
+)
+const llmFormValidation = computed(() => validateLLMModelForm({
+  name: llmName.value,
+  provider: llmProvider.value,
+  credentialMode: llmCredentialMode.value,
+  baseURL: llmBaseURL.value,
+  model: llmModel.value,
+  credential: llmApiKey.value,
+  credentialRequired: !llmEditingModelID.value || llmSettings.value?.models.find((saved) => saved.id === llmEditingModelID.value)?.configured === false,
+  editingModelID: llmEditingModelID.value,
+  existingModels: llmSettings.value?.models ?? [],
+}))
+const llmBaseURLError = computed(() => llmFormValidation.value.baseURL)
+const llmCanDiscover = computed(() => {
+  if (isGoogleServiceAccountMode.value || llmBaseURLError.value) return false
+  if (llmApiKey.value.trim()) return true
+  const saved = llmSettings.value?.models.find((model) => model.id === llmEditingModelID.value)
+  if (!saved?.configured) return false
+  const savedProvider = inferLLMProvider(saved.provider, saved.baseURL).trim().toLowerCase()
+  const sameProvider = savedProvider === llmProvider.value.trim().toLowerCase()
+  const sameBaseURL = saved.baseURL.trim().replace(/\/+$/, '') === llmBaseURL.value.trim().replace(/\/+$/, '')
+  return sameProvider && sameBaseURL
+})
+const llmNameError = computed(() => llmValidationAttempted.value ? llmFormValidation.value.name : '')
+const llmModelError = computed(() => llmValidationAttempted.value ? llmFormValidation.value.model : '')
+const llmCredentialError = computed(() => llmValidationAttempted.value ? llmFormValidation.value.credential : '')
+const llmEditorDirty = computed(() => {
+  const baseline = llmEditorBaseline.value
+  return baseline !== null && JSON.stringify(currentLLMEditorSnapshot()) !== JSON.stringify(baseline)
+})
 interface LandingStarterPrompt {
   id: string
   label: string
@@ -3705,17 +3778,58 @@ function isGoogleCloudBaseURL(baseURL: string): boolean {
   return baseURL.trim().toLowerCase().replace(/\/+$/, '').startsWith('https://aiplatform.googleapis.com/')
 }
 
-function selectLLMProvider(provider: string) {
-  if (provider === llmProvider.value) return
-  llmProvider.value = provider
+function currentLLMEditorSnapshot(): LLMEditorSnapshot {
+  return {
+    name: llmName.value,
+    provider: llmProvider.value,
+    credentialMode: llmCredentialMode.value,
+    baseURL: llmBaseURL.value,
+    model: llmModel.value,
+    apiKey: llmApiKey.value,
+  }
+}
+
+function clearLLMDiscovery() {
+  llmDiscoverySerial += 1
+  llmDiscoveryLoading.value = false
+  llmDiscoveredModels.value = []
+  llmDiscoveryError.value = null
+  llmDiscoveryStatus.value = null
+}
+
+function selectLLMProvider(preset: LLMProviderPreset) {
+  if (preset === llmProviderPreset.value) return
+  const selection = llmProviderSelection(preset, llmBaseURL.value)
+  llmProviderPreset.value = preset
+  llmProvider.value = selection.provider
   llmCredentialMode.value = 'api-key'
-  if (provider === GOOGLE_AI_STUDIO_PROVIDER) {
-    llmBaseURL.value = GEMINI_BASE_URL
+  llmApiKey.value = ''
+  llmValidationAttempted.value = false
+  clearLLMDiscovery()
+  llmBaseURL.value = selection.baseURL
+  if (preset === 'google') {
     llmModel.value = GEMINI_DEFAULT_MODEL
     return
   }
-  llmBaseURL.value = 'https://api.openai.com/v1'
-  llmModel.value = OPENAI_DEFAULT_MODEL
+  llmModel.value = preset === 'openai' ? OPENAI_DEFAULT_MODEL : ''
+}
+
+function updateLLMCredentialMode(mode: LLMCredentialMode) {
+  if (mode === llmCredentialMode.value) return
+  llmCredentialMode.value = mode
+  llmApiKey.value = ''
+  llmValidationAttempted.value = false
+  clearLLMDiscovery()
+}
+
+function updateLLMBaseURL(value: string) {
+  llmBaseURL.value = value
+  clearLLMDiscovery()
+}
+
+function updateLLMAPIKey(value: string) {
+  llmApiKey.value = value
+  clearLLMDiscovery()
 }
 
 function openLLMEditor(modelID?: string) {
@@ -3727,11 +3841,51 @@ function openLLMEditor(modelID?: string) {
   llmName.value = saved?.name ?? ''
   const provider = inferLLMProvider(saved?.provider ?? OPENAI_COMPATIBLE_PROVIDER, saved?.baseURL ?? 'https://api.openai.com/v1')
   llmProvider.value = provider
+  llmProviderPreset.value = inferLLMProviderPreset(provider, saved?.baseURL ?? 'https://api.openai.com/v1')
   llmCredentialMode.value = isGoogleCloudBaseURL(saved?.baseURL ?? '') ? 'service-account-json' : 'api-key'
   llmBaseURL.value = normalizeLLMBaseURLInput(provider, saved?.baseURL ?? '', llmCredentialMode.value)
   llmModel.value = normalizeLLMModelInput(provider, saved?.model ?? '', llmCredentialMode.value)
   llmApiKey.value = ''
+  llmValidationAttempted.value = false
+  clearLLMDiscovery()
   llmEditorOpen.value = true
+  llmEditorBaseline.value = currentLLMEditorSnapshot()
+}
+
+async function discoverLLMModels() {
+  if (!llmCanDiscover.value || llmDiscoveryLoading.value) return
+  const serial = ++llmDiscoverySerial
+  const contextFingerprint = appContextFingerprint(props.ctx)
+  const requestRoute = routePath.value
+  llmDiscoveryLoading.value = true
+  llmDiscoveryError.value = null
+  llmDiscoveryStatus.value = null
+  try {
+    const result = await api.discoverLLMModels(props.ctx, {
+      provider: llmProvider.value,
+      baseURL: llmBaseURL.value,
+      ...(llmApiKey.value.trim() ? { apiKey: llmApiKey.value } : {}),
+      ...(llmEditingModelID.value ? { existingModelID: llmEditingModelID.value } : {}),
+    })
+    if (serial !== llmDiscoverySerial || contextFingerprint !== appContextFingerprint(props.ctx) || requestRoute !== routePath.value) return
+    llmDiscoveredModels.value = result.models
+    const selectable = result.models.filter((model) => model.compatibility !== 'unsuitable').length
+    const omitted = result.models.length - selectable
+    llmDiscoveryStatus.value = selectable > 0
+      ? `${selectable} model${selectable === 1 ? '' : 's'} available${omitted > 0 ? `; ${omitted} non-chat model${omitted === 1 ? '' : 's'} omitted` : ''}.`
+      : 'No compatible chat models were found. You can still enter a model ID manually.'
+  } catch (e) {
+    if (serial !== llmDiscoverySerial || contextFingerprint !== appContextFingerprint(props.ctx) || requestRoute !== routePath.value) return
+    llmDiscoveredModels.value = []
+    llmDiscoveryError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    if (serial === llmDiscoverySerial) llmDiscoveryLoading.value = false
+  }
+}
+
+function selectDiscoveredLLMModel(model: ProjectLLMDiscoveredModel) {
+  llmModel.value = model.id
+  if (!llmName.value.trim()) llmName.value = model.name
 }
 
 function openNewLLMModelEditor() {
@@ -3750,8 +3904,14 @@ function openModelEditor(modelID?: string) {
   openNewLLMModelEditor()
 }
 
-function cancelLLMEditor() {
+async function cancelLLMEditor() {
   if (llmSaving.value) return
+  if (llmEditorDirty.value && !(await confirmDialog({
+    title: 'Discard model changes?',
+    message: 'Your unsaved model configuration changes will be lost.',
+    confirmLabel: 'Discard changes',
+    danger: true,
+  }))) return
   const routeOwnedCreation = isCreateModelRoute.value
   const returnRoute = routeOwnedCreation
     ? (modelsReturnRoute.value === CREATE_PROJECT_ROUTE ? CREATE_PROJECT_ROUTE : MODELS_ROUTE)
@@ -3761,6 +3921,8 @@ function cancelLLMEditor() {
   llmActionError.value = null
   llmEditorOpen.value = false
   llmEditingModelID.value = null
+  llmEditorBaseline.value = null
+  llmValidationAttempted.value = false
   if (returnRoute) {
     modelsReturnRoute.value = ''
     props.navigate(returnRoute, { replace: true })
@@ -3780,7 +3942,11 @@ watch(
     }
     if (previous && llmCreateRouteSession.value) {
       llmCreateRouteSession.value = false
-      if (!llmEditingModelID.value) llmEditorOpen.value = false
+      if (!llmEditingModelID.value) {
+        llmEditorOpen.value = false
+        llmEditorBaseline.value = null
+        llmValidationAttempted.value = false
+      }
     }
   },
   { immediate: true, flush: 'sync' },
@@ -3861,7 +4027,8 @@ function normalizeLLMModelInput(provider: string, model: string, credentialMode:
 async function saveLLMSettings() {
   llmStatus.value = null
   llmActionError.value = null
-  if (llmBaseURLError.value) return
+  llmValidationAttempted.value = true
+  if (hasLLMModelFormErrors(llmFormValidation.value)) return
   const routeOwnedCreation = isCreateModelRoute.value && !llmEditingModelID.value
   const editingID = llmEditingModelID.value
   const returnRoute = routeOwnedCreation
@@ -3880,12 +4047,14 @@ async function saveLLMSettings() {
     if (llmApiKey.value.trim()) body.apiKey = llmApiKey.value.trim()
     const settings = editingID
       ? await api.patchLLMModel(mutationContext, editingID, body)
-      : await api.createLLMModel(mutationContext, body)
+      : await api.createLLMModel(mutationContext, { ...body, apiKey: llmApiKey.value.trim() })
     if (!llmModelMutationIsCurrent(guard)) return
     applyLLMSettings(settings)
-    llmStatus.value = editingID ? 'Model updated.' : 'Model added.'
+    llmStatus.value = editingID ? 'Model updated.' : 'Model connected.'
     llmEditorOpen.value = false
     llmEditingModelID.value = null
+    llmEditorBaseline.value = null
+    llmValidationAttempted.value = false
     if (returnRoute) {
       modelsReturnRoute.value = ''
       props.navigate(returnRoute, { replace: true })
@@ -3906,9 +4075,17 @@ async function deleteLLMModel(modelID: string) {
   }
   const saved = llmSettings.value?.models.find((model) => model.id === modelID)
   if (!saved) return
+  const fallbackDefault = saved.default
+    ? llmSettings.value?.models.find((model) => model.id !== modelID && model.configured)
+    : null
+  const deleteMessage = saved.default
+    ? fallbackDefault
+      ? `Existing runs keep their audit history. ${fallbackDefault.name} will become the default for new projects and turns.`
+      : 'Existing runs keep their audit history. No model will remain available for new projects or turns.'
+    : 'Existing runs keep their audit history, but this model will no longer be available for new turns.'
   if (!(await confirmDialog({
     title: `Delete ${saved.name}?`,
-    message: 'Existing runs keep their audit history, but this model will no longer be available for new turns.',
+    message: deleteMessage,
     danger: true,
     confirmLabel: 'Delete model',
   }))) return
@@ -7373,7 +7550,7 @@ function isMissingCodeConnectionError(value: string | null): boolean {
   <div v-else-if="!isBuilderVisible" class="min-h-0 bg-surface text-text-primary">
     <div class="flex min-h-full w-full flex-col gap-4">
       <Tabs
-        v-if="!isCreateModelRoute"
+        v-if="!isCreateModelRoute && !llmEditorOpen"
         :tabs="appStudioSectionTabs"
         :active="isModelsRoute || isCreateModelRoute ? 'models' : 'projects'"
         aria-label="App Studio sections"
@@ -7829,8 +8006,8 @@ function isMissingCodeConnectionError(value: string | null): boolean {
           <ArrowLeft class="h-3.5 w-3.5" :stroke-width="1.75" /> Models
         </button>
         <header v-if="isCreateModelRoute" class="k-create-header">
-          <h1 class="k-create-title">Add model</h1>
-          <p class="k-create-description">Configure the model credentials App Studio uses when creating and chatting in projects.</p>
+          <h1 class="k-create-title">Connect model</h1>
+          <p class="k-create-description">Add a credentialed model connection for project creation and chat.</p>
         </header>
         <div id="app-studio-models-host" class="min-h-[420px]" />
       </section>
@@ -9676,16 +9853,29 @@ function isMissingCodeConnectionError(value: string | null): boolean {
             :editing-model-i-d="llmEditingModelID"
             :name="llmName"
             :provider="llmProvider"
+            :provider-preset="llmProviderPreset"
             :credential-mode="llmCredentialMode"
             :base-u-r-l="llmBaseURL"
             :model="llmModel"
             :api-key="llmApiKey"
+            :name-error="llmNameError"
             :base-u-r-l-error="llmBaseURLError"
+            :model-error="llmModelError"
+            :credential-error="llmCredentialError"
+            :credential-required="llmCredentialRequired"
             :base-u-r-l-placeholder="llmBaseURLPlaceholder"
             :api-key-placeholder="llmApiKeyPlaceholder"
             :api-key-hint="llmApiKeyHint"
+            :provider-guidance="llmProviderGuidance"
+            :model-hint="llmModelHint"
             :google-provider="isGoogleGeminiProvider"
             :google-service-account-mode="isGoogleServiceAccountMode"
+            :custom-provider="isCustomLLMProvider"
+            :discovered-models="llmDiscoveredModels"
+            :discovery-loading="llmDiscoveryLoading"
+            :discovery-error="llmDiscoveryError"
+            :discovery-status="llmDiscoveryStatus"
+            :can-discover="llmCanDiscover"
             @retry="loadLLMSettings"
             @open-editor="openModelEditor"
             @cancel-editor="cancelLLMEditor"
@@ -9693,11 +9883,13 @@ function isMissingCodeConnectionError(value: string | null): boolean {
             @delete="deleteLLMModel"
             @set-default="setDefaultLLMModel"
             @select-provider="selectLLMProvider"
+            @discover="discoverLLMModels"
+            @select-discovered-model="selectDiscoveredLLMModel"
             @update:name="llmName = $event"
-            @update:credential-mode="llmCredentialMode = $event"
-            @update:base-u-r-l="llmBaseURL = $event"
+            @update:credential-mode="updateLLMCredentialMode"
+            @update:base-u-r-l="updateLLMBaseURL"
             @update:model="llmModel = $event"
-            @update:api-key="llmApiKey = $event"
+            @update:api-key="updateLLMAPIKey"
           />
 
           <footer v-if="settingsProject && !publishingInWorkbench && !historyInWorkbench" class="flex flex-wrap items-center justify-between gap-3 border-t border-border-subtle pt-4">

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -3870,10 +3870,11 @@ async function discoverLLMModels() {
     if (serial !== llmDiscoverySerial || contextFingerprint !== appContextFingerprint(props.ctx) || requestRoute !== routePath.value) return
     llmDiscoveredModels.value = result.models
     const selectable = result.models.filter((model) => model.compatibility !== 'unsuitable').length
-    const omitted = result.models.length - selectable
-    llmDiscoveryStatus.value = selectable > 0
-      ? `${selectable} model${selectable === 1 ? '' : 's'} available${omitted > 0 ? `; ${omitted} non-chat model${omitted === 1 ? '' : 's'} omitted` : ''}.`
-      : 'No compatible chat models were found. You can still enter a model ID manually.'
+    const unavailable = result.models.length - selectable
+    const total = result.models.length
+    llmDiscoveryStatus.value = total > 0
+      ? `${total} model${total === 1 ? '' : 's'} found${unavailable > 0 ? `; ${unavailable} marked unavailable for chat` : ''}.`
+      : 'No models were found. You can still enter a model ID manually.'
   } catch (e) {
     if (serial !== llmDiscoverySerial || contextFingerprint !== appContextFingerprint(props.ctx) || requestRoute !== routePath.value) return
     llmDiscoveredModels.value = []

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -7551,7 +7551,8 @@ function isMissingCodeConnectionError(value: string | null): boolean {
   <div v-else-if="!isBuilderVisible" class="min-h-0 bg-surface text-text-primary">
     <div class="flex min-h-full w-full flex-col gap-4">
       <Tabs
-        v-if="!isCreateModelRoute && !llmEditorOpen"
+        v-if="!isCreateModelRoute"
+        v-show="!llmEditorOpen"
         :tabs="appStudioSectionTabs"
         :active="isModelsRoute || isCreateModelRoute ? 'models' : 'projects'"
         aria-label="App Studio sections"

--- a/providers/app-studio/portal/src/ModelIDSelector.vue
+++ b/providers/app-studio/portal/src/ModelIDSelector.vue
@@ -1,0 +1,300 @@
+<script setup lang="ts">
+import { Check, ChevronDown, Search } from 'lucide-vue-next'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
+
+import { filterDiscoveredModels, modelSelectorOptions, type ModelSelectorOption } from './modelIDSelection'
+import { ensureFarosUIStyles } from './portalkit/styles'
+import type { ProjectLLMDiscoveredModel } from './types'
+
+ensureFarosUIStyles()
+
+const props = defineProps<{
+  modelValue: string
+  models: ProjectLLMDiscoveredModel[]
+  disabled?: boolean
+  invalid?: boolean
+  describedBy?: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+  select: [model: ProjectLLMDiscoveredModel]
+}>()
+
+const instanceID = useId()
+const listboxID = `model-id-options-${instanceID}`
+const root = ref<HTMLElement | null>(null)
+const trigger = ref<HTMLButtonElement | null>(null)
+const panel = ref<HTMLElement | null>(null)
+const searchInput = ref<HTMLInputElement | null>(null)
+const open = ref(false)
+const query = ref('')
+const activeIndex = ref(0)
+const panelStyle = ref<Record<string, string>>({})
+
+const selectedModel = computed(() => props.models.find(model => model.id === props.modelValue))
+const selectedLabel = computed(() => selectedModel.value?.name || props.modelValue || 'Select or enter a model ID')
+const matchingModels = computed(() => filterDiscoveredModels(props.models, query.value))
+const manualCandidate = computed(() => query.value.trim())
+const optionList = computed<ModelSelectorOption[]>(() => modelSelectorOptions(props.models, query.value))
+const activeDescendant = computed(() => open.value && optionList.value[activeIndex.value]
+  ? optionID(activeIndex.value)
+  : undefined)
+const optionSummary = computed(() => {
+  const total = props.models.length
+  const noun = total === 1 ? 'model' : 'models'
+  return query.value.trim()
+    ? `${matchingModels.value.length} of ${total} ${noun}`
+    : `${total} ${noun}`
+})
+
+watch(query, () => {
+  activeIndex.value = firstEnabledIndex(optionList.value)
+})
+
+watch(optionList, options => {
+  if (!options[activeIndex.value] || options[activeIndex.value].disabled) {
+    activeIndex.value = firstEnabledIndex(options)
+  }
+})
+
+function optionID(index: number): string {
+  return `${listboxID}-option-${index}`
+}
+
+function firstEnabledIndex(options: ModelSelectorOption[]): number {
+  const index = options.findIndex(option => !option.disabled)
+  return index >= 0 ? index : 0
+}
+
+function updatePanelPosition() {
+  const anchor = root.value ?? trigger.value
+  if (!anchor || typeof window === 'undefined') return
+  const rect = anchor.getBoundingClientRect()
+  const viewportWidth = window.innerWidth
+  const viewportHeight = window.innerHeight
+  const gap = 6
+  const edge = 8
+  const width = Math.min(Math.max(rect.width, 320), Math.max(viewportWidth - edge * 2, 0))
+  const left = Math.min(Math.max(rect.left, edge), Math.max(viewportWidth - width - edge, edge))
+  const roomBelow = viewportHeight - rect.bottom - gap - edge
+  const roomAbove = rect.top - gap - edge
+  const openAbove = roomBelow < 240 && roomAbove > roomBelow
+  const availableHeight = Math.min(360, Math.max(openAbove ? roomAbove : roomBelow, 0))
+
+  panelStyle.value = openAbove
+    ? {
+        bottom: `${viewportHeight - rect.top + gap}px`,
+        left: `${left}px`,
+        width: `${width}px`,
+        '--k-table-filter-panel-max-height': `${availableHeight}px`,
+      }
+    : {
+        left: `${left}px`,
+        top: `${rect.bottom + gap}px`,
+        width: `${width}px`,
+        '--k-table-filter-panel-max-height': `${availableHeight}px`,
+      }
+}
+
+async function openSelector() {
+  if (props.disabled || open.value) return
+  query.value = ''
+  const selectedIndex = optionList.value.findIndex(option => option.value === props.modelValue)
+  activeIndex.value = selectedIndex >= 0 && !optionList.value[selectedIndex]?.disabled
+    ? selectedIndex
+    : firstEnabledIndex(optionList.value)
+  open.value = true
+  await nextTick()
+  updatePanelPosition()
+  searchInput.value?.focus()
+  scrollActiveOption()
+}
+
+function closeSelector(focusTrigger = false) {
+  if (!open.value) return
+  open.value = false
+  query.value = ''
+  if (focusTrigger) nextTick(() => trigger.value?.focus())
+}
+
+function toggleSelector() {
+  if (open.value) closeSelector()
+  else void openSelector()
+}
+
+function chooseOption(option: ModelSelectorOption) {
+  if (option.disabled) return
+  emit('update:modelValue', option.value)
+  if (option.model) emit('select', option.model)
+  closeSelector(true)
+}
+
+function moveActive(delta: number) {
+  const options = optionList.value
+  if (options.length === 0 || options.every(option => option.disabled)) return
+  let next = activeIndex.value
+  do {
+    next = (next + delta + options.length) % options.length
+  } while (options[next]?.disabled)
+  activeIndex.value = next
+  scrollActiveOption()
+}
+
+function scrollActiveOption() {
+  nextTick(() => {
+    if (typeof document === 'undefined') return
+    document.getElementById(optionID(activeIndex.value))?.scrollIntoView({ block: 'nearest' })
+  })
+}
+
+function onSearchKeydown(event: KeyboardEvent) {
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveActive(1)
+    return
+  }
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveActive(-1)
+    return
+  }
+  if (event.key === 'Home') {
+    event.preventDefault()
+    activeIndex.value = firstEnabledIndex(optionList.value)
+    scrollActiveOption()
+    return
+  }
+  if (event.key === 'End') {
+    event.preventDefault()
+    const reversedIndex = [...optionList.value].reverse().findIndex(option => !option.disabled)
+    activeIndex.value = reversedIndex >= 0 ? optionList.value.length - reversedIndex - 1 : 0
+    scrollActiveOption()
+    return
+  }
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    const option = optionList.value[activeIndex.value]
+    if (option) chooseOption(option)
+    return
+  }
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeSelector(true)
+  }
+}
+
+function onTriggerKeydown(event: KeyboardEvent) {
+  if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+  event.preventDefault()
+  void openSelector()
+}
+
+function onDocumentPointerDown(event: PointerEvent) {
+  if (!open.value) return
+  const target = event.target as Node | null
+  if (target && (root.value?.contains(target) || panel.value?.contains(target))) return
+  closeSelector()
+}
+
+function onDocumentFocusIn(event: FocusEvent) {
+  if (!open.value) return
+  const target = event.target as Node | null
+  if (target && (root.value?.contains(target) || panel.value?.contains(target))) return
+  closeSelector()
+}
+
+function onViewportChange() {
+  if (open.value) updatePanelPosition()
+}
+
+onMounted(() => {
+  document.addEventListener('pointerdown', onDocumentPointerDown)
+  document.addEventListener('focusin', onDocumentFocusIn)
+  window.addEventListener('resize', onViewportChange)
+  window.addEventListener('scroll', onViewportChange, true)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', onDocumentPointerDown)
+  document.removeEventListener('focusin', onDocumentFocusIn)
+  window.removeEventListener('resize', onViewportChange)
+  window.removeEventListener('scroll', onViewportChange, true)
+})
+</script>
+
+<template>
+  <div ref="root" class="min-w-0">
+    <button
+      id="model-id"
+      ref="trigger"
+      type="button"
+      class="k-input flex h-10 w-full min-w-0 items-center justify-between gap-2 text-left font-mono text-[12px]"
+      :class="invalid ? 'border-danger/50 focus:border-danger focus:shadow-[0_0_0_3px_var(--color-danger-subtle)]' : ''"
+      :disabled="disabled"
+      :aria-controls="listboxID"
+      :aria-expanded="open"
+      :aria-invalid="invalid"
+      :aria-describedby="describedBy"
+      aria-required="true"
+      aria-haspopup="listbox"
+      @click="toggleSelector"
+      @keydown="onTriggerKeydown"
+    >
+      <span class="truncate" :class="modelValue ? 'text-text-primary' : 'text-text-muted'">{{ selectedLabel }}</span>
+      <ChevronDown class="h-3.5 w-3.5 shrink-0 text-text-muted transition-transform" :class="{ 'rotate-180': open }" :stroke-width="1.75" aria-hidden="true" />
+    </button>
+
+    <Teleport v-if="open" to="body">
+      <div
+        ref="panel"
+        class="k-menu k-table__filter-panel k-table__filter-panel--searchable"
+        :style="panelStyle"
+      >
+        <label class="k-table__filter-search">
+          <span class="sr-only">Search model IDs</span>
+          <Search :stroke-width="1.75" aria-hidden="true" />
+          <input
+            ref="searchInput"
+            v-model="query"
+            type="search"
+            role="combobox"
+            autocomplete="off"
+            aria-autocomplete="list"
+            :aria-activedescendant="activeDescendant"
+            :aria-controls="listboxID"
+            aria-expanded="true"
+            aria-label="Search model IDs"
+            placeholder="Find a model or enter an ID…"
+            @keydown="onSearchKeydown"
+          >
+        </label>
+        <div class="k-table__filter-meta" aria-live="polite">{{ optionSummary }}</div>
+        <ul :id="listboxID" class="k-table__filter-options" role="listbox" aria-label="Model IDs">
+          <li
+            v-for="(option, index) in optionList"
+            :id="optionID(index)"
+            :key="option.key"
+            class="k-table__filter-option min-h-10"
+            :class="{
+              'is-active': index === activeIndex && !option.disabled,
+              'cursor-not-allowed opacity-50': option.disabled,
+            }"
+            role="option"
+            :aria-disabled="option.disabled || undefined"
+            :aria-selected="option.value === modelValue"
+            @mouseenter="!option.disabled && (activeIndex = index)"
+            @mousedown.prevent
+            @click="chooseOption(option)"
+          >
+            <Check :stroke-width="1.75" aria-hidden="true" />
+            <span class="min-w-0 flex-1 truncate">{{ option.manual ? `Use “${option.label}”` : option.label }}</span>
+            <span v-if="option.model?.compatibility === 'recommended'" class="shrink-0 text-[8px] font-semibold uppercase tracking-wide text-accent">Recommended</span>
+            <span v-else-if="option.disabled" class="shrink-0 text-[8px] font-semibold uppercase tracking-wide text-text-muted">Not for chat</span>
+          </li>
+        </ul>
+        <p v-if="models.length === 0 && !manualCandidate" class="k-table__filter-empty">Find models to load this provider’s catalog, or type a model ID above.</p>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/providers/app-studio/portal/src/ModelsSettings.vue
+++ b/providers/app-studio/portal/src/ModelsSettings.vue
@@ -167,9 +167,9 @@ const emit = defineEmits<{
         </button>
       </div>
 
-      <form v-if="editorOpen || creationRoute" class="k-create-surface" aria-label="Model configuration form" :aria-busy="saving" novalidate @submit.prevent="emit('save')">
+      <form v-if="editorOpen || creationRoute" class="k-create-surface" :class="{ 'k-create-surface--wide': creationRoute }" aria-label="Model configuration form" :aria-busy="saving" novalidate @submit.prevent="emit('save')">
         <div class="k-create-body">
-          <div v-if="!creationRoute" class="flex items-start gap-3">
+          <div v-if="!creationRoute" class="flex flex-wrap items-start gap-3">
             <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface text-text-muted"><KeyRound class="h-4 w-4" :stroke-width="1.75" /></div>
             <div class="min-w-0">
               <h4 class="text-[13px] font-semibold text-text-primary">{{ editingModelID ? 'Edit model' : 'New model' }}</h4>

--- a/providers/app-studio/portal/src/ModelsSettings.vue
+++ b/providers/app-studio/portal/src/ModelsSettings.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { Check, ChevronRight, Cpu, KeyRound, Loader2, Pencil, Plus, Star, Trash2 } from 'lucide-vue-next'
+import { computed } from 'vue'
+import { Check, ChevronRight, Cpu, KeyRound, Loader2, Pencil, Plus, RefreshCw, Star, Trash2 } from 'lucide-vue-next'
 import StatusBadge from './portalkit/StatusBadge.vue'
-import type { ProjectLLMSettings } from './types'
+import type { LLMProviderPreset } from './llmDiscovery'
+import type { ProjectLLMDiscoveredModel, ProjectLLMSettings } from './types'
 
 type LLMCredentialMode = 'api-key' | 'service-account-json'
 
-defineProps<{
+const props = defineProps<{
   settings: ProjectLLMSettings | null
   loading: boolean
   loadError: string | null
@@ -17,17 +19,33 @@ defineProps<{
   editingModelID: string | null
   name: string
   provider: string
+  providerPreset: LLMProviderPreset
   credentialMode: LLMCredentialMode
   baseURL: string
   model: string
   apiKey: string
+  nameError: string
   baseURLError: string
+  modelError: string
+  credentialError: string
+  credentialRequired: boolean
   baseURLPlaceholder: string
   apiKeyPlaceholder: string
   apiKeyHint: string
+  providerGuidance: string
+  modelHint: string
   googleProvider: boolean
   googleServiceAccountMode: boolean
+  customProvider: boolean
+  discoveredModels: ProjectLLMDiscoveredModel[]
+  discoveryLoading: boolean
+  discoveryError: string | null
+  discoveryStatus: string | null
+  canDiscover: boolean
 }>()
+
+const selectableDiscoveredModels = computed(() => props.discoveredModels.filter((model) => model.compatibility !== 'unsuitable'))
+const recommendedDiscoveredModels = computed(() => selectableDiscoveredModels.value.filter((model) => model.compatibility === 'recommended').slice(0, 4))
 
 const emit = defineEmits<{
   retry: []
@@ -36,7 +54,9 @@ const emit = defineEmits<{
   save: []
   delete: [modelID: string]
   setDefault: [modelID: string]
-  selectProvider: [provider: string]
+  selectProvider: [provider: LLMProviderPreset]
+  discover: []
+  selectDiscoveredModel: [model: ProjectLLMDiscoveredModel]
   'update:name': [value: string]
   'update:credentialMode': [mode: LLMCredentialMode]
   'update:baseURL': [value: string]
@@ -46,26 +66,22 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <section class="grid gap-4" :aria-label="creationRoute ? 'New model' : 'Models'">
-    <div v-if="!creationRoute" class="flex flex-wrap items-start justify-between gap-3">
-      <div class="min-w-0">
-        <h3 class="text-[14px] font-semibold text-text-primary">{{ creationRoute ? 'New model' : 'Models' }}</h3>
-        <p class="mt-1 max-w-2xl text-[12px] leading-5 text-text-muted">
-          {{ creationRoute
-            ? 'Add a workspace model connection for project creation and chat.'
-            : 'Add workspace model connections, choose the default for project creation, and select a model per chat turn.' }}
-        </p>
-      </div>
-      <button
-        v-if="!creationRoute && !editorOpen && !(loading && !settings)"
-        type="button"
-        class="inline-flex h-9 shrink-0 items-center gap-2 rounded-md border border-accent bg-accent px-3 text-[12px] font-semibold text-surface shadow-[0_0_16px_var(--color-accent-glow)] transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
-        :disabled="(settings?.models.length ?? 0) >= 20"
-        @click="emit('openEditor')"
+  <section class="grid gap-4" :aria-label="creationRoute ? 'Connect model' : 'Models'">
+    <div v-if="!creationRoute && !editorOpen && !(loading && !settings) && (settings?.models.length ?? 0) > 0" class="flex justify-end">
+      <span
+        class="inline-flex"
+        :title="(settings?.models.length ?? 0) >= 20 ? 'This workspace already has the maximum of 20 models.' : undefined"
       >
-        <Plus class="h-4 w-4" :stroke-width="1.75" />
-        New model
-      </button>
+        <button
+          type="button"
+          class="k-btn k-btn--primary shrink-0"
+          :disabled="(settings?.models.length ?? 0) >= 20"
+          @click="emit('openEditor')"
+        >
+          <Plus class="h-4 w-4" :stroke-width="1.75" />
+          Connect model
+        </button>
+      </span>
     </div>
 
     <div v-if="loading && !settings && !creationRoute" class="grid min-h-48 content-start gap-3 rounded-md border border-dashed border-border-subtle bg-surface p-4" role="status" aria-live="polite" aria-busy="true">
@@ -75,7 +91,7 @@ const emit = defineEmits<{
     </div>
     <div v-else-if="loadError && !settings && !creationRoute" class="flex min-h-48 flex-col items-start justify-center gap-2 rounded-md border border-danger/30 bg-danger-subtle p-4 text-[12px] text-danger" role="alert">
       <div>{{ loadError }}</div>
-      <button type="button" class="font-medium underline underline-offset-2" @click="emit('retry')">Retry</button>
+      <button type="button" class="rounded-sm font-medium underline underline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger" @click="emit('retry')">Retry</button>
     </div>
 
     <template v-else>
@@ -85,17 +101,16 @@ const emit = defineEmits<{
       </div>
       <div v-if="loadError" class="flex flex-wrap items-center gap-2 rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-[12px] text-danger" role="alert">
         <span>{{ loadError }}</span>
-        <button type="button" class="font-medium underline underline-offset-2" @click="emit('retry')">Retry</button>
+        <button type="button" class="rounded-sm font-medium underline underline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger" @click="emit('retry')">Retry</button>
       </div>
       <div v-if="actionError" class="rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-[12px] text-danger" role="alert">{{ actionError }}</div>
       <div v-else-if="status" class="rounded-md border border-success/30 bg-success-subtle px-3 py-2 text-[12px] text-success" role="status" aria-live="polite">{{ status }}</div>
 
-      <div v-if="settings?.models.length && !creationRoute" class="grid gap-3 sm:grid-cols-2">
+      <div v-if="settings?.models.length && !creationRoute && !editorOpen" class="grid gap-3 sm:grid-cols-2">
         <article
           v-for="saved in settings.models"
           :key="saved.id"
-          class="grid gap-3 rounded-lg border bg-surface p-4 transition"
-          :class="editingModelID === saved.id ? 'border-accent/50' : 'border-border-subtle'"
+          class="grid gap-3 rounded-lg border border-border-subtle bg-surface p-4 transition-colors hover:border-border-default"
           :aria-label="`Model ${saved.name}`"
         >
           <div class="flex min-w-0 items-start gap-3">
@@ -109,20 +124,32 @@ const emit = defineEmits<{
               </div>
               <p class="mt-0.5 truncate font-mono text-[11px] text-text-muted" :title="saved.model">{{ saved.model }}</p>
             </div>
-            <StatusBadge :status="saved.configured ? 'Configured' : 'Needs credential'" :tone="saved.configured ? 'success' : 'warning'" />
+            <StatusBadge :status="saved.configured ? 'Credential saved' : 'Needs credential'" :tone="saved.configured ? 'success' : 'warning'" />
           </div>
           <dl class="border-y border-border-subtle py-2 text-[11px]">
             <dt class="text-[9px] font-semibold uppercase tracking-wide text-text-muted">Endpoint</dt>
             <dd class="mt-1 truncate font-mono text-text-secondary" :title="saved.baseURL">{{ saved.baseURL }}</dd>
           </dl>
           <div class="flex flex-wrap items-center gap-1">
-            <button type="button" class="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-[11px] font-medium text-text-secondary transition hover:bg-surface-hover hover:text-text-primary" @click="emit('openEditor', saved.id)">
+            <button type="button" class="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-[11px] font-medium text-text-secondary transition hover:bg-surface-hover hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:opacity-50" :disabled="saving" @click="emit('openEditor', saved.id)">
               <Pencil class="h-3.5 w-3.5" :stroke-width="1.75" /> Edit
             </button>
-            <button v-if="!saved.default" type="button" class="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-[11px] font-medium text-text-secondary transition hover:bg-surface-hover hover:text-text-primary disabled:opacity-50" :disabled="saving || !saved.configured" @click="emit('setDefault', saved.id)">
-              <Star class="h-3.5 w-3.5" :stroke-width="1.75" /> Make default
-            </button>
-            <button type="button" class="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-text-muted transition hover:bg-danger-subtle hover:text-danger disabled:opacity-50" :disabled="saving" :aria-label="`Delete ${saved.name}`" @click="emit('delete', saved.id)">
+            <span
+              v-if="!saved.default"
+              class="inline-flex"
+              :title="!saved.configured ? 'Add a credential before making this model the default.' : undefined"
+            >
+              <button
+                type="button"
+                class="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-[11px] font-medium text-text-secondary transition hover:bg-surface-hover hover:text-text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:opacity-50"
+                :disabled="saving || !saved.configured"
+                :aria-label="!saved.configured ? `Make ${saved.name} default unavailable: add a credential first` : `Make ${saved.name} default`"
+                @click="emit('setDefault', saved.id)"
+              >
+                <Star class="h-3.5 w-3.5" :stroke-width="1.75" /> Make default
+              </button>
+            </span>
+            <button type="button" class="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-text-muted transition hover:bg-danger-subtle hover:text-danger focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger disabled:opacity-50" :disabled="saving" :aria-label="`Delete ${saved.name}`" @click="emit('delete', saved.id)">
               <Trash2 class="h-3.5 w-3.5" :stroke-width="1.75" />
             </button>
           </div>
@@ -133,76 +160,123 @@ const emit = defineEmits<{
         <div class="flex h-10 w-10 items-center justify-center rounded-lg border border-border-subtle bg-surface-overlay text-text-muted"><Cpu class="h-5 w-5" :stroke-width="1.75" /></div>
         <div>
           <h4 class="text-[13px] font-semibold text-text-primary">No models configured</h4>
-          <p class="mt-1 max-w-md text-[12px] leading-5 text-text-muted">Add a provider endpoint and credential before creating or chatting in projects.</p>
+          <p class="mt-1 max-w-md text-[12px] leading-5 text-text-muted">Connect a provider endpoint and credential before creating or chatting in projects.</p>
         </div>
-        <button type="button" class="inline-flex h-9 items-center gap-2 rounded-md border border-accent bg-accent px-3 text-[12px] font-semibold text-surface shadow-[0_0_16px_var(--color-accent-glow)] transition hover:bg-accent-hover" @click="emit('openEditor')">
-          <Plus class="h-4 w-4" :stroke-width="1.75" /> Add model
+        <button type="button" class="k-btn k-btn--primary" @click="emit('openEditor')">
+          <Plus class="h-4 w-4" :stroke-width="1.75" /> Connect model
         </button>
       </div>
 
-      <form v-if="editorOpen || creationRoute" :class="creationRoute ? 'k-create-surface k-create-surface--wide' : 'rounded-lg border border-border-subtle bg-surface-overlay/40 p-4'" aria-label="Model configuration form" @submit.prevent="emit('save')">
-        <div :class="creationRoute ? 'k-create-body' : 'grid gap-4'">
-        <div v-if="!creationRoute" class="flex items-start gap-3">
-          <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface text-text-muted"><KeyRound class="h-4 w-4" :stroke-width="1.75" /></div>
-          <div class="min-w-0">
-            <h4 class="text-[13px] font-semibold text-text-primary">{{ editingModelID && !creationRoute ? 'Edit model' : 'New model' }}</h4>
-            <p class="mt-0.5 text-[11px] leading-4 text-text-muted">Give this connection a recognizable name, then configure its endpoint and workspace credential.</p>
+      <form v-if="editorOpen || creationRoute" class="k-create-surface" aria-label="Model configuration form" :aria-busy="saving" novalidate @submit.prevent="emit('save')">
+        <div class="k-create-body">
+          <div v-if="!creationRoute" class="flex items-start gap-3">
+            <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface text-text-muted"><KeyRound class="h-4 w-4" :stroke-width="1.75" /></div>
+            <div class="min-w-0">
+              <h4 class="text-[13px] font-semibold text-text-primary">{{ editingModelID ? 'Edit model' : 'New model' }}</h4>
+              <p class="mt-0.5 text-[11px] leading-4 text-text-muted">Give this connection a recognizable name, then configure its endpoint and workspace credential.</p>
+            </div>
           </div>
-        </div>
 
-        <label class="grid gap-1.5 text-[11px] font-medium text-text-secondary">
-          Display name
-          <input :value="name" class="h-10 rounded-md border border-border-subtle bg-surface px-3 text-[13px] text-text-primary outline-none transition placeholder:text-text-muted focus:border-accent/50" placeholder="e.g. GPT-5.6 High" :disabled="saving" @input="emit('update:name', ($event.target as HTMLInputElement).value)" />
-        </label>
+          <label for="model-display-name" class="grid gap-1.5 text-[11px] font-medium text-text-secondary">
+            Display name
+            <input
+              id="model-display-name"
+              :value="name"
+              class="k-input h-10"
+              :class="nameError ? 'border-danger/50 focus:border-danger focus:shadow-[0_0_0_3px_var(--color-danger-subtle)]' : ''"
+              placeholder="e.g. GPT-5.6 High"
+              maxlength="80"
+              :disabled="saving"
+              :aria-invalid="Boolean(nameError)"
+              aria-required="true"
+              :aria-describedby="nameError ? 'model-display-name-error' : 'model-display-name-hint'"
+              @input="emit('update:name', ($event.target as HTMLInputElement).value)"
+            />
+            <span v-if="nameError" id="model-display-name-error" class="text-[11px] font-normal leading-4 text-danger" role="alert">{{ nameError }}</span>
+            <span v-else id="model-display-name-hint" class="text-[11px] font-normal leading-4 text-text-muted">Use a name people can recognize in project and chat model pickers.</span>
+          </label>
 
-        <section class="grid gap-3 border-t border-border-subtle pt-4" aria-labelledby="model-provider-heading">
-          <h5 id="model-provider-heading" class="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Provider</h5>
-          <div class="grid gap-3 sm:grid-cols-2">
-            <label class="grid min-w-0 gap-1.5 text-[11px] font-medium text-text-secondary">Provider preset
-              <span class="relative block">
-                <select :value="provider" class="h-10 w-full appearance-none rounded-md border border-border-subtle bg-surface px-3 pr-9 text-[13px] text-text-primary outline-none transition focus:border-accent/50" :disabled="saving" @change="emit('selectProvider', ($event.target as HTMLSelectElement).value)">
-                  <option value="openai-compatible">OpenAI-compatible</option><option value="google-ai-studio">Google</option>
-                </select>
-                <ChevronRight class="pointer-events-none absolute right-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 rotate-90 text-text-muted" :stroke-width="1.75" />
+          <section class="grid gap-3 border-t border-border-subtle pt-4" aria-labelledby="model-provider-heading">
+            <h5 id="model-provider-heading" class="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Connection</h5>
+            <div class="grid gap-3 sm:grid-cols-2">
+              <label for="model-provider" class="grid min-w-0 gap-1.5 text-[11px] font-medium text-text-secondary">Provider
+                <span class="relative block">
+                  <select id="model-provider" :value="providerPreset" class="k-input h-10 appearance-none pr-9" :disabled="saving" aria-describedby="model-provider-hint" @change="emit('selectProvider', ($event.target as HTMLSelectElement).value as LLMProviderPreset)">
+                    <option value="openai">OpenAI</option>
+                    <option value="google">Google AI Studio</option>
+                    <option value="custom">Custom OpenAI-compatible</option>
+                  </select>
+                  <ChevronRight class="pointer-events-none absolute right-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 rotate-90 text-text-muted" :stroke-width="1.75" />
+                </span>
+                <span id="model-provider-hint" class="text-[11px] font-normal leading-4 text-text-muted">{{ providerGuidance }}</span>
+              </label>
+              <label v-if="googleProvider" for="model-credential-method" class="grid min-w-0 content-start gap-1.5 text-[11px] font-medium text-text-secondary">Credential method
+                <span class="relative block">
+                  <select id="model-credential-method" :value="credentialMode" class="k-input h-10 appearance-none pr-9" :disabled="saving" @change="emit('update:credentialMode', ($event.target as HTMLSelectElement).value as LLMCredentialMode)">
+                    <option value="api-key">Gemini API key</option>
+                    <option value="service-account-json">Vertex AI service account</option>
+                  </select>
+                  <ChevronRight class="pointer-events-none absolute right-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 rotate-90 text-text-muted" :stroke-width="1.75" />
+                </span>
+              </label>
+              <label v-else-if="customProvider" for="model-base-url" class="grid min-w-0 gap-1.5 text-[11px] font-medium text-text-secondary">Base URL
+                <input id="model-base-url" :value="baseURL" class="k-input h-10 min-w-0 font-mono text-[12px]" :class="baseURLError ? 'border-danger/50 focus:border-danger focus:shadow-[0_0_0_3px_var(--color-danger-subtle)]' : ''" :placeholder="baseURLPlaceholder" :disabled="saving" :aria-invalid="Boolean(baseURLError)" aria-required="true" aria-describedby="model-base-url-help" type="url" @input="emit('update:baseURL', ($event.target as HTMLInputElement).value)" />
+                <span id="model-base-url-help" class="text-[11px] font-normal leading-4" :class="baseURLError ? 'text-danger' : 'text-text-muted'" :role="baseURLError ? 'alert' : undefined">{{ baseURLError || 'App Studio adds /chat/completions and queries /models.' }}</span>
+              </label>
+              <div v-else class="grid min-w-0 content-start gap-1.5 text-[11px] font-medium text-text-secondary">
+                API endpoint
+                <div class="flex h-10 min-w-0 items-center rounded-md border border-border-subtle bg-surface px-3 font-mono text-[11px] text-text-muted">
+                  <span class="truncate" :title="baseURL">{{ baseURL }}</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="grid gap-2 border-t border-border-subtle pt-4" aria-labelledby="model-credential-heading">
+            <h5 id="model-credential-heading" class="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Credential</h5>
+            <label for="model-credential" class="sr-only">{{ googleServiceAccountMode ? 'Service account JSON' : 'API key' }}</label>
+            <textarea v-if="googleServiceAccountMode" id="model-credential" :value="apiKey" class="k-input min-h-[140px] resize-y font-mono text-[12px] leading-5" :class="credentialError ? 'border-danger/50 focus:border-danger focus:shadow-[0_0_0_3px_var(--color-danger-subtle)]' : ''" :placeholder="apiKeyPlaceholder" autocomplete="off" :disabled="saving" :aria-invalid="Boolean(credentialError)" :aria-required="credentialRequired" aria-describedby="model-credential-help" @input="emit('update:apiKey', ($event.target as HTMLTextAreaElement).value)" />
+            <input v-else id="model-credential" :value="apiKey" class="k-input h-10" :class="credentialError ? 'border-danger/50 focus:border-danger focus:shadow-[0_0_0_3px_var(--color-danger-subtle)]' : ''" :placeholder="editingModelID && !credentialRequired ? `${apiKeyPlaceholder} (leave blank to keep current)` : apiKeyPlaceholder" type="password" autocomplete="new-password" :disabled="saving" :aria-invalid="Boolean(credentialError)" :aria-required="credentialRequired" aria-describedby="model-credential-help" @input="emit('update:apiKey', ($event.target as HTMLInputElement).value)" />
+            <p id="model-credential-help" class="text-[11px] leading-4" :class="credentialError ? 'text-danger' : 'text-text-muted'" :role="credentialError ? 'alert' : undefined">{{ credentialError || apiKeyHint }}</p>
+          </section>
+
+          <section class="grid gap-3 border-t border-border-subtle pt-4" aria-labelledby="model-selection-heading">
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <h5 id="model-selection-heading" class="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Model</h5>
+              <span class="inline-flex" :title="!canDiscover ? (googleServiceAccountMode ? 'Vertex AI model discovery is not available yet.' : 'Enter a credential before finding models.') : undefined">
+                <button type="button" class="k-btn k-btn--ghost h-8 px-2.5 text-[11px]" :disabled="saving || discoveryLoading || !canDiscover" @click="emit('discover')">
+                  <Loader2 v-if="discoveryLoading" class="h-3.5 w-3.5 animate-spin" :stroke-width="1.75" />
+                  <RefreshCw v-else class="h-3.5 w-3.5" :stroke-width="1.75" />
+                  {{ discoveryLoading ? 'Finding models…' : 'Find models' }}
+                </button>
               </span>
+            </div>
+            <label for="model-id" class="grid min-w-0 content-start gap-1.5 text-[11px] font-medium text-text-secondary">Model ID
+              <input id="model-id" :value="model" list="model-discovery-options" class="k-input h-10 min-w-0 font-mono text-[12px]" :class="modelError ? 'border-danger/50 focus:border-danger focus:shadow-[0_0_0_3px_var(--color-danger-subtle)]' : ''" placeholder="e.g. gpt-5.4" :disabled="saving" :aria-invalid="Boolean(modelError)" aria-required="true" :aria-describedby="modelError ? 'model-id-error' : 'model-id-hint'" @input="emit('update:model', ($event.target as HTMLInputElement).value)" />
+              <datalist id="model-discovery-options">
+                <option v-for="available in selectableDiscoveredModels" :key="available.id" :value="available.id">{{ available.name }}</option>
+              </datalist>
+              <span v-if="modelError" id="model-id-error" class="text-[11px] font-normal leading-4 text-danger" role="alert">{{ modelError }}</span>
+              <span v-else id="model-id-hint" class="text-[11px] font-normal leading-4 text-text-muted">{{ modelHint }} Find models to populate suggestions, or enter an ID manually.</span>
             </label>
-            <label v-if="googleProvider" class="grid min-w-0 gap-1.5 text-[11px] font-medium text-text-secondary">Credential method
-              <span class="relative block">
-                <select :value="credentialMode" class="h-10 w-full appearance-none rounded-md border border-border-subtle bg-surface px-3 pr-9 text-[13px] text-text-primary outline-none transition focus:border-accent/50" :disabled="saving" @change="emit('update:credentialMode', ($event.target as HTMLSelectElement).value as LLMCredentialMode)">
-                  <option value="api-key">Gemini API key</option><option value="service-account-json">Vertex AI service account</option>
-                </select>
-                <ChevronRight class="pointer-events-none absolute right-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 rotate-90 text-text-muted" :stroke-width="1.75" />
-              </span>
-            </label>
-          </div>
-        </section>
-
-        <section class="grid gap-3 border-t border-border-subtle pt-4" aria-labelledby="model-endpoint-heading">
-          <h5 id="model-endpoint-heading" class="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Model endpoint</h5>
-          <div class="grid gap-3 sm:grid-cols-2">
-            <label class="grid min-w-0 gap-1.5 text-[11px] font-medium text-text-secondary">Base URL
-              <input :value="baseURL" class="h-10 min-w-0 rounded-md border bg-surface px-3 font-mono text-[12px] text-text-primary outline-none transition placeholder:text-text-muted" :class="baseURLError ? 'border-danger/50 focus:border-danger' : 'border-border-subtle focus:border-accent/50'" :placeholder="baseURLPlaceholder" :disabled="saving" :aria-invalid="Boolean(baseURLError)" type="url" @input="emit('update:baseURL', ($event.target as HTMLInputElement).value)" />
-              <span class="text-[11px] font-normal leading-4" :class="baseURLError ? 'text-danger' : 'text-text-muted'">{{ baseURLError || (googleProvider ? 'Provider API base URL.' : 'Base URL only. App Studio adds /chat/completions.') }}</span>
-            </label>
-            <label class="grid min-w-0 content-start gap-1.5 text-[11px] font-medium text-text-secondary">Model ID
-              <input :value="model" class="h-10 min-w-0 rounded-md border border-border-subtle bg-surface px-3 font-mono text-[12px] text-text-primary outline-none transition placeholder:text-text-muted focus:border-accent/50" placeholder="Model ID" :disabled="saving" @input="emit('update:model', ($event.target as HTMLInputElement).value)" />
-            </label>
-          </div>
-        </section>
-
-        <section class="grid gap-2 border-t border-border-subtle pt-4" aria-labelledby="model-credential-heading">
-          <h5 id="model-credential-heading" class="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Credential</h5>
-          <textarea v-if="googleServiceAccountMode" :value="apiKey" class="min-h-[140px] resize-y rounded-md border border-border-subtle bg-surface px-3 py-2.5 font-mono text-[12px] leading-5 text-text-primary outline-none transition placeholder:text-text-muted focus:border-accent/50" :placeholder="apiKeyPlaceholder" autocomplete="off" :disabled="saving" @input="emit('update:apiKey', ($event.target as HTMLTextAreaElement).value)" />
-          <input v-else :value="apiKey" class="h-10 rounded-md border border-border-subtle bg-surface px-3 text-[13px] text-text-primary outline-none transition placeholder:text-text-muted focus:border-accent/50" :placeholder="editingModelID && !creationRoute ? `${apiKeyPlaceholder} (leave blank to keep current)` : apiKeyPlaceholder" type="password" autocomplete="off" :disabled="saving" @input="emit('update:apiKey', ($event.target as HTMLInputElement).value)" />
-          <p class="text-[11px] leading-4 text-text-muted">{{ apiKeyHint || (editingModelID && !creationRoute ? 'Leave blank to keep the current credential.' : 'A credential is required before this model can be selected in chat.') }}</p>
-        </section>
+            <div v-if="recommendedDiscoveredModels.length" class="grid gap-2" aria-label="Recommended models">
+              <span class="text-[9px] font-semibold uppercase tracking-wide text-text-muted">Recommended for App Studio</span>
+              <div class="flex flex-wrap gap-2">
+                <button v-for="available in recommendedDiscoveredModels" :key="available.id" type="button" class="rounded-sm border border-accent/25 bg-accent-subtle px-2.5 py-1.5 font-mono text-[10px] font-medium text-accent transition hover:border-accent/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent" :disabled="saving" @click="emit('selectDiscoveredModel', available)">
+                  {{ available.name }}
+                </button>
+              </div>
+            </div>
+            <p v-if="discoveryError" class="rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-[11px] leading-4 text-danger" role="alert">{{ discoveryError }} You can still enter a model ID manually.</p>
+            <p v-else-if="discoveryStatus" class="text-[11px] leading-4 text-text-muted" role="status" aria-live="polite">{{ discoveryStatus }}</p>
+          </section>
 
         </div>
-        <footer :class="creationRoute ? 'k-create-actions' : 'flex flex-wrap items-center justify-end gap-2 border-t border-border-subtle pt-3'">
-          <button type="button" :class="creationRoute ? 'k-btn k-btn--ghost' : 'inline-flex h-9 items-center justify-center rounded-md border border-border-subtle px-3 text-[13px] font-medium text-text-secondary transition hover:bg-surface-hover'" :disabled="saving" @click="emit('cancelEditor')">Cancel</button>
-          <button :class="creationRoute ? 'k-btn k-btn--primary' : 'inline-flex h-9 items-center justify-center gap-2 rounded-md border border-accent bg-accent px-3 text-[13px] font-semibold text-surface shadow-[0_0_16px_var(--color-accent-glow)] transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60 disabled:shadow-none'" :disabled="saving || !name.trim() || !model.trim() || Boolean(baseURLError)">
+        <footer class="k-create-actions">
+          <button type="button" class="k-btn k-btn--ghost" :disabled="saving" @click="emit('cancelEditor')">Cancel</button>
+          <button class="k-btn k-btn--primary" :disabled="saving">
             <Loader2 v-if="saving" class="h-4 w-4 animate-spin" :stroke-width="1.75" /><Check v-else class="h-4 w-4" :stroke-width="1.75" />
-            {{ editingModelID && !creationRoute ? 'Save changes' : 'Add model' }}
+            {{ saving ? (editingModelID && !creationRoute ? 'Saving changes…' : 'Connecting model…') : (editingModelID && !creationRoute ? 'Save changes' : 'Connect model') }}
           </button>
         </footer>
       </form>

--- a/providers/app-studio/portal/src/ModelsSettings.vue
+++ b/providers/app-studio/portal/src/ModelsSettings.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { Check, ChevronRight, Cpu, KeyRound, Loader2, Pencil, Plus, RefreshCw, Star, Trash2 } from 'lucide-vue-next'
+import ModelIDSelector from './ModelIDSelector.vue'
 import StatusBadge from './portalkit/StatusBadge.vue'
 import type { LLMProviderPreset } from './llmDiscovery'
 import type { ProjectLLMDiscoveredModel, ProjectLLMSettings } from './types'
@@ -44,8 +45,7 @@ const props = defineProps<{
   canDiscover: boolean
 }>()
 
-const selectableDiscoveredModels = computed(() => props.discoveredModels.filter((model) => model.compatibility !== 'unsuitable'))
-const recommendedDiscoveredModels = computed(() => selectableDiscoveredModels.value.filter((model) => model.compatibility === 'recommended').slice(0, 4))
+const recommendedDiscoveredModels = computed(() => props.discoveredModels.filter((model) => model.compatibility === 'recommended').slice(0, 4))
 
 const emit = defineEmits<{
   retry: []
@@ -252,12 +252,17 @@ const emit = defineEmits<{
               </span>
             </div>
             <label for="model-id" class="grid min-w-0 content-start gap-1.5 text-[11px] font-medium text-text-secondary">Model ID
-              <input id="model-id" :value="model" list="model-discovery-options" class="k-input h-10 min-w-0 font-mono text-[12px]" :class="modelError ? 'border-danger/50 focus:border-danger focus:shadow-[0_0_0_3px_var(--color-danger-subtle)]' : ''" placeholder="e.g. gpt-5.4" :disabled="saving" :aria-invalid="Boolean(modelError)" aria-required="true" :aria-describedby="modelError ? 'model-id-error' : 'model-id-hint'" @input="emit('update:model', ($event.target as HTMLInputElement).value)" />
-              <datalist id="model-discovery-options">
-                <option v-for="available in selectableDiscoveredModels" :key="available.id" :value="available.id">{{ available.name }}</option>
-              </datalist>
+              <ModelIDSelector
+                :model-value="model"
+                :models="discoveredModels"
+                :disabled="saving"
+                :invalid="Boolean(modelError)"
+                :described-by="modelError ? 'model-id-error' : 'model-id-hint'"
+                @update:model-value="emit('update:model', $event)"
+                @select="emit('selectDiscoveredModel', $event)"
+              />
               <span v-if="modelError" id="model-id-error" class="text-[11px] font-normal leading-4 text-danger" role="alert">{{ modelError }}</span>
-              <span v-else id="model-id-hint" class="text-[11px] font-normal leading-4 text-text-muted">{{ modelHint }} Find models to populate suggestions, or enter an ID manually.</span>
+              <span v-else id="model-id-hint" class="text-[11px] font-normal leading-4 text-text-muted">{{ modelHint }} Find models to load the full catalog, then search or enter an ID.</span>
             </label>
             <div v-if="recommendedDiscoveredModels.length" class="grid gap-2" aria-label="Recommended models">
               <span class="text-[9px] font-semibold uppercase tracking-wide text-text-muted">Recommended for App Studio</span>

--- a/providers/app-studio/portal/src/api.ts
+++ b/providers/app-studio/portal/src/api.ts
@@ -23,6 +23,7 @@ import type {
   ProjectAssistantThreadItem,
   ProjectAssistantTurn,
   ProjectLLMSettings,
+  ProjectLLMModelDiscovery,
   ProjectIntegration,
   ProjectProviderActionGrant,
   ProjectProviderResourceReference,
@@ -826,6 +827,13 @@ export const api = {
     return request<ProjectLLMSettings>(ctx, 'GET', `${baseURL(ctx)}/llm-settings`)
   },
 
+  async discoverLLMModels(
+    ctx: FarosContext | null,
+    body: { provider: string; baseURL: string; apiKey?: string; existingModelID?: string },
+  ): Promise<ProjectLLMModelDiscovery> {
+    return request<ProjectLLMModelDiscovery>(ctx, 'POST', `${baseURL(ctx)}/llm-settings/models/discover`, body)
+  },
+
   async patchLLMSettings(
     ctx: FarosContext | null,
     body: { provider?: string; baseURL?: string; model?: string; apiKey?: string },
@@ -835,7 +843,7 @@ export const api = {
 
   async createLLMModel(
     ctx: FarosContext | null,
-    body: { name: string; provider?: string; baseURL?: string; model: string; apiKey?: string },
+    body: { name: string; provider?: string; baseURL?: string; model: string; apiKey: string },
   ): Promise<ProjectLLMSettings> {
     return request<ProjectLLMSettings>(ctx, 'POST', `${baseURL(ctx)}/llm-settings/models`, body)
   },

--- a/providers/app-studio/portal/src/llmDiscovery.test.mjs
+++ b/providers/app-studio/portal/src/llmDiscovery.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import ts from 'typescript'
+
+const source = await readFile(new URL('./llmDiscovery.ts', import.meta.url), 'utf8')
+const { outputText } = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.ES2022, target: ts.ScriptTarget.ES2022 },
+})
+const moduleURL = `data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`
+const { inferLLMProviderPreset, llmProviderSelection } = await import(moduleURL)
+
+test('infers known providers without changing persisted provider identifiers', () => {
+  assert.equal(inferLLMProviderPreset('openai-compatible', 'https://api.openai.com/v1/'), 'openai')
+  assert.equal(inferLLMProviderPreset('google-ai-studio', 'https://generativelanguage.googleapis.com'), 'google')
+  assert.equal(inferLLMProviderPreset('openai-compatible', 'https://gateway.example/v1'), 'custom')
+})
+
+test('maps provider presets to known endpoints and leaves custom endpoints editable', () => {
+  assert.deepEqual(llmProviderSelection('openai'), {
+    provider: 'openai-compatible',
+    baseURL: 'https://api.openai.com/v1',
+  })
+  assert.deepEqual(llmProviderSelection('google'), {
+    provider: 'google-ai-studio',
+    baseURL: 'https://generativelanguage.googleapis.com',
+  })
+  assert.deepEqual(llmProviderSelection('custom', 'https://gateway.example/v1'), {
+    provider: 'openai-compatible',
+    baseURL: 'https://gateway.example/v1',
+  })
+  assert.equal(llmProviderSelection('custom', 'https://api.openai.com/v1').baseURL, '')
+})

--- a/providers/app-studio/portal/src/llmDiscovery.ts
+++ b/providers/app-studio/portal/src/llmDiscovery.ts
@@ -1,0 +1,32 @@
+export type LLMProviderPreset = 'openai' | 'google' | 'custom'
+
+export const OPENAI_API_BASE_URL = 'https://api.openai.com/v1'
+export const GOOGLE_AI_STUDIO_BASE_URL = 'https://generativelanguage.googleapis.com'
+
+export interface LLMProviderSelection {
+  provider: 'openai-compatible' | 'google-ai-studio'
+  baseURL: string
+}
+
+export function inferLLMProviderPreset(provider: string, baseURL: string): LLMProviderPreset {
+  if (provider.trim().toLowerCase() === 'google-ai-studio') return 'google'
+  return normalizeBaseURL(baseURL) === OPENAI_API_BASE_URL ? 'openai' : 'custom'
+}
+
+export function llmProviderSelection(preset: LLMProviderPreset, currentBaseURL = ''): LLMProviderSelection {
+  if (preset === 'google') {
+    return { provider: 'google-ai-studio', baseURL: GOOGLE_AI_STUDIO_BASE_URL }
+  }
+  if (preset === 'openai') {
+    return { provider: 'openai-compatible', baseURL: OPENAI_API_BASE_URL }
+  }
+  const normalizedCurrent = normalizeBaseURL(currentBaseURL)
+  return {
+    provider: 'openai-compatible',
+    baseURL: normalizedCurrent === OPENAI_API_BASE_URL || normalizedCurrent === GOOGLE_AI_STUDIO_BASE_URL ? '' : currentBaseURL,
+  }
+}
+
+function normalizeBaseURL(value: string): string {
+  return value.trim().replace(/\/+$/, '').toLowerCase()
+}

--- a/providers/app-studio/portal/src/llmSettingsValidation.test.mjs
+++ b/providers/app-studio/portal/src/llmSettingsValidation.test.mjs
@@ -12,7 +12,7 @@ const { outputText } = ts.transpileModule(source, {
   },
 })
 const moduleURL = `data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`
-const { validateLLMBaseURL } = await import(moduleURL)
+const { hasLLMModelFormErrors, validateLLMBaseURL, validateLLMModelForm } = await import(moduleURL)
 
 test('accepts an OpenAI-compatible API base URL', () => {
   assert.equal(validateLLMBaseURL('openai-compatible', 'https://opencode.ai/zen/v1'), '')
@@ -47,4 +47,58 @@ test('validates Google URL syntax while leaving its operation paths alone', () =
   assert.equal(validateLLMBaseURL('google-ai-studio', ''), '')
   assert.equal(validateLLMBaseURL('google-ai-studio', 'not-a-url'), 'Enter an absolute HTTP(S) base URL.')
   assert.equal(validateLLMBaseURL('google-ai-studio', 'file:///tmp/model'), 'Base URL must use HTTP or HTTPS.')
+})
+
+test('requires a credential when connecting a model while preserving blank-on-edit semantics', () => {
+  const input = {
+    name: 'GPT High',
+    provider: 'openai-compatible',
+    credentialMode: 'api-key',
+    baseURL: 'https://api.openai.com/v1',
+    model: 'gpt-5.4',
+    credential: '',
+    existingModels: [],
+  }
+  const creating = validateLLMModelForm(input)
+  assert.equal(creating.credential, 'Enter a credential to connect this model.')
+  assert.equal(hasLLMModelFormErrors(creating), true)
+
+  const editing = validateLLMModelForm({ ...input, editingModelID: 'gpt-high' })
+  assert.equal(editing.credential, '')
+  assert.equal(hasLLMModelFormErrors(editing), false)
+
+  const repairingIncomplete = validateLLMModelForm({ ...input, editingModelID: 'gpt-high', credentialRequired: true })
+  assert.equal(repairingIncomplete.credential, 'Enter a credential to connect this model.')
+})
+
+test('reports field-specific name and model errors before the API request', () => {
+  const errors = validateLLMModelForm({
+    name: 'GPT High!',
+    provider: 'openai-compatible',
+    credentialMode: 'api-key',
+    baseURL: 'https://api.openai.com/v1',
+    model: '',
+    credential: 'secret',
+    existingModels: [{ id: 'gpt-high', name: 'GPT High' }],
+  })
+  assert.equal(errors.name, 'A model with this display name already exists.')
+  assert.equal(errors.model, 'Enter the provider’s exact model ID.')
+})
+
+test('validates Google credential shape near the credential field', () => {
+  const base = {
+    name: 'Gemini Fast',
+    provider: 'google-ai-studio',
+    baseURL: 'https://aiplatform.googleapis.com',
+    model: 'google/gemini-3.5-flash',
+    existingModels: [],
+  }
+  assert.equal(
+    validateLLMModelForm({ ...base, credentialMode: 'service-account-json', credential: '{"type":"service_account"}' }).credential,
+    'Paste a complete Google service-account key. Missing: project_id, client_email, private_key, token_uri.',
+  )
+  assert.equal(
+    validateLLMModelForm({ ...base, credentialMode: 'api-key', credential: 'ya29.oauth-token' }).credential,
+    'Enter a Gemini API key, not an OAuth or JWT token.',
+  )
 })

--- a/providers/app-studio/portal/src/llmSettingsValidation.ts
+++ b/providers/app-studio/portal/src/llmSettingsValidation.ts
@@ -1,6 +1,33 @@
 const OPENAI_COMPATIBLE_PROVIDER = 'openai-compatible'
+const GOOGLE_AI_STUDIO_PROVIDER = 'google-ai-studio'
 const CHAT_COMPLETIONS_SUFFIX = '/chat/completions'
 const UNSUPPORTED_OPERATION_SUFFIXES = ['/responses', '/messages']
+
+export type LLMCredentialMode = 'api-key' | 'service-account-json'
+
+export interface LLMModelFormCandidate {
+  id: string
+  name: string
+}
+
+export interface LLMModelFormInput {
+  name: string
+  provider: string
+  credentialMode: LLMCredentialMode
+  baseURL: string
+  model: string
+  credential: string
+  credentialRequired?: boolean
+  editingModelID?: string | null
+  existingModels?: LLMModelFormCandidate[]
+}
+
+export interface LLMModelFormErrors {
+  name: string
+  baseURL: string
+  model: string
+  credential: string
+}
 
 export function validateLLMBaseURL(provider: string, value: string): string {
   const raw = value.trim()
@@ -30,4 +57,80 @@ export function validateLLMBaseURL(provider: string, value: string): string {
     return `This endpoint uses ${unsupportedSuffix}, but the OpenAI-compatible provider requires a /chat/completions model. Choose a compatible model and enter its base URL.`
   }
   return ''
+}
+
+export function validateLLMModelForm(input: LLMModelFormInput): LLMModelFormErrors {
+  const name = input.name.trim()
+  const model = input.model.trim()
+  const credential = input.credential.trim()
+  const credentialRequired = input.credentialRequired ?? !input.editingModelID
+  const errors: LLMModelFormErrors = {
+    name: '',
+    baseURL: validateLLMBaseURL(input.provider, input.baseURL),
+    model: '',
+    credential: '',
+  }
+
+  if (!name) {
+    errors.name = 'Enter a display name.'
+  } else if (name.length > 80) {
+    errors.name = 'Use 80 characters or fewer.'
+  } else {
+    const candidateID = modelConfigurationID(name)
+    const duplicate = (input.existingModels ?? []).some((saved) =>
+      saved.id !== input.editingModelID && modelConfigurationID(saved.name) === candidateID,
+    )
+    if (duplicate) errors.name = 'A model with this display name already exists.'
+  }
+
+  if (!model) errors.model = 'Enter the provider’s exact model ID.'
+
+  if (!credential) {
+    if (credentialRequired) errors.credential = 'Enter a credential to connect this model.'
+    return errors
+  }
+
+  if (input.provider.trim().toLowerCase() !== GOOGLE_AI_STUDIO_PROVIDER) return errors
+
+  if (input.credentialMode === 'service-account-json') {
+    errors.credential = validateGoogleServiceAccountJSON(credential)
+  } else if (looksLikeOAuthOrJWT(credential)) {
+    errors.credential = 'Enter a Gemini API key, not an OAuth or JWT token.'
+  }
+  return errors
+}
+
+export function hasLLMModelFormErrors(errors: LLMModelFormErrors): boolean {
+  return Boolean(errors.name || errors.baseURL || errors.model || errors.credential)
+}
+
+function modelConfigurationID(value: string): string {
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+  return normalized.slice(0, 63).replace(/-+$/g, '') || 'default'
+}
+
+function validateGoogleServiceAccountJSON(raw: string): string {
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch {
+    return 'Paste valid Google service-account JSON.'
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return 'Paste a Google service-account JSON object.'
+  }
+  const credential = value as Record<string, unknown>
+  const missing = ['project_id', 'client_email', 'private_key', 'token_uri']
+    .filter((field) => typeof credential[field] !== 'string' || !String(credential[field]).trim())
+  if (credential.type !== 'service_account' || missing.length > 0) {
+    const detail = missing.length > 0 ? ` Missing: ${missing.join(', ')}.` : ''
+    return `Paste a complete Google service-account key.${detail}`
+  }
+  return ''
+}
+
+function looksLikeOAuthOrJWT(value: string): boolean {
+  if (value.startsWith('ya29.')) return true
+  const parts = value.split('.')
+  return parts.length === 3 && parts.every(Boolean) && parts[0].startsWith('eyJ')
 }

--- a/providers/app-studio/portal/src/modelIDSelection.test.mjs
+++ b/providers/app-studio/portal/src/modelIDSelection.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import ts from 'typescript'
+
+const source = await readFile(new URL('./modelIDSelection.ts', import.meta.url), 'utf8')
+const { outputText } = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.ES2022, target: ts.ScriptTarget.ES2022 },
+})
+const moduleURL = `data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`
+const { filterDiscoveredModels, modelSelectorOptions } = await import(moduleURL)
+
+const catalog = [
+  { id: 'gpt-5.4', name: 'GPT 5.4', compatibility: 'recommended' },
+  { id: 'gpt-5.4-nano', name: 'GPT 5.4 Nano', compatibility: 'available' },
+  { id: 'gpt-5.6', name: 'GPT 5.6', compatibility: 'recommended' },
+  { id: 'o4-mini', name: 'o4 mini', compatibility: 'available' },
+  { id: 'text-embedding-3-large', name: 'Text Embedding 3 Large', compatibility: 'unsuitable' },
+]
+
+test('an empty selector query exposes the complete discovered catalog', () => {
+  const options = modelSelectorOptions(catalog, '')
+  assert.deepEqual(options.map(option => option.value), catalog.map(model => model.id))
+  assert.equal(options.at(-1).disabled, true)
+})
+
+test('search filters by model ID or display name without changing the catalog', () => {
+  assert.deepEqual(filterDiscoveredModels(catalog, '5.4').map(model => model.id), ['gpt-5.4', 'gpt-5.4-nano'])
+  assert.deepEqual(filterDiscoveredModels(catalog, 'O4 MINI').map(model => model.id), ['o4-mini'])
+  assert.equal(catalog.length, 5)
+})
+
+test('manual IDs are explicit options and exact discovered IDs are not duplicated', () => {
+  const custom = modelSelectorOptions(catalog, 'vendor/new-chat-model')
+  assert.deepEqual(custom[0], {
+    key: 'manual:vendor/new-chat-model',
+    value: 'vendor/new-chat-model',
+    label: 'vendor/new-chat-model',
+    manual: true,
+    disabled: false,
+  })
+  const exact = modelSelectorOptions(catalog, 'gpt-5.6')
+  assert.equal(exact.filter(option => option.value === 'gpt-5.6').length, 1)
+  assert.equal(exact[0].manual, false)
+
+  const partial = modelSelectorOptions(catalog, 'gpt-5.4-n')
+  assert.equal(partial[0].value, 'gpt-5.4-nano')
+  assert.equal(partial.at(-1).value, 'gpt-5.4-n')
+  assert.equal(partial.at(-1).manual, true)
+})

--- a/providers/app-studio/portal/src/modelIDSelection.ts
+++ b/providers/app-studio/portal/src/modelIDSelection.ts
@@ -1,0 +1,46 @@
+import type { ProjectLLMDiscoveredModel } from './types'
+
+export interface ModelSelectorOption {
+  key: string
+  value: string
+  label: string
+  model?: ProjectLLMDiscoveredModel
+  manual: boolean
+  disabled: boolean
+}
+
+export function filterDiscoveredModels(
+  models: ProjectLLMDiscoveredModel[],
+  query: string,
+): ProjectLLMDiscoveredModel[] {
+  const needle = query.trim().toLocaleLowerCase()
+  if (!needle) return models
+  return models.filter(model =>
+    model.id.toLocaleLowerCase().includes(needle)
+      || model.name.toLocaleLowerCase().includes(needle),
+  )
+}
+
+export function modelSelectorOptions(
+  models: ProjectLLMDiscoveredModel[],
+  query: string,
+): ModelSelectorOption[] {
+  const candidate = query.trim()
+  const discovered = filterDiscoveredModels(models, query).map(model => ({
+    key: model.id,
+    value: model.id,
+    label: model.name,
+    model,
+    manual: false,
+    disabled: model.compatibility === 'unsuitable',
+  }))
+  const exactMatch = models.some(model => model.id.toLocaleLowerCase() === candidate.toLocaleLowerCase())
+  if (!candidate || exactMatch) return discovered
+  return [...discovered, {
+    key: `manual:${candidate}`,
+    value: candidate,
+    label: candidate,
+    manual: true,
+    disabled: false,
+  }]
+}

--- a/providers/app-studio/portal/src/modelIDSelector.test.mjs
+++ b/providers/app-studio/portal/src/modelIDSelector.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import { createServer } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+
+const vite = await createServer({
+  appType: 'custom',
+  cacheDir: '/tmp/faros-vite-app-studio-model-id-selector',
+  configFile: false,
+  plugins: [vue()],
+  server: { middlewareMode: true },
+})
+const { default: ModelIDSelector } = await vite.ssrLoadModule('/src/ModelIDSelector.vue')
+test.after(async () => vite.close())
+
+test('renders a Faros-owned combobox trigger instead of a native datalist', async () => {
+  const html = await renderToString(createSSRApp(ModelIDSelector, {
+    modelValue: 'gpt-5.4',
+    models: [
+      { id: 'gpt-5.4', name: 'GPT 5.4', compatibility: 'recommended' },
+      { id: 'o4-mini', name: 'o4 mini', compatibility: 'available' },
+    ],
+    describedBy: 'model-id-hint',
+  }))
+
+  assert.match(html, /id="model-id"/)
+  assert.match(html, /aria-haspopup="listbox"/)
+  assert.match(html, /aria-describedby="model-id-hint"/)
+  assert.match(html, /GPT 5\.4/)
+  assert.doesNotMatch(html, /<datalist/)
+})
+
+test('implements the filter-selector search and full-catalog interaction pattern', async () => {
+  const source = await readFile(new URL('./ModelIDSelector.vue', import.meta.url), 'utf8')
+
+  assert.match(source, /query\.value = ''[\s\S]*open\.value = true/)
+  assert.match(source, /modelSelectorOptions\(props\.models, query\.value\)/)
+  assert.match(source, /k-menu k-table__filter-panel k-table__filter-panel--searchable/)
+  assert.match(source, /role="combobox"[\s\S]*aria-autocomplete="list"/)
+  assert.match(source, /\{\{ optionSummary \}\}/)
+  assert.match(source, /Recommended/)
+  assert.match(source, /Not for chat/)
+  assert.match(source, /Use “\$\{option\.label\}”/)
+})

--- a/providers/app-studio/portal/src/modelsSettings.test.mjs
+++ b/providers/app-studio/portal/src/modelsSettings.test.mjs
@@ -173,7 +173,7 @@ test('renders discovered suggestions while preserving manual model entry', async
   const html = await render({
     editorOpen: true,
     canDiscover: true,
-    discoveryStatus: '2 models available; 1 non-chat model omitted.',
+    discoveryStatus: '3 models found; 1 marked unavailable for chat.',
     discoveredModels: [
       { id: 'gpt-5.6', name: 'gpt-5.6', compatibility: 'recommended' },
       { id: 'custom-chat', name: 'custom-chat', compatibility: 'available' },
@@ -182,11 +182,11 @@ test('renders discovered suggestions while preserving manual model entry', async
   })
 
   assert.match(html, /Recommended for App Studio/)
-  assert.match(html, /value="gpt-5\.6"/)
-  assert.match(html, /value="custom-chat"/)
-  assert.doesNotMatch(html, /value="text-embedding-3-large"/)
-  assert.match(html, /enter an ID manually/)
-  assert.match(html, /1 non-chat model omitted/)
+  assert.match(html, /id="model-id"/)
+  assert.match(html, /aria-haspopup="listbox"/)
+  assert.doesNotMatch(html, /<datalist/)
+  assert.match(html, /search or enter an ID/)
+  assert.match(html, /3 models found; 1 marked unavailable for chat/)
 })
 
 test('keeps discovery failure separate from manual model validation', async () => {

--- a/providers/app-studio/portal/src/modelsSettings.test.mjs
+++ b/providers/app-studio/portal/src/modelsSettings.test.mjs
@@ -28,16 +28,29 @@ const baseProps = {
   editingModelID: null,
   name: '',
   provider: 'openai-compatible',
+  providerPreset: 'openai',
   credentialMode: 'api-key',
   baseURL: 'https://api.openai.com/v1',
   model: 'gpt-5.4',
   apiKey: '',
+  nameError: '',
   baseURLError: '',
+  modelError: '',
+  credentialError: '',
+  credentialRequired: true,
   baseURLPlaceholder: 'Base URL',
   apiKeyPlaceholder: 'API key',
   apiKeyHint: '',
+  providerGuidance: 'Use an OpenAI-compatible provider.',
+  modelHint: 'Use the provider model ID.',
   googleProvider: false,
   googleServiceAccountMode: false,
+  customProvider: false,
+  discoveredModels: [],
+  discoveryLoading: false,
+  discoveryError: null,
+  discoveryStatus: null,
+  canDiscover: false,
 }
 
 async function render(props = {}) {
@@ -63,7 +76,7 @@ test('presents multiple workspace models with explicit default and readiness sta
   assert.match(html, /aria-label="Model Gemini Fast"/)
   assert.match(html, /gpt-5\.4/)
   assert.match(html, /Default/)
-  assert.match(html, /Configured/)
+  assert.match(html, /Credential saved/)
   assert.match(html, /Needs credential/)
   assert.match(html, /Make default/)
   assert.doesNotMatch(html, /aria-label="Model configuration form"/)
@@ -73,8 +86,7 @@ test('uses an explicit empty state before opening the model form', async () => {
   const html = await render()
 
   assert.match(html, /No models configured/)
-  assert.match(html, /New model/)
-  assert.match(html, /Add model/)
+  assert.match(html, /Connect model/)
   assert.doesNotMatch(html, /aria-label="Model configuration form"/)
 })
 
@@ -91,11 +103,10 @@ test('route-owned model creation keeps the collection out of the form surface', 
     },
   })
 
-  assert.match(html, /aria-label="New model"/)
+  assert.match(html, /aria-label="Connect model"/)
   assert.match(html, /aria-label="Model configuration form"/)
-  assert.doesNotMatch(html, />New model</)
   assert.doesNotMatch(html, /aria-label="Model GPT High"/)
-  assert.doesNotMatch(html, />New model<\/button>/)
+  assert.doesNotMatch(html, />Connect model<\/button>/)
 })
 
 test('route-owned model creation keeps the form actionable when settings load fails', async () => {
@@ -118,23 +129,137 @@ test('renders a guided provider, endpoint, and credential form', async () => {
     editorOpen: true,
     name: 'Gemini Fast',
     provider: 'google-ai-studio',
+    providerPreset: 'google',
     credentialMode: 'service-account-json',
     baseURL: 'https://aiplatform.googleapis.com',
     model: 'google/gemini-3.5-flash',
     apiKeyPlaceholder: 'Service account JSON',
     apiKeyHint: 'Paste the Google service-account JSON key.',
+    providerGuidance: 'Use a Gemini API key for Google AI Studio, or a service-account key for Vertex AI.',
+    modelHint: 'Use the exact Vertex AI model identifier, including its publisher prefix.',
     googleProvider: true,
     googleServiceAccountMode: true,
   })
 
   assert.match(html, /aria-label="Model configuration form"/)
-  assert.match(html, /Provider preset/)
+  assert.match(html, /id="model-provider"/)
+  assert.match(html, /Use a Gemini API key for Google AI Studio/)
   assert.match(html, /Display name/)
   assert.match(html, /Credential method/)
   assert.match(html, /Vertex AI service account/)
-  assert.match(html, /Model endpoint/)
+  assert.match(html, /Find models/)
   assert.match(html, /Service account JSON/)
-  assert.match(html, /Add model/)
+  assert.match(html, /Connect model/)
+})
+
+test('offers known provider endpoints and keeps custom endpoints editable', async () => {
+  const openAI = await render({ editorOpen: true, providerPreset: 'openai', canDiscover: true })
+  assert.match(openAI, />OpenAI</)
+  assert.match(openAI, /https:\/\/api\.openai\.com\/v1/)
+  assert.doesNotMatch(openAI, /id="model-base-url"/)
+
+  const custom = await render({
+    editorOpen: true,
+    providerPreset: 'custom',
+    customProvider: true,
+    baseURL: 'https://gateway.example/v1',
+  })
+  assert.match(custom, /Custom OpenAI-compatible/)
+  assert.match(custom, /id="model-base-url"/)
+  assert.match(custom, /queries \/models/)
+})
+
+test('renders discovered suggestions while preserving manual model entry', async () => {
+  const html = await render({
+    editorOpen: true,
+    canDiscover: true,
+    discoveryStatus: '2 models available; 1 non-chat model omitted.',
+    discoveredModels: [
+      { id: 'gpt-5.6', name: 'gpt-5.6', compatibility: 'recommended' },
+      { id: 'custom-chat', name: 'custom-chat', compatibility: 'available' },
+      { id: 'text-embedding-3-large', name: 'text-embedding-3-large', compatibility: 'unsuitable' },
+    ],
+  })
+
+  assert.match(html, /Recommended for App Studio/)
+  assert.match(html, /value="gpt-5\.6"/)
+  assert.match(html, /value="custom-chat"/)
+  assert.doesNotMatch(html, /value="text-embedding-3-large"/)
+  assert.match(html, /enter an ID manually/)
+  assert.match(html, /1 non-chat model omitted/)
+})
+
+test('keeps discovery failure separate from manual model validation', async () => {
+  const html = await render({
+    editorOpen: true,
+    discoveryError: 'Provider model discovery returned 401 Unauthorized.',
+  })
+
+  assert.match(html, /Provider model discovery returned 401 Unauthorized/)
+  assert.match(html, /You can still enter a model ID manually/)
+  assert.match(html, /id="model-id"/)
+})
+
+test('editing replaces the collection with one focused form', async () => {
+  const html = await render({
+    editorOpen: true,
+    editingModelID: 'gpt-high',
+    name: 'GPT High',
+    settings: {
+      provider: 'openai-compatible',
+      baseURL: 'https://api.openai.com/v1',
+      model: 'gpt-5.4',
+      configured: true,
+      defaultModelID: 'gpt-high',
+      models: [{ id: 'gpt-high', name: 'GPT High', provider: 'openai-compatible', baseURL: 'https://api.openai.com/v1', model: 'gpt-5.4', configured: true, default: true }],
+    },
+  })
+
+  assert.match(html, /Edit model/)
+  assert.match(html, /aria-label="Model configuration form"/)
+  assert.match(html, /class="k-create-surface"/)
+  assert.match(html, /Save changes/)
+  assert.doesNotMatch(html, /aria-label="Model GPT High"/)
+})
+
+test('associates field guidance and validation errors with their controls', async () => {
+  const html = await render({
+    editorOpen: true,
+    nameError: 'Enter a display name.',
+    modelError: 'Enter the provider’s exact model ID.',
+    credentialError: 'Enter a credential to connect this model.',
+  })
+
+  assert.match(html, /id="model-display-name"[^>]*aria-invalid="true"[^>]*aria-describedby="model-display-name-error"/)
+  assert.match(html, /id="model-id"[^>]*aria-invalid="true"[^>]*aria-describedby="model-id-error"/)
+  assert.match(html, /id="model-credential"[^>]*aria-invalid="true"[^>]*aria-describedby="model-credential-help"/)
+  assert.match(html, /id="model-display-name"[^>]*border-danger/)
+  assert.match(html, /id="model-id"[^>]*border-danger/)
+  assert.match(html, /Enter a credential to connect this model\./)
+})
+
+test('announces the active model mutation and disables competing card actions', async () => {
+  const editing = await render({
+    editorOpen: true,
+    editingModelID: 'gpt-high',
+    name: 'GPT High',
+    saving: true,
+  })
+  assert.match(editing, /aria-busy="true"/)
+  assert.match(editing, /Saving changes…/)
+
+  const collection = await render({
+    saving: true,
+    settings: {
+      provider: 'openai-compatible',
+      baseURL: 'https://api.openai.com/v1',
+      model: 'gpt-5.4',
+      configured: true,
+      defaultModelID: 'gpt-high',
+      models: [{ id: 'gpt-high', name: 'GPT High', provider: 'openai-compatible', baseURL: 'https://api.openai.com/v1', model: 'gpt-5.4', configured: true, default: true }],
+    },
+  })
+  assert.match(collection, /<button type="button"[^>]*disabled[^>]*>\s*<svg[^>]*>[\s\S]*?<\/svg> Edit/)
 })
 
 test('App Studio owns save state while the extracted surface owns presentation', async () => {
@@ -146,7 +271,8 @@ test('App Studio owns save state while the extracted surface owns presentation',
   assert.match(app, /v-if="showSettings[\s\S]*\(\(isModelsRoute \|\| isCreateModelRoute\) && !\(initializing && !loading\)\)"/)
   assert.match(app, /<ModelsSettings[\s\S]*:creation-route="isCreateModelRoute"/)
   assert.match(app, /<ModelsSettings[\s\S]*@save="saveLLMSettings"[\s\S]*@delete="deleteLLMModel"[\s\S]*@set-default="setDefaultLLMModel"/)
-  assert.match(app, /function selectLLMProvider[\s\S]*llmBaseURL\.value = GEMINI_BASE_URL[\s\S]*llmBaseURL\.value = 'https:\/\/api\.openai\.com\/v1'/)
+  assert.match(app, /function selectLLMProvider[\s\S]*llmProviderSelection[\s\S]*llmProviderPreset\.value = preset/)
+  assert.match(app, /async function discoverLLMModels[\s\S]*api\.discoverLLMModels[\s\S]*existingModelID/)
   assert.match(app, /async function saveLLMSettings[\s\S]*api\.patchLLMModel[\s\S]*api\.createLLMModel/)
   assert.match(app, /async function deleteLLMModel[\s\S]*api\.deleteLLMModel/)
   assert.match(app, /catch \(e\)[\s\S]*llmActionError\.value = e instanceof Error/)
@@ -159,7 +285,7 @@ test('model creation replaces its route entry and nested navigation accepts repl
   ])
 
   assert.match(app, /function openNewLLMModelEditor\(\)[\s\S]*props\.navigate\(CREATE_MODEL_ROUTE\)/)
-  assert.match(app, /function cancelLLMEditor\(\)[\s\S]*const returnRoute = routeOwnedCreation[\s\S]*props\.navigate\(returnRoute, \{ replace: true \}\)/)
+  assert.match(app, /async function cancelLLMEditor\(\)[\s\S]*Discard model changes\?[\s\S]*const returnRoute = routeOwnedCreation[\s\S]*props\.navigate\(returnRoute, \{ replace: true \}\)/)
   assert.match(app, /const routeOwnedCreation = isCreateModelRoute\.value && !llmEditingModelID\.value[\s\S]*const returnRoute = routeOwnedCreation[\s\S]*props\.navigate\(returnRoute, \{ replace: true \}\)/)
   assert.match(app, /const detail = \(e as CustomEvent<\{ path\?: unknown; replace\?: unknown \}>\)\.detail/)
   assert.match(app, /Nested provider tabs have one persisted descriptor rather than their own/)
@@ -211,7 +337,7 @@ test('uses the stored project-creation destination and Models fallback for route
   assert.match(app, /modelsReturnRoute\.value === CREATE_PROJECT_ROUTE \? CREATE_PROJECT_ROUTE : MODELS_ROUTE/)
   assert.match(app, /function openNewLLMModelEditor\(\)[\s\S]*if \(!modelsReturnRoute\.value && isCreateRoute\.value\) modelsReturnRoute\.value = CREATE_PROJECT_ROUTE/)
 
-  const cancelStart = app.indexOf('function cancelLLMEditor')
+  const cancelStart = app.indexOf('async function cancelLLMEditor')
   const saveStart = app.indexOf('async function saveLLMSettings')
   const saveEnd = app.indexOf('\nasync function deleteLLMModel', saveStart)
   assert.match(app.slice(cancelStart, saveStart), /const returnRoute = routeOwnedCreation[\s\S]*modelsReturnRoute\.value = ''[\s\S]*props\.navigate\(returnRoute, \{ replace: true \}\)/)

--- a/providers/app-studio/portal/src/types.ts
+++ b/providers/app-studio/portal/src/types.ts
@@ -484,6 +484,20 @@ export interface ProjectLLMSettings {
   models: ProjectLLMModelSettings[]
 }
 
+export type ProjectLLMModelCompatibility = 'recommended' | 'available' | 'unsuitable'
+
+export interface ProjectLLMDiscoveredModel {
+  id: string
+  name: string
+  compatibility: ProjectLLMModelCompatibility
+  capabilities?: string[]
+}
+
+export interface ProjectLLMModelDiscovery {
+  models: ProjectLLMDiscoveredModel[]
+  source: string
+}
+
 export interface ProviderChild {
   displayName: string
   builtinRoute: string


### PR DESCRIPTION
## Summary

- add provider-first setup for OpenAI, Google AI Studio, and custom OpenAI-compatible endpoints
- discover provider model catalogs server-side and normalize recommended, available, and unsuitable choices
- preserve manual model entry and protect stored credentials from reuse against changed endpoints
- harden model creation and editing validation, default handling, and destructive-action guidance

## Verification

- go test -count=1 ./api
- node --test --test-concurrency=1 src/*.test.mjs
- npm run typecheck
- npm run build
- Impeccable detector: no findings
- git diff --check

## Boundaries

- Anthropic direct discovery is excluded until App Studio has a native Messages API adapter
- Vertex AI service-account model discovery keeps manual model entry as the fallback