### PR TITLE
Keep waiting out transient Failed phases while a run sandbox provisions

### DIFF
--- a/providers/app-studio/api/assistant_run_sandbox_lifecycle.go
+++ b/providers/app-studio/api/assistant_run_sandbox_lifecycle.go
@@ -344,11 +344,20 @@ func projectAssistantRunSandboxInstanceReadiness(obj *unstructured.Unstructured,
 	}
 	phase, _, _ := unstructured.NestedString(obj.Object, "status", "phase")
 	if strings.EqualFold(strings.TrimSpace(phase), "failed") || strings.EqualFold(strings.TrimSpace(phase), "error") {
+		// A failed phase is not a durable verdict on its own: Infrastructure
+		// derives it from any Ready=False condition, and the kro backend holds
+		// Ready=False ("cluster mutated") while its first provisioning pass
+		// converges, so every fresh instance transits Failed. Only a failed
+		// validation ends the wait early; anything else keeps polling until
+		// the ready timeout expires.
+		if detail, invalid := projectAssistantRunSandboxInvalidCondition(obj); invalid {
+			return false, true, detail
+		}
 		message, _, _ := unstructured.NestedString(obj.Object, "status", "message")
 		if strings.TrimSpace(message) == "" {
 			message = "instance reported a failed phase"
 		}
-		return false, true, message
+		return false, false, message
 	}
 
 	rawGeneration, found, err := unstructured.NestedFieldNoCopy(obj.Object, "metadata", "generation")
@@ -375,6 +384,9 @@ func projectAssistantRunSandboxInstanceReadiness(obj *unstructured.Unstructured,
 	if err != nil || !found {
 		return false, false, "status.conditions is missing"
 	}
+	if detail, invalid := projectAssistantRunSandboxInvalidCondition(obj); invalid {
+		return false, true, detail
+	}
 	readyCondition := false
 	for _, raw := range conditions {
 		condition, ok := raw.(map[string]any)
@@ -382,18 +394,6 @@ func projectAssistantRunSandboxInstanceReadiness(obj *unstructured.Unstructured,
 			continue
 		}
 		conditionType, _ := condition["type"].(string)
-		if strings.EqualFold(strings.TrimSpace(conditionType), "valid") {
-			status, _ := condition["status"].(string)
-			if !strings.EqualFold(strings.TrimSpace(status), "true") {
-				reasonText, _ := condition["reason"].(string)
-				message, _ := condition["message"].(string)
-				detail := strings.TrimSpace(strings.Join([]string{strings.TrimSpace(reasonText), strings.TrimSpace(message)}, ": "))
-				if detail == "" {
-					detail = "instance values are not valid"
-				}
-				return false, true, detail
-			}
-		}
 		if conditionType != "Ready" {
 			continue
 		}
@@ -439,6 +439,39 @@ func projectAssistantRunSandboxInstanceReadiness(obj *unstructured.Unstructured,
 		}
 	}
 	return true, false, ""
+}
+
+// projectAssistantRunSandboxInvalidCondition reports whether the instance
+// carries a non-true Valid condition — the one terminal signal in an instance
+// status. Validation is evaluated before provisioning, so its verdict does not
+// churn while the backend converges the runtime graph.
+func projectAssistantRunSandboxInvalidCondition(obj *unstructured.Unstructured) (string, bool) {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return "", false
+	}
+	for _, raw := range conditions {
+		condition, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		conditionType, _ := condition["type"].(string)
+		if !strings.EqualFold(strings.TrimSpace(conditionType), "valid") {
+			continue
+		}
+		status, _ := condition["status"].(string)
+		if strings.EqualFold(strings.TrimSpace(status), "true") {
+			return "", false
+		}
+		reasonText, _ := condition["reason"].(string)
+		message, _ := condition["message"].(string)
+		detail := strings.TrimSpace(strings.Join([]string{strings.TrimSpace(reasonText), strings.TrimSpace(message)}, ": "))
+		if detail == "" {
+			detail = "instance values are not valid"
+		}
+		return detail, true
+	}
+	return "", false
 }
 
 // projectAssistantRunSandboxObservedGenerationValue accepts the numeric forms

--- a/providers/app-studio/api/assistant_run_sandbox_test.go
+++ b/providers/app-studio/api/assistant_run_sandbox_test.go
@@ -918,6 +918,79 @@ func TestProjectAssistantRunSandboxInstanceReadyTimeoutIncludesStatus(t *testing
 	}
 }
 
