### PR TITLE
Fall back to spec.version when entries carry no chart version

### DIFF
--- a/pkg/hub/restapi/org_providers.go
+++ b/pkg/hub/restapi/org_providers.go
@@ -178,14 +178,16 @@ type OrgProviderView struct {
 	APIExportName string `json:"apiExportName,omitempty"`
 	Ready         bool   `json:"ready"`
 
-	// InstalledChartVersion is the Helm chart version the Org's copy is running,
-	// read from the selfHosting recipe its chart registered — the chart stamps
-	// its own version there, so this tracks what was actually installed.
-	InstalledChartVersion string `json:"installedChartVersion,omitempty"`
-	// AvailableChartVersion is the chart version the platform's copy of the same
-	// provider currently publishes — what an upgrade would move to. Empty when
-	// the provider has no platform counterpart (an Org-authored provider).
-	AvailableChartVersion string `json:"availableChartVersion,omitempty"`
+	// InstalledVersion is the version the Org's copy is running, and
+	// AvailableVersion is what the platform's copy of the same provider runs
+	// now — the pair the upgrade verdict compared. Chart versions from the
+	// selfHosting recipe when both sides carry one; otherwise the entries'
+	// spec.version, because not every provider stamps a chart version — the
+	// infrastructure operator registers from its embedded manifest, which has
+	// no chart to read one from. AvailableVersion is empty when the provider
+	// has no installable platform counterpart (an Org-authored provider).
+	InstalledVersion string `json:"installedVersion,omitempty"`
+	AvailableVersion string `json:"availableVersion,omitempty"`
 	// UpgradeAvailable is true when the installed and available versions are
 	// both known and differ. The hub owns the comparison so the portal cannot
 	// drift from however "needs an upgrade" is defined later.
@@ -635,20 +637,38 @@ func (h *Handler) orgProviderView(orgUUID string, ws kcp.OrgProviderWorkspace) O
 	view.APIExportName = prov.APIExportName
 	view.Ready = prov.Ready()
 
-	// Upgrade signal: what the Org's chart stamped into its own recipe versus
-	// what the platform's copy of the same provider publishes now. Get (not
-	// GetForOrg) is deliberate — the Org's copy shadows the platform one in
-	// org-scoped resolution, and the platform entry is exactly the thing being
-	// compared against.
+	// Upgrade signal: what the Org's copy registered versus what the platform's
+	// copy of the same provider runs now. Get (not GetForOrg) is deliberate —
+	// the Org's copy shadows the platform one in org-scoped resolution, and the
+	// platform entry is exactly the thing being compared against. Gated on the
+	// platform recipe being installable because that is also what makes the
+	// rendered upgrade command exist.
+	platform, ok := h.mgr.providers.Get(ws.Name)
+	if !ok || !platform.SelfHosting.Installable() {
+		return view
+	}
+	// Prefer chart versions (what `helm upgrade --version` actually moves), but
+	// only when BOTH entries carry one — comparing a chart version against a
+	// provider version is apples to oranges. Providers registered from an
+	// embedded manifest rather than the chart's own template (the
+	// infrastructure operator) carry no chart version at all, and for those the
+	// entries' spec.version is the only signal there is.
+	installed, available := "", ""
 	if prov.SelfHosting != nil {
-		view.InstalledChartVersion = prov.SelfHosting.ChartVersion
+		installed = prov.SelfHosting.ChartVersion
 	}
-	if platform, ok := h.mgr.providers.Get(ws.Name); ok && platform.SelfHosting.Installable() {
-		view.AvailableChartVersion = platform.SelfHosting.ChartVersion
+	if platform.SelfHosting != nil {
+		available = platform.SelfHosting.ChartVersion
 	}
-	view.UpgradeAvailable = view.InstalledChartVersion != "" &&
-		view.AvailableChartVersion != "" &&
-		view.InstalledChartVersion != view.AvailableChartVersion
+	if installed == "" || available == "" {
+		installed, available = prov.Version, platform.Version
+	}
+	if installed == "" || available == "" {
+		return view
+	}
+	view.InstalledVersion = installed
+	view.AvailableVersion = available
+	view.UpgradeAvailable = installed != available
 	return view
 }
 

--- a/pkg/hub/restapi/org_providers_test.go
+++ b/pkg/hub/restapi/org_providers_test.go
@@ -384,10 +384,13 @@ func TestListWorkspaces_ExcludesOrgProvidersContainer(t *testing.T) {
 	}
 }
 
