### PR TITLE
Surface BYO provider upgrades with a values-preserving helm command

### DIFF
--- a/pkg/hub/providers/selfhosting.go
+++ b/pkg/hub/providers/selfhosting.go
@@ -88,7 +88,12 @@ type InstallInstructions struct {
 	// saved as, relative to the working directory.
 	KubeconfigFilename string          `json:"kubeconfigFilename"`
 	Steps              []InstallStep   `json:"steps"`
-	Values             []ResolvedValue `json:"values,omitempty"`
+	// Upgrade is the single command that moves an already-installed copy to
+	// ChartVersion while keeping the values the release was installed with.
+	// Rendered separately from Steps because an upgrade needs none of them:
+	// the namespace, Secret, and values all survive from the original install.
+	Upgrade *InstallStep    `json:"upgrade,omitempty"`
+	Values  []ResolvedValue `json:"values,omitempty"`
 	DocsURL            string          `json:"docsURL,omitempty"`
 	// ValuesDoc is the chart's values reference in Markdown, carried inline by
 	// the provider so the portal can render it without leaving the install
@@ -316,6 +321,25 @@ func RenderInstallInstructions(sh *SelfHosting, opts InstallOptions) InstallInst
 				"use needs cluster-admin in the target cluster.",
 			Command: helm.String(),
 		},
+	}
+
+	// The upgrade path deliberately does not repeat the --set flags:
+	// --reuse-values carries forward whatever the release was actually
+	// installed with, including anything the operator set by hand that these
+	// instructions never knew about. Re-listing values here would clobber
+	// those local edits with the hub's current defaults.
+	upgrade := &strings.Builder{}
+	fmt.Fprintf(upgrade, "helm upgrade %s %s", release, chartRef)
+	if out.ChartVersion != "" {
+		fmt.Fprintf(upgrade, " --version %s", out.ChartVersion)
+	}
+	fmt.Fprintf(upgrade, " \\\n  --namespace %s \\\n  --reuse-values", namespace)
+	out.Upgrade = &InstallStep{
+		Title: "Upgrade the provider",
+		Description: "For an existing install only. --reuse-values keeps the values the release was " +
+			"installed with — including any you set by hand — and the namespace and credential Secret " +
+			"stay as they are. Run it with the same cluster credentials as the install.",
+		Command: upgrade.String(),
 	}
 	return out
 }

--- a/pkg/hub/providers/selfhosting.go
+++ b/pkg/hub/providers/selfhosting.go
@@ -86,15 +86,15 @@ type InstallInstructions struct {
 	ChartVersion  string `json:"chartVersion,omitempty"`
 	// KubeconfigFilename is what the instructions assume the credential was
 	// saved as, relative to the working directory.
-	KubeconfigFilename string          `json:"kubeconfigFilename"`
-	Steps              []InstallStep   `json:"steps"`
+	KubeconfigFilename string        `json:"kubeconfigFilename"`
+	Steps              []InstallStep `json:"steps"`
 	// Upgrade is the single command that moves an already-installed copy to
 	// ChartVersion while keeping the values the release was installed with.
 	// Rendered separately from Steps because an upgrade needs none of them:
 	// the namespace, Secret, and values all survive from the original install.
 	Upgrade *InstallStep    `json:"upgrade,omitempty"`
 	Values  []ResolvedValue `json:"values,omitempty"`
-	DocsURL            string          `json:"docsURL,omitempty"`
+	DocsURL string          `json:"docsURL,omitempty"`
 	// ValuesDoc is the chart's values reference in Markdown, carried inline by
 	// the provider so the portal can render it without leaving the install
 	// panel and without reaching the internet.

--- a/pkg/hub/providers/selfhosting_test.go
+++ b/pkg/hub/providers/selfhosting_test.go
@@ -73,6 +73,36 @@ func TestRenderInstallInstructions(t *testing.T) {
 	}
 }
 
