### PR TITLE
Align CI Go toolchain with go.mod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: ./.github/actions/free-disk-space
     - uses: actions/setup-go@v5
       with:
-        go-version: v1.26.1
+        go-version-file: go.mod
     - name: Build
       run: make build
 
@@ -28,7 +28,7 @@ jobs:
     - uses: ./.github/actions/free-disk-space
     - uses: actions/setup-go@v5
       with:
-        go-version: v1.26.1
+        go-version-file: go.mod
     - name: Test
       run: make test
 
@@ -39,7 +39,7 @@ jobs:
     - uses: ./.github/actions/free-disk-space
     - uses: actions/setup-go@v5
       with:
-        go-version: v1.26.1
+        go-version-file: go.mod
     - name: Lint
       run: make lint
 
@@ -71,7 +71,7 @@ jobs:
     - uses: ./.github/actions/free-disk-space
     - uses: actions/setup-go@v5
       with:
-        go-version: v1.26.1
+        go-version-file: go.mod
     - name: Verify codegen
       run: make verify-codegen
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.26.1
+          go-version-file: go.mod
 
       # These suites build the provider binaries and assert on their behaviour,
       # so they must exercise THIS commit's provider-sdk, not the last published
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.26.1
+          go-version-file: go.mod
 
       - name: Install kind
         uses: helm/kind-action@v1
@@ -148,7 +148,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.26.1
+          go-version-file: go.mod
 
       - name: Install kind
         uses: helm/kind-action@v1
@@ -208,7 +208,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.26.1
+          go-version-file: go.mod
 
       - name: Install kind
         uses: helm/kind-action@v1
@@ -279,7 +279,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.26.1
+          go-version-file: go.mod
 
       - name: Install kind
         uses: helm/kind-action@v1
@@ -351,7 +351,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.26.1
+          go-version-file: go.mod
 
       - name: Install kind
         uses: helm/kind-action@v1

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v5
       with:
-        go-version: v1.26.1
+        go-version-file: go.mod
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'
     - name: Set LDFLAGS

--- a/.github/workflows/infrastructure-templates-e2e.yaml
+++ b/.github/workflows/infrastructure-templates-e2e.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.26.1
+          go-version-file: go.mod
 
       - name: Install kind
         uses: helm/kind-action@v1

--- a/.github/workflows/tilt-e2e.yaml
+++ b/.github/workflows/tilt-e2e.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.26.1
+          go-version-file: faros/go.mod
           cache-dependency-path: faros/go.sum
 
       # Node + npm are needed by `make build-portal` (vite), which the Tilt


### PR DESCRIPTION
## Summary
- make all GitHub Actions setup-go steps read the required version from go.mod
- use faros/go.mod in the Tilt workflow's nested checkout
- prevent stale hardcoded toolchains from auto-downloading into GOMODCACHE before cache restoration

## Context
Job 99504059288 installed Go 1.26.1 while go.mod required 1.26.3. The automatic 1.26.3 toolchain download collided with setup-go's cache restore, leaving dependencies uncached; a subsequent proxy.golang.org HTTP/2 failure then stopped build-hub before the provider E2E tests ran.

## Validation
- parsed all 18 workflow YAML files
- verified all 13 setup-go version inputs now use go-version-file
- git diff --check

Failed job: https://github.com/faroshq/faros/actions/runs/33397081450/job/99504059288?pr=578