### PR TITLE
App Studio: add first-time setup for Git and models

### DIFF
--- a/providers/app-studio/api/code_repository.go
+++ b/providers/app-studio/api/code_repository.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -88,9 +87,17 @@ type ProjectCreateReadinessView struct {
 
 type ProjectCreateGitConnectionReadiness struct {
 	Ready         bool   `json:"ready"`
+	Status        string `json:"status"`
 	ConnectionRef string `json:"connectionRef,omitempty"`
 	Message       string `json:"message,omitempty"`
 }
+
+const (
+	projectCreateGitStatusReady             = "ready"
+	projectCreateGitStatusProviderMissing   = "provider-missing"
+	projectCreateGitStatusConnectionMissing = "connection-missing"
+	projectCreateGitStatusValidating        = "validating"
+)
 
 type codeResourceGetter func(ctx context.Context, gvr schema.GroupVersionResource, name string) (*unstructured.Unstructured, error)
 type codeResourceLister func(ctx context.Context, gvr schema.GroupVersionResource, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
@@ -213,25 +220,31 @@ func repositoryAdopted(repo *unstructured.Unstructured) bool {
 }
 
 func projectCreateReadiness(ctx context.Context, c *asclient.Client) (ProjectCreateReadinessView, error) {
-	connectionRef, err := selectCodeConnection(ctx, c, "")
+	gitConnection, err := inspectCodeConnectionReadiness(ctx, c)
 	if err != nil {
-		var validationErr *ValidationError
-		if errors.As(err, &validationErr) {
-			return ProjectCreateReadinessView{
-				GitConnection: ProjectCreateGitConnectionReadiness{
-					Ready:   false,
-					Message: err.Error(),
-				},
-			}, nil
-		}
 		return ProjectCreateReadinessView{}, err
 	}
-	return ProjectCreateReadinessView{
-		GitConnection: ProjectCreateGitConnectionReadiness{
-			Ready:         true,
-			ConnectionRef: connectionRef,
-		},
-	}, nil
+	return ProjectCreateReadinessView{GitConnection: gitConnection}, nil
+}
+
+func inspectCodeConnectionReadiness(ctx context.Context, c *asclient.Client) (ProjectCreateGitConnectionReadiness, error) {
+	list, err := c.Resource(codeConnectionResource, "").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if codeProviderResourceMissing(err) {
+			return ProjectCreateGitConnectionReadiness{Status: projectCreateGitStatusProviderMissing, Message: "Enable the Code provider before creating App Studio projects"}, nil
+		}
+		return ProjectCreateGitConnectionReadiness{}, fmt.Errorf("list Code connections: %w", err)
+	}
+	sort.Slice(list.Items, func(i, j int) bool { return list.Items[i].GetName() < list.Items[j].GetName() })
+	for i := range list.Items {
+		if unstructuredConditionTrue(&list.Items[i], codeConditionValidated) {
+			return ProjectCreateGitConnectionReadiness{Ready: true, Status: projectCreateGitStatusReady, ConnectionRef: list.Items[i].GetName()}, nil
+		}
+	}
+	if len(list.Items) == 0 {
+		return ProjectCreateGitConnectionReadiness{Status: projectCreateGitStatusConnectionMissing, Message: "You need to connect to a Git account before you can continue"}, nil
+	}
+	return ProjectCreateGitConnectionReadiness{Status: projectCreateGitStatusValidating, Message: "Your Git connection is still validating"}, nil
 }
 
 func selectCodeConnection(ctx context.Context, c *asclient.Client, requested string) (string, error) {
@@ -246,22 +259,14 @@ func selectCodeConnection(ctx context.Context, c *asclient.Client, requested str
 		return requested, nil
 	}
 
-	list, err := c.Resource(codeConnectionResource, "").List(ctx, metav1.ListOptions{})
+	readiness, err := inspectCodeConnectionReadiness(ctx, c)
 	if err != nil {
-		return "", codeProviderRequestError("list Code connections", err)
+		return "", err
 	}
-	sort.Slice(list.Items, func(i, j int) bool {
-		return list.Items[i].GetName() < list.Items[j].GetName()
-	})
-	for i := range list.Items {
-		if unstructuredConditionTrue(&list.Items[i], codeConditionValidated) {
-			return list.Items[i].GetName(), nil
-		}
+	if readiness.Ready {
+		return readiness.ConnectionRef, nil
 	}
-	if len(list.Items) == 0 {
-		return "", newValidationError("You need to connect to a Git account before you can continue")
-	}
-	return "", newValidationError("wait for a Code connection to validate before creating an App Studio project")
+	return "", newValidationError(readiness.Message)
 }
 
 func repositoryName(ctx context.Context, c *asclient.Client, requested, displayName string) (string, error) {
@@ -437,12 +442,19 @@ func codeProviderRequestError(op string, err error) error {
 	if err == nil {
 		return nil
 	}
-	msg := strings.ToLower(err.Error())
-	if strings.Contains(msg, "server could not find the requested resource") ||
-		strings.Contains(msg, "the server doesn't have a resource type") {
+	if codeProviderResourceMissing(err) {
 		return newValidationError("enable the Code provider before creating App Studio projects")
 	}
 	return fmt.Errorf("%s: %w", op, err)
+}
+
+func codeProviderResourceMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "server could not find the requested resource") ||
+		strings.Contains(msg, "the server doesn't have a resource type")
 }
 
 func unstructuredConditionTrue(obj *unstructured.Unstructured, condType string) bool {

--- a/providers/app-studio/api/code_repository.go
+++ b/providers/app-studio/api/code_repository.go
@@ -97,6 +97,11 @@ const (
 	projectCreateGitStatusProviderMissing   = "provider-missing"
 	projectCreateGitStatusConnectionMissing = "connection-missing"
 	projectCreateGitStatusValidating        = "validating"
+	projectCreateGitStatusFailed            = "failed"
+
+	codeConnectionReasonCredentialUnavailable = "CredentialUnavailable"
+	codeConnectionReasonProviderNotFound      = "ProviderNotFound"
+	codeConnectionReasonValidationFailed      = "ValidationFailed"
 )
 
 type codeResourceGetter func(ctx context.Context, gvr schema.GroupVersionResource, name string) (*unstructured.Unstructured, error)
@@ -243,6 +248,36 @@ func inspectCodeConnectionReadiness(ctx context.Context, c *asclient.Client) (Pr
 	}
 	if len(list.Items) == 0 {
 		return ProjectCreateGitConnectionReadiness{Status: projectCreateGitStatusConnectionMissing, Message: "You need to connect to a Git account before you can continue"}, nil
+	}
+	var firstFailure *ProjectCreateGitConnectionReadiness
+	hasPending := false
+	for i := range list.Items {
+		status, reason, message, found := unstructuredCondition(&list.Items[i], codeConditionValidated)
+		observedGeneration, observed, _ := unstructured.NestedInt64(list.Items[i].Object, "status", "observedGeneration")
+		if !found || status != string(metav1.ConditionFalse) || !observed || observedGeneration < list.Items[i].GetGeneration() {
+			hasPending = true
+			continue
+		}
+		switch reason {
+		case codeConnectionReasonProviderNotFound, codeConnectionReasonValidationFailed:
+			if firstFailure == nil {
+				if strings.TrimSpace(message) == "" {
+					message = "The Git connection could not be validated. Review its credential and try again."
+				}
+				firstFailure = &ProjectCreateGitConnectionReadiness{
+					Status:        projectCreateGitStatusFailed,
+					ConnectionRef: list.Items[i].GetName(),
+					Message:       message,
+				}
+			}
+		case codeConnectionReasonCredentialUnavailable:
+			hasPending = true
+		default:
+			hasPending = true
+		}
+	}
+	if firstFailure != nil && !hasPending {
+		return *firstFailure, nil
 	}
 	return ProjectCreateGitConnectionReadiness{Status: projectCreateGitStatusValidating, Message: "Your Git connection is still validating"}, nil
 }

--- a/providers/app-studio/api/code_repository_test.go
+++ b/providers/app-studio/api/code_repository_test.go
@@ -88,6 +88,48 @@ func TestProjectCreateReadinessReportsConnectionValidation(t *testing.T) {
 	}
 }
 
+func TestProjectCreateReadinessReportsTerminalConnectionFailure(t *testing.T) {
+	client := newCodeRepositoryTestClient(codeConnectionObjectWithValidationCondition(
+		"github",
+		metav1.ConditionFalse,
+		codeConnectionReasonValidationFailed,
+		"credential rejected by GitHub",
+		true,
+	))
+
+	readiness, err := projectCreateReadiness(context.Background(), client)
+	if err != nil {
+		t.Fatalf("projectCreateReadiness returned error: %v", err)
+	}
+	if readiness.GitConnection.Status != projectCreateGitStatusFailed {
+		t.Fatalf("GitConnection.Status = %q, want %q", readiness.GitConnection.Status, projectCreateGitStatusFailed)
+	}
+	if readiness.GitConnection.ConnectionRef != "github" {
+		t.Fatalf("GitConnection.ConnectionRef = %q, want github", readiness.GitConnection.ConnectionRef)
+	}
+	if readiness.GitConnection.Message != "credential rejected by GitHub" {
+		t.Fatalf("GitConnection.Message = %q, want provider validation detail", readiness.GitConnection.Message)
+	}
+}
+
+func TestProjectCreateReadinessKeepsTransientConnectionPending(t *testing.T) {
+	client := newCodeRepositoryTestClient(codeConnectionObjectWithValidationCondition(
+		"github",
+		metav1.ConditionFalse,
+		codeConnectionReasonCredentialUnavailable,
+		"credential Secret is not visible yet",
+		true,
+	))
+
+	readiness, err := projectCreateReadiness(context.Background(), client)
+	if err != nil {
+		t.Fatalf("projectCreateReadiness returned error: %v", err)
+	}
+	if readiness.GitConnection.Status != projectCreateGitStatusValidating {
+		t.Fatalf("GitConnection.Status = %q, want %q", readiness.GitConnection.Status, projectCreateGitStatusValidating)
+	}
+}
+
 func newCodeRepositoryTestClient(objects ...runtime.Object) *asclient.Client {
 	return asclient.NewFromDynamic(fake.NewSimpleDynamicClientWithCustomListKinds(
 		runtime.NewScheme(),
@@ -99,11 +141,22 @@ func newCodeRepositoryTestClient(objects ...runtime.Object) *asclient.Client {
 }
 
 func codeConnectionObjectWithValidated(name string, status metav1.ConditionStatus) *unstructured.Unstructured {
+	return codeConnectionObjectWithValidationCondition(name, status, "", "", false)
+}
+
+func codeConnectionObjectWithValidationCondition(name string, status metav1.ConditionStatus, reason, message string, reconciled bool) *unstructured.Unstructured {
+	condition := map[string]any{"type": codeConditionValidated, "status": string(status)}
+	if reason != "" {
+		condition["reason"] = reason
+	}
+	if message != "" {
+		condition["message"] = message
+	}
 	u := &unstructured.Unstructured{
 		Object: map[string]any{
 			"status": map[string]any{
 				"conditions": []any{
-					map[string]any{"type": codeConditionValidated, "status": string(status)},
+					condition,
 				},
 			},
 		},
@@ -111,5 +164,9 @@ func codeConnectionObjectWithValidated(name string, status metav1.ConditionStatu
 	u.SetAPIVersion(codeSchemeGroupVersion.String())
 	u.SetKind("Connection")
 	u.SetName(name)
+	u.SetGeneration(1)
+	if reconciled {
+		_ = unstructured.SetNestedField(u.Object, int64(1), "status", "observedGeneration")
+	}
 	return u
 }

--- a/providers/app-studio/api/code_repository_test.go
+++ b/providers/app-studio/api/code_repository_test.go
@@ -39,6 +39,9 @@ func TestProjectCreateReadinessRequiresValidatedGitConnection(t *testing.T) {
 	if readiness.GitConnection.Ready {
 		t.Fatalf("GitConnection.Ready = true, want false")
 	}
+	if readiness.GitConnection.Status != projectCreateGitStatusConnectionMissing {
+		t.Fatalf("GitConnection.Status = %q, want %q", readiness.GitConnection.Status, projectCreateGitStatusConnectionMissing)
+	}
 	if readiness.GitConnection.ConnectionRef != "" {
 		t.Fatalf("GitConnection.ConnectionRef = %q, want empty", readiness.GitConnection.ConnectionRef)
 	}
@@ -59,11 +62,29 @@ func TestProjectCreateReadinessSelectsValidatedGitConnection(t *testing.T) {
 	if !readiness.GitConnection.Ready {
 		t.Fatalf("GitConnection.Ready = false, want true")
 	}
+	if readiness.GitConnection.Status != projectCreateGitStatusReady {
+		t.Fatalf("GitConnection.Status = %q, want %q", readiness.GitConnection.Status, projectCreateGitStatusReady)
+	}
 	if readiness.GitConnection.ConnectionRef != "github" {
 		t.Fatalf("GitConnection.ConnectionRef = %q, want github", readiness.GitConnection.ConnectionRef)
 	}
 	if readiness.GitConnection.Message != "" {
 		t.Fatalf("GitConnection.Message = %q, want empty", readiness.GitConnection.Message)
+	}
+}
+
+func TestProjectCreateReadinessReportsConnectionValidation(t *testing.T) {
+	client := newCodeRepositoryTestClient(codeConnectionObjectWithValidated("github", metav1.ConditionFalse))
+
+	readiness, err := projectCreateReadiness(context.Background(), client)
+	if err != nil {
+		t.Fatalf("projectCreateReadiness returned error: %v", err)
+	}
+	if readiness.GitConnection.Status != projectCreateGitStatusValidating {
+		t.Fatalf("GitConnection.Status = %q, want %q", readiness.GitConnection.Status, projectCreateGitStatusValidating)
+	}
+	if readiness.GitConnection.Message != "Your Git connection is still validating" {
+		t.Fatalf("GitConnection.Message = %q, want validation guidance", readiness.GitConnection.Message)
 	}
 }
 

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -37,6 +37,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	einoopenai "github.com/cloudwego/eino-ext/components/model/openai"
 	einoschema "github.com/cloudwego/eino/schema"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -1926,19 +1927,50 @@ func normalizeProjectLLMSettings(settings *projectLLMSettings) error {
 func verifyProjectLLMConnection(ctx context.Context, settings projectLLMSettings) error {
 	model, err := newProjectEinoChatModel(ctx, settings)
 	if err != nil {
+		if errors.Is(err, errProjectLLMNotConfigured) {
+			return newValidationError("credential cannot be empty")
+		}
 		return err
 	}
 	response, err := model.Generate(ctx, []*einoschema.Message{
 		einoschema.UserMessage("Reply with OK to confirm this model connection."),
 	})
 	if err != nil {
-		return fmt.Errorf("AI model connection failed: %w", err)
+		return classifyProjectLLMConnectionTestError(ctx, err)
 	}
 	if response == nil {
 		return errors.New("AI model connection failed: provider returned no response")
 	}
 	return nil
 }
+
+func classifyProjectLLMConnectionTestError(ctx context.Context, err error) error {
+	wrapped := fmt.Errorf("AI model connection failed: %w", err)
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return &projectLLMConnectionTestError{Kind: projectLLMConnectionTestTimeout, Err: wrapped}
+	}
+	var apiErr *einoopenai.APIError
+	if errors.As(err, &apiErr) && apiErr.HTTPStatusCode >= 400 && apiErr.HTTPStatusCode < 500 {
+		return &projectLLMConnectionTestError{Kind: projectLLMConnectionTestRejected, Err: wrapped}
+	}
+	return &projectLLMConnectionTestError{Kind: projectLLMConnectionTestUpstream, Err: wrapped}
+}
+
+type projectLLMConnectionTestErrorKind string
+
+const (
+	projectLLMConnectionTestRejected projectLLMConnectionTestErrorKind = "rejected"
+	projectLLMConnectionTestUpstream projectLLMConnectionTestErrorKind = "upstream"
+	projectLLMConnectionTestTimeout  projectLLMConnectionTestErrorKind = "timeout"
+)
+
+type projectLLMConnectionTestError struct {
+	Kind projectLLMConnectionTestErrorKind
+	Err  error
+}
+
+func (e *projectLLMConnectionTestError) Error() string { return e.Err.Error() }
+func (e *projectLLMConnectionTestError) Unwrap() error { return e.Err }
 
 func validateProjectLLMBaseURL(provider, raw string) error {
 	if strings.EqualFold(strings.TrimSpace(provider), projectLLMProviderGoogle) {

--- a/providers/app-studio/api/llm.go
+++ b/providers/app-studio/api/llm.go
@@ -1923,6 +1923,23 @@ func normalizeProjectLLMSettings(settings *projectLLMSettings) error {
 	return nil
 }
 
+func verifyProjectLLMConnection(ctx context.Context, settings projectLLMSettings) error {
+	model, err := newProjectEinoChatModel(ctx, settings)
+	if err != nil {
+		return err
+	}
+	response, err := model.Generate(ctx, []*einoschema.Message{
+		einoschema.UserMessage("Reply with OK to confirm this model connection."),
+	})
+	if err != nil {
+		return fmt.Errorf("AI model connection failed: %w", err)
+	}
+	if response == nil {
+		return errors.New("AI model connection failed: provider returned no response")
+	}
+	return nil
+}
+
 func validateProjectLLMBaseURL(provider, raw string) error {
 	if strings.EqualFold(strings.TrimSpace(provider), projectLLMProviderGoogle) {
 		return nil

--- a/providers/app-studio/api/llm_registry.go
+++ b/providers/app-studio/api/llm_registry.go
@@ -62,6 +62,13 @@ type CreateProjectLLMModelRequest struct {
 	APIKey   string `json:"apiKey"`
 }
 
+type TestProjectLLMConnectionRequest struct {
+	Provider string `json:"provider,omitempty"`
+	BaseURL  string `json:"baseURL,omitempty"`
+	Model    string `json:"model"`
+	APIKey   string `json:"apiKey"`
+}
+
 type PatchProjectLLMModelRequest struct {
 	Name     *string `json:"name,omitempty"`
 	Provider *string `json:"provider,omitempty"`
@@ -519,6 +526,28 @@ func (s *Server) createProjectLLMModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, registry.view())
+}
+
+func (s *Server) testProjectLLMConnection(w http.ResponseWriter, r *http.Request) {
+	if _, _, ok := s.requireProjectClient(w, r); !ok {
+		return
+	}
+	var request TestProjectLLMConnectionRequest
+	if !decodeStrictJSON(w, r, &request) {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	if err := verifyProjectLLMConnection(ctx, projectLLMSettings{
+		Provider: request.Provider,
+		BaseURL:  request.BaseURL,
+		Model:    request.Model,
+		APIKey:   request.APIKey,
+	}); err != nil {
+		writeProjectError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
 func (s *Server) patchProjectLLMModel(w http.ResponseWriter, r *http.Request) {

--- a/providers/app-studio/api/llm_registry.go
+++ b/providers/app-studio/api/llm_registry.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -544,10 +545,26 @@ func (s *Server) testProjectLLMConnection(w http.ResponseWriter, r *http.Request
 		Model:    request.Model,
 		APIKey:   request.APIKey,
 	}); err != nil {
-		writeProjectError(w, err)
+		writeProjectLLMConnectionTestError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func writeProjectLLMConnectionTestError(w http.ResponseWriter, err error) {
+	var connectionErr *projectLLMConnectionTestError
+	if !errors.As(err, &connectionErr) {
+		writeProjectError(w, err)
+		return
+	}
+	switch connectionErr.Kind {
+	case projectLLMConnectionTestRejected:
+		writeStatus(w, http.StatusUnprocessableEntity, "InvalidConnection", connectionErr.Error())
+	case projectLLMConnectionTestTimeout:
+		writeStatus(w, http.StatusGatewayTimeout, "GatewayTimeout", "Model connection test timed out before the provider responded.")
+	default:
+		writeStatus(w, http.StatusBadGateway, "BadGateway", connectionErr.Error())
+	}
 }
 
 func (s *Server) patchProjectLLMModel(w http.ResponseWriter, r *http.Request) {

--- a/providers/app-studio/api/llm_test.go
+++ b/providers/app-studio/api/llm_test.go
@@ -67,6 +67,68 @@ func TestVerifyProjectLLMConnectionCallsConfiguredModel(t *testing.T) {
 	}
 }
 
+func TestVerifyProjectLLMConnectionClassifiesProviderRejection(t *testing.T) {
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":{"message":"invalid API key","type":"invalid_request_error","code":"invalid_api_key"}}`)
+	}))
+	defer provider.Close()
+
+	err := verifyProjectLLMConnection(context.Background(), projectLLMSettings{
+		Provider: defaultProjectLLMProvider,
+		BaseURL:  provider.URL + "/v1",
+		Model:    "test-model",
+		APIKey:   "invalid-key",
+	})
+	var connectionErr *projectLLMConnectionTestError
+	if !errors.As(err, &connectionErr) {
+		t.Fatalf("verifyProjectLLMConnection error = %T %v, want projectLLMConnectionTestError", err, err)
+	}
+	if connectionErr.Kind != projectLLMConnectionTestRejected {
+		t.Fatalf("connection error kind = %q, want %q", connectionErr.Kind, projectLLMConnectionTestRejected)
+	}
+}
+
+func TestVerifyProjectLLMConnectionClassifiesTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+	err := classifyProjectLLMConnectionTestError(ctx, context.DeadlineExceeded)
+	var connectionErr *projectLLMConnectionTestError
+	if !errors.As(err, &connectionErr) {
+		t.Fatalf("verifyProjectLLMConnection error = %T %v, want projectLLMConnectionTestError", err, err)
+	}
+	if connectionErr.Kind != projectLLMConnectionTestTimeout {
+		t.Fatalf("connection error kind = %q, want %q", connectionErr.Kind, projectLLMConnectionTestTimeout)
+	}
+}
+
+func TestWriteProjectLLMConnectionTestErrorUsesActionableStatuses(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       projectLLMConnectionTestErrorKind
+		wantStatus int
+		wantBody   string
+	}{
+		{name: "rejected", kind: projectLLMConnectionTestRejected, wantStatus: http.StatusUnprocessableEntity, wantBody: "InvalidConnection"},
+		{name: "upstream", kind: projectLLMConnectionTestUpstream, wantStatus: http.StatusBadGateway, wantBody: "BadGateway"},
+		{name: "timeout", kind: projectLLMConnectionTestTimeout, wantStatus: http.StatusGatewayTimeout, wantBody: "Model connection test timed out"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			writeProjectLLMConnectionTestError(recorder, &projectLLMConnectionTestError{Kind: tt.kind, Err: errors.New("provider failure")})
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if !strings.Contains(recorder.Body.String(), tt.wantBody) {
+				t.Fatalf("body = %s, want %q", recorder.Body.String(), tt.wantBody)
+			}
+		})
+	}
+}
+
 func TestProjectToolCallTerminalStatusPreservesCanceledSpellings(t *testing.T) {
 	for _, spelling := range []string{"canceled", "cancelled"} {
 		result := `{"status":"` + spelling + `"}`

--- a/providers/app-studio/api/llm_test.go
+++ b/providers/app-studio/api/llm_test.go
@@ -19,6 +19,9 @@ package api
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -27,6 +30,42 @@ import (
 	einoschema "github.com/cloudwego/eino/schema"
 	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
 )
+
+func TestVerifyProjectLLMConnectionCallsConfiguredModel(t *testing.T) {
+	var sawRequest bool
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("request path = %q, want /v1/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want bearer credential", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		if !strings.Contains(string(body), "Reply with OK") {
+			t.Errorf("request body did not contain connection prompt: %s", body)
+		}
+		sawRequest = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"connection-test","object":"chat.completion","created":1,"model":"test-model","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}`)
+	}))
+	defer provider.Close()
+
+	err := verifyProjectLLMConnection(context.Background(), projectLLMSettings{
+		Provider: defaultProjectLLMProvider,
+		BaseURL:  provider.URL + "/v1",
+		Model:    "test-model",
+		APIKey:   "test-key",
+	})
+	if err != nil {
+		t.Fatalf("verifyProjectLLMConnection returned error: %v", err)
+	}
+	if !sawRequest {
+		t.Fatal("configured model was not called")
+	}
+}
 
 func TestProjectToolCallTerminalStatusPreservesCanceledSpellings(t *testing.T) {
 	for _, spelling := range []string{"canceled", "cancelled"} {

--- a/providers/app-studio/api/server.go
+++ b/providers/app-studio/api/server.go
@@ -276,6 +276,7 @@ func (s *Server) Register(r *mux.Router) {
 	r.HandleFunc("/api/projects/llm-settings", s.getProjectLLMSettings).Methods(http.MethodGet)
 	r.HandleFunc("/api/projects/llm-settings", s.patchProjectLLMSettings).Methods(http.MethodPatch)
 	r.HandleFunc("/api/projects/llm-settings/models/discover", s.discoverProjectLLMModels).Methods(http.MethodPost)
+	r.HandleFunc("/api/projects/llm-settings/test", s.testProjectLLMConnection).Methods(http.MethodPost)
 	r.HandleFunc("/api/projects/llm-settings/models", s.createProjectLLMModel).Methods(http.MethodPost)
 	r.HandleFunc("/api/projects/llm-settings/models/{model}", s.patchProjectLLMModel).Methods(http.MethodPatch)
 	r.HandleFunc("/api/projects/llm-settings/models/{model}", s.deleteProjectLLMModel).Methods(http.MethodDelete)

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -164,6 +164,7 @@ import {
   type ProjectDeletionIdentity,
 } from './projectDeletion'
 import NewProjectWizard from './NewProjectWizard.vue'
+import FirstTimeSetup from './FirstTimeSetup.vue'
 import ProjectIntegrations from './ProjectIntegrations.vue'
 import {
   ConversationRunController,
@@ -480,6 +481,7 @@ const appStudioSectionTabs = [
 ] as const
 const MISSING_CODE_CONNECTION_ERROR = 'You need to connect to a Git account before you can continue'
 const CODE_CONNECTIONS_URL = '/ui/providers/code/connections'
+const CODE_PROVIDER_CATALOG_URL = '/providers'
 const PUBLISHING_DOMAIN_SUFFIX = '.faros.app'
 const DEVELOPMENT_PREVIEW_AUTH_RETRY_MS = 2000
 const PROJECT_TOOL_CATEGORIES = new Set(['developer', 'workloads'])
@@ -890,6 +892,11 @@ const llmModel = ref(OPENAI_DEFAULT_MODEL)
 const llmApiKey = ref('')
 const llmCredentialMode = ref<LLMCredentialMode>('api-key')
 const llmSaving = ref(false)
+const llmTesting = ref(false)
+const llmTestStatus = ref<string | null>(null)
+const llmTestError = ref<string | null>(null)
+const llmTestedFingerprint = ref('')
+let llmConnectionTestSerial = 0
 const llmStatus = ref<string | null>(null)
 const llmActionError = ref<string | null>(null)
 const llmEditorOpen = ref(false)
@@ -904,6 +911,8 @@ const llmDiscoveryLoading = ref(false)
 const llmDiscoveryError = ref<string | null>(null)
 const llmDiscoveryStatus = ref<string | null>(null)
 let llmDiscoverySerial = 0
+const setupSessionActive = ref(false)
+const setupCompletionVisible = ref(false)
 const messagesRef = ref<HTMLDivElement | null>(null)
 const expandedMessageTimestampID = ref<string | null>(null)
 const expandedAssistantProgressIDs = ref<Set<string>>(new Set())
@@ -1109,6 +1118,9 @@ function invalidateProjectContextState() {
   releaseLoadSerial += 1
   historyLoadSerial += 1
   invalidateLLMModelMutationState()
+  invalidateLLMConnectionTest()
+  setupSessionActive.value = false
+  setupCompletionVisible.value = false
 
   clearInitializationRetry()
   clearProjectThumbnailURLs()
@@ -1454,6 +1466,10 @@ const isCreateModelRoute = computed(() => routePath.value === CREATE_MODEL_ROUTE
 const selectedNameFromPath = computed(() => (isCreateRoute.value || isModelsRoute.value || isCreateModelRoute.value ? '' : routeSegment.value))
 const isAppStudioLandingRoute = computed(() => isProjectIndexRoute.value || isCreateRoute.value || isModelsRoute.value || isCreateModelRoute.value)
 const modelsReturnRoute = ref('')
+const llmCreateReturnLabel = computed(() => modelsReturnRoute.value === CREATE_PROJECT_ROUTE ? 'Workspace setup' : 'Models')
+const llmCreateDescription = computed(() => modelsReturnRoute.value === CREATE_PROJECT_ROUTE
+  ? 'Connect and verify the model App Studio will use for project creation and chat.'
+  : 'Configure the model credentials App Studio uses when creating and chatting in projects.')
 const projectRouteLoading = computed(() => Boolean(
   projectOpenLoading.value ||
   (
@@ -1545,7 +1561,7 @@ const assistantComposerStopDisabled = computed(() => assistantComposerStopContro
 const configuredLLMModels = computed(() => (llmSettings.value?.models ?? []).filter((model) => model.configured))
 const selectedLLMModel = computed(() => configuredLLMModels.value.find((model) => model.id === selectedLLMModelID.value) ?? configuredLLMModels.value[0])
 const llmConfigured = computed(() => configuredLLMModels.value.length > 0)
-const canStartProjectFromPrompt = computed(() => !createSetupLoading.value && canSubmitCreatePrompt(prompt.value, createReadiness.value) && (llmSettings.value?.configured ?? false))
+const canStartProjectFromPrompt = computed(() => !createSetupLoading.value && canSubmitCreatePrompt(prompt.value, createReadiness.value) && llmConfigured.value)
 const assistantComposerHasChipContent = computed(() => assistantComposerParts.value.some((part) => part.type !== 'text'))
 const canSendPrompt = computed(() =>
   llmConfigured.value &&
@@ -1613,14 +1629,40 @@ const createSetupItemsForPrompt = computed(() => createSetupItems({
   llmConfigured: llmConfigured.value,
   checkingGit: createReadinessChecking.value,
 }))
-const createSetupLoading = computed(() => createReadinessChecking.value || llmSettingsLoading.value)
+const llmSettingsChecking = computed(() => llmSettingsLoading.value || (!!props.ctx?.token && llmSettings.value === null && !llmSettingsError.value))
+const createSetupLoading = computed(() => createReadinessChecking.value || llmSettingsChecking.value)
 const createPromptSubmitTitle = computed(() => {
   if (createSetupLoading.value) return 'Checking workspace setup'
   if (createSetupItemsForPrompt.value.length > 0) return 'Complete setup before preparing a project'
   return prompt.value.trim() ? 'Prepare project for review' : 'Describe what you want to build'
 })
-const createSetupVisible = computed(() => !createSetupLoading.value && (createSetupItemsForPrompt.value.length > 0 || !!createReadinessError.value))
+const createSetupVisible = computed(() => createSetupItemsForPrompt.value.length > 0 || !!createReadinessError.value || !!llmSettingsError.value)
 const createSetupErrorMessage = computed(() => createReadinessError.value || llmSettingsError.value || '')
+const firstTimeSetupVisible = computed(() => isCreateRoute.value && (createSetupLoading.value || createSetupVisible.value || setupCompletionVisible.value))
+const setupModelName = computed(() => selectedLLMModel.value?.model || llmSettings.value?.model || '')
+
+watch([isCreateRoute, createSetupLoading, createSetupVisible], ([onCreateRoute, loadingSetup, setupVisible]) => {
+  if (!onCreateRoute || loadingSetup) return
+  if (setupVisible) {
+    setupSessionActive.value = true
+    setupCompletionVisible.value = false
+  } else if (setupSessionActive.value) {
+    setupCompletionVisible.value = true
+  }
+}, { immediate: true })
+
+async function finishFirstTimeSetup() {
+  setupSessionActive.value = false
+  setupCompletionVisible.value = false
+  await nextTick()
+  promptRef.value?.focus()
+}
+
+function leaveFirstTimeSetup() {
+  setupSessionActive.value = false
+  setupCompletionVisible.value = false
+  props.navigate('')
+}
 function deleteProjectMessage(project: Project): string {
   const projectName = project.displayName || project.name
   const repositoryName = project.repository?.name || project.repository?.ref
@@ -2284,6 +2326,11 @@ const developmentPreviewUnavailableMessage = computed(() => {
   return developmentPreviewReadinessMessage.value || 'Development instance is not ready.'
 })
 
+function handleCreateSetupWake() {
+  if (!isCreateRoute.value || createSetupLoading.value || !firstTimeSetupVisible.value) return
+  void Promise.all([loadCreateReadiness(), loadLLMSettings()])
+}
+
 onMounted(() => {
   appComponentMounted = true
   void nextTick(observeSplitRegion)
@@ -2302,6 +2349,9 @@ onMounted(() => {
   window.addEventListener('focus', reloadActiveAssistantConversation)
   window.addEventListener('online', reloadActiveAssistantConversation)
   window.addEventListener('pageshow', reloadActiveAssistantConversation)
+  window.addEventListener('focus', handleCreateSetupWake)
+  window.addEventListener('online', handleCreateSetupWake)
+  window.addEventListener('pageshow', handleCreateSetupWake)
   document.addEventListener('pointerdown', handleLandingImportOutside)
   document.addEventListener('keydown', handleLandingImportEscape)
   document.addEventListener('visibilitychange', handleDevelopmentPreviewVisibilityChange)
@@ -2590,6 +2640,9 @@ onBeforeUnmount(() => {
   window.removeEventListener('focus', reloadActiveAssistantConversation)
   window.removeEventListener('online', reloadActiveAssistantConversation)
   window.removeEventListener('pageshow', reloadActiveAssistantConversation)
+  window.removeEventListener('focus', handleCreateSetupWake)
+  window.removeEventListener('online', handleCreateSetupWake)
+  window.removeEventListener('pageshow', handleCreateSetupWake)
   document.removeEventListener('pointerdown', handleLandingImportOutside)
   document.removeEventListener('keydown', handleLandingImportEscape)
   document.removeEventListener('visibilitychange', handleDevelopmentPreviewVisibilityChange)
@@ -3834,6 +3887,7 @@ function updateLLMAPIKey(value: string) {
 
 function openLLMEditor(modelID?: string) {
   invalidateLLMModelMutationState()
+  invalidateLLMConnectionTest()
   llmStatus.value = null
   llmActionError.value = null
   const saved = llmSettings.value?.models.find((model) => model.id === modelID)
@@ -4025,11 +4079,36 @@ function normalizeLLMModelInput(provider: string, model: string, credentialMode:
   return credentialMode === 'service-account-json' ? GOOGLE_CLOUD_DEFAULT_MODEL : GEMINI_DEFAULT_MODEL
 }
 
+const llmConnectionFingerprint = computed(() => JSON.stringify([
+  llmProvider.value.trim(), llmCredentialMode.value, llmBaseURL.value.trim(), llmModel.value.trim(), llmApiKey.value.trim(),
+]))
+const llmConnectionTested = computed(() => Boolean(llmTestedFingerprint.value) && llmTestedFingerprint.value === llmConnectionFingerprint.value)
+const llmConnectionTestRequired = computed(() => isCreateModelRoute.value && modelsReturnRoute.value === CREATE_PROJECT_ROUTE && setupSessionActive.value)
+
+function invalidateLLMConnectionTest() {
+  llmConnectionTestSerial += 1
+  llmTesting.value = false
+  llmTestStatus.value = null
+  llmTestError.value = null
+  llmTestedFingerprint.value = ''
+}
+
+watch(llmConnectionFingerprint, () => {
+  if (!llmTestedFingerprint.value || llmConnectionTested.value) return
+  llmTestStatus.value = null
+  llmTestError.value = null
+  llmTestedFingerprint.value = ''
+})
+
 async function saveLLMSettings() {
   llmStatus.value = null
   llmActionError.value = null
   llmValidationAttempted.value = true
   if (hasLLMModelFormErrors(llmFormValidation.value)) return
+  if (llmConnectionTestRequired.value && !llmConnectionTested.value) {
+    llmTestError.value = 'Test this connection before saving it for the workspace.'
+    return
+  }
   const routeOwnedCreation = isCreateModelRoute.value && !llmEditingModelID.value
   const editingID = llmEditingModelID.value
   const returnRoute = routeOwnedCreation
@@ -4057,6 +4136,7 @@ async function saveLLMSettings() {
     llmEditorBaseline.value = null
     llmValidationAttempted.value = false
     if (returnRoute) {
+      if (returnRoute === CREATE_PROJECT_ROUTE && setupSessionActive.value) setupCompletionVisible.value = true
       modelsReturnRoute.value = ''
       props.navigate(returnRoute, { replace: true })
     }
@@ -4065,6 +4145,40 @@ async function saveLLMSettings() {
     llmActionError.value = e instanceof Error ? e.message : String(e)
   } finally {
     if (llmModelMutationIsCurrent(guard)) llmSaving.value = false
+  }
+}
+
+async function testLLMConnection() {
+  llmTestStatus.value = null
+  llmTestError.value = null
+  if (llmBaseURLError.value) return
+  if (!llmModel.value.trim()) {
+    llmTestError.value = 'Enter a model ID before testing the connection.'
+    return
+  }
+  if (!llmApiKey.value.trim()) {
+    llmTestError.value = 'Enter a credential before testing the connection.'
+    return
+  }
+  const serial = ++llmConnectionTestSerial
+  const fingerprint = llmConnectionFingerprint.value
+  llmTesting.value = true
+  try {
+    const result = await api.testLLMConnection(props.ctx, {
+      provider: llmProvider.value.trim() || OPENAI_COMPATIBLE_PROVIDER,
+      baseURL: normalizeLLMBaseURLInput(llmProvider.value, llmBaseURL.value, llmCredentialMode.value),
+      model: normalizeLLMModelInput(llmProvider.value, llmModel.value, llmCredentialMode.value),
+      apiKey: llmApiKey.value.trim(),
+    })
+    if (serial !== llmConnectionTestSerial || fingerprint !== llmConnectionFingerprint.value) return
+    if (!result.ok) throw new Error('The provider did not confirm this connection.')
+    llmTestedFingerprint.value = fingerprint
+    llmTestStatus.value = 'Connection verified. The model responded successfully.'
+  } catch (e) {
+    if (serial !== llmConnectionTestSerial || fingerprint !== llmConnectionFingerprint.value) return
+    llmTestError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    if (serial === llmConnectionTestSerial) llmTesting.value = false
   }
 }
 
@@ -7767,10 +7881,28 @@ function isMissingCodeConnectionError(value: string | null): boolean {
       <div v-else-if="showNewProjectComposer">
         <main
           class="flex min-h-0 flex-1 justify-center py-4"
-          :class="wizardOpen ? 'items-start' : 'items-center'"
+          :class="wizardOpen || firstTimeSetupVisible ? 'items-start' : 'items-center'"
         >
           <section class="w-full max-w-[1060px]">
-            <template v-if="wizardOpen">
+            <template v-if="firstTimeSetupVisible">
+              <FirstTimeSetup
+                :readiness="createReadiness"
+                :llm-configured="llmConfigured"
+                :llm-model="setupModelName"
+                :loading="createSetupLoading"
+                :git-error="createReadinessError || ''"
+                :llm-error="llmSettingsError || ''"
+                :completion="setupCompletionVisible"
+                :code-connections-url="CODE_CONNECTIONS_URL"
+                :code-catalog-url="CODE_PROVIDER_CATALOG_URL"
+                @connect-model="openSettings"
+                @retry="onWizardSetupRetry"
+                @finish="finishFirstTimeSetup"
+                @back="leaveFirstTimeSetup"
+              />
+            </template>
+
+            <template v-else-if="wizardOpen">
               <NewProjectWizard
                 :ctx="props.ctx"
                 :initial-prompt="prompt"
@@ -8005,11 +8137,11 @@ function isMissingCodeConnectionError(value: string | null): boolean {
 
       <section v-else-if="isModelsRoute || isCreateModelRoute" :class="isCreateModelRoute ? 'k-create-page pb-6' : 'min-h-0 pb-6'">
         <button v-if="isCreateModelRoute" type="button" class="k-btn k-btn--ghost k-back-action" :disabled="llmSaving" @click="cancelLLMEditor">
-          <ArrowLeft class="h-3.5 w-3.5" :stroke-width="1.75" /> Models
+          <ArrowLeft class="h-3.5 w-3.5" :stroke-width="1.75" /> {{ llmCreateReturnLabel }}
         </button>
         <header v-if="isCreateModelRoute" class="k-create-header">
-          <h1 class="k-create-title">Connect model</h1>
-          <p class="k-create-description">Add a credentialed model connection for project creation and chat.</p>
+          <h1 class="k-create-title">{{ llmConnectionTestRequired ? 'Connect an AI model' : 'Connect model' }}</h1>
+          <p class="k-create-description">{{ llmConnectionTestRequired ? llmCreateDescription : 'Add a credentialed model connection for project creation and chat.' }}</p>
         </header>
         <div id="app-studio-models-host" class="min-h-[420px]" />
       </section>
@@ -9878,10 +10010,16 @@ function isMissingCodeConnectionError(value: string | null): boolean {
             :discovery-error="llmDiscoveryError"
             :discovery-status="llmDiscoveryStatus"
             :can-discover="llmCanDiscover"
+            :testing="llmTesting"
+            :test-status="llmTestStatus"
+            :test-error="llmTestError"
+            :require-connection-test="llmConnectionTestRequired"
+            :connection-tested="llmConnectionTested"
             @retry="loadLLMSettings"
             @open-editor="openModelEditor"
             @cancel-editor="cancelLLMEditor"
             @save="saveLLMSettings"
+            @test="testLLMConnection"
             @delete="deleteLLMModel"
             @set-default="setDefaultLLMModel"
             @select-provider="selectLLMProvider"

--- a/providers/app-studio/portal/src/FirstTimeSetup.vue
+++ b/providers/app-studio/portal/src/FirstTimeSetup.vue
@@ -23,6 +23,7 @@ const gitState = computed<SetupState>(() => {
   if (props.loading) return 'checking'
   if (props.gitError) return 'error'
   if (props.readiness?.gitConnection.ready) return 'ready'
+  if (props.readiness?.gitConnection.status === 'failed') return 'error'
   if (props.readiness?.gitConnection.status === 'validating') return 'pending'
   return 'missing'
 })
@@ -32,11 +33,14 @@ const modelState = computed<SetupState>(() => {
   return props.llmConfigured ? 'ready' : 'missing'
 })
 const activeStep = computed<'git' | 'model'>(() => gitState.value === 'ready' ? 'model' : 'git')
-const gitAction = computed(() => props.readiness?.gitConnection.status === 'provider-missing'
-  ? { href: props.codeCatalogUrl, label: 'Enable Code provider' }
-  : props.readiness?.gitConnection.status === 'validating'
-    ? { href: props.codeConnectionsUrl, label: 'View Git connection' }
-    : { href: props.codeConnectionsUrl, label: 'Connect GitHub' })
+const gitAction = computed(() => {
+  switch (props.readiness?.gitConnection.status) {
+    case 'provider-missing': return { href: props.codeCatalogUrl, label: 'Enable Code provider' }
+    case 'failed': return { href: props.codeConnectionsUrl, label: 'Fix Git connection' }
+    case 'validating': return { href: props.codeConnectionsUrl, label: 'View Git connection' }
+    default: return { href: props.codeConnectionsUrl, label: 'Connect GitHub' }
+  }
+})
 const retryVisible = computed(() => gitState.value === 'error' || gitState.value === 'pending' || modelState.value === 'error')
 
 function stateLabel(state: SetupState): string {
@@ -49,7 +53,7 @@ function stateLabel(state: SetupState): string {
 </script>
 
 <template>
-  <section class="mx-auto grid w-full max-w-[900px] overflow-hidden rounded-lg border border-border-subtle bg-surface shadow-sm md:grid-cols-[220px_minmax(0,1fr)]" aria-labelledby="app-studio-setup-title">
+  <section class="mx-auto grid w-full max-w-[900px] overflow-hidden rounded-lg border border-border-subtle bg-surface shadow-sm md:grid-cols-[220px_minmax(0,1fr)]" aria-label="App Studio workspace setup">
     <aside class="border-b border-border-subtle bg-surface-raised px-5 py-5 md:min-h-[500px] md:border-b-0 md:border-r">
       <h2 class="text-[18px] font-semibold leading-6 text-text-primary">Workspace setup</h2>
       <p class="mt-1 text-[12px] leading-5 text-text-secondary">Connect the two services App Studio needs before you build.</p>
@@ -97,7 +101,7 @@ function stateLabel(state: SetupState): string {
           <div class="flex gap-3 py-4"><GitBranch class="mt-0.5 h-4 w-4 shrink-0 text-accent" :stroke-width="1.75" /><div><h3 class="text-[13px] font-medium text-text-primary">Git keeps every project durable</h3><p class="mt-1 text-[12px] leading-5 text-text-secondary">App Studio creates a repository and saves each change there.</p></div></div>
           <div class="flex gap-3 py-4"><Cpu class="mt-0.5 h-4 w-4 shrink-0 text-accent" :stroke-width="1.75" /><div><h3 class="text-[13px] font-medium text-text-primary">An AI model builds with you</h3><p class="mt-1 text-[12px] leading-5 text-text-secondary">It plans the project, writes code, and responds to your feedback.</p></div></div>
         </div>
-        <p v-if="gitError" class="mt-5 rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-[12px] leading-5 text-danger" role="alert">{{ gitError }}</p>
+        <p v-if="gitError || gitState === 'error'" class="mt-5 rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-[12px] leading-5 text-danger" role="alert">{{ gitError || readiness?.gitConnection.message || 'The Git connection could not be validated. Review it and try again.' }}</p>
         <p v-else-if="gitState === 'pending'" class="mt-5 rounded-md border border-warning/30 bg-warning-subtle px-3 py-2 text-[12px] leading-5 text-warning" role="status">{{ readiness?.gitConnection.message || 'Your Git connection is still validating.' }}</p>
         <div class="mt-6 flex flex-wrap items-center gap-3">
           <a :href="gitAction.href" target="_blank" rel="noopener noreferrer" class="k-btn k-btn--primary no-underline">{{ gitAction.label }} <ExternalLink class="h-3.5 w-3.5" :stroke-width="1.75" /></a>

--- a/providers/app-studio/portal/src/FirstTimeSetup.vue
+++ b/providers/app-studio/portal/src/FirstTimeSetup.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { ArrowRight, Check, Cpu, ExternalLink, GitBranch, Loader2, RefreshCw } from 'lucide-vue-next'
+import type { ProjectCreateReadiness } from './createReadiness'
+
+const props = withDefaults(defineProps<{
+  readiness: ProjectCreateReadiness | null
+  llmConfigured: boolean
+  llmModel?: string
+  loading: boolean
+  gitError?: string
+  llmError?: string
+  completion?: boolean
+  codeConnectionsUrl: string
+  codeCatalogUrl: string
+}>(), { llmModel: '', gitError: '', llmError: '', completion: false })
+
+const emit = defineEmits<{ connectModel: []; retry: []; finish: []; back: [] }>()
+
+type SetupState = 'checking' | 'ready' | 'missing' | 'pending' | 'error'
+
+const gitState = computed<SetupState>(() => {
+  if (props.loading) return 'checking'
+  if (props.gitError) return 'error'
+  if (props.readiness?.gitConnection.ready) return 'ready'
+  if (props.readiness?.gitConnection.status === 'validating') return 'pending'
+  return 'missing'
+})
+const modelState = computed<SetupState>(() => {
+  if (props.loading) return 'checking'
+  if (props.llmError) return 'error'
+  return props.llmConfigured ? 'ready' : 'missing'
+})
+const activeStep = computed<'git' | 'model'>(() => gitState.value === 'ready' ? 'model' : 'git')
+const gitAction = computed(() => props.readiness?.gitConnection.status === 'provider-missing'
+  ? { href: props.codeCatalogUrl, label: 'Enable Code provider' }
+  : props.readiness?.gitConnection.status === 'validating'
+    ? { href: props.codeConnectionsUrl, label: 'View Git connection' }
+    : { href: props.codeConnectionsUrl, label: 'Connect GitHub' })
+const retryVisible = computed(() => gitState.value === 'error' || gitState.value === 'pending' || modelState.value === 'error')
+
+function stateLabel(state: SetupState): string {
+  if (state === 'ready') return 'Connected'
+  if (state === 'checking') return 'Checking'
+  if (state === 'pending') return 'Validating'
+  if (state === 'error') return 'Check failed'
+  return 'Not connected'
+}
+</script>
+
+<template>
+  <section class="mx-auto grid w-full max-w-[900px] overflow-hidden rounded-lg border border-border-subtle bg-surface shadow-sm md:grid-cols-[220px_minmax(0,1fr)]" aria-labelledby="app-studio-setup-title">
+    <aside class="border-b border-border-subtle bg-surface-raised px-5 py-5 md:min-h-[500px] md:border-b-0 md:border-r">
+      <h2 class="text-[18px] font-semibold leading-6 text-text-primary">Workspace setup</h2>
+      <p class="mt-1 text-[12px] leading-5 text-text-secondary">Connect the two services App Studio needs before you build.</p>
+      <ol class="m-0 mt-5 grid list-none grid-cols-2 gap-3 p-0 md:grid-cols-1">
+        <li v-for="item in [{ id: 'git', label: 'Git', state: gitState }, { id: 'model', label: 'AI model', state: modelState }]" :key="item.id" class="flex min-w-0 items-start gap-2.5 rounded-md px-2 py-2" :class="activeStep === item.id && !completion ? 'bg-surface-hover' : ''" :aria-current="activeStep === item.id && !completion ? 'step' : undefined">
+          <span class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md border font-mono text-[11px]" :class="item.state === 'ready' ? 'border-success/40 bg-success-subtle text-success' : activeStep === item.id && !completion ? 'border-accent/50 bg-accent-subtle text-accent' : 'border-border-default bg-surface text-text-muted'" aria-hidden="true">
+            <Check v-if="item.state === 'ready'" class="h-3.5 w-3.5" :stroke-width="2" />
+            <Loader2 v-else-if="item.state === 'checking'" class="h-3.5 w-3.5 animate-spin motion-reduce:animate-none" :stroke-width="1.75" />
+            <span v-else>{{ item.id === 'git' ? '1' : '2' }}</span>
+          </span>
+          <span class="min-w-0">
+            <span class="block text-[13px] font-medium" :class="item.state === 'ready' ? 'text-success' : 'text-text-primary'">{{ item.label }}</span>
+            <span class="mt-0.5 block text-[11px] leading-4" :class="item.state === 'error' ? 'text-danger' : item.state === 'pending' ? 'text-warning' : 'text-text-muted'">{{ stateLabel(item.state) }}</span>
+          </span>
+        </li>
+      </ol>
+    </aside>
+
+    <div class="min-w-0 px-5 py-7 sm:px-8 sm:py-9">
+      <div v-if="loading" class="grid gap-5" role="status" aria-live="polite" aria-busy="true">
+        <div class="shimmer h-7 w-56 rounded-md bg-surface-overlay" />
+        <div class="shimmer h-16 w-full rounded-md bg-surface-overlay" />
+        <div class="shimmer h-24 w-full rounded-md bg-surface-overlay" />
+        <span class="text-[12px] text-text-muted">Checking workspace connections…</span>
+      </div>
+
+      <div v-else-if="completion" class="flex min-h-[390px] flex-col justify-center">
+        <div class="flex h-11 w-11 items-center justify-center rounded-full border border-success/50 bg-success-subtle text-success"><Check class="h-5 w-5" :stroke-width="1.75" /></div>
+        <h1 id="app-studio-setup-title" class="mt-5 text-[26px] font-semibold leading-8 text-text-primary">App Studio is ready</h1>
+        <p class="mt-2 max-w-[58ch] text-[14px] leading-6 text-text-secondary">Git and an AI model are connected for this workspace. You can now create a project from the usual new-project screen.</p>
+        <dl class="mt-6 divide-y divide-border-subtle border-y border-border-subtle text-[12px]">
+          <div class="flex min-w-0 items-center justify-between gap-4 py-3"><dt class="flex items-center gap-2 font-medium text-success"><GitBranch class="h-3.5 w-3.5" :stroke-width="1.75" /> GitHub</dt><dd class="min-w-0 truncate font-mono text-text-secondary">{{ readiness?.gitConnection.connectionRef || 'Connected' }}</dd></div>
+          <div class="flex min-w-0 items-center justify-between gap-4 py-3"><dt class="flex items-center gap-2 font-medium text-success"><Cpu class="h-3.5 w-3.5" :stroke-width="1.75" /> AI model</dt><dd class="min-w-0 truncate font-mono text-text-secondary">{{ llmModel || 'Connected' }}</dd></div>
+        </dl>
+        <div class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <button type="button" class="k-btn k-btn--ghost justify-center" @click="emit('back')">Back to projects</button>
+          <button type="button" class="k-btn k-btn--primary justify-center" @click="emit('finish')">Create your first project <ArrowRight class="h-4 w-4" :stroke-width="1.75" /></button>
+        </div>
+      </div>
+
+      <div v-else-if="activeStep === 'git'">
+        <h1 id="app-studio-setup-title" class="text-[26px] font-semibold leading-8 text-text-primary">Set up App Studio</h1>
+        <p class="mt-2 max-w-[62ch] text-[14px] leading-6 text-text-secondary">Connect Git and an AI model once for this workspace. After setup, you’ll move to the usual new-project screen.</p>
+        <div class="mt-6 divide-y divide-border-subtle border-y border-border-subtle">
+          <div class="flex gap-3 py-4"><GitBranch class="mt-0.5 h-4 w-4 shrink-0 text-accent" :stroke-width="1.75" /><div><h3 class="text-[13px] font-medium text-text-primary">Git keeps every project durable</h3><p class="mt-1 text-[12px] leading-5 text-text-secondary">App Studio creates a repository and saves each change there.</p></div></div>
+          <div class="flex gap-3 py-4"><Cpu class="mt-0.5 h-4 w-4 shrink-0 text-accent" :stroke-width="1.75" /><div><h3 class="text-[13px] font-medium text-text-primary">An AI model builds with you</h3><p class="mt-1 text-[12px] leading-5 text-text-secondary">It plans the project, writes code, and responds to your feedback.</p></div></div>
+        </div>
+        <p v-if="gitError" class="mt-5 rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-[12px] leading-5 text-danger" role="alert">{{ gitError }}</p>
+        <p v-else-if="gitState === 'pending'" class="mt-5 rounded-md border border-warning/30 bg-warning-subtle px-3 py-2 text-[12px] leading-5 text-warning" role="status">{{ readiness?.gitConnection.message || 'Your Git connection is still validating.' }}</p>
+        <div class="mt-6 flex flex-wrap items-center gap-3">
+          <a :href="gitAction.href" target="_blank" rel="noopener noreferrer" class="k-btn k-btn--primary no-underline">{{ gitAction.label }} <ExternalLink class="h-3.5 w-3.5" :stroke-width="1.75" /></a>
+          <button v-if="retryVisible" type="button" class="k-btn k-btn--ghost" @click="emit('retry')"><RefreshCw class="h-3.5 w-3.5" :stroke-width="1.75" /> Check again</button>
+        </div>
+      </div>
+
+      <div v-else>
+        <div class="flex flex-wrap items-center gap-2 text-[12px] text-success"><Check class="h-3.5 w-3.5" :stroke-width="2" /> GitHub connected <span v-if="readiness?.gitConnection.connectionRef" class="font-mono text-text-muted">{{ readiness.gitConnection.connectionRef }}</span></div>
+        <h1 id="app-studio-setup-title" class="mt-5 text-[26px] font-semibold leading-8 text-text-primary">Connect an AI model</h1>
+        <p class="mt-2 max-w-[62ch] text-[14px] leading-6 text-text-secondary">Add the provider credential App Studio will use to plan projects, write code, and respond to feedback.</p>
+        <div class="mt-6 flex gap-3 border-y border-border-subtle py-4"><Cpu class="mt-0.5 h-4 w-4 shrink-0 text-accent" :stroke-width="1.75" /><div><h3 class="text-[13px] font-medium text-text-primary">Your credential stays in this workspace</h3><p class="mt-1 text-[12px] leading-5 text-text-secondary">App Studio tests the provider connection before saving it for project creation and chat.</p></div></div>
+        <p v-if="llmError" class="mt-5 rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-[12px] leading-5 text-danger" role="alert">{{ llmError }}</p>
+        <div class="mt-6 flex flex-wrap items-center gap-3">
+          <button type="button" class="k-btn k-btn--primary" @click="emit('connectModel')">Connect AI model <ArrowRight class="h-4 w-4" :stroke-width="1.75" /></button>
+          <button v-if="retryVisible" type="button" class="k-btn k-btn--ghost" @click="emit('retry')"><RefreshCw class="h-3.5 w-3.5" :stroke-width="1.75" /> Check again</button>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/providers/app-studio/portal/src/ModelsSettings.vue
+++ b/providers/app-studio/portal/src/ModelsSettings.vue
@@ -43,6 +43,11 @@ const props = defineProps<{
   discoveryError: string | null
   discoveryStatus: string | null
   canDiscover: boolean
+  testing: boolean
+  testStatus: string | null
+  testError: string | null
+  requireConnectionTest: boolean
+  connectionTested: boolean
 }>()
 
 const recommendedDiscoveredModels = computed(() => props.discoveredModels.filter((model) => model.compatibility === 'recommended').slice(0, 4))
@@ -52,6 +57,7 @@ const emit = defineEmits<{
   openEditor: [modelID?: string]
   cancelEditor: []
   save: []
+  test: []
   delete: [modelID: string]
   setDefault: [modelID: string]
   selectProvider: [provider: LLMProviderPreset]
@@ -105,6 +111,8 @@ const emit = defineEmits<{
       </div>
       <div v-if="actionError" class="rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-[12px] text-danger" role="alert">{{ actionError }}</div>
       <div v-else-if="status" class="rounded-md border border-success/30 bg-success-subtle px-3 py-2 text-[12px] text-success" role="status" aria-live="polite">{{ status }}</div>
+      <div v-if="testError" class="rounded-md border border-danger/30 bg-danger-subtle px-3 py-2 text-[12px] text-danger" role="alert">{{ testError }}</div>
+      <div v-else-if="testStatus" class="flex items-center gap-2 rounded-md border border-success/30 bg-success-subtle px-3 py-2 text-[12px] text-success" role="status" aria-live="polite"><Check class="h-3.5 w-3.5" :stroke-width="2" />{{ testStatus }}</div>
 
       <div v-if="settings?.models.length && !creationRoute && !editorOpen" class="grid gap-3 sm:grid-cols-2">
         <article
@@ -278,10 +286,16 @@ const emit = defineEmits<{
 
         </div>
         <footer class="k-create-actions">
-          <button type="button" class="k-btn k-btn--ghost" :disabled="saving" @click="emit('cancelEditor')">Cancel</button>
-          <button class="k-btn k-btn--primary" :disabled="saving">
+          <button type="button" class="k-btn k-btn--ghost" :disabled="saving || testing" @click="emit('cancelEditor')">Cancel</button>
+          <button type="button" class="k-btn k-btn--ghost" :disabled="saving || testing || !model.trim() || !apiKey.trim() || Boolean(baseURLError)" @click="emit('test')">
+            <Loader2 v-if="testing" class="h-4 w-4 animate-spin motion-reduce:animate-none" :stroke-width="1.75" />
+            <Check v-else-if="connectionTested" class="h-4 w-4 text-success" :stroke-width="2" />
+            <RefreshCw v-else class="h-4 w-4" :stroke-width="1.75" />
+            {{ testing ? 'Testing…' : connectionTested ? 'Connection verified' : 'Test connection' }}
+          </button>
+          <button class="k-btn k-btn--primary" :disabled="saving || testing || (requireConnectionTest && !connectionTested)">
             <Loader2 v-if="saving" class="h-4 w-4 animate-spin" :stroke-width="1.75" /><Check v-else class="h-4 w-4" :stroke-width="1.75" />
-            {{ saving ? (editingModelID && !creationRoute ? 'Saving changes…' : 'Connecting model…') : (editingModelID && !creationRoute ? 'Save changes' : 'Connect model') }}
+            {{ saving ? (editingModelID && !creationRoute ? 'Saving changes…' : 'Connecting model…') : requireConnectionTest ? 'Save and finish' : (editingModelID && !creationRoute ? 'Save changes' : 'Connect model') }}
           </button>
         </footer>
       </form>

--- a/providers/app-studio/portal/src/api.ts
+++ b/providers/app-studio/portal/src/api.ts
@@ -105,6 +105,7 @@ function baseURL(ctx: FarosContext | null): string {
 
 interface ProjectAPIRequestOptions {
   timeoutMS?: number
+  timeoutMessage?: string
 }
 
 const ASSISTANT_THREAD_PAGE_SIZE = 500
@@ -130,7 +131,7 @@ async function request<T>(ctx: FarosContext | null, method: string, path: string
     })
     text = await res.text()
   } catch (error) {
-    if (timedOut) throw new ProjectAPIRequestError('preview console request timed out', 408)
+    if (timedOut) throw new ProjectAPIRequestError(options.timeoutMessage || 'request timed out', 408)
     throw error
   } finally {
     if (timeout !== undefined) window.clearTimeout(timeout)
@@ -846,6 +847,16 @@ export const api = {
     body: { name: string; provider?: string; baseURL?: string; model: string; apiKey: string },
   ): Promise<ProjectLLMSettings> {
     return request<ProjectLLMSettings>(ctx, 'POST', `${baseURL(ctx)}/llm-settings/models`, body)
+  },
+
+  async testLLMConnection(
+    ctx: FarosContext | null,
+    body: { provider?: string; baseURL?: string; model: string; apiKey: string },
+  ): Promise<{ ok: boolean }> {
+    return request<{ ok: boolean }>(ctx, 'POST', `${baseURL(ctx)}/llm-settings/test`, body, {
+      timeoutMS: 35_000,
+      timeoutMessage: 'model connection test timed out',
+    })
   },
 
   async patchLLMModel(

--- a/providers/app-studio/portal/src/api.ts
+++ b/providers/app-studio/portal/src/api.ts
@@ -110,6 +110,7 @@ interface ProjectAPIRequestOptions {
 
 const ASSISTANT_THREAD_PAGE_SIZE = 500
 const MAX_ASSISTANT_THREAD_PAGES = 100
+const PREVIEW_CONSOLE_TIMEOUT_MESSAGE = 'preview console request timed out'
 
 async function request<T>(ctx: FarosContext | null, method: string, path: string, body?: unknown, options: ProjectAPIRequestOptions = {}): Promise<T> {
   const headers = tenantHeaders({ token: ctx?.token, json: body !== undefined })
@@ -1093,7 +1094,7 @@ export const api = {
       'POST',
       `${baseURL(ctx)}/${encodeURIComponent(name)}/preview-console/sessions`,
       { generation, protocolVersion: 1, portalInstanceID },
-      { timeoutMS: 8_000 },
+      { timeoutMS: 8_000, timeoutMessage: PREVIEW_CONSOLE_TIMEOUT_MESSAGE },
     )
   },
 
@@ -1110,7 +1111,7 @@ export const api = {
       'POST',
       `${baseURL(ctx)}/${encodeURIComponent(name)}/preview-console/sessions/${encodeURIComponent(sessionID)}/events`,
       { generation, protocolVersion: 1, droppedCount, events },
-      { timeoutMS: 5_000 },
+      { timeoutMS: 5_000, timeoutMessage: PREVIEW_CONSOLE_TIMEOUT_MESSAGE },
     )
   },
 
@@ -1124,7 +1125,7 @@ export const api = {
       'DELETE',
       `${baseURL(ctx)}/${encodeURIComponent(name)}/preview-console/sessions/${encodeURIComponent(sessionID)}`,
       undefined,
-      { timeoutMS: 3_000 },
+      { timeoutMS: 3_000, timeoutMessage: PREVIEW_CONSOLE_TIMEOUT_MESSAGE },
     )
   },
 }

--- a/providers/app-studio/portal/src/createReadiness.ts
+++ b/providers/app-studio/portal/src/createReadiness.ts
@@ -1,7 +1,7 @@
 export interface ProjectCreateReadiness {
   gitConnection: {
     ready: boolean
-    status?: 'ready' | 'provider-missing' | 'connection-missing' | 'validating'
+    status?: 'ready' | 'provider-missing' | 'connection-missing' | 'validating' | 'failed'
     connectionRef?: string
     message?: string
   }

--- a/providers/app-studio/portal/src/createReadiness.ts
+++ b/providers/app-studio/portal/src/createReadiness.ts
@@ -1,6 +1,7 @@
 export interface ProjectCreateReadiness {
   gitConnection: {
     ready: boolean
+    status?: 'ready' | 'provider-missing' | 'connection-missing' | 'validating'
     connectionRef?: string
     message?: string
   }

--- a/providers/app-studio/portal/src/firstTimeSetup.test.mjs
+++ b/providers/app-studio/portal/src/firstTimeSetup.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import { createServer } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+
+const vite = await createServer({ appType: 'custom', cacheDir: '/tmp/faros-vite-first-time-setup', configFile: false, plugins: [vue()], server: { middlewareMode: true, hmr: false } })
+const { default: FirstTimeSetup } = await vite.ssrLoadModule('/src/FirstTimeSetup.vue')
+test.after(async () => vite.close())
+
+const base = {
+  readiness: { gitConnection: { ready: false, status: 'connection-missing' } },
+  llmConfigured: false,
+  llmModel: '',
+  loading: false,
+  gitError: '',
+  llmError: '',
+  completion: false,
+  codeConnectionsUrl: '/ui/providers/code/connections',
+  codeCatalogUrl: '/providers',
+}
+const render = (props = {}) => renderToString(createSSRApp(FirstTimeSetup, { ...base, ...props }))
+
+test('keeps first-time setup separate from the project prompt', async () => {
+  const html = await render()
+  assert.match(html, /Set up App Studio/)
+  assert.match(html, /Git keeps every project durable/)
+  assert.match(html, /Connect GitHub/)
+  assert.doesNotMatch(html, /What are we building|Describe what you want to build|<textarea/)
+})
+
+test('advances from Git to model setup using real readiness', async () => {
+  const html = await render({ readiness: { gitConnection: { ready: true, status: 'ready', connectionRef: 'github-workspace' } } })
+  assert.match(html, /GitHub connected/)
+  assert.match(html, /Connect an AI model/)
+  assert.match(html, /tests the provider connection before saving/)
+})
+
+test('completion hands off to normal project creation', async () => {
+  const html = await render({
+    readiness: { gitConnection: { ready: true, status: 'ready', connectionRef: 'github-workspace' } },
+    llmConfigured: true,
+    llmModel: 'gpt-5.4',
+    completion: true,
+  })
+  assert.match(html, /App Studio is ready/)
+  assert.match(html, /Create your first project/)
+  assert.match(html, /gpt-5\.4/)
+})
+
+test('App gates the new-project composer behind setup', async () => {
+  const app = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
+  assert.match(app, /<template v-if="firstTimeSetupVisible">[\s\S]*<FirstTimeSetup[\s\S]*<template v-else-if="wizardOpen">/)
+  assert.match(app, /@connect-model="openSettings"/)
+  assert.match(app, /@finish="finishFirstTimeSetup"/)
+})

--- a/providers/app-studio/portal/src/firstTimeSetup.test.mjs
+++ b/providers/app-studio/portal/src/firstTimeSetup.test.mjs
@@ -25,6 +25,8 @@ const render = (props = {}) => renderToString(createSSRApp(FirstTimeSetup, { ...
 
 test('keeps first-time setup separate from the project prompt', async () => {
   const html = await render()
+  assert.match(html, /aria-label="App Studio workspace setup"/)
+  assert.doesNotMatch(html, /aria-labelledby="app-studio-setup-title"/)
   assert.match(html, /Set up App Studio/)
   assert.match(html, /Git keeps every project durable/)
   assert.match(html, /Connect GitHub/)
@@ -36,6 +38,22 @@ test('advances from Git to model setup using real readiness', async () => {
   assert.match(html, /GitHub connected/)
   assert.match(html, /Connect an AI model/)
   assert.match(html, /tests the provider connection before saving/)
+})
+
+test('surfaces terminal Git validation failures with a recovery action', async () => {
+  const html = await render({
+    readiness: {
+      gitConnection: {
+        ready: false,
+        status: 'failed',
+        connectionRef: 'github-workspace',
+        message: 'The git host rejected the credential.',
+      },
+    },
+  })
+  assert.match(html, /The git host rejected the credential\./)
+  assert.match(html, /Fix Git connection/)
+  assert.match(html, /Check failed/)
 })
 
 test('completion hands off to normal project creation', async () => {

--- a/providers/app-studio/portal/src/modelsSettings.test.mjs
+++ b/providers/app-studio/portal/src/modelsSettings.test.mjs
@@ -11,7 +11,7 @@ const vite = await createServer({
   cacheDir: '/tmp/faros-vite-app-studio-models',
   configFile: false,
   plugins: [vue()],
-  server: { middlewareMode: true },
+  server: { middlewareMode: true, hmr: false },
 })
 const { default: ModelsSettings } = await vite.ssrLoadModule('/src/ModelsSettings.vue')
 test.after(async () => vite.close())
@@ -51,6 +51,11 @@ const baseProps = {
   discoveryError: null,
   discoveryStatus: null,
   canDiscover: false,
+  testing: false,
+  testStatus: null,
+  testError: null,
+  requireConnectionTest: false,
+  connectionTested: false,
 }
 
 async function render(props = {}) {
@@ -150,6 +155,7 @@ test('renders a guided provider, endpoint, and credential form', async () => {
   assert.match(html, /Find models/)
   assert.match(html, /Service account JSON/)
   assert.match(html, /Connect model/)
+  assert.match(html, /Test connection/)
 })
 
 test('offers known provider endpoints and keeps custom endpoints editable', async () => {
@@ -260,6 +266,23 @@ test('announces the active model mutation and disables competing card actions', 
     },
   })
   assert.match(collection, /<button type="button"[^>]*disabled[^>]*>\s*<svg[^>]*>[\s\S]*?<\/svg> Edit/)
+})
+
+test('first-time setup requires a verified model response before save and finish', async () => {
+  const html = await render({ creationRoute: true, name: 'OpenAI', apiKey: 'test-key', requireConnectionTest: true })
+  assert.match(html, /Test connection/)
+  assert.match(html, /Save and finish/)
+  assert.match(html, /<button class="k-btn k-btn--primary" disabled>[\s\S]*Save and finish/)
+
+  const verified = await render({
+    creationRoute: true,
+    name: 'OpenAI',
+    apiKey: 'test-key',
+    requireConnectionTest: true,
+    connectionTested: true,
+    testStatus: 'Connection verified. The model responded successfully.',
+  })
+  assert.match(verified, /Connection verified\. The model responded successfully\./)
 })
 
 test('App Studio owns save state while the extracted surface owns presentation', async () => {

--- a/providers/app-studio/portal/src/newProjectWizard.test.mjs
+++ b/providers/app-studio/portal/src/newProjectWizard.test.mjs
@@ -2,12 +2,15 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 import { createServer } from 'vite'
+import vue from '@vitejs/plugin-vue'
 import { createSSRApp } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 
 const vite = await createServer({
   appType: 'custom',
   cacheDir: '/tmp/faros-vite-new-project-wizard',
+  configFile: false,
+  plugins: [vue()],
   server: { middlewareMode: true, hmr: false },
 })
 const { default: NewProjectWizard } = await vite.ssrLoadModule('/src/NewProjectWizard.vue')
@@ -142,13 +145,13 @@ test('provider styles define their own spacing scale for standalone utility layo
 })
 
 test('App replaces the landing composer with the wizard and wires cancel to restore the exact prompt focus', () => {
-  const wizardBlock = appSource.match(/<template v-if="wizardOpen">[\s\S]*?<\/template>/)?.[0]
+  const wizardBlock = appSource.match(/<template v-else-if="wizardOpen">[\s\S]*?<\/template>/)?.[0]
   assert.ok(wizardBlock, 'wizard must occupy the landing surface when open')
   assert.match(wizardBlock, /<NewProjectWizard/)
   assert.match(wizardBlock, /:initial-prompt="prompt"/)
   assert.match(wizardBlock, /@cancel="onWizardCancel"/)
   assert.match(appSource, /<template v-else>\s*<div[\s\S]*?<form[\s\S]*v-if="!wizardOpen"/)
-  assert.match(appSource, /:class="wizardOpen \? 'items-start' : 'items-center'"/)
+  assert.match(appSource, /:class="wizardOpen \|\| firstTimeSetupVisible \? 'items-start' : 'items-center'"/)
 
   const cancelFunction = appSource.match(/async function onWizardCancel\(\) \{([\s\S]*?)\n\}/)?.[1]
   assert.ok(cancelFunction, 'cancel handler must remain explicit')

--- a/providers/app-studio/portal/src/previewConsole.test.mjs
+++ b/providers/app-studio/portal/src/previewConsole.test.mjs
@@ -65,6 +65,8 @@ test('App preview automatically shares console evidence without a capture contro
   assert.match(apiSource, /timeoutMS: 8_000/)
   assert.match(apiSource, /timeoutMS: 5_000/)
   assert.match(apiSource, /timeoutMS: 3_000/)
+  assert.equal((apiSource.match(/timeoutMessage: PREVIEW_CONSOLE_TIMEOUT_MESSAGE/g) ?? []).length, 3)
+  assert.match(apiSource, /PREVIEW_CONSOLE_TIMEOUT_MESSAGE = 'preview console request timed out'/)
 
   const recoveryStart = appSource.indexOf('function scheduleDevelopmentPreviewRecovery()')
 	  const recoveryEnd = appSource.indexOf('function handleDevelopmentPreviewVisibilityChange()', recoveryStart)


### PR DESCRIPTION
## Summary

- replace the mixed prerequisite messaging on the new-project route with a dedicated first-time setup experience
- guide users through Git readiness and model credentials before showing the project prompt
- distinguish missing, validating, and ready Git states
- require a successful model connection test before onboarding can finish
- hand users back to the existing project creation flow once setup is complete

## Verification

- npm test in providers/app-studio/portal
- npm run typecheck in providers/app-studio/portal
- npm run build in providers/app-studio/portal
- go test ./api in providers/app-studio
- desktop and mobile visual inspection with no horizontal overflow
- git diff --check