-// The upgrade signal compares the chart version the Org's copy registered (its
-// chart stamps its own version into its CatalogEntry recipe) against the chart
-// version the platform's copy publishes now. The hub owns the comparison so the
-// portal only renders the verdict.
+// The upgrade signal measures the Org's copy against the baseline of what the
+// platform ("managed") copy of the same provider runs now — BYO installs are
+// never upgraded automatically, so this verdict is the only thing telling an
+// Org its copy fell behind. Chart versions are compared when both entries carry
+// one; entries registered from an embedded manifest (the infrastructure
+// operator) have none, and fall back to the entries' spec.version. The hub owns
+// the comparison so the portal only renders the verdict.
 func TestListOrgProviders_ReportsUpgradeAvailable(t *testing.T) {
 	selfHosting := func(chartVersion string) *providers.SelfHosting {
 		return &providers.SelfHosting{
@@ -398,15 +401,48 @@ func TestListOrgProviders_ReportsUpgradeAvailable(t *testing.T) {
 		}
 	}
 	for _, tc := range []struct {
-		name          string
-		installed     string
-		platform      string
-		wantUpgrade   bool
-		wantAvailable string
+		name            string
+		orgChart        string
+		platformChart   string
+		orgVersion      string
+		platformVersion string
+		hasPlatform     bool
+		wantUpgrade     bool
+		wantInstalled   string
+		wantAvailable   string
 	}{
-		{name: "behind the platform", installed: "0.5.0", platform: "0.6.0", wantUpgrade: true, wantAvailable: "0.6.0"},
-		{name: "up to date", installed: "0.6.0", platform: "0.6.0", wantUpgrade: false, wantAvailable: "0.6.0"},
-		{name: "no platform counterpart", installed: "0.5.0", platform: "", wantUpgrade: false, wantAvailable: ""},
+		{
+			name: "behind the platform", hasPlatform: true,
+			orgChart: "0.5.0", platformChart: "0.6.0",
+			orgVersion: "1.2.0", platformVersion: "1.3.0",
+			wantUpgrade: true, wantInstalled: "0.5.0", wantAvailable: "0.6.0",
+		},
+		{
+			name: "up to date", hasPlatform: true,
+			orgChart: "0.6.0", platformChart: "0.6.0",
+			orgVersion: "1.3.0", platformVersion: "1.3.0",
+			wantUpgrade: false, wantInstalled: "0.6.0", wantAvailable: "0.6.0",
+		},
+		{
+			// The infrastructure-operator shape: registered from an embedded
+			// manifest, so no chart version on either side — spec.version is
+			// the only signal.
+			name: "manifest-registered falls back to spec.version", hasPlatform: true,
+			orgVersion: "v0.1.12", platformVersion: "v0.1.16",
+			wantUpgrade: true, wantInstalled: "v0.1.12", wantAvailable: "v0.1.16",
+		},
+		{
+			// Mixed metadata must not compare apples to oranges: the org copy
+			// carries a chart version, the platform entry does not.
+			name: "mixed chart metadata falls back to spec.version", hasPlatform: true,
+			orgChart:   "0.5.0",
+			orgVersion: "1.3.0", platformVersion: "1.3.0",
+			wantUpgrade: false, wantInstalled: "1.3.0", wantAvailable: "1.3.0",
+		},
+		{
+			name: "no platform counterpart", orgChart: "0.5.0", orgVersion: "1.2.0",
+			wantUpgrade: false, wantInstalled: "", wantAvailable: "",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			org := &tenancyv1alpha1.Organization{
@@ -424,13 +460,13 @@ func TestListOrgProviders_ReportsUpgradeAvailable(t *testing.T) {
 
 			registry := providers.NewRegistry()
 			registry.Upsert(providers.Provider{
-				Name: "edges", OrgUUID: "org-a", Version: "1.2.0",
-				EndpointsValid: true, SelfHosting: selfHosting(tc.installed),
+				Name: "edges", OrgUUID: "org-a", Version: tc.orgVersion,
+				EndpointsValid: true, SelfHosting: selfHosting(tc.orgChart),
 			})
-			if tc.platform != "" {
+			if tc.hasPlatform {
 				registry.Upsert(providers.Provider{
-					Name: "edges", Version: "1.3.0",
-					EndpointsValid: true, SelfHosting: selfHosting(tc.platform),
+					Name: "edges", Version: tc.platformVersion,
+					EndpointsValid: true, SelfHosting: selfHosting(tc.platformChart),
 				})
 			}
 			mgr.WithProviderRegistry(registry)
@@ -457,11 +493,11 @@ func TestListOrgProviders_ReportsUpgradeAvailable(t *testing.T) {
 			if view.UpgradeAvailable != tc.wantUpgrade {
 				t.Errorf("upgradeAvailable: got %v, want %v (%+v)", view.UpgradeAvailable, tc.wantUpgrade, view)
 			}
-			if view.InstalledChartVersion != tc.installed {
-				t.Errorf("installedChartVersion: got %q, want %q", view.InstalledChartVersion, tc.installed)
+			if view.InstalledVersion != tc.wantInstalled {
+				t.Errorf("installedVersion: got %q, want %q", view.InstalledVersion, tc.wantInstalled)
 			}
-			if view.AvailableChartVersion != tc.wantAvailable {
-				t.Errorf("availableChartVersion: got %q, want %q", view.AvailableChartVersion, tc.wantAvailable)
+			if view.AvailableVersion != tc.wantAvailable {
+				t.Errorf("availableVersion: got %q, want %q", view.AvailableVersion, tc.wantAvailable)
 			}
 		})
 	}

--- a/portal/src/components/SelfHostInstructions.vue
+++ b/portal/src/components/SelfHostInstructions.vue
@@ -89,11 +89,11 @@ function downloadKubeconfig() {
             <ArrowUpCircle class="h-4 w-4 text-accent" :stroke-width="2" />
             {{ upgrade.title }}
             <span
-              v-if="registration.provider.installedChartVersion && registration.provider.availableChartVersion"
+              v-if="registration.provider.installedVersion && registration.provider.availableVersion"
               class="font-mono text-[10px] font-normal text-text-muted"
             >
-              v{{ registration.provider.installedChartVersion }} &rarr;
-              v{{ registration.provider.availableChartVersion }}
+              {{ registration.provider.installedVersion }} &rarr;
+              {{ registration.provider.availableVersion }}
             </span>
           </h4>
           <p v-if="upgrade.description" class="mt-0.5 text-[11px] text-text-muted">{{ upgrade.description }}</p>

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -490,8 +490,8 @@ function dependencyNotice(p: ProviderDTO): string {
                 </div>
                 <p class="mt-0.5 truncate font-mono text-[10px] text-text-muted">
                   {{ p.name }}<span v-if="p.version"> · {{ p.version }}</span><span
-                    v-if="p.upgradeAvailable && p.installedChartVersion && p.availableChartVersion"
-                  > · chart v{{ p.installedChartVersion }} &rarr; v{{ p.availableChartVersion }}</span>
+                    v-if="p.upgradeAvailable && p.installedVersion && p.availableVersion"
+                  > · {{ p.installedVersion }} &rarr; {{ p.availableVersion }}</span>
                 </p>
                 <!-- The gap between "workspace exists" and "chart installed" is
                      where a half-finished install sits; say so explicitly. -->

--- a/portal/src/stores/orgProviders.ts
+++ b/portal/src/stores/orgProviders.ts
@@ -59,11 +59,12 @@ export interface OrgProvider {
   version?: string
   apiExportName?: string
   ready: boolean
-  // Chart version the org's copy is running vs. what the platform's copy of
-  // the same provider publishes now. The hub owns the comparison; the UI only
-  // renders upgradeAvailable.
-  installedChartVersion?: string
-  availableChartVersion?: string
+  // What the org's copy runs vs. the baseline of what the platform's managed
+  // copy runs now (chart versions when both entries carry one, the entries'
+  // spec.version otherwise). The hub owns the comparison; the UI only renders
+  // upgradeAvailable.
+  installedVersion?: string
+  availableVersion?: string
   upgradeAvailable?: boolean
 }
 


### PR DESCRIPTION
## What

Follow-up to #582. The upgrade verdict compared `selfHosting.chart.version` on both CatalogEntries — but not every provider stamps one. The infrastructure provider registers its CatalogEntry from the operator's embedded manifest (`catalogEntry.enabled=false`), which has no chart to read a version from, so neither the org's copy nor the platform baseline carried a chart version and the "Update available" signal could never fire for it.

Verified on a live install: an org's self-hosted infrastructure copy registered at `v0.1.12` sat silently behind the platform's managed baseline of `v0.1.16`.

## How

BYO installs are never upgraded automatically — the whole point of this signal is to measure an org's copy against the baseline of what the platform's managed copy runs. When either entry lacks a chart version, the comparison now falls back to the entries' `spec.version` (which the infrastructure operator stamps from `FAROS_PROVIDER_VERSION`). A chart version is never compared against a provider version — the fallback replaces both sides.

Fields renamed `installedChartVersion`/`availableChartVersion` → `installedVersion`/`availableVersion` to match what they now hold; the UI shows the raw values (they already carry their own `v` prefix where applicable).

## Tests

Extended `TestListOrgProviders_ReportsUpgradeAvailable` with the manifest-registered (no chart versions) and mixed-metadata cases, alongside the existing chart-version paths. `go test`, `go vet`, and `vue-tsc -b` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)