### PR TITLE
Fix App Studio empty-route flicker

### DIFF
--- a/portal/src/components/AppLayout.sidenav.test.mjs
+++ b/portal/src/components/AppLayout.sidenav.test.mjs
@@ -22,6 +22,7 @@ import * as ts from 'typescript'
 
 const components = path.dirname(new URL(import.meta.url).pathname)
 const appLayout = fs.readFileSync(path.join(components, 'AppLayout.vue'), 'utf8')
+const helpSupportModal = fs.readFileSync(path.join(components, 'HelpSupportModal.vue'), 'utf8')
 const providerNavOverflow = fs.readFileSync(path.join(components, 'ProviderNavOverflow.vue'), 'utf8')
 const accountMenu = fs.readFileSync(path.join(components, 'AccountAccessMenu.vue'), 'utf8')
 const sidebarExpansion = fs.readFileSync(path.join(components, '..', 'composables', 'useSidebarExpansion.ts'), 'utf8')
@@ -220,7 +221,10 @@ test('extracted shell ownership stays one-way and fences pointer lifecycles', ()
 })
 
 test('shell recovery and context status are present without claiming unconditional liveness', () => {
-  assert.ok((appLayout.match(/aria-label="Help — open Faros documentation"/g) ?? []).length >= 3)
+  assert.equal((appLayout.match(/aria-label="Open help and community"/g) ?? []).length, 3)
+  assert.equal((appLayout.match(/aria-controls="help-support-dialog"/g) ?? []).length, 3)
+  assert.equal((appLayout.match(/@click="showHelpModal = true"/g) ?? []).length, 3)
+  assert.match(appLayout, /<HelpSupportModal v-if="showHelpModal" @close="showHelpModal = false" \/>/)
   assert.ok((appLayout.match(/@click="retryProviderBindings"/g) ?? []).length >= 3)
   assert.match(appLayout, /providerBindingsStale = computed\(\(\) => providersStore\.bindingsStale\)/)
   assert.match(appLayout, /const contextStatus = computed<ContextStatus>/)
@@ -264,6 +268,32 @@ test('shell recovery and context status are present without claiming uncondition
   assert.doesNotMatch(appLayout, /shell-context-status[\s\S]{0,120}text-\[(?:7|8|9)px\] font-semibold uppercase tracking-widest/)
   assert.match(appLayout, /@media \(pointer: coarse\)/)
   assert.match(appLayout, /min-height: 44px/)
+})
+
+test('help modal prioritizes docs and keeps community support accessible', () => {
+  assert.match(helpSupportModal, /const docsURL = 'https:\/\/faros\.sh\/docs\/'/)
+  assert.match(helpSupportModal, /const discordURL = 'https:\/\/discord\.gg\/VjUA7zyhC'/)
+  assert.match(helpSupportModal, /const issuesURL = 'https:\/\/github\.com\/faroshq\/faros\/issues'/)
+  assert.match(helpSupportModal, /role="dialog"/)
+  assert.match(helpSupportModal, /id="help-support-dialog"/)
+  assert.match(helpSupportModal, /aria-modal="true"/)
+  assert.match(helpSupportModal, /aria-labelledby="help-support-title"/)
+  assert.match(helpSupportModal, /aria-describedby="help-support-description"/)
+  assert.match(helpSupportModal, /@click\.self="\$emit\('close'\)"/)
+  assert.match(helpSupportModal, /useEscapeKey\(\(\) => emit\('close'\)\)/)
+  assert.match(helpSupportModal, /nextTick\(\(\) => closeButton\.value\?\.focus\(\)\)/)
+  assert.match(helpSupportModal, /nextTick\(\(\) => target\?\.isConnected && target\.focus\(\)\)/)
+  assert.match(helpSupportModal, /event\.shiftKey && document\.activeElement === first/)
+  assert.match(helpSupportModal, /!event\.shiftKey && document\.activeElement === last/)
+
+  const docs = helpSupportModal.indexOf('Documentation')
+  const secondary = helpSupportModal.indexOf('More ways to get help')
+  const discord = helpSupportModal.indexOf('Discord community')
+  const issues = helpSupportModal.indexOf('GitHub issues')
+  assert.ok(docs >= 0 && docs < secondary && secondary < discord && discord < issues)
+  assert.equal((helpSupportModal.match(/target="_blank"/g) ?? []).length, 3)
+  assert.equal((helpSupportModal.match(/rel="noreferrer noopener"/g) ?? []).length, 3)
+  assert.doesNotMatch(helpSupportModal, /systems operational|Contact support|Troubleshooting/)
 })
 
 test('dock movement is learnable and account actions name the resulting placement', () => {

--- a/portal/src/components/AppLayout.vue
+++ b/portal/src/components/AppLayout.vue
@@ -8,11 +8,12 @@ import { useSidebarExpansion } from '@/composables/useSidebarExpansion'
 import { useNavigationDock } from '@/composables/useNavigationDock'
 import { useDelayedLoading } from '@/portalkit/useDelayedLoading'
 import CliQuickstartModal from '@/components/CliQuickstartModal.vue'
+import HelpSupportModal from '@/components/HelpSupportModal.vue'
 import AccountAccessMenu from '@/components/AccountAccessMenu.vue'
 import ProviderNavOverflow from '@/components/ProviderNavOverflow.vue'
 import WorkspaceSwitcher from '@/components/WorkspaceSwitcher.vue'
 import FirstWorkspaceWizard from '@/components/FirstWorkspaceWizard.vue'
-import { Hexagon, LayoutDashboard, GripHorizontal, GripVertical, Puzzle, Dot, PanelLeftClose, PanelLeftOpen, ChevronDown, CircleHelp, ExternalLink, Loader2, RefreshCw, CircleAlert } from 'lucide-vue-next'
+import { Hexagon, LayoutDashboard, GripHorizontal, GripVertical, Puzzle, Dot, PanelLeftClose, PanelLeftOpen, ChevronDown, CircleHelp, Loader2, RefreshCw, CircleAlert } from 'lucide-vue-next'
 import { useProvidersStore } from '@/stores/providers'
 import { useAdminStore } from '@/stores/admin'
 import { categoryIcons, fallbackCategoryIcon } from '@/lib/categoryIcons'
@@ -244,6 +245,7 @@ function retryWorkspaceHydration() {
 }
 
 const showCliModal = ref(false)
+const showHelpModal = ref(false)
 
 // --- Collapsible sidebar rail ---
 // The vertical dock defaults to a 56px icon rail so the canvas isn't taxed by
@@ -758,19 +760,20 @@ const contextStatus = computed<ContextStatus>(() => {
 
       <div class="mx-2 my-2 h-px bg-border-default/50" />
 
-      <a
-        href="https://faros.sh/docs/"
-        target="_blank"
-        rel="noreferrer noopener"
-        aria-label="Help — open Faros documentation"
+      <button
+        type="button"
+        aria-label="Open help and community"
+        aria-haspopup="dialog"
+        aria-controls="help-support-dialog"
+        :aria-expanded="showHelpModal"
         class="shell-help mb-2 flex items-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
         :class="sidebarExpanded ? 'w-full gap-2 px-2.5 py-2' : 'h-8 w-8 justify-center p-0'"
         :title="sidebarExpanded ? undefined : 'Help'"
+        @click="showHelpModal = true"
       >
         <CircleHelp class="h-4 w-4 shrink-0" :stroke-width="1.75" aria-hidden="true" />
         <span v-if="sidebarExpanded" class="text-[11px] font-medium">Help</span>
-        <ExternalLink v-if="sidebarExpanded" class="ml-auto h-3 w-3 text-text-secondary" :stroke-width="1.75" aria-hidden="true" />
-      </a>
+      </button>
 
       <!-- Identity, access, and the infrequent organization context share one
            account flyout. Workspace remains the separate operating control. -->
@@ -888,17 +891,19 @@ const contextStatus = computed<ContextStatus>(() => {
           <RefreshCw class="h-3 w-3" :class="providerBindingState === 'loading' ? 'animate-spin' : ''" :stroke-width="1.75" aria-hidden="true" />
         </button>
       </div>
-      <a
-        href="https://faros.sh/docs/"
-        target="_blank"
-        rel="noreferrer noopener"
-        aria-label="Help — open Faros documentation"
+      <button
+        type="button"
+        aria-label="Open help and community"
+        aria-haspopup="dialog"
+        aria-controls="help-support-dialog"
+        :aria-expanded="showHelpModal"
         class="shell-help flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
         title="Help"
+        @click="showHelpModal = true"
       >
         <CircleHelp class="h-4 w-4 shrink-0" :stroke-width="1.75" aria-hidden="true" />
         <span class="hidden xl:inline text-[10px] font-medium">Help</span>
-      </a>
+      </button>
       <AccountAccessMenu
         :show-platform-admin="adminStore.isAdmin === true"
         :show-undock="dockState.mode !== 'float'"
@@ -1073,17 +1078,19 @@ const contextStatus = computed<ContextStatus>(() => {
             <RefreshCw class="h-3 w-3" :class="providerBindingState === 'loading' ? 'animate-spin' : ''" :stroke-width="1.75" aria-hidden="true" />
           </button>
         </div>
-        <a
-          href="https://faros.sh/docs/"
-          target="_blank"
-          rel="noreferrer noopener"
-          aria-label="Help — open Faros documentation"
+        <button
+          type="button"
+          aria-label="Open help and community"
+          aria-haspopup="dialog"
+          aria-controls="help-support-dialog"
+          :aria-expanded="showHelpModal"
           class="shell-help flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
           title="Help"
+          @click="showHelpModal = true"
         >
           <CircleHelp class="h-4 w-4 shrink-0" :stroke-width="1.75" aria-hidden="true" />
           <span class="hidden 2xl:inline text-[10px] font-medium">Help</span>
-        </a>
+        </button>
         <AccountAccessMenu
           :show-platform-admin="adminStore.isAdmin === true"
           :show-undock="hasCustomPos && !isDragging"
@@ -1097,6 +1104,7 @@ const contextStatus = computed<ContextStatus>(() => {
 
     <!-- CLI quickstart modal -->
     <CliQuickstartModal v-if="showCliModal" @close="showCliModal = false" />
+    <HelpSupportModal v-if="showHelpModal" @close="showHelpModal = false" />
 
   </div>
 </template>

--- a/portal/src/components/HelpSupportModal.vue
+++ b/portal/src/components/HelpSupportModal.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { BookOpen, CircleHelp, ExternalLink, Github, MessageCircle, X } from 'lucide-vue-next'
+import { useEscapeKey } from '@/composables/useEscapeKey'
+
+const emit = defineEmits<{ close: [] }>()
+
+const docsURL = 'https://faros.sh/docs/'
+const discordURL = 'https://discord.gg/VjUA7zyhC'
+const issuesURL = 'https://github.com/faroshq/faros/issues'
+
+useEscapeKey(() => emit('close'))
+
+const dialogRef = ref<HTMLElement | null>(null)
+const closeButton = ref<HTMLButtonElement | null>(null)
+let previousFocus: HTMLElement | null = null
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key !== 'Tab') return
+  const focusable = Array.from(dialogRef.value?.querySelectorAll<HTMLElement>(
+    'button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])',
+  ) ?? [])
+  if (!focusable.length) return
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+onMounted(() => {
+  previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
+  window.addEventListener('keydown', onKeydown)
+  nextTick(() => closeButton.value?.focus())
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown)
+  const target = previousFocus
+  previousFocus = null
+  nextTick(() => target?.isConnected && target.focus())
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="k-modal-overlay" @click.self="$emit('close')">
+      <section
+        id="help-support-dialog"
+        ref="dialogRef"
+        class="k-modal w-full max-w-xl max-h-[90vh] overflow-y-auto p-0"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="help-support-title"
+        aria-describedby="help-support-description"
+      >
+        <header class="flex items-center gap-3 border-b border-border-subtle bg-surface-overlay/60 px-4 py-3.5 sm:px-5">
+          <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-accent/30 bg-accent-subtle text-accent" aria-hidden="true">
+            <CircleHelp class="h-[18px] w-[18px]" :stroke-width="1.75" />
+          </span>
+          <div class="min-w-0 flex-1">
+            <h2 id="help-support-title" class="text-[15px] font-bold text-text-primary">Help &amp; community</h2>
+            <p id="help-support-description" class="mt-0.5 text-[11px] leading-relaxed text-text-secondary">
+              Find an answer, ask the community, or report a problem.
+            </p>
+          </div>
+          <button
+            ref="closeButton"
+            type="button"
+            class="k-btn k-btn--ghost flex h-8 w-8 shrink-0 items-center justify-center p-0 text-text-muted transition-colors hover:text-text-primary"
+            aria-label="Close help and community dialog"
+            @click="$emit('close')"
+          >
+            <X class="h-4 w-4" :stroke-width="2" aria-hidden="true" />
+          </button>
+        </header>
+
+        <div class="p-4 sm:p-5">
+          <a
+            :href="docsURL"
+            target="_blank"
+            rel="noreferrer noopener"
+            class="group grid min-h-[92px] grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-lg border border-accent/30 bg-accent-subtle/60 p-3.5 text-left transition-colors hover:border-accent/50 hover:bg-accent-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 sm:grid-cols-[auto_minmax(0,1fr)_auto]"
+          >
+            <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-accent text-on-accent" aria-hidden="true">
+              <BookOpen class="h-[18px] w-[18px]" :stroke-width="1.75" />
+            </span>
+            <span class="min-w-0">
+              <span class="block text-[12px] font-semibold text-text-primary">Documentation</span>
+              <span class="mt-0.5 block text-[11px] leading-relaxed text-text-secondary">
+                Guides, setup, CLI reference, providers, and architecture.
+              </span>
+            </span>
+            <span class="col-start-2 flex items-center gap-1.5 text-[10px] font-semibold text-accent-hover sm:col-start-auto">
+              Explore docs
+              <ExternalLink class="h-3 w-3" :stroke-width="2" aria-hidden="true" />
+            </span>
+          </a>
+
+          <div class="my-4 flex items-center gap-2 font-mono text-[9px] font-medium uppercase tracking-[0.15em] text-text-muted after:h-px after:flex-1 after:bg-border-subtle">
+            More ways to get help
+          </div>
+
+          <div class="overflow-hidden rounded-lg border border-border-subtle bg-surface-overlay/40">
+            <a
+              :href="discordURL"
+              target="_blank"
+              rel="noreferrer noopener"
+              class="group grid min-h-[78px] grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 p-3.5 transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/30"
+            >
+              <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay text-text-secondary" aria-hidden="true">
+                <MessageCircle class="h-[18px] w-[18px]" :stroke-width="1.75" />
+              </span>
+              <span class="min-w-0">
+                <span class="block text-[12px] font-semibold text-text-primary">Discord community</span>
+                <span class="mt-0.5 block text-[11px] leading-relaxed text-text-secondary">
+                  Ask questions and compare approaches with people building Faros.
+                </span>
+              </span>
+              <span class="flex items-center gap-1.5 text-[10px] font-semibold text-text-secondary transition-colors group-hover:text-text-primary">
+                <span class="hidden sm:inline">Join Discord</span>
+                <ExternalLink class="h-3 w-3" :stroke-width="2" aria-hidden="true" />
+              </span>
+            </a>
+
+            <a
+              :href="issuesURL"
+              target="_blank"
+              rel="noreferrer noopener"
+              class="group grid min-h-[78px] grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 border-t border-border-subtle p-3.5 transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/30"
+            >
+              <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay text-text-secondary" aria-hidden="true">
+                <Github class="h-[18px] w-[18px]" :stroke-width="1.75" />
+              </span>
+              <span class="min-w-0">
+                <span class="block text-[12px] font-semibold text-text-primary">GitHub issues</span>
+                <span class="mt-0.5 block text-[11px] leading-relaxed text-text-secondary">
+                  Search known problems or file a reproducible issue.
+                </span>
+              </span>
+              <span class="flex items-center gap-1.5 text-[10px] font-semibold text-text-secondary transition-colors group-hover:text-text-primary">
+                <span class="hidden sm:inline">Browse issues</span>
+                <ExternalLink class="h-3 w-3" :stroke-width="2" aria-hidden="true" />
+              </span>
+            </a>
+          </div>
+        </div>
+
+      </section>
+    </div>
+  </Teleport>
+</template>

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -26,7 +26,6 @@ import {
   PanelLeft,
   PanelRight,
   Plus,
-  RefreshCw,
   Search,
   Send,
   Settings2,
@@ -135,6 +134,7 @@ import ModelPicker from './ModelPicker.vue'
 import AssistantRichComposer from './AssistantRichComposer.vue'
 import AssistantMessageQueue from './AssistantMessageQueue.vue'
 import AssistantMessageAnnotations from './AssistantMessageAnnotations.vue'
+import DevelopmentPreviewToolbar from './DevelopmentPreviewToolbar.vue'
 import {
   ASSISTANT_MESSAGE_QUEUE_MAX_ITEMS,
   assistantMessageQueueStorageKey,
@@ -9075,58 +9075,20 @@ function isMissingCodeConnectionError(value: string | null): boolean {
         :aria-labelledby="workbenchTabControlID(activeWorkbenchTab)"
       >
         <div class="flex h-full min-h-[420px] flex-col gap-3">
-          <div class="flex min-w-0 items-center justify-between gap-3">
-            <div class="flex min-w-0 items-center gap-2">
-              <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay">
-                <AppWindow class="h-4 w-4 text-accent" :stroke-width="1.75" />
-              </div>
-              <div class="min-w-0">
-                <div class="truncate text-[13px] font-semibold text-text-primary">Development</div>
-                <div class="truncate text-[12px] text-text-muted">{{ developmentBinding?.provider || 'app-studio' }}</div>
-              </div>
-              <StatusBadge :status="developmentPreviewPhase" />
-            </div>
-            <div class="ml-auto flex shrink-0 items-center gap-2">
-              <button
-                type="button"
-                class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border px-3 text-[12px] font-medium transition disabled:cursor-not-allowed disabled:opacity-60"
-                :class="developmentPreviewAnnotationMode
-                  ? 'border-accent/40 bg-accent-subtle text-accent'
-                  : 'border-border-subtle bg-surface text-text-secondary hover:bg-surface-hover hover:text-text-primary'"
-                :disabled="messageStreaming || !developmentPreviewCanAnnotate"
-                :aria-pressed="developmentPreviewAnnotationMode"
-                :title="developmentPreviewCanAnnotate ? (developmentPreviewAnnotationMode ? 'Stop annotating' : 'Annotate preview') : 'Annotation becomes available when the preview connects'"
-                @click="toggleDevelopmentPreviewAnnotation"
-              >
-                <span class="relative h-3.5 w-3.5 shrink-0">
-                  <MessageSquare class="h-3.5 w-3.5" :stroke-width="1.75" />
-                  <Plus class="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-accent p-px text-on-accent" :stroke-width="2.5" />
-                </span>
-                {{ developmentPreviewAnnotationMode ? 'Annotating' : 'Annotate' }}
-              </button>
-              <button
-                type="button"
-                class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-border-subtle bg-surface px-3 text-[12px] font-medium text-text-secondary transition hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
-                :disabled="!selected || !developmentBinding || messageStreaming || developmentSyncBusy"
-                title="Sync"
-                @click="syncDevelopmentPreview"
-              >
-                <Loader2 v-if="developmentSyncBusy" class="h-3.5 w-3.5 animate-spin" :stroke-width="1.75" />
-                <RefreshCw v-else class="h-3.5 w-3.5" :stroke-width="1.75" />
-                Sync
-              </button>
-              <button
-                type="button"
-                class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-border-subtle bg-surface px-3 text-[12px] font-medium text-text-secondary transition hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
-                :disabled="!selected || !developmentBinding || !developmentPreviewCanOpenInBrowser"
-                title="Open a separate browser tab for the development preview"
-                @click="openDevelopmentPreviewInBrowser"
-              >
-                <ExternalLink class="h-3.5 w-3.5" :stroke-width="1.75" />
-                {{ developmentPreviewOpenButtonLabel }}
-              </button>
-            </div>
-          </div>
+          <DevelopmentPreviewToolbar
+            :provider="developmentBinding?.provider || 'app-studio'"
+            :phase="developmentPreviewPhase"
+            :annotation-mode="developmentPreviewAnnotationMode"
+            :annotation-available="developmentPreviewCanAnnotate"
+            :annotation-disabled="messageStreaming || !developmentPreviewCanAnnotate"
+            :sync-busy="developmentSyncBusy"
+            :sync-disabled="!selected || !developmentBinding || messageStreaming || developmentSyncBusy"
+            :open-disabled="!selected || !developmentBinding || !developmentPreviewCanOpenInBrowser"
+            :open-label="developmentPreviewOpenButtonLabel"
+            @annotate="toggleDevelopmentPreviewAnnotation"
+            @sync="syncDevelopmentPreview"
+            @open-browser="openDevelopmentPreviewInBrowser"
+          />
           <div v-if="developmentSyncError || developmentPreviewAuthorizationError" class="rounded-md border border-danger/30 bg-danger-subtle p-3 text-[12px] text-danger" role="alert" aria-live="assertive" aria-atomic="true">
             {{ developmentSyncError || developmentPreviewAuthorizationError }}
           </div>

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -683,10 +683,7 @@ const pendingFollowUp = computed<PendingFollowUpView | null>(() => {
 const hasPendingReview = computed(() => pendingFollowUp.value !== null || pendingApproval.value !== null)
 const loading = ref(true)
 const projectsLoaded = ref(false)
-const projectInitialPending = computed(() =>
-  (loading.value || !projectsLoaded.value) && projects.value.length === 0,
-)
-const showProjectInitialLoading = useDelayedLoading(projectInitialPending)
+const emptyProjectRedirectPending = ref(false)
 const projectOpenLoading = ref(false)
 const threadHistoryLoading = ref(false)
 const selectingThreadID = ref('')
@@ -1463,6 +1460,12 @@ const isProjectIndexRoute = computed(() => routeSegment.value === '')
 const isCreateRoute = computed(() => routeSegment.value === CREATE_PROJECT_ROUTE)
 const isModelsRoute = computed(() => routeSegment.value === MODELS_ROUTE)
 const isCreateModelRoute = computed(() => routePath.value === CREATE_MODEL_ROUTE)
+const projectIndexRoutePending = computed(() =>
+  isProjectIndexRoute.value &&
+  projects.value.length === 0 &&
+  (loading.value || !projectsLoaded.value || emptyProjectRedirectPending.value),
+)
+const showProjectIndexRouteLoading = useDelayedLoading(projectIndexRoutePending)
 const selectedNameFromPath = computed(() => (isCreateRoute.value || isModelsRoute.value || isCreateModelRoute.value ? '' : routeSegment.value))
 const isAppStudioLandingRoute = computed(() => isProjectIndexRoute.value || isCreateRoute.value || isModelsRoute.value || isCreateModelRoute.value)
 const modelsReturnRoute = ref('')
@@ -2654,6 +2657,7 @@ onBeforeUnmount(() => {
 
 async function load() {
   const requestGuard = beginProjectRequest()
+  emptyProjectRedirectPending.value = false
   // Invalidate every assistant-thread operation before resetting its visible
   // latches. The request/context guards keep late responses harmless while a
   // replacement load establishes the new project/thread state.
@@ -2725,6 +2729,10 @@ async function load() {
       return
     }
     if (visibleProjectList.length === 0) {
+      // Keep the unresolved index behind the neutral loading gate until the
+      // host commits the canonical create route. Without this latch Vue can
+      // paint one empty Projects frame between list settlement and routing.
+      emptyProjectRedirectPending.value = true
       activeProjectContextFingerprint = ''
       resetProjectOpenLatch()
       resetThreadHistoryLatch()
@@ -2735,7 +2743,7 @@ async function load() {
       selected.value = null
       messages.value = []
       resetWorkbench()
-      props.navigate(CREATE_PROJECT_ROUTE)
+      props.navigate(CREATE_PROJECT_ROUTE, { replace: true })
       return
     }
     const pathName = selectedNameFromPath.value
@@ -7662,6 +7670,19 @@ function isMissingCodeConnectionError(value: string | null): boolean {
     </div>
   </div>
 
+  <div v-else-if="projectIndexRoutePending" class="min-h-0 bg-surface text-text-primary">
+    <div
+      v-if="showProjectIndexRouteLoading"
+      class="k-delayed-loading flex min-h-[260px] items-center justify-center gap-2 text-[13px] text-text-muted"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <Loader2 class="h-4 w-4 animate-spin text-accent" :stroke-width="1.75" aria-hidden="true" />
+      <span>Loading App Studio…</span>
+    </div>
+  </div>
+
   <div v-else-if="!isBuilderVisible" class="min-h-0 bg-surface text-text-primary">
     <div class="flex min-h-full w-full flex-col gap-4">
       <Tabs
@@ -7734,26 +7755,7 @@ function isMissingCodeConnectionError(value: string | null): boolean {
         </div>
 
         <template v-if="projectLayout === 'grid'">
-          <div
-            v-if="projectInitialPending"
-            class="k-delayed-loading grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-5 pb-8"
-            :role="showProjectInitialLoading ? 'status' : undefined"
-            :aria-live="showProjectInitialLoading ? 'polite' : undefined"
-            :aria-busy="showProjectInitialLoading ? 'true' : undefined"
-            :aria-hidden="showProjectInitialLoading ? undefined : 'true'"
-          >
-            <article v-for="skeleton in 6" :key="skeleton" class="overflow-hidden rounded-lg border border-border-subtle bg-surface-raised" aria-hidden="true">
-              <div class="shimmer aspect-[16/9] border-b border-border-subtle bg-surface" />
-              <div class="grid gap-2 p-3">
-                <div class="shimmer h-4 w-2/3 rounded bg-surface-overlay" />
-                <div class="shimmer h-3 w-full rounded bg-surface-overlay" />
-                <div class="shimmer h-3 w-4/5 rounded bg-surface-overlay" />
-                <div class="shimmer mt-2 h-3 w-1/3 rounded bg-surface-overlay" />
-              </div>
-            </article>
-          </div>
-
-          <div v-else-if="filteredProjects.length" class="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-5 pb-8">
+          <div v-if="filteredProjects.length" class="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-5 pb-8">
             <article
               v-for="project in filteredProjects"
               :key="`${project.name}:${project.uid ?? ''}`"

--- a/providers/app-studio/portal/src/DevelopmentPreviewToolbar.vue
+++ b/providers/app-studio/portal/src/DevelopmentPreviewToolbar.vue
@@ -1,0 +1,261 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  AppWindow,
+  Ellipsis,
+  ExternalLink,
+  Loader2,
+  MessageSquare,
+  Plus,
+  RefreshCw,
+} from 'lucide-vue-next'
+import StatusBadge from './portalkit/StatusBadge.vue'
+import { previewToolbarLayout } from './previewToolbarLayout'
+
+const props = defineProps<{
+  provider: string
+  phase: string
+  annotationMode: boolean
+  annotationAvailable: boolean
+  annotationDisabled: boolean
+  syncBusy: boolean
+  syncDisabled: boolean
+  openDisabled: boolean
+  openLabel: string
+}>()
+
+const emit = defineEmits<{
+  annotate: []
+  sync: []
+  openBrowser: []
+}>()
+
+const root = ref<HTMLElement | null>(null)
+const overflowTrigger = ref<HTMLButtonElement | null>(null)
+const overflowMenu = ref<HTMLElement | null>(null)
+const overflowOpen = ref(false)
+const toolbarWidth = ref(0)
+const layout = computed(() => previewToolbarLayout(toolbarWidth.value))
+let toolbarResizeObserver: ResizeObserver | undefined
+
+function syncToolbarWidth(width = root.value?.getBoundingClientRect().width ?? 0): void {
+  toolbarWidth.value = width
+}
+
+function closeOverflow(restoreFocus = false): void {
+  if (!overflowOpen.value) return
+  overflowOpen.value = false
+  if (restoreFocus) void nextTick(() => overflowTrigger.value?.focus())
+}
+
+function openOverflow(focusMenu = false): void {
+  overflowOpen.value = true
+  if (!focusMenu) return
+  void nextTick(() => {
+    overflowMenu.value
+      ?.querySelector<HTMLButtonElement>('[role^="menuitem"]:not(:disabled)')
+      ?.focus()
+  })
+}
+
+function toggleOverflow(): void {
+  if (overflowOpen.value) closeOverflow()
+  else openOverflow()
+}
+
+function runAnnotation(): void {
+  if (props.annotationDisabled) return
+  emit('annotate')
+  closeOverflow(true)
+}
+
+function runSync(): void {
+  if (props.syncDisabled) return
+  emit('sync')
+  closeOverflow(true)
+}
+
+function runOpenBrowser(): void {
+  if (props.openDisabled) return
+  emit('openBrowser')
+  closeOverflow(true)
+}
+
+function handleDocumentPointerDown(event: PointerEvent): void {
+  if (!overflowOpen.value || root.value?.contains(event.target as Node)) return
+  closeOverflow()
+}
+
+function handleFocusOut(event: FocusEvent): void {
+  const next = event.relatedTarget
+  if (next instanceof Node && root.value?.contains(next)) return
+  closeOverflow()
+}
+
+function handleMenuKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    closeOverflow(true)
+    return
+  }
+  if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return
+  const items = Array.from(
+    overflowMenu.value?.querySelectorAll<HTMLButtonElement>('[role^="menuitem"]:not(:disabled)') ?? [],
+  ).filter((item) => item.offsetParent !== null)
+  if (!items.length) return
+  const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement)
+  let nextIndex = 0
+  if (event.key === 'End') nextIndex = items.length - 1
+  else if (event.key === 'ArrowUp') nextIndex = currentIndex <= 0 ? items.length - 1 : currentIndex - 1
+  else if (event.key === 'ArrowDown') nextIndex = currentIndex < 0 || currentIndex === items.length - 1 ? 0 : currentIndex + 1
+  event.preventDefault()
+  event.stopPropagation()
+  items[nextIndex]?.focus()
+}
+
+onMounted(() => {
+  document.addEventListener('pointerdown', handleDocumentPointerDown)
+  syncToolbarWidth()
+  if (typeof ResizeObserver !== 'undefined' && root.value) {
+    toolbarResizeObserver = new ResizeObserver((entries) => {
+      syncToolbarWidth(entries[0]?.contentRect.width)
+      closeOverflow()
+    })
+    toolbarResizeObserver.observe(root.value)
+  }
+})
+
+onBeforeUnmount(() => {
+  toolbarResizeObserver?.disconnect()
+  document.removeEventListener('pointerdown', handleDocumentPointerDown)
+})
+</script>
+
+<template>
+  <header
+    ref="root"
+    class="preview-toolbar flex min-w-0 items-center justify-between gap-3"
+    :data-preview-toolbar-layout="layout"
+    @focusout="handleFocusOut"
+  >
+    <div class="preview-toolbar__identity flex min-w-0 items-center gap-2">
+      <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface-overlay">
+        <AppWindow class="h-4 w-4 text-accent" :stroke-width="1.75" aria-hidden="true" />
+      </div>
+      <div class="min-w-0">
+        <div class="truncate text-[13px] font-semibold text-text-primary">Development</div>
+        <div v-if="layout !== 'collapsed'" class="preview-toolbar__identity-meta truncate text-[12px] text-text-muted">{{ provider }}</div>
+      </div>
+      <StatusBadge class="shrink-0" :status="phase" />
+    </div>
+
+    <div class="ml-auto flex shrink-0 items-center gap-2">
+      <button
+        v-if="layout !== 'collapsed'"
+        type="button"
+        class="preview-toolbar__primary-action inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-60"
+        :class="annotationMode
+          ? 'border-accent/40 bg-accent-subtle text-accent'
+          : 'border-border-subtle bg-surface text-text-secondary hover:bg-surface-hover hover:text-text-primary'"
+        :disabled="annotationDisabled"
+        :aria-pressed="annotationMode"
+        :aria-label="annotationMode ? 'Stop annotating' : 'Annotate preview'"
+        :data-k-tip="annotationAvailable ? (annotationMode ? 'Stop annotating' : 'Annotate preview') : 'Annotation becomes available when the preview connects'"
+        @click="runAnnotation"
+      >
+        <span class="relative h-3.5 w-3.5 shrink-0">
+          <MessageSquare class="h-3.5 w-3.5" :stroke-width="1.75" aria-hidden="true" />
+          <Plus class="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-accent p-px text-on-accent" :stroke-width="2.5" aria-hidden="true" />
+        </span>
+      </button>
+
+      <button
+        v-if="layout === 'expanded'"
+        type="button"
+        class="preview-toolbar__secondary-action inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface text-text-secondary transition hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-60"
+        :disabled="syncDisabled"
+        :aria-label="syncBusy ? 'Syncing preview' : 'Sync preview'"
+        :data-k-tip="syncBusy ? 'Syncing preview…' : 'Sync preview'"
+        @click="runSync"
+      >
+        <Loader2 v-if="syncBusy" class="h-3.5 w-3.5 animate-spin" :stroke-width="1.75" aria-hidden="true" />
+        <RefreshCw v-else class="h-3.5 w-3.5" :stroke-width="1.75" aria-hidden="true" />
+      </button>
+
+      <button
+        v-if="layout === 'expanded'"
+        type="button"
+        class="preview-toolbar__secondary-action inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border-subtle bg-surface text-text-secondary transition hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-60"
+        :disabled="openDisabled"
+        :aria-label="openLabel"
+        :data-k-tip="openLabel"
+        @click="runOpenBrowser"
+      >
+        <ExternalLink class="h-3.5 w-3.5" :stroke-width="1.75" aria-hidden="true" />
+      </button>
+
+      <div v-if="layout !== 'expanded'" class="preview-toolbar__overflow relative shrink-0">
+        <button
+          ref="overflowTrigger"
+          type="button"
+          class="flex h-7 w-7 items-center justify-center rounded-md border border-border-subtle bg-surface text-text-secondary transition hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          data-k-tip="More preview actions"
+          aria-label="More preview actions"
+          aria-haspopup="menu"
+          :aria-expanded="overflowOpen"
+          @click.stop="toggleOverflow"
+          @keydown.down.stop.prevent="openOverflow(true)"
+        >
+          <Ellipsis class="h-4 w-4" :stroke-width="1.75" aria-hidden="true" />
+        </button>
+
+        <div
+          v-if="overflowOpen"
+          ref="overflowMenu"
+          class="absolute right-0 top-10 z-50 w-52 rounded-md border border-border-default bg-surface-overlay p-1 shadow-xl"
+          role="menu"
+          aria-label="Preview actions"
+          @keydown="handleMenuKeydown"
+        >
+          <button
+            v-if="layout === 'collapsed'"
+            type="button"
+            role="menuitemcheckbox"
+            class="preview-toolbar__overflow-annotation flex w-full items-center gap-2 rounded-sm px-2.5 py-2 text-left text-[12px] text-text-secondary transition hover:bg-surface-hover hover:text-text-primary focus:bg-surface-hover focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="annotationDisabled"
+            :aria-checked="annotationMode"
+            @click="runAnnotation"
+          >
+            <span class="relative h-3.5 w-3.5 shrink-0">
+              <MessageSquare class="h-3.5 w-3.5" :stroke-width="1.75" aria-hidden="true" />
+              <Plus class="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-accent p-px text-on-accent" :stroke-width="2.5" aria-hidden="true" />
+            </span>
+            {{ annotationMode ? 'Stop annotating' : 'Annotate preview' }}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            class="flex w-full items-center gap-2 rounded-sm px-2.5 py-2 text-left text-[12px] text-text-secondary transition hover:bg-surface-hover hover:text-text-primary focus:bg-surface-hover focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="syncDisabled"
+            @click="runSync"
+          >
+            <Loader2 v-if="syncBusy" class="h-3.5 w-3.5 animate-spin" :stroke-width="1.75" aria-hidden="true" />
+            <RefreshCw v-else class="h-3.5 w-3.5" :stroke-width="1.75" aria-hidden="true" />
+            {{ syncBusy ? 'Syncing preview…' : 'Sync preview' }}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            class="flex w-full items-center gap-2 rounded-sm px-2.5 py-2 text-left text-[12px] text-text-secondary transition hover:bg-surface-hover hover:text-text-primary focus:bg-surface-hover focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="openDisabled"
+            @click="runOpenBrowser"
+          >
+            <ExternalLink class="h-3.5 w-3.5" :stroke-width="1.75" aria-hidden="true" />
+            {{ openLabel }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </header>
+</template>

--- a/providers/app-studio/portal/src/conversationResilience.test.mjs
+++ b/providers/app-studio/portal/src/conversationResilience.test.mjs
@@ -188,7 +188,7 @@ test('App keeps central loading surfaces honest while project state hydrates', a
   assert.match(appSource, /Connecting to preview…/)
   assert.match(appSource, /const assistantComposerStopControl = computed\(\(\) => assistantComposerStopControlState\(/)
   assert.match(appSource, /Loading provider catalog…/)
-  assert.match(appSource, /class="shimmer aspect-\[16\/9\]/)
+  assert.match(appSource, /v-else-if="projectIndexRoutePending"[\s\S]*Loading App Studio…/)
   assert.match(appSource, /:busy-action="publishingBusyAction"[\s\S]*:busy-target="publishingBusyTarget \?\? undefined"/)
 })
 

--- a/providers/app-studio/portal/src/portalConformance.test.mjs
+++ b/providers/app-studio/portal/src/portalConformance.test.mjs
@@ -38,15 +38,21 @@ test('keeps dashboard tile snapshots visible across background refresh failures'
   assert.match(dashboardTile, /generation !== contextGeneration/)
 })
 
-test('keeps project search and creation controls mounted during the initial list read', () => {
-  const headerStart = app.indexOf('<header v-if="isProjectIndexRoute"')
-  const galleryStart = app.indexOf('v-if="projectInitialPending"', headerStart)
-  assert.ok(headerStart >= 0 && galleryStart > headerStart)
-  const controls = app.slice(headerStart, galleryStart)
-  assert.match(controls, />\s*New project\s*</)
-  assert.match(controls, /placeholder="Search"/)
-  assert.doesNotMatch(controls, /v-if="projectsLoaded && projects\.length > 0"/)
-  assert.match(controls, /:disabled="loading \|\| !projectsLoaded"/)
+test('keeps the project index unpainted until the empty-project route decision settles', () => {
+  assert.match(app, /const projectIndexRoutePending = computed\(\(\) =>[\s\S]*isProjectIndexRoute\.value[\s\S]*projects\.value\.length === 0[\s\S]*emptyProjectRedirectPending\.value/)
+
+  const routeGateStart = app.indexOf('<div v-else-if="projectIndexRoutePending"')
+  const landingStart = app.indexOf('<div v-else-if="!isBuilderVisible"', routeGateStart)
+  assert.ok(routeGateStart >= 0 && landingStart > routeGateStart)
+  const routeGate = app.slice(routeGateStart, landingStart)
+  assert.match(routeGate, /v-if="showProjectIndexRouteLoading"/)
+  assert.match(routeGate, /Loading App Studio…/)
+  assert.doesNotMatch(routeGate, />Projects</)
+
+  const emptyListStart = app.indexOf('if (visibleProjectList.length === 0)')
+  const pathStart = app.indexOf('const pathName = selectedNameFromPath.value', emptyListStart)
+  const emptyList = app.slice(emptyListStart, pathStart)
+  assert.ok(emptyList.indexOf('emptyProjectRedirectPending.value = true') < emptyList.indexOf("props.navigate(CREATE_PROJECT_ROUTE, { replace: true })"))
 })
 
 test('presents Projects and Models through the shared tabs surface without a generic settings action', () => {

--- a/providers/app-studio/portal/src/previewAccess.test.mjs
+++ b/providers/app-studio/portal/src/previewAccess.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
 const app = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
+const previewToolbar = await readFile(new URL('./DevelopmentPreviewToolbar.vue', import.meta.url), 'utf8')
 
 function functionSource(name, nextName) {
   const start = app.indexOf(`async function ${name}`)
@@ -28,11 +29,9 @@ test('shows development access in Project Settings only for compatible templates
   assert.match(selector, /option value="public">Anyone with link/)
   assert.match(selector, /developmentPreviewAccessBusy \|\| !developmentPreviewAccessConverged/)
 
-  const toolbarStart = app.indexOf('v-else-if="activeWorkbenchTab?.kind === \'preview\'"')
-  const toolbarEnd = app.indexOf('{{ developmentPreviewOpenButtonLabel }}', toolbarStart)
-  const toolbar = app.slice(toolbarStart, toolbarEnd)
-  assert.doesNotMatch(toolbar, /Development preview access/)
-  assert.doesNotMatch(toolbar, /developmentPreviewAccessConfigurable/)
+  assert.match(app, /<DevelopmentPreviewToolbar/)
+  assert.doesNotMatch(previewToolbar, /Development preview access/)
+  assert.doesNotMatch(previewToolbar, /developmentPreviewAccessConfigurable/)
 })
 
 test('requires confirmation before public access and not when returning to private', () => {

--- a/providers/app-studio/portal/src/previewActionsMenu.test.mjs
+++ b/providers/app-studio/portal/src/previewActionsMenu.test.mjs
@@ -1,6 +1,15 @@
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
+import ts from 'typescript'
+
+async function importTypeScriptModule(relativePath) {
+  const source = await readFile(new URL(relativePath, import.meta.url), 'utf8')
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+  })
+  return import(`data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`)
+}
 
 test('moves environment mutations out of the preview toolbar', async () => {
   const app = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
@@ -16,22 +25,68 @@ test('moves environment mutations out of the preview toolbar', async () => {
 
 test('leaves only primary preview actions visible in the toolbar', async () => {
   const source = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
+  const toolbar = await readFile(new URL('./DevelopmentPreviewToolbar.vue', import.meta.url), 'utf8')
+  const styles = await readFile(new URL('./style.css', import.meta.url), 'utf8')
   const toolbarStart = source.indexOf('v-else-if="activeWorkbenchTab?.kind === \'preview\'"')
-  const toolbar = source.slice(toolbarStart, source.indexOf('<div v-if="developmentSyncError', toolbarStart))
-  assert.match(toolbar, /developmentPreviewAnnotationMode \? 'Annotating' : 'Annotate'/)
-  assert.match(toolbar, /:aria-pressed="developmentPreviewAnnotationMode"/)
-  assert.match(toolbar, /title="Sync"/)
-  assert.match(toolbar, /developmentPreviewOpenButtonLabel/)
-  assert.doesNotMatch(toolbar, /More preview actions/)
+  const preview = source.slice(toolbarStart, source.indexOf('<div v-if="developmentSyncError', toolbarStart))
+  assert.match(preview, /<DevelopmentPreviewToolbar/)
+  assert.match(preview, /:annotation-mode="developmentPreviewAnnotationMode"/)
+  assert.match(preview, /@annotate="toggleDevelopmentPreviewAnnotation"/)
+  assert.match(preview, /@sync="syncDevelopmentPreview"/)
+  assert.match(preview, /@open-browser="openDevelopmentPreviewInBrowser"/)
+  assert.match(toolbar, /annotationMode \? 'Stop annotating' : 'Annotate preview'/)
+  assert.match(toolbar, /:aria-pressed="annotationMode"/)
+  assert.match(toolbar, /:data-k-tip="syncBusy \? 'Syncing preview…' : 'Sync preview'"/)
+  assert.match(toolbar, /:data-k-tip="openLabel"/)
+  assert.match(toolbar, /data-k-tip="More preview actions"/)
+  assert.doesNotMatch(toolbar, /after:(?:content|top|right|bottom|left|translate)/)
+  assert.match(styles, /\.preview-toolbar \[data-k-tip\]::after\s*\{[\s\S]*content: attr\(data-k-tip\);[\s\S]*inset: calc\(100% \+ 6px\) 0 auto auto;[\s\S]*transform: none;/)
+  assert.doesNotMatch(toolbar, /title="(?:Sync|Open a separate browser tab|More preview actions)"/)
+  const expandedOpenButton = toolbar.slice(
+    toolbar.indexOf(':aria-label="openLabel"'),
+    toolbar.indexOf('</button>', toolbar.indexOf(':aria-label="openLabel"')),
+  )
+  assert.match(expandedOpenButton, /<ExternalLink/)
+  assert.doesNotMatch(expandedOpenButton, /\{\{\s*openLabel\s*\}\}/)
+  assert.match(toolbar, /More preview actions/)
+  assert.match(toolbar, /role="menu"/)
+  assert.match(toolbar, /role="menuitem"/)
+  assert.match(toolbar, /aria-haspopup="menu"/)
+  assert.match(toolbar, /v-if="layout !== 'collapsed'"[\s\S]*preview-toolbar__primary-action/)
+  assert.equal((toolbar.match(/v-if="layout === 'expanded'"/g) ?? []).length, 2)
+  assert.match(toolbar, /v-if="layout !== 'expanded'" class="preview-toolbar__overflow/)
+  assert.match(toolbar, /v-if="layout === 'collapsed'"[\s\S]*role="menuitemcheckbox"/)
   assert.doesNotMatch(toolbar, /Load from Git/i)
   assert.doesNotMatch(toolbar, /aria-label="Development preview access"/)
   assert.equal((toolbar.match(/<select/g) ?? []).length, 0)
   assert.doesNotMatch(toolbar, />Switch template</)
 })
 
+test('selects one mutually exclusive preview toolbar layout from its measured width', async () => {
+  const { previewToolbarLayout } = await importTypeScriptModule('./previewToolbarLayout.ts')
+  assert.equal(previewToolbarLayout(900), 'expanded')
+  assert.equal(previewToolbarLayout(521), 'expanded')
+  assert.equal(previewToolbarLayout(520), 'compact')
+  assert.equal(previewToolbarLayout(381), 'compact')
+  assert.equal(previewToolbarLayout(380), 'collapsed')
+  assert.equal(previewToolbarLayout(0), 'collapsed')
+  assert.equal(previewToolbarLayout(Number.NaN), 'collapsed')
+})
+
+test('keeps the responsive preview overflow keyboard and pointer accessible', async () => {
+  const toolbar = await readFile(new URL('./DevelopmentPreviewToolbar.vue', import.meta.url), 'utf8')
+  assert.match(toolbar, /@keydown\.down\.stop\.prevent="openOverflow\(true\)"/)
+  assert.match(toolbar, /\['ArrowDown', 'ArrowUp', 'Home', 'End'\]/)
+  assert.match(toolbar, /event\.key === 'Escape'[\s\S]*closeOverflow\(true\)/)
+  assert.match(toolbar, /document\.addEventListener\('pointerdown', handleDocumentPointerDown\)/)
+  assert.match(toolbar, /new ResizeObserver\(\(entries\) => \{[\s\S]*syncToolbarWidth\(entries\[0\]\?\.contentRect\.width\)[\s\S]*closeOverflow\(\)/)
+  assert.match(toolbar, /document\.removeEventListener\('pointerdown', handleDocumentPointerDown\)/)
+})
+
 test('keeps annotation visible as a first-class preview action with an anchored comment editor', async () => {
   const app = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
   assert.doesNotMatch(app, /<PreviewActionsMenu/)
+  assert.match(app, /<DevelopmentPreviewToolbar/)
   assert.match(app, /const developmentPreviewAnnotationEditorStyle = computed/)
   assert.match(app, /const developmentPreviewAnnotationPinSignature = computed\(\(\) => assistantComposerParts\.value/)
   assert.match(app, /const \[validatedPart\] = projectAssistantComposerParts\(\[\{ type: 'annotation', annotation \}\]\)[\s\S]*assistantComposerParts\.value = draft\.annotationID[\s\S]*?: \[\.\.\.assistantComposerParts\.value, validatedPart\][\s\S]*syncDevelopmentPreviewAnnotationPins\(\)/)

--- a/providers/app-studio/portal/src/previewToolbarLayout.ts
+++ b/providers/app-studio/portal/src/previewToolbarLayout.ts
@@ -1,0 +1,12 @@
+export const PREVIEW_TOOLBAR_SECONDARY_COLLAPSE_WIDTH = 520
+export const PREVIEW_TOOLBAR_ALL_COLLAPSE_WIDTH = 380
+
+export type PreviewToolbarLayout = 'expanded' | 'compact' | 'collapsed'
+
+export function previewToolbarLayout(width: number): PreviewToolbarLayout {
+  if (!Number.isFinite(width) || width <= PREVIEW_TOOLBAR_ALL_COLLAPSE_WIDTH) {
+    return 'collapsed'
+  }
+  if (width <= PREVIEW_TOOLBAR_SECONDARY_COLLAPSE_WIDTH) return 'compact'
+  return 'expanded'
+}

--- a/providers/app-studio/portal/src/projectLayout.test.mjs
+++ b/providers/app-studio/portal/src/projectLayout.test.mjs
@@ -13,14 +13,13 @@ test('defaults and persists the Projects layout through the shared browser prefe
   assert.match(app, /<LayoutSelector v-model="projectLayout"[^>]*aria-label="Project layout"/)
 })
 
-test('keeps the existing gallery as the grid branch and uses table loading geometry in list mode', () => {
+test('keeps the existing gallery as the grid branch after route resolution and uses the canonical table in list mode', () => {
   const branchStart = app.indexOf('<template v-if="projectLayout === \'grid\'">')
   const listStart = app.indexOf('<ResourceTable', branchStart)
   assert.ok(branchStart >= 0 && listStart > branchStart)
 
   const grid = app.slice(branchStart, listStart)
-  assert.match(grid, /v-if="projectInitialPending"/)
-  assert.match(grid, /:aria-hidden="showProjectInitialLoading \? undefined : 'true'"/)
+  assert.doesNotMatch(grid, /projectInitialPending|showProjectInitialLoading|shimmer/)
   assert.match(grid, /v-for="project in filteredProjects"/)
   assert.match(grid, /v-if="projectThumbnailURLs\[project\.name\]"/)
   assert.match(grid, /@click="enterProject\(project\)"/)

--- a/providers/app-studio/portal/src/publishingControls.test.mjs
+++ b/providers/app-studio/portal/src/publishingControls.test.mjs
@@ -476,11 +476,11 @@ test('settles terminal project-list failures and keeps a visible Retry action', 
 
   const landingStart = app.indexOf('<div v-else-if="!isBuilderVisible"')
   const errorStart = app.indexOf('<div v-if="error && !projectDeletionError"', landingStart)
-  const skeletonStart = app.indexOf('v-if="projectInitialPending"', errorStart)
-  assert.ok(landingStart >= 0 && errorStart > landingStart && skeletonStart > errorStart)
-  const listError = app.slice(errorStart, skeletonStart)
+  const gridStart = app.indexOf('<template v-if="projectLayout === \'grid\'">', errorStart)
+  assert.ok(landingStart >= 0 && errorStart > landingStart && gridStart > errorStart)
+  const listError = app.slice(errorStart, gridStart)
   assert.ok(listError.includes('@click="load"'))
-  assert.match(app, /const projectInitialPending = computed\(\(\) =>[\s\S]*\(loading\.value \|\| !projectsLoaded\.value\) && projects\.value\.length === 0/)
+  assert.match(app, /const projectIndexRoutePending = computed\(\(\) =>[\s\S]*isProjectIndexRoute\.value[\s\S]*projects\.value\.length === 0[\s\S]*emptyProjectRedirectPending\.value/)
 })
 
 test('commits a thread selection only after history succeeds and clears the pending state', () => {

--- a/providers/app-studio/portal/src/style.css
+++ b/providers/app-studio/portal/src/style.css
@@ -32,6 +32,7 @@
 @source "./ProjectIntegrations.vue";
 @source "./portalkit/StatusBadge.vue";
 @source "./ProjectHistory.vue";
+@source "./DevelopmentPreviewToolbar.vue";
 
 @theme inline {
   /* Sharp radius scale — plain values (not host pointers), mirroring the host
@@ -89,6 +90,15 @@ faros-provider-app-studio *::after {
    layout box to the provider while remaining descendants of the scoped root. */
 faros-provider-app-studio .app-studio-overlay-root {
   display: contents;
+}
+
+/* The preview toolbar sits at the top of a scroll container. Keep its shared
+   tooltips inside that viewport without using Tailwind's after:* variants,
+   which would replace attr(data-k-tip) with an empty generated content value. */
+.preview-toolbar [data-k-tip]::after {
+  content: attr(data-k-tip);
+  inset: calc(100% + 6px) 0 auto auto;
+  transform: none;
 }
 
 @keyframes app-studio-running-ripple {


### PR DESCRIPTION
## Summary
- gate the Projects index while the initial empty-project route decision is unresolved
- hold the neutral loading surface until the host commits the create route
- replace the transient root route and update loading-state regression coverage

## Verification
- npm test
- npm run typecheck
- npm run build
- Impeccable design detector: no findings
- git diff --check