### PR TITLE
Bump multicluster-runtime so SkipNameValidation reaches controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/e2e-framework v0.6.0
 	sigs.k8s.io/kind v0.31.0
-	sigs.k8s.io/multicluster-runtime v0.24.1
+	sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -782,6 +782,8 @@ sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7
 sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/multicluster-runtime v0.24.1 h1:YlGqqk91ui0/VEXqemPd2+Z4UBmgvS2YwXaj2cItHQI=
 sigs.k8s.io/multicluster-runtime v0.24.1/go.mod h1:4+GrvEeaX0hg5MVZT02JNhF2nKZauyGhifjrkbc7yhc=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466 h1:HYYeZtY7dp5L0cQjfQyhjM0OYFw506WZeb+jgTihxas=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466/go.mod h1:il5JnZbcx4gNtmROaSm+zrXfO5/jZJQwZp1bTrx0i5g=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=

--- a/providers/app-studio/go.mod
+++ b/providers/app-studio/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/client-go v0.36.2
 	k8s.io/klog/v2 v2.140.0
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/multicluster-runtime v0.24.1
+	sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/providers/app-studio/go.sum
+++ b/providers/app-studio/go.sum
@@ -443,6 +443,8 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/multicluster-runtime v0.24.1 h1:YlGqqk91ui0/VEXqemPd2+Z4UBmgvS2YwXaj2cItHQI=
 sigs.k8s.io/multicluster-runtime v0.24.1/go.mod h1:4+GrvEeaX0hg5MVZT02JNhF2nKZauyGhifjrkbc7yhc=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466 h1:HYYeZtY7dp5L0cQjfQyhjM0OYFw506WZeb+jgTihxas=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466/go.mod h1:il5JnZbcx4gNtmROaSm+zrXfO5/jZJQwZp1bTrx0i5g=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=