+func TestRenderInstallInstructionsUpgradeCommand(t *testing.T) {
+	got := RenderInstallInstructions(baseSelfHosting(), baseOptions())
+
+	if got.Upgrade == nil {
+		t.Fatal("want an upgrade step, got nil")
+	}
+	cmd := got.Upgrade.Command
+	for _, want := range []string{
+		"helm upgrade quickstart oci://ghcr.io/faroshq/charts/faros-quickstart-provider",
+		"--version 0.1.4",
+		"--namespace faros-provider-quickstart",
+		"--reuse-values",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("upgrade command missing %q\ngot:\n%s", want, cmd)
+		}
+	}
+	// --install would create a release where none exists; the upgrade path is
+	// for an existing install only, and a typo'd release name should fail loudly
+	// rather than quietly install a second copy with no values.
+	if strings.Contains(cmd, "--install") {
+		t.Errorf("upgrade command must not carry --install:\n%s", cmd)
+	}
+	// --set flags would clobber values the operator changed by hand since the
+	// install; --reuse-values is the whole point of the separate command.
+	if strings.Contains(cmd, "--set") {
+		t.Errorf("upgrade command must not carry --set flags:\n%s", cmd)
+	}
+}
+
 func TestRenderInstallInstructionsResolvesIdentityHash(t *testing.T) {
 	sh := baseSelfHosting()
 	sh.RequiredValues = []SelfHostingValue{

--- a/pkg/hub/restapi/org_providers.go
+++ b/pkg/hub/restapi/org_providers.go
@@ -177,6 +177,19 @@ type OrgProviderView struct {
 	Version       string `json:"version,omitempty"`
 	APIExportName string `json:"apiExportName,omitempty"`
 	Ready         bool   `json:"ready"`
+
+	// InstalledChartVersion is the Helm chart version the Org's copy is running,
+	// read from the selfHosting recipe its chart registered — the chart stamps
+	// its own version there, so this tracks what was actually installed.
+	InstalledChartVersion string `json:"installedChartVersion,omitempty"`
+	// AvailableChartVersion is the chart version the platform's copy of the same
+	// provider currently publishes — what an upgrade would move to. Empty when
+	// the provider has no platform counterpart (an Org-authored provider).
+	AvailableChartVersion string `json:"availableChartVersion,omitempty"`
+	// UpgradeAvailable is true when the installed and available versions are
+	// both known and differ. The hub owns the comparison so the portal cannot
+	// drift from however "needs an upgrade" is defined later.
+	UpgradeAvailable bool `json:"upgradeAvailable,omitempty"`
 }
 
 // RegisterOrgProviderResponse carries the install credential back exactly once
@@ -621,6 +634,21 @@ func (h *Handler) orgProviderView(orgUUID string, ws kcp.OrgProviderWorkspace) O
 	view.Version = prov.Version
 	view.APIExportName = prov.APIExportName
 	view.Ready = prov.Ready()
+
+	// Upgrade signal: what the Org's chart stamped into its own recipe versus
+	// what the platform's copy of the same provider publishes now. Get (not
+	// GetForOrg) is deliberate — the Org's copy shadows the platform one in
+	// org-scoped resolution, and the platform entry is exactly the thing being
+	// compared against.
+	if prov.SelfHosting != nil {
+		view.InstalledChartVersion = prov.SelfHosting.ChartVersion
+	}
+	if platform, ok := h.mgr.providers.Get(ws.Name); ok && platform.SelfHosting.Installable() {
+		view.AvailableChartVersion = platform.SelfHosting.ChartVersion
+	}
+	view.UpgradeAvailable = view.InstalledChartVersion != "" &&
+		view.AvailableChartVersion != "" &&
+		view.InstalledChartVersion != view.AvailableChartVersion
 	return view
 }
 

--- a/pkg/hub/restapi/org_providers_test.go
+++ b/pkg/hub/restapi/org_providers_test.go
@@ -22,6 +22,7 @@ import (
 
 	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
 	"github.com/faroshq/faros/pkg/hub/kcp"
+	"github.com/faroshq/faros/pkg/hub/providers"
 	"github.com/faroshq/faros/pkg/hub/tenant"
 	"github.com/faroshq/faros/pkg/kcppaths"
 )
@@ -32,6 +33,9 @@ import (
 // refused install from leaving a live credential behind.
 type fakeOrgProviderOps struct {
 	targets []kcp.EdgeInstallTarget
+	// workspaces is what ListOrgProviderWorkspaces returns — the providers the
+	// org already registered.
+	workspaces []kcp.OrgProviderWorkspace
 	// registered records EnsureOrgProviderWorkspace calls.
 	registered []string
 	// recordedEdges maps "org/provider" → "workspace/edge" as stamped by
@@ -55,7 +59,7 @@ func (f *fakeOrgProviderOps) EnsureOrgProviderWorkspace(_ context.Context, _, na
 }
 
 func (f *fakeOrgProviderOps) ListOrgProviderWorkspaces(context.Context, string) ([]kcp.OrgProviderWorkspace, error) {
-	return nil, nil
+	return f.workspaces, nil
 }
 
 func (f *fakeOrgProviderOps) GetOrgProviderWorkspace(context.Context, string, string) (*kcp.OrgProviderWorkspace, error) {
@@ -377,6 +381,89 @@ func TestListWorkspaces_ExcludesOrgProvidersContainer(t *testing.T) {
 		if ws.UUID == kcppaths.OrgProvidersWorkspaceName {
 			t.Fatalf("workspace list leaked the org-providers container: %+v", got.Items)
 		}
+	}
+}
+
+// The upgrade signal compares the chart version the Org's copy registered (its
+// chart stamps its own version into its CatalogEntry recipe) against the chart
+// version the platform's copy publishes now. The hub owns the comparison so the
+// portal only renders the verdict.
+func TestListOrgProviders_ReportsUpgradeAvailable(t *testing.T) {
+	selfHosting := func(chartVersion string) *providers.SelfHosting {
+		return &providers.SelfHosting{
+			Supported:    true,
+			ChartRepo:    "oci://ghcr.io/faroshq/charts",
+			ChartName:    "faros-edges-provider",
+			ChartVersion: chartVersion,
+		}
+	}
+	for _, tc := range []struct {
+		name          string
+		installed     string
+		platform      string
+		wantUpgrade   bool
+		wantAvailable string
+	}{
+		{name: "behind the platform", installed: "0.5.0", platform: "0.6.0", wantUpgrade: true, wantAvailable: "0.6.0"},
+		{name: "up to date", installed: "0.6.0", platform: "0.6.0", wantUpgrade: false, wantAvailable: "0.6.0"},
+		{name: "no platform counterpart", installed: "0.5.0", platform: "", wantUpgrade: false, wantAvailable: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			org := &tenancyv1alpha1.Organization{
+				ObjectMeta: metav1.ObjectMeta{Name: "org-a"},
+				Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "A"},
+			}
+			alice := &tenancyv1alpha1.User{
+				ObjectMeta: metav1.ObjectMeta{Name: "alice"},
+				Spec:       tenancyv1alpha1.UserSpec{Email: "alice@example.com", RBACIdentity: "faros:alice@example.com"},
+			}
+			mgr, _, _ := newTestManager(t, org, alice)
+			mgr.WithOrgProviders(&fakeOrgProviderOps{
+				workspaces: []kcp.OrgProviderWorkspace{{Name: "edges", Cluster: "cl-1", Phase: "Ready"}},
+			}, &fakeCredMinter{})
+
+			registry := providers.NewRegistry()
+			registry.Upsert(providers.Provider{
+				Name: "edges", OrgUUID: "org-a", Version: "1.2.0",
+				EndpointsValid: true, SelfHosting: selfHosting(tc.installed),
+			})
+			if tc.platform != "" {
+				registry.Upsert(providers.Provider{
+					Name: "edges", Version: "1.3.0",
+					EndpointsValid: true, SelfHosting: selfHosting(tc.platform),
+				})
+			}
+			mgr.WithProviderRegistry(registry)
+
+			srv := newTestServer(t, mgr, adminTC("alice", "org-a", ""))
+			defer srv.Close()
+
+			resp, err := http.Get(srv.URL + "/api/orgs/org-a/providers")
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status: got %d, want 200", resp.StatusCode)
+			}
+			var got ListResponse[OrgProviderView]
+			if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if len(got.Items) != 1 {
+				t.Fatalf("items: got %d, want 1 (%+v)", len(got.Items), got.Items)
+			}
+			view := got.Items[0]
+			if view.UpgradeAvailable != tc.wantUpgrade {
+				t.Errorf("upgradeAvailable: got %v, want %v (%+v)", view.UpgradeAvailable, tc.wantUpgrade, view)
+			}
+			if view.InstalledChartVersion != tc.installed {
+				t.Errorf("installedChartVersion: got %q, want %q", view.InstalledChartVersion, tc.installed)
+			}
+			if view.AvailableChartVersion != tc.wantAvailable {
+				t.Errorf("availableChartVersion: got %q, want %q", view.AvailableChartVersion, tc.wantAvailable)
+			}
+		})
 	}
 }
 

