### PR TITLE
Fix Linux edge detail view broken by a spec.labels selection

### DIFF
--- a/providers/edges/portal/src/api.test.ts
+++ b/providers/edges/portal/src/api.test.ts
@@ -206,7 +206,11 @@ describe('unchanged edge fleet and CRUD contracts', () => {
       kind: 'LinuxServer',
       spec: { sshPort: 2200, sshUserMapping: 'provided' },
     })
-    expect(call?.query).toContain('sshPort sshUserMapping sshKeySecretRef { name namespace } sshCredentialsRef { name namespace }')
+    expect(call?.query).toContain('spec { sshPort sshUserMapping sshKeySecretRef { name namespace } sshCredentialsRef { name namespace } }')
+    // Scheduling labels exist only on KubernetesClusterSpec. GraphQL rejects
+    // the whole query on one unknown field, so selecting spec.labels here
+    // broke the entire Linux edge detail view (regression from #567).
+    expect(call?.query).not.toContain('spec { labels')
   })
 
   it('keeps listEdges as the unpaged merged fleet query and preserves kind/status joins', async () => {

--- a/providers/edges/portal/src/api.ts
+++ b/providers/edges/portal/src/api.ts
@@ -216,8 +216,12 @@ export async function listEdges(): Promise<Edge[]> {
 export async function getEdge(name: string, type: EdgeType): Promise<EdgeDetail> {
   const kind = type === 'server' ? 'LinuxServer' : 'KubernetesCluster'
   const apiVersion = 'edges.faros.sh/v1alpha1'
+  // The two specs share no fields: scheduling labels exist only on
+  // KubernetesClusterSpec, and the SSH fields only on LinuxServerSpec. GraphQL
+  // rejects the entire query on one unknown field, so selecting a field the
+  // kind does not have breaks the whole detail view, not just that column.
   const specSelection = type === 'server'
-    ? `labels sshPort sshUserMapping sshKeySecretRef { name namespace } sshCredentialsRef { name namespace }`
+    ? `sshPort sshUserMapping sshKeySecretRef { name namespace } sshCredentialsRef { name namespace }`
     : 'labels'
   const data = await graphql<{
     edges_faros_sh?: {


### PR DESCRIPTION
## What

Every Linux server detail view in the edges UI failed with:

```
Cannot query field "labels" on type "EdgesFarosShV1alpha1LinuxServerSpec".
```

## Why

Regression from #567 (Standardize resource instance UX across providers): it added `labels` to **both** branches of the GetEdge spec selection, but scheduling labels exist only on `KubernetesClusterSpec` — `LinuxServerSpec` has none. GraphQL rejects the entire query on a single unknown field, so the whole Linux edge detail view broke rather than just missing one column. The Detail view itself was already correct — it only renders scheduling labels for the kubernetes branch.

## How

Drop `labels` from the server branch of the spec selection, and pin the contract in the query test: the server query must contain the exact SSH spec selection and must not select `spec { labels`.

## Tests

All 84 edges portal tests and `vue-tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)