### PR TITLE
fix(app-studio): support file paths in sandbox grep

### DIFF
--- a/providers/app-studio/api/assistant_eino_filesystem.go
+++ b/providers/app-studio/api/assistant_eino_filesystem.go
@@ -77,6 +77,7 @@ Examples:
 Usage:
 - Use grep only to answer a concrete unresolved question. If prior tool results already answer that question, use them instead of searching again.
 - Do not use grep for open-ended exploration or successive rounds of speculative search.
+- The optional path may identify either a project-relative file or directory.
 - Narrow the search to the most relevant project-relative path, file glob, or language type.
 - You can call multiple tools in a single response. Batch independent targeted searches.
 - Once the current question and relevant edit locations are resolved, read the most relevant file and advance to the next allowed task action. Use another targeted grep only for a different concrete unresolved question.

--- a/providers/app-studio/api/assistant_run_sandbox_protocol.go
+++ b/providers/app-studio/api/assistant_run_sandbox_protocol.go
@@ -523,6 +523,53 @@ func sandboxFileTypeMatch(filePath, fileType string) bool {
 	return ext == fileType
 }
 
+func sandboxGrepGlobMatch(pattern, candidate string) bool {
+	if sandboxGlobMatch(pattern, candidate) {
+		return true
+	}
+	pattern = strings.TrimPrefix(strings.TrimSpace(pattern), "/")
+	return pattern != "" && !strings.Contains(pattern, "/") && sandboxGlobMatch(pattern, path.Base(candidate))
+}
+
+func (c projectAssistantDataPlaneSandboxClient) workspaceGrepFiles(
+	ctx context.Context,
+	id identity,
+	ref dataPlaneRef,
+	request projectAssistantSandboxWorkspaceRequest,
+) ([]string, map[string]projectAssistantSandboxReadWireFile, uint64, string, error) {
+	listed, listErr := c.workspaceList(ctx, id, ref, projectAssistantSandboxWorkspaceRequest{Path: request.Path, Limit: workspace.MaxListLimit})
+	if listErr == nil {
+		paths := make([]string, 0, len(listed.Entries))
+		for _, entry := range listed.Entries {
+			if strings.EqualFold(entry.Type, "file") && sandboxFileTypeMatch(entry.Path, request.FileType) && sandboxGrepGlobMatch(request.Glob, entry.Path) {
+				paths = append(paths, entry.Path)
+			}
+		}
+		if len(paths) == 0 {
+			return paths, map[string]projectAssistantSandboxReadWireFile{}, listed.SourceRevision, listed.SourceDigest, nil
+		}
+		files, revision, digest, _, err := c.workspaceReadFiles(ctx, id, ref, paths)
+		return paths, files, revision, digest, err
+	}
+
+	clean, cleanErr := sandboxWorkspacePath(request.Path, false)
+	if cleanErr != nil {
+		return nil, nil, 0, "", listErr
+	}
+	files, revision, digest, status, readErr := c.workspaceReadFiles(ctx, id, ref, []string{clean})
+	if readErr != nil || status == http.StatusNotFound {
+		return nil, nil, 0, "", listErr
+	}
+	if _, ok := files[clean]; !ok {
+		return nil, nil, 0, "", listErr
+	}
+	paths := []string{}
+	if sandboxFileTypeMatch(clean, request.FileType) && sandboxGrepGlobMatch(request.Glob, clean) {
+		paths = append(paths, clean)
+	}
+	return paths, files, revision, digest, nil
+}
+
 func (c projectAssistantDataPlaneSandboxClient) workspaceGrep(ctx context.Context, id identity, ref dataPlaneRef, request projectAssistantSandboxWorkspaceRequest) (projectAssistantSandboxWorkspaceResponse, error) {
 	pattern := request.GrepPattern
 	if strings.TrimSpace(pattern) == "" {
@@ -532,17 +579,7 @@ func (c projectAssistantDataPlaneSandboxClient) workspaceGrep(ctx context.Contex
 	if err != nil {
 		return projectAssistantSandboxWorkspaceResponse{}, fmt.Errorf("invalid grep pattern: %w", err)
 	}
-	listed, err := c.workspaceList(ctx, id, ref, projectAssistantSandboxWorkspaceRequest{Path: request.Path, Limit: workspace.MaxListLimit})
-	if err != nil {
-		return projectAssistantSandboxWorkspaceResponse{}, err
-	}
-	paths := make([]string, 0, len(listed.Entries))
-	for _, entry := range listed.Entries {
-		if strings.EqualFold(entry.Type, "file") && sandboxFileTypeMatch(entry.Path, request.FileType) && sandboxGlobMatch(request.Glob, entry.Path) {
-			paths = append(paths, entry.Path)
-		}
-	}
-	files, revision, digest, _, err := c.workspaceReadFiles(ctx, id, ref, paths)
+	paths, files, revision, digest, err := c.workspaceGrepFiles(ctx, id, ref, request)
 	if err != nil {
 		return projectAssistantSandboxWorkspaceResponse{}, err
 	}

--- a/providers/app-studio/api/assistant_run_sandbox_test.go
+++ b/providers/app-studio/api/assistant_run_sandbox_test.go
@@ -1875,6 +1875,92 @@ func TestProjectAssistantDataPlaneSandboxClientUsesWorkerWorkspaceWire(t *testin
 	}
 }
 
+func TestProjectAssistantDataPlaneSandboxClientGrepSupportsFileAndDirectoryPaths(t *testing.T) {
+	var operations []string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/workspace/list"):
+			var request projectAssistantSandboxListWireRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode list request: %v", err)
+			}
+			operations = append(operations, "list:"+request.Path)
+			switch request.Path {
+			case "src/style.css":
+				http.Error(w, "readdirent /workspace/src/style.css: not a directory", http.StatusBadRequest)
+			case "src":
+				_ = json.NewEncoder(w).Encode(projectAssistantSandboxListWireResponse{
+					Entries: []projectAssistantSandboxListWireEntry{
+						{Path: "src/main.js", Type: "file", Size: 12},
+						{Path: "src/style.css", Type: "file", Size: 38},
+					},
+					SourceRevision: 12,
+					SourceDigest:   "project",
+				})
+			default:
+				http.Error(w, "no such file or directory", http.StatusNotFound)
+			}
+		case strings.HasSuffix(r.URL.Path, "/workspace/read"):
+			var request projectAssistantSandboxReadWireRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode read request: %v", err)
+			}
+			operations = append(operations, "read:"+strings.Join(request.Paths, ","))
+			if len(request.Paths) != 1 || request.Paths[0] != "src/style.css" {
+				http.Error(w, "file not found", http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(projectAssistantSandboxReadWireResponse{
+				Files: []projectAssistantSandboxReadWireFile{{
+					Path: "src/style.css", Content: ".settings-card {\n}\n.settings-card {\n}\n", Bytes: 38, Digest: "style",
+				}},
+				SourceRevision: 12,
+				SourceDigest:   "project",
+			})
+		default:
+			t.Fatalf("unexpected workspace path %s", r.URL.Path)
+		}
+	})
+	client := projectAssistantDataPlaneSandboxClient{server: &Server{
+		hubBase: "http://sandbox.test", mcpInsecureSkipTLSVerify: true,
+		sandboxDataPlaneClientFactory: func(time.Duration) *http.Client {
+			return &http.Client{Transport: sandboxRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				recorder := httptest.NewRecorder()
+				handler.ServeHTTP(recorder, r)
+				return recorder.Result(), nil
+			})}
+		},
+	}}
+	id := identity{clusterID: "cluster", token: "token"}
+	ref := dataPlaneRef{Resource: "instances", Name: "as-run-shop-123", Component: "workspace"}
+
+	for _, searchPath := range []string{"src/style.css", "src"} {
+		response, err := client.Workspace(context.Background(), id, ref, projectAssistantSandboxWorkspaceRequest{
+			Action: "grep", Path: searchPath, GrepPattern: `\.settings-card \{`, Glob: "*.css", FileType: "css",
+		})
+		if err != nil {
+			t.Fatalf("grep path %q: %v", searchPath, err)
+		}
+		if response.SourceRevision != 12 || response.SourceDigest != "sha256:project" || len(response.Matches) != 2 {
+			t.Fatalf("grep path %q response = %#v", searchPath, response)
+		}
+		if response.Matches[0].Path != "src/style.css" || response.Matches[0].Line != 1 || response.Matches[1].Line != 3 {
+			t.Fatalf("grep path %q matches = %#v", searchPath, response.Matches)
+		}
+	}
+
+	_, err := client.Workspace(context.Background(), id, ref, projectAssistantSandboxWorkspaceRequest{
+		Action: "grep", Path: "src/missing.css", GrepPattern: "settings", Glob: "*.css",
+	})
+	if err == nil || !strings.Contains(err.Error(), "workspace list endpoint returned 404") {
+		t.Fatalf("missing file grep error = %v", err)
+	}
+	if got, want := strings.Join(operations, ";"), "list:src/style.css;read:src/style.css;list:src;read:src/style.css;list:src/missing.css;read:src/missing.css"; got != want {
+		t.Fatalf("grep operations = %q, want %q", got, want)
+	}
+}
+
 func TestProjectAssistantDataPlaneSandboxCheckpointWithNoChangesUsesDiffFence(t *testing.T) {
 	var paths []string
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- allow sandbox `grep` to target an exact project file, matching the exposed tool schema
- retain directory search behavior and make basename globs such as `*.css` work for nested files
- preserve the original list error when a path is neither a readable directory nor a readable file
- add cohesive regression coverage for file paths, directory paths, filters, source metadata, and missing paths

## Verification

- `make fix-lint`
- `make lint`
- `go test -count=1 -run '^TestProjectAssistantDataPlaneSandboxClientGrepSupportsFileAndDirectoryPaths$' ./api` (from `providers/app-studio`)
- `go test -count=1 ./api` (from `providers/app-studio`)
- `go test -count=1 ./...` (from `providers/app-studio`)
- Local Tilt: App Studio rebuilt healthy, and a read-only Plan-mode run against `cat-care-app` used `grep` with `path: src/style.css` and `glob: *.css`, succeeded with five references, and invoked no mutation tools (`run-a8f397d6-b833-46f3-875f-62bc5491a768`).