--- a/providers/code/go.mod
+++ b/providers/code/go.mod
@@ -15,7 +15,7 @@ require (
 	k8s.io/client-go v0.36.2
 	k8s.io/klog/v2 v2.140.0
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/multicluster-runtime v0.24.1
+	sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466
 )
 
 require (

--- a/providers/code/go.sum
+++ b/providers/code/go.sum
@@ -229,6 +229,8 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/multicluster-runtime v0.24.1 h1:YlGqqk91ui0/VEXqemPd2+Z4UBmgvS2YwXaj2cItHQI=
 sigs.k8s.io/multicluster-runtime v0.24.1/go.mod h1:4+GrvEeaX0hg5MVZT02JNhF2nKZauyGhifjrkbc7yhc=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466 h1:HYYeZtY7dp5L0cQjfQyhjM0OYFw506WZeb+jgTihxas=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466/go.mod h1:il5JnZbcx4gNtmROaSm+zrXfO5/jZJQwZp1bTrx0i5g=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=

--- a/providers/databricks/go.mod
+++ b/providers/databricks/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/client-go v0.36.2
 	k8s.io/klog/v2 v2.140.0
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/multicluster-runtime v0.24.1
+	sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466
 )
 
 require (

--- a/providers/databricks/go.sum
+++ b/providers/databricks/go.sum
@@ -221,6 +221,8 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/multicluster-runtime v0.24.1 h1:YlGqqk91ui0/VEXqemPd2+Z4UBmgvS2YwXaj2cItHQI=
 sigs.k8s.io/multicluster-runtime v0.24.1/go.mod h1:4+GrvEeaX0hg5MVZT02JNhF2nKZauyGhifjrkbc7yhc=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466 h1:HYYeZtY7dp5L0cQjfQyhjM0OYFw506WZeb+jgTihxas=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466/go.mod h1:il5JnZbcx4gNtmROaSm+zrXfO5/jZJQwZp1bTrx0i5g=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=

--- a/providers/edges/go.mod
+++ b/providers/edges/go.mod
@@ -20,7 +20,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/multicluster-runtime v0.24.1
+	sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/providers/edges/go.sum
+++ b/providers/edges/go.sum
@@ -569,6 +569,8 @@ sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7
 sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/multicluster-runtime v0.24.1 h1:YlGqqk91ui0/VEXqemPd2+Z4UBmgvS2YwXaj2cItHQI=
 sigs.k8s.io/multicluster-runtime v0.24.1/go.mod h1:4+GrvEeaX0hg5MVZT02JNhF2nKZauyGhifjrkbc7yhc=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466 h1:HYYeZtY7dp5L0cQjfQyhjM0OYFw506WZeb+jgTihxas=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466/go.mod h1:il5JnZbcx4gNtmROaSm+zrXfO5/jZJQwZp1bTrx0i5g=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=

--- a/providers/infrastructure/go.mod
+++ b/providers/infrastructure/go.mod
@@ -14,7 +14,7 @@ require (
 	k8s.io/client-go v0.36.2
 	k8s.io/klog/v2 v2.140.0
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/multicluster-runtime v0.24.1
+	sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/providers/infrastructure/go.sum
+++ b/providers/infrastructure/go.sum
@@ -270,6 +270,8 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/multicluster-runtime v0.24.1 h1:YlGqqk91ui0/VEXqemPd2+Z4UBmgvS2YwXaj2cItHQI=
 sigs.k8s.io/multicluster-runtime v0.24.1/go.mod h1:4+GrvEeaX0hg5MVZT02JNhF2nKZauyGhifjrkbc7yhc=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466 h1:HYYeZtY7dp5L0cQjfQyhjM0OYFw506WZeb+jgTihxas=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466/go.mod h1:il5JnZbcx4gNtmROaSm+zrXfO5/jZJQwZp1bTrx0i5g=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=

--- a/providers/kuery/go.mod
+++ b/providers/kuery/go.mod
@@ -14,7 +14,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/multicluster-runtime v0.24.1
+	sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466
 )
 
 require (

--- a/providers/kuery/go.sum
+++ b/providers/kuery/go.sum
@@ -347,6 +347,8 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/multicluster-runtime v0.24.1 h1:YlGqqk91ui0/VEXqemPd2+Z4UBmgvS2YwXaj2cItHQI=
 sigs.k8s.io/multicluster-runtime v0.24.1/go.mod h1:4+GrvEeaX0hg5MVZT02JNhF2nKZauyGhifjrkbc7yhc=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466 h1:HYYeZtY7dp5L0cQjfQyhjM0OYFw506WZeb+jgTihxas=
+sigs.k8s.io/multicluster-runtime v0.24.2-0.20260817130819-087d80cae466/go.mod h1:il5JnZbcx4gNtmROaSm+zrXfO5/jZJQwZp1bTrx0i5g=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=


### PR DESCRIPTION
## Summary

The leader-elected providers (infrastructure, code, databricks) rebuild their controller and manager on every leadership term, relying on `manager.Options.Controller.SkipNameValidation` to allow re-registering the same controller name in one process (added in #531). multicluster-runtime v0.24.1 silently drops that option: its forked builder calls controller-runtime's **unmanaged** constructor, which never falls back to the manager's controller config.

The result in prod: after a pod's first leadership term, the instance controller fails to build with

```
instance controller: NOT started: registering instance reconciler: controller with name infra-instance already exists
```

the term callback returns immediately, the lease is released, and both replicas flap in a ~2s acquire/fail/release loop forever. No Instance created after the first lease churn is ever reconciled (observed on the BYO mini cluster: `app-studio-search`, `app-studio-browser`, `todo-app-dev` stuck with no status).

## Fix

Upstream fixed this on main (kubernetes-sigs/multicluster-runtime#177, c0b95d8 "Honour managers' options when creating a controller": constructors now call `DefaultFromConfig` on the manager's controller options), but no release contains it. This bumps every module that pulls multicluster-runtime from `v0.24.1` to the current main pseudo-version `v0.24.2-0.20260817130819-087d80cae466`. No faros code changes needed — the existing `SkipNameValidation` setting now takes effect.

## Testing

- `go build ./...` passes in the root module and all six bumped provider modules.
- Root cause verified against the live flapping pods on the BYO mini cluster; a rollout restart is the stopgap until new provider images ship from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)