+func TestProjectAssistantRunSandboxInstanceReadinessRetriesTransientFailedPhase(t *testing.T) {
+	components := map[string]projectTemplateComponent{"workspace": {WorkspacePath: "."}}
+	failed := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"generation": int64(1)},
+		"status": map[string]any{
+			"phase":   "Failed",
+			"message": "resource reconciliation failed: cluster mutated",
+			"conditions": []any{map[string]any{
+				"type":               "Ready",
+				"status":             "False",
+				"observedGeneration": int64(1),
+			}},
+		},
+	}}
+	ready, terminal, reason := projectAssistantRunSandboxInstanceReadiness(failed, components)
+	if ready || terminal {
+		t.Fatalf("readiness = %t terminal = %t reason = %q, want transient failed phase to stay retryable", ready, terminal, reason)
+	}
+	if !strings.Contains(reason, "cluster mutated") {
+		t.Fatalf("reason = %q, want the mirrored backend message", reason)
+	}
+}
+
+func TestProjectAssistantRunSandboxInstanceReadinessFailedValidationIsTerminal(t *testing.T) {
+	components := map[string]projectTemplateComponent{"workspace": {WorkspacePath: "."}}
+	invalid := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"generation": int64(1)},
+		"status": map[string]any{
+			"phase":   "Failed",
+			"message": "values failed validation",
+			"conditions": []any{map[string]any{
+				"type":    "Valid",
+				"status":  "False",
+				"reason":  "InvalidValues",
+				"message": "name is required",
+			}},
+		},
+	}}
+	ready, terminal, reason := projectAssistantRunSandboxInstanceReadiness(invalid, components)
+	if ready || !terminal {
+		t.Fatalf("readiness = %t terminal = %t reason = %q, want failed validation to end the wait", ready, terminal, reason)
+	}
+	if !strings.Contains(reason, "InvalidValues") || !strings.Contains(reason, "name is required") {
+		t.Fatalf("reason = %q, want the validation detail", reason)
+	}
+}
+
+func TestProjectAssistantRunSandboxInstanceReadyWaitOutlivesTransientFailedPhase(t *testing.T) {
+	components := map[string]projectTemplateComponent{"workspace": {WorkspacePath: "."}}
+	failed := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"generation": int64(1)},
+		"status": map[string]any{
+			"phase":   "Failed",
+			"message": "resource reconciliation failed: cluster mutated",
+		},
+	}}
+	ready := &unstructured.Unstructured{Object: map[string]any{"metadata": map[string]any{"generation": int64(1)}}}
+	_ = unstructured.SetNestedField(ready.Object, readyRunSandboxStatus(1), "status")
+	objects := []*unstructured.Unstructured{failed, ready}
+	calls := 0
+	err := waitForProjectAssistantRunSandboxInstanceReady(context.Background(), 100*time.Millisecond, time.Millisecond, components, func(context.Context) (*unstructured.Unstructured, error) {
+		object := objects[calls]
+		calls++
+		return object, nil
+	})
+	if err != nil {
+		t.Fatalf("readiness wait = %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("readiness polls = %d, want failed then ready", calls)
+	}
+}
+
 func TestProjectAssistantRunSandboxInstanceReadinessRequiresCurrentRuntimeState(t *testing.T) {
 	components := map[string]projectTemplateComponent{"workspace": {WorkspacePath: "."}}
 	tests := []struct {


### PR DESCRIPTION
## Problem

Assistant runs in App Studio failed with `File read failed` (`wait for run sandbox instance ...: instance is not ready: instance reported a failed phase`) whenever a fresh `universal-coding-sandbox` instance was provisioned.

The chain:

1. kro's first reconcile pass creates the sandbox's resources and requeues itself with `cluster mutated`, holding the runtime CR at `Ready=False` until the next pass converges (kro `pkg/controller/instance/resources.go`).
2. The infrastructure provider's `derivePhase` mirrors any `Ready=False` condition as `phase: Failed`, so every fresh Instance transits `Failed` during normal provisioning.
3. App Studio's readiness fence treated `Failed`/`Error` as instantly terminal, aborted the wait well inside its 2-minute ready timeout, rolled back, and deleted the instance.

Whether a run survived was a race between App Studio's status poll and kro's first pass.

## Fix

`projectAssistantRunSandboxInstanceReadiness` now treats a failed phase as a retryable observation bounded by the existing ready timeout. Early termination is reserved for a non-true `Valid` condition — validation is evaluated before provisioning, so its verdict does not churn while the runtime graph converges. The `Valid` scan is extracted into `projectAssistantRunSandboxInvalidCondition`, shared by the failed-phase path and the Ready path so terminal semantics stay in one place.

## Testing

- New unit tests: a transient `Failed` phase (kro's `cluster mutated` message) stays retryable and surfaces the mirrored backend message; `Failed` + `Valid=False` still ends the wait with the validation detail; the wait loop rides through a failed→ready sequence.
- Full `providers/app-studio/api` package passes.
- Verified live against the local Tilt stack: before the fix, `as-run-faros-pitch-slides-*` instances were killed on the transient `Failed` mirror and every `read_file` failed; after it, the instance converges to `Ready`, the workspace pod reaches `3/3 Running`, and file reads return real content.

A follow-up worth considering separately: `derivePhase` in the infrastructure provider could report `Pending` instead of `Failed` for a not-yet-Ready instance, which would remove the misleading phase for every Instance consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)