### PR TITLE
Generate upgrades with --reset-then-reuse-values, not --reuse-values

### DIFF
--- a/pkg/hub/providers/selfhosting.go
+++ b/pkg/hub/providers/selfhosting.go
@@ -323,22 +323,30 @@ func RenderInstallInstructions(sh *SelfHosting, opts InstallOptions) InstallInst
 		},
 	}
 
-	// The upgrade path deliberately does not repeat the --set flags:
-	// --reuse-values carries forward whatever the release was actually
-	// installed with, including anything the operator set by hand that these
-	// instructions never knew about. Re-listing values here would clobber
-	// those local edits with the hub's current defaults.
+	// The upgrade path deliberately does not repeat the --set flags: the
+	// release's own values carry forward, including anything the operator set
+	// by hand that these instructions never knew about. Re-listing values here
+	// would clobber those local edits with the hub's current defaults.
+	//
+	// --reset-then-reuse-values, NOT --reuse-values. The plain form reuses the
+	// old release's values verbatim and never merges the NEW chart's defaults,
+	// so the first release that introduces a value block (and templates against
+	// it) crashes every existing install with a nil-pointer template error.
+	// reset-then-reuse starts from the new chart's defaults and lays the
+	// operator's previous overrides on top — new values appear, local edits
+	// survive. Requires Helm 3.14+.
 	upgrade := &strings.Builder{}
 	fmt.Fprintf(upgrade, "helm upgrade %s %s", release, chartRef)
 	if out.ChartVersion != "" {
 		fmt.Fprintf(upgrade, " --version %s", out.ChartVersion)
 	}
-	fmt.Fprintf(upgrade, " \\\n  --namespace %s \\\n  --reuse-values", namespace)
+	fmt.Fprintf(upgrade, " \\\n  --namespace %s \\\n  --reset-then-reuse-values", namespace)
 	out.Upgrade = &InstallStep{
 		Title: "Upgrade the provider",
-		Description: "For an existing install only. --reuse-values keeps the values the release was " +
-			"installed with — including any you set by hand — and the namespace and credential Secret " +
-			"stay as they are. Run it with the same cluster credentials as the install.",
+		Description: "For an existing install only. --reset-then-reuse-values (Helm 3.14+) picks up the " +
+			"new chart's defaults and keeps every value you set on the existing release — and the " +
+			"namespace and credential Secret stay as they are. Run it with the same cluster credentials " +
+			"as the install.",
 		Command: upgrade.String(),
 	}
 	return out

--- a/pkg/hub/providers/selfhosting_test.go
+++ b/pkg/hub/providers/selfhosting_test.go
@@ -84,11 +84,18 @@ func TestRenderInstallInstructionsUpgradeCommand(t *testing.T) {
 		"helm upgrade quickstart oci://ghcr.io/faroshq/charts/faros-quickstart-provider",
 		"--version 0.1.4",
 		"--namespace faros-provider-quickstart",
-		"--reuse-values",
+		"--reset-then-reuse-values",
 	} {
 		if !strings.Contains(cmd, want) {
 			t.Errorf("upgrade command missing %q\ngot:\n%s", want, cmd)
 		}
+	}
+	// Plain --reuse-values never merges the NEW chart's defaults, so the first
+	// chart release introducing a value block crashes every existing install
+	// with a nil-pointer template error (seen live: infrastructure 0.1.16
+	// adding codingSandbox). Guard the exact flag, not just its prefix.
+	if strings.Contains(cmd, " --reuse-values") {
+		t.Errorf("upgrade command must use --reset-then-reuse-values, not --reuse-values:\n%s", cmd)
 	}
 	// --install would create a release where none exists; the upgrade path is
 	// for an existing install only, and a typo'd release name should fail loudly
@@ -97,7 +104,7 @@ func TestRenderInstallInstructionsUpgradeCommand(t *testing.T) {
 		t.Errorf("upgrade command must not carry --install:\n%s", cmd)
 	}
 	// --set flags would clobber values the operator changed by hand since the
-	// install; --reuse-values is the whole point of the separate command.
+	// install; reusing the release's values is the whole point of the command.
 	if strings.Contains(cmd, "--set") {
 		t.Errorf("upgrade command must not carry --set flags:\n%s", cmd)
 	}

--- a/providers/infrastructure/deploy/chart/templates/deployment.yaml
+++ b/providers/infrastructure/deploy/chart/templates/deployment.yaml
@@ -1,7 +1,7 @@
-{{- if and .Values.codingSandbox.enabled (not (regexMatch `^[^@\s]+@sha256:[a-f0-9]{64}$` (default "" .Values.development.images.universal))) }}
+{{- if and (.Values.codingSandbox).enabled (not (regexMatch `^[^@\s]+@sha256:[a-f0-9]{64}$` (default "" .Values.development.images.universal))) }}
 {{- fail "codingSandbox.enabled=true requires development.images.universal to be an immutable name@sha256:<64 lowercase hex digits> reference" }}
 {{- end }}
