### PR TITLE
fix(app-studio): refresh code explorer after edits

### DIFF
--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -807,6 +807,7 @@ const developmentPreviewAccessError = ref<string | null>(null)
 const developmentPreviewOverrideURL = ref<string | null>(null)
 const developmentPreviewAuthorizationKey = ref('')
 const developmentPreviewFrameKey = ref(0)
+const codeExplorerRefreshRevision = ref(0)
 const developmentPreviewFrameRef = ref<HTMLIFrameElement | null>(null)
 const developmentPreviewFrameLoaded = ref(false)
 const developmentPreviewDocumentState = ref<PreviewBridgeConnectionState>('disabled')
@@ -5932,6 +5933,7 @@ function applyAssistantSnapshot(snapshot: ProjectAssistantSnapshot, projectName 
     conversationStatus.value = ''
     assistantRunController.disconnect()
     if (normalized.message.metadata?.previewRefreshNeeded === true) {
+      codeExplorerRefreshRevision.value += 1
       void refreshDevelopmentPreviewFrame('Preview refreshed', { refreshProject: true })
     }
   } else if (requiresLiveControls) {
@@ -10059,7 +10061,11 @@ function isMissingCodeConnectionError(value: string | null): boolean {
         :id="workbenchTabPanelID(activeWorkbenchTab)"
         :aria-labelledby="workbenchTabControlID(activeWorkbenchTab)"
       >
-        <CodeExplorer :ctx="props.ctx" :project-name="selected?.name || ''" />
+        <CodeExplorer
+          :ctx="props.ctx"
+          :project-name="selected?.name || ''"
+          :refresh-revision="codeExplorerRefreshRevision"
+        />
       </div>
 
       <div

--- a/providers/app-studio/portal/src/CodeExplorer.test.mjs
+++ b/providers/app-studio/portal/src/CodeExplorer.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 import { createServer } from 'vite'
 
 const source = await readFile(new URL('./CodeExplorer.vue', import.meta.url), 'utf8')
+const appSource = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
 const vite = await createServer({ appType: 'custom', server: { middlewareMode: true, hmr: false } })
 const { codeExplorerTreeState } = await vite.ssrLoadModule('/src/CodeExplorer.vue')
 test.after(async () => vite.close())
@@ -34,7 +35,7 @@ test('keeps a cached tree visible and reports refresh failure separately from in
   assert.equal(codeExplorerTreeState(true, true, null), 'refreshing')
   assert.equal(codeExplorerTreeState(false, true, 'Could not refresh files.'), 'refresh-error')
   assert.equal(codeExplorerTreeState(false, true, null), 'ready')
-  assert.match(source, /class="app-studio-touch-target[^\"]*focus-visible:ring-2[^\"]*" @click="loadTree">Retry refresh<\/button>/)
+  assert.match(source, /class="app-studio-touch-target[^\"]*focus-visible:ring-2[^\"]*" @click="refreshWorkspaceSnapshot">Retry refresh<\/button>/)
 })
 
 test('adapts the explorer to one pane on mobile and exposes a complete keyboard tree', () => {
@@ -53,4 +54,17 @@ test('adapts the explorer to one pane on mobile and exposes a complete keyboard 
   assert.match(source, /event\.key === 'ArrowDown'/)
   assert.match(source, /event\.key === 'ArrowRight'/)
   assert.match(source, /event\.key === 'Home'/)
+})
+
+test('refreshes the tree and selected file after a workspace revision changes', () => {
+  assert.match(source, /refreshRevision: number/)
+  assert.match(source, /async function refreshWorkspaceSnapshot\(\)[\s\S]*const path = selectedPath\.value[\s\S]*await loadTree\(\)[\s\S]*await openFile\(path, projectName, requestContext\)/)
+  assert.match(source, /\(\) => props\.refreshRevision[\s\S]*void refreshWorkspaceSnapshot\(\)/)
+  assert.match(source, /@click="refreshWorkspaceSnapshot"/)
+})
+
+test('advances the explorer revision only for an accepted terminal workspace mutation', () => {
+  assert.match(appSource, /const codeExplorerRefreshRevision = ref\(0\)/)
+  assert.match(appSource, /assistantRunTerminal\(normalized\.run\.status\) && acceptedTerminal[\s\S]*normalized\.message\.metadata\?\.previewRefreshNeeded === true[\s\S]*codeExplorerRefreshRevision\.value \+= 1/)
+  assert.match(appSource, /<CodeExplorer[\s\S]*:refresh-revision="codeExplorerRefreshRevision"/)
 })

--- a/providers/app-studio/portal/src/CodeExplorer.vue
+++ b/providers/app-studio/portal/src/CodeExplorer.vue
@@ -39,6 +39,7 @@ import { api } from './api'
 const props = defineProps<{
   ctx: FarosContext | null
   projectName: string
+  refreshRevision: number
 }>()
 
 const files = ref<ProjectFileInfo[]>([])
@@ -51,6 +52,7 @@ const content = ref<ProjectFileContent | null>(null)
 const loadingFile = ref(false)
 const fileError = ref<string | null>(null)
 let fileRequestSerial = 0
+let workspaceRefreshSerial = 0
 
 const collapsed = ref<Set<string>>(new Set())
 const mobileTreeOpen = ref(true)
@@ -244,12 +246,26 @@ async function openFile(path: string, projectName = props.projectName, requestCo
   }
 }
 
+async function refreshWorkspaceSnapshot() {
+  const projectName = props.projectName
+  const requestContext = props.ctx
+  if (!projectName) return
+  const serial = ++workspaceRefreshSerial
+  const path = selectedPath.value
+  await loadTree()
+  if (serial !== workspaceRefreshSerial || !isCurrentProject(projectName, requestContext)) return
+  if (path && selectedPath.value === path && files.value.some((file) => file.path === path)) {
+    await openFile(path, projectName, requestContext)
+  }
+}
+
 const contentLines = computed(() => (content.value?.content ?? '').split('\n'))
 const treeState = computed(() => codeExplorerTreeState(loadingTree.value, files.value.length > 0, treeError.value))
 
 watch(
   () => [props.projectName, props.ctx] as const,
   () => {
+    workspaceRefreshSerial++
     treeRequestSerial++
     fileRequestSerial++
     files.value = []
@@ -276,6 +292,13 @@ watch(rows, (visibleRows) => {
     activeTreePath.value = visibleRows.find((row) => row.node.path === selectedPath.value)?.node.path ?? visibleRows[0].node.path
   }
 })
+
+watch(
+  () => props.refreshRevision,
+  () => {
+    if (props.projectName) void refreshWorkspaceSnapshot()
+  },
+)
 </script>
 
 <template>
@@ -294,7 +317,7 @@ watch(rows, (visibleRows) => {
           title="Refresh"
           aria-label="Refresh workspace files"
           :disabled="loadingTree"
-          @click="loadTree"
+          @click="refreshWorkspaceSnapshot"
         >
           <Loader2 v-if="loadingTree" class="h-4 w-4 animate-spin" aria-hidden="true" />
           <RefreshCw v-else class="h-4 w-4" aria-hidden="true" />
@@ -305,7 +328,7 @@ watch(rows, (visibleRows) => {
         <div v-else-if="treeState === 'refresh-error'" class="mx-2 mb-2 grid gap-1 rounded-md border border-warning/30 bg-warning-subtle px-2.5 py-2 text-[11px] leading-4 text-warning" role="alert" aria-live="polite">
           <span>{{ treeError }}</span>
           <span class="text-text-muted">Showing the last loaded tree.</span>
-          <button type="button" class="app-studio-touch-target inline-flex w-fit items-center rounded-sm font-medium underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40" @click="loadTree">Retry refresh</button>
+          <button type="button" class="app-studio-touch-target inline-flex w-fit items-center rounded-sm font-medium underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40" @click="refreshWorkspaceSnapshot">Retry refresh</button>
         </div>
         <div v-else-if="treeState === 'initial-loading'" class="grid gap-2 px-3 py-3" role="status" aria-live="polite" aria-label="Loading workspace files">
           <span class="sr-only">Loading workspace files…</span>

--- a/providers/app-studio/portal/src/previewState.test.mjs
+++ b/providers/app-studio/portal/src/previewState.test.mjs
@@ -221,7 +221,7 @@ test('an unavailable iframe is replaced when the browser tab wakes', () => {
 test('terminal preview refresh hydrates the selected project before authorizing', () => {
   assert.match(
     appSource,
-    /normalized\.message\.metadata\?\.previewRefreshNeeded === true\)\s*\{\s*void refreshDevelopmentPreviewFrame\('Preview refreshed', \{ refreshProject: true \}\)/,
+    /normalized\.message\.metadata\?\.previewRefreshNeeded === true\)\s*\{\s*codeExplorerRefreshRevision\.value \+= 1\s*void refreshDevelopmentPreviewFrame\('Preview refreshed', \{ refreshProject: true \}\)/,
   )
   assert.match(
     appSource,


### PR DESCRIPTION
## Summary

- refresh the CodeExplorer after successful assistant workspace mutations
- reload both the file tree and the currently selected file
- fence overlapping refreshes and preserve cached-tree error behavior
- make manual Refresh and Retry update selected file contents too

## Verification

- npm test
- npm run typecheck
- node --test src/CodeExplorer.test.mjs src/previewState.test.mjs
- git diff --check