### PR TITLE
fix(tilt): select IPv4 host gateway

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -711,7 +711,7 @@ KRO_KUBECONFIG=%s
 CTX=%s
 GW=%s
 gateway_ip=''
-host_gateway="$(docker exec %s getent hosts host.docker.internal 2>/dev/null | cut -d' ' -f1)"
+host_gateway="$(docker exec %s getent ahostsv4 host.docker.internal 2>/dev/null | awk 'NR == 1 {print $1}')"
 if [ -z "$host_gateway" ]; then
   host_gateway="$(docker inspect -f '%s' %s)"
 fi
@@ -801,7 +801,7 @@ local_resource(
     cmd='make build-infrastructure-provider',
     serve_cmd=('''
 set -eu
-host_gateway="$(docker exec {kro_node} getent hosts host.docker.internal 2>/dev/null | cut -d' ' -f1)"
+host_gateway="$(docker exec {kro_node} getent ahostsv4 host.docker.internal 2>/dev/null | awk 'NR == 1 {{print $1}}')"
 if [ -z "$host_gateway" ]; then
   host_gateway="$(docker inspect -f '{docker_gateway_format}' {kro_node})"
 fi

--- a/hack/scripts/verify-tilt-browser-deployment.test.sh
+++ b/hack/scripts/verify-tilt-browser-deployment.test.sh
@@ -59,9 +59,23 @@ regular_dns = section(
     "local_resource(\n    'app-studio-preview-dns',",
     "\n\nlocal_resource(\n    'kro-mgmt-down',",
 )
+regular_infrastructure = section(
+    tilt,
+    "local_resource(\n    'infrastructure',",
+    "\n\nlocal_resource(\n    'infrastructure-register',",
+)
 require(
     "preview_hub_public_host" in regular_dns,
     "regular Tilt preview DNS must map the public hub hostname for Browser pods",
+)
+require(
+    "getent ahostsv4 host.docker.internal 2>/dev/null | awk 'NR == 1 {print $1}'" in regular_dns,
+    "regular Tilt preview DNS must select exactly one IPv4 host gateway address",
+)
+require(
+    "getent ahostsv4 host.docker.internal 2>/dev/null | awk 'NR == 1 {{print $1}}'"
+    in regular_infrastructure,
+    "regular Tilt infrastructure must select exactly one IPv4 host gateway address",
 )
 
 cluster_dns_setup = section(


### PR DESCRIPTION
## Summary

- resolve host.docker.internal through the IPv4-specific NSS lookup
- select exactly one address before passing it to CoreDNS and the infrastructure provider
- add static regression coverage for both local Tilt call sites

## Validation

- bash hack/scripts/configure-tilt-preview-dns.test.sh
- bash hack/scripts/verify-tilt-browser-deployment.test.sh
- git diff --check
- live Tilt app-studio-preview-dns resource reports Ready=True