-{{- if and .Values.codingSandbox.enabled (not (regexMatch `^[^@\s]+@sha256:[a-f0-9]{64}$` (default "" .Values.development.agentImage))) }}
+{{- if and (.Values.codingSandbox).enabled (not (regexMatch `^[^@\s]+@sha256:[a-f0-9]{64}$` (default "" .Values.development.agentImage))) }}
 {{- fail "codingSandbox.enabled=true requires development.agentImage to be an immutable name@sha256:<64 lowercase hex digits> reference" }}
 {{- end }}
 {{- if not .Values.operator.enabled }}
@@ -60,7 +60,7 @@ spec:
             - name: INFRASTRUCTURE_KUBECONFIG
               value: /tmp/infrastructure.kubeconfig
             - name: FAROS_CODING_SANDBOX_ENABLED
-              value: {{ .Values.codingSandbox.enabled | quote }}
+              value: {{ (.Values.codingSandbox).enabled | default false | quote }}
             {{- if .Values.development.images.universal }}
             - name: FAROS_DEV_IMAGE_UNIVERSAL
               value: {{ .Values.development.images.universal | quote }}
@@ -121,7 +121,7 @@ spec:
             - name: FAROS_PROVIDER_NAME
               value: "infrastructure"
             - name: FAROS_CODING_SANDBOX_ENABLED
-              value: {{ .Values.codingSandbox.enabled | quote }}
+              value: {{ (.Values.codingSandbox).enabled | default false | quote }}
             {{- if .Values.hub.insecure }}
             - name: FAROS_HUB_INSECURE
               value: "true"

--- a/providers/infrastructure/deploy/chart/templates/operator-config.yaml
+++ b/providers/infrastructure/deploy/chart/templates/operator-config.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.operator.enabled -}}
 {{- $providerSecret := .Values.operator.providerKubeconfigSecret.name | default (printf "%s-provider-kubeconfig" (include "infrastructure.fullname" .)) -}}
 {{- $runtimeSecret := .Values.operator.runtimeKubeconfigSecret.name | default (printf "%s-runtime-kubeconfig" (include "infrastructure.fullname" .)) -}}
-{{- if and .Values.codingSandbox.enabled (not (regexMatch `^[^@\s]+@sha256:[a-f0-9]{64}$` (default "" .Values.development.images.universal))) }}
+{{- if and (.Values.codingSandbox).enabled (not (regexMatch `^[^@\s]+@sha256:[a-f0-9]{64}$` (default "" .Values.development.images.universal))) }}
 {{- fail "codingSandbox.enabled=true requires development.images.universal to be an immutable name@sha256:<64 lowercase hex digits> reference" }}
 {{- end }}
-{{- if and .Values.codingSandbox.enabled (not (regexMatch `^[^@\s]+@sha256:[a-f0-9]{64}$` (default "" .Values.development.agentImage))) }}
+{{- if and (.Values.codingSandbox).enabled (not (regexMatch `^[^@\s]+@sha256:[a-f0-9]{64}$` (default "" .Values.development.agentImage))) }}
 {{- fail "codingSandbox.enabled=true requires development.agentImage to be an immutable name@sha256:<64 lowercase hex digits> reference" }}
 {{- end }}
 {{- if .Values.operator.providerKubeconfig }}
@@ -89,7 +89,7 @@ spec:
     replicas: {{ .Values.operator.provider.replicas }}
     port: {{ .Values.operator.provider.port }}
   codingSandbox:
-    enabled: {{ .Values.codingSandbox.enabled }}
+    enabled: {{ (.Values.codingSandbox).enabled | default false }}
   {{- if or .Values.development.agentImage .Values.development.images }}
   development:
     {{- with .Values.development.agentImage }}


### PR DESCRIPTION
## What

Running the generated BYO upgrade command against a live install failed:

```
Error: UPGRADE FAILED: template: faros-infrastructure-provider/templates/operator-config.yaml:4:18:
executing "..." at <.Values.codingSandbox.enabled>: nil pointer evaluating interface{}.enabled
```

## Why

Plain `--reuse-values` reuses the old release's values verbatim and **never merges the new chart's defaults**. Chart 0.1.16 introduced the `codingSandbox` block; the old release's values had no such key, so the template crashed. Any chart release that introduces a new value block would break every existing BYO install the same way — the exact opposite of what the generated upgrade command is for.

## How

- The generated command now uses `--reset-then-reuse-values` (Helm 3.14+): start from the new chart's defaults, lay the operator's previous overrides on top. New values appear, local edits survive. Step description updated to say so.
- The infrastructure chart's `codingSandbox` dereferences are now nil-safe (`(.Values.codingSandbox).enabled`, with `default false` at value-rendering sites), so even a hand-typed `--reuse-values` upgrade resolves to the chart default instead of a template nil-pointer error.

## Tests

- `TestRenderInstallInstructionsUpgradeCommand` now pins `--reset-then-reuse-values` and rejects a bare ` --reuse-values`.
- `helm template` renders clean both with defaults and with `codingSandbox=null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)