--- a/portal/src/components/SelfHostInstructions.vue
+++ b/portal/src/components/SelfHostInstructions.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import MarkdownIt from 'markdown-it'
-import { Copy, Check, Download, AlertTriangle, ExternalLink, ChevronRight } from 'lucide-vue-next'
+import { Copy, Check, Download, AlertTriangle, ExternalLink, ChevronRight, ArrowUpCircle } from 'lucide-vue-next'
 import type { OrgProviderRegistration } from '@/stores/orgProviders'
 
 // Renders the credential + Helm steps the hub generated for one self-hosted
@@ -21,6 +21,13 @@ const copied = ref<string | null>(null)
 const unresolvedValues = computed(
   () => props.registration.instructions?.values?.filter((v) => v.unresolved) ?? [],
 )
+
+// The hub decides whether an upgrade is due (installed vs. published chart
+// version); this component only needs the verdict plus the rendered command.
+const upgrade = computed(() => {
+  const step = props.registration.instructions?.upgrade
+  return props.registration.provider.upgradeAvailable && step ? step : null
+})
 
 // html: false is load-bearing, not a style choice. valuesDoc comes from a
 // CatalogEntry, and for an org-owned provider that entry is written by whoever
@@ -68,6 +75,48 @@ function downloadKubeconfig() {
 
 <template>
   <div class="space-y-4">
+    <!-- Upgrade, shown first and only when one is due. A running install needs
+         none of the steps below — the namespace, credential Secret, and values
+         all survive from the original install — so the one command is the whole
+         path, and burying it under the install steps would read as "reinstall". -->
+    <section
+      v-if="upgrade"
+      class="rounded-lg border border-accent/40 bg-accent/5 p-4"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0">
+          <h4 class="flex items-center gap-1.5 text-sm font-semibold text-text-primary">
+            <ArrowUpCircle class="h-4 w-4 text-accent" :stroke-width="2" />
+            {{ upgrade.title }}
+            <span
+              v-if="registration.provider.installedChartVersion && registration.provider.availableChartVersion"
+              class="font-mono text-[10px] font-normal text-text-muted"
+            >
+              v{{ registration.provider.installedChartVersion }} &rarr;
+              v{{ registration.provider.availableChartVersion }}
+            </span>
+          </h4>
+          <p v-if="upgrade.description" class="mt-0.5 text-[11px] text-text-muted">{{ upgrade.description }}</p>
+        </div>
+        <button
+          type="button"
+          class="k-btn k-btn--ghost inline-flex flex-shrink-0 items-center gap-1 px-2.5 py-1 text-[11px] text-text-muted transition-colors hover:text-accent"
+          @click="copy('upgrade', upgrade.command)"
+        >
+          <component :is="copied === 'upgrade' ? Check : Copy" class="h-3 w-3" :stroke-width="2" />
+          Copy
+        </button>
+      </div>
+      <pre
+        class="mt-3 overflow-x-auto rounded-md border border-border-subtle bg-surface-base p-3 font-mono text-[10px] leading-relaxed text-text-secondary"
+      >{{ upgrade.command }}</pre>
+      <p class="mt-2 text-[11px] text-text-muted">
+        To change values at the same time, add <code class="font-mono text-text-secondary">--set</code> flags
+        (or a values file) to this command — see the chart values reference below. The install
+        steps that follow are for a fresh install and are not part of an upgrade.
+      </p>
+    </section>
+
     <!-- Credential. Step 1 of the flow even though the commands come after:
          nothing else works without the file on disk. -->
     <section class="rounded-lg border border-border-subtle bg-surface-overlay/60 p-4">

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -7,7 +7,7 @@ import { confirmDialog } from '@/portalkit/confirm'
 import { useProvidersStore, type ProviderDTO, type PermissionClaim } from '@/stores/providers'
 import { useOrgProvidersStore, type OrgProviderRegistration } from '@/stores/orgProviders'
 import { categoryIcons, fallbackCategoryIcon } from '@/lib/categoryIcons'
-import { Puzzle, ExternalLink, AlertCircle, AlertTriangle, Plus, X, Loader2, Search, Server, Trash2, RefreshCw } from 'lucide-vue-next'
+import { Puzzle, ExternalLink, AlertCircle, AlertTriangle, ArrowUpCircle, Plus, X, Loader2, Search, Server, Trash2, RefreshCw } from 'lucide-vue-next'
 
 const providers = useProvidersStore()
 const orgProviders = useOrgProvidersStore()
@@ -432,11 +432,12 @@ function dependencyNotice(p: ProviderDTO): string {
           <div class="mb-4 flex items-start justify-between gap-3">
             <div>
               <h2 class="text-base font-semibold text-text-primary">
-                Install {{ activeRegistration.provider.name }}
+                {{ activeRegistration.provider.upgradeAvailable ? 'Upgrade' : 'Install' }}
+                {{ activeRegistration.provider.name }}
               </h2>
               <p class="mt-0.5 text-[11px] text-text-muted">
-                Run these in the cluster where you want
-                {{ activeRegistration.provider.name }} to run.
+                Run these in the cluster where
+                {{ activeRegistration.provider.upgradeAvailable ? `${activeRegistration.provider.name} is running` : `you want ${activeRegistration.provider.name} to run` }}.
               </p>
             </div>
             <button
@@ -480,9 +481,17 @@ function dependencyNotice(p: ProviderDTO): string {
                   >
                     {{ p.registered ? 'Installed' : 'Awaiting install' }}
                   </span>
+                  <span
+                    v-if="p.upgradeAvailable"
+                    class="rounded-sm border border-warning/30 bg-warning-subtle px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider text-warning"
+                  >
+                    Update available
+                  </span>
                 </div>
                 <p class="mt-0.5 truncate font-mono text-[10px] text-text-muted">
-                  {{ p.name }}<span v-if="p.version"> · {{ p.version }}</span>
+                  {{ p.name }}<span v-if="p.version"> · {{ p.version }}</span><span
+                    v-if="p.upgradeAvailable && p.installedChartVersion && p.availableChartVersion"
+                  > · chart v{{ p.installedChartVersion }} &rarr; v{{ p.availableChartVersion }}</span>
                 </p>
                 <!-- The gap between "workspace exists" and "chart installed" is
                      where a half-finished install sits; say so explicitly. -->
@@ -490,8 +499,25 @@ function dependencyNotice(p: ProviderDTO): string {
                   The workspace is ready but the provider has not registered itself yet.
                   Run the install steps, then this flips to Installed.
                 </p>
+                <p v-else-if="p.upgradeAvailable" class="mt-1 text-[11px] text-text-muted">
+                  A newer chart is published. Upgrade shows one command that keeps the
+                  Helm values you installed with.
+                </p>
               </div>
               <div class="flex items-center gap-2">
+                <!-- Upgrade opens the same instructions panel; the panel leads
+                     with the upgrade command when the hub says one is due. -->
+                <button
+                  v-if="p.upgradeAvailable"
+                  type="button"
+                  class="k-btn k-btn--primary px-2.5 py-1 text-[11px] disabled:opacity-60"
+                  :disabled="!!selfHostBusy[p.name]"
+                  @click="showInstructions(p.name)"
+                >
+                  <Loader2 v-if="selfHostBusy[p.name]" class="h-3 w-3 animate-spin" :stroke-width="2" />
+                  <ArrowUpCircle v-else class="h-3 w-3" :stroke-width="2" />
+                  Upgrade
+                </button>
                 <button
                   type="button"
                   class="k-btn k-btn--ghost px-2.5 py-1 text-[11px] text-text-muted transition-colors hover:text-accent disabled:opacity-60"

--- a/portal/src/stores/orgProviders.ts
+++ b/portal/src/stores/orgProviders.ts
@@ -34,6 +34,9 @@ export interface InstallInstructions {
   chartVersion?: string
   kubeconfigFilename: string
   steps: InstallStep[]
+  // One command that moves an existing install to chartVersion while keeping
+  // the values it was installed with (helm --reuse-values).
+  upgrade?: InstallStep
   values?: ResolvedValue[]
   docsURL?: string
   // The chart's values reference in Markdown, carried inline by the provider so
@@ -56,6 +59,12 @@ export interface OrgProvider {
   version?: string
   apiExportName?: string
   ready: boolean
+  // Chart version the org's copy is running vs. what the platform's copy of
+  // the same provider publishes now. The hub owns the comparison; the UI only
+  // renders upgradeAvailable.
+  installedChartVersion?: string
+  availableChartVersion?: string
+  upgradeAvailable?: boolean
 }
 
 // Registration is the credential plus the steps that use it. The credential is


### PR DESCRIPTION
## What

The self-hosted (BYO) provider flow showed how to install, but never whether an upgrade was due or how to run one without losing the Helm values the release was installed with. This adds the upgrade path end to end.

## How

Every provider chart already stamps its own version into the CatalogEntry recipe it registers (`selfHosting.chart.version: {{ .Chart.Version }}`), so the hub can compare what the org's copy is running against what the platform's copy of the same provider publishes now. The hub owns the comparison; the portal only renders the verdict.

**Hub**
- `OrgProviderView` gains `installedChartVersion`, `availableChartVersion`, and `upgradeAvailable` — computed in `orgProviderView`, so both the list endpoint and the kubeconfig/instructions endpoint carry it.
- `InstallInstructions` gains a rendered `upgrade` step: `helm upgrade <release> <chart> --version <new> --namespace <ns> --reuse-values`. It deliberately repeats no `--set` flags (`--reuse-values` carries forward whatever the release was installed with, including hand-set values the hub never knew about) and omits `--install` (a typo'd release name should fail loudly, not quietly install a second copy).

**Portal**
- Running-provider rows show an "Update available" badge, the chart version transition, and a primary **Upgrade** button; the panel title switches between Install and Upgrade.
- `SelfHostInstructions` leads with the upgrade command (versions, copy button, note on adding `--set` for value changes) when one is due, and marks the install steps below as fresh-install-only.

An org-authored provider with no platform counterpart never shows an upgrade prompt — there is nothing to compare against.

## Tests

- `TestListOrgProviders_ReportsUpgradeAvailable`: behind / up-to-date / no-platform-counterpart through the real HTTP endpoint with a real registry.
- `TestRenderInstallInstructionsUpgradeCommand`: pins the command shape (has `--reuse-values`, lacks `--install` and `--set`).
- `go build ./...`, `go vet`, `vue-tsc -b`, and the Vite build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)