### PR TITLE
Let portal pages use the full viewport width

### DIFF
--- a/portal/src/components/AppLayout.sidenav.test.mjs
+++ b/portal/src/components/AppLayout.sidenav.test.mjs
@@ -55,9 +55,9 @@ const { flattenProviderItems, hasActiveNavRoute, isActiveRoute, isProviderItemAc
 const { isFiniteDockPosition } = finiteDockPositionModule
 const { clampDockPosition } = clampDockPositionModule
 
-test('ordinary pages use the shared wide desktop column without becoming full bleed', () => {
+test('ordinary pages use the shared fluid desktop column without becoming full bleed', () => {
   assert.match(appLayout, /'relative z-10 min-h-0 min-w-0 flex-1'/)
-  assert.match(appLayout, /layoutProps\.fullBleed \? 'h-full min-h-0' : 'mx-auto w-full max-w-7xl'/)
+  assert.match(appLayout, /layoutProps\.fullBleed \? 'h-full min-h-0' : 'w-full'/)
   assert.doesNotMatch(appLayout, /max-w-5xl/)
 })
 

--- a/portal/src/components/AppLayout.vue
+++ b/portal/src/components/AppLayout.vue
@@ -161,11 +161,12 @@ const mainStyle = computed(() => {
 const slotClass = computed(() => [
   'relative z-10',
   // Single source of truth for page content width: every non-full-bleed page
-  // renders in the SAME centered max-w-7xl column so the layout doesn't shift
+  // renders in the SAME fluid full-width column so the layout doesn't shift
   // when navigating. Pages must NOT add their own mx-auto/max-w-* wrapper —
-  // that reintroduces per-page width drift. Full-bleed provider workbenches opt
-  // out and manage their own width.
-  layoutProps.fullBleed ? 'h-full min-h-0' : 'mx-auto w-full max-w-7xl',
+  // that reintroduces per-page width drift. Wide-screen density comes from
+  // responsive grid columns inside each page, not from capping the column.
+  // Full-bleed provider workbenches opt out and manage their own width.
+  layoutProps.fullBleed ? 'h-full min-h-0' : 'w-full',
 ])
 
 // Static destinations precede categorized provider entries. Everything

--- a/portal/src/pages/BonkersPage.vue
+++ b/portal/src/pages/BonkersPage.vue
@@ -104,7 +104,7 @@ function handleLogout() {
 
     <!-- Main content -->
     <main class="min-w-0 flex-1 overflow-y-auto">
-      <div class="mx-auto w-full max-w-5xl px-8 py-5">
+      <div class="w-full px-8 py-5">
         <header class="mb-6 flex items-center justify-between">
           <h1 class="flex items-center gap-2 text-[17px] font-bold">
             <ShieldAlert class="h-5 w-5 text-accent" :stroke-width="1.75" />

--- a/portal/src/pages/DashboardPage.conformance.test.mjs
+++ b/portal/src/pages/DashboardPage.conformance.test.mjs
@@ -11,8 +11,8 @@ test('dashboard inherits the shared provider page width and padding from AppLayo
 })
 
 test('dashboard sizes its grid from the shared content column without crushing tiles', () => {
-  assert.match(page, /const MIN_TILE_WIDTH = 240/)
-  assert.match(page, /const MAX_DASHBOARD_COLUMNS = 4/)
+  assert.match(page, /const MIN_TILE_WIDTH = 320/)
+  assert.match(page, /const MAX_DASHBOARD_COLUMNS = 8/)
   assert.match(page, /const pageWidth = ref\(1280\)/)
   assert.match(page, /new ResizeObserver\(measure\)/)
   assert.match(page, /Math\.max\(1, Math\.min\(MAX_DASHBOARD_COLUMNS, columns\)\)/)

--- a/portal/src/pages/DashboardPage.vue
+++ b/portal/src/pages/DashboardPage.vue
@@ -60,14 +60,14 @@ const gated = computed(() =>
 const candidateNames = computed(() => gated.value.map((p) => p.name))
 
 // Responsive column count follows the dashboard's actual content width, not
-// the browser viewport. AppLayout caps this column at max-w-7xl and the nav can
-// consume different amounts of the viewport, so viewport sizing made cards
-// unusably narrow at both phone and ultrawide sizes.
+// the browser viewport. AppLayout's column is fluid and the nav can consume
+// different amounts of the viewport, so viewport sizing made cards unusably
+// narrow at both phone and ultrawide sizes.
 const pageRef = ref<HTMLElement | null>(null)
 const pageWidth = ref(1280)
 const TILE_GAP = 16
-const MIN_TILE_WIDTH = 240
-const MAX_DASHBOARD_COLUMNS = 4
+const MIN_TILE_WIDTH = 320
+const MAX_DASHBOARD_COLUMNS = 8
 let pageResizeObserver: ResizeObserver | null = null
 let fallbackResize: (() => void) | null = null
 

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -557,7 +557,7 @@ function dependencyNotice(p: ProviderDTO): string {
                 : 'No provider in this catalog publishes a self-hosting recipe yet.'
             }}
           </div>
-          <ul v-else class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <ul v-else class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
             <li
               v-for="p in availableToSelfHost"
               :key="p.name"
@@ -659,7 +659,7 @@ function dependencyNotice(p: ProviderDTO): string {
           No providers match your search.
         </div>
 
-        <ul v-else class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <ul v-else class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
           <template v-for="(p, i) in orderedCards" :key="p.name">
           <!-- Full-width section divider inside the same grid, so the cards
                below it keep their column alignment. -->


### PR DESCRIPTION
## Summary

The shared AppLayout content column was capped (`max-w-5xl`, bumped to `max-w-7xl` in #592), which left roughly 60% of a 2560px screen as empty background on the providers catalog and every other portal page. This makes the column fluid and gets wide-screen density from responsive grids instead of a hard cap:

- **AppLayout**: drop the max-width cap on the shared non-full-bleed content column (`w-full`); the comment now documents that density comes from per-page responsive grids.
- **ProvidersPage**: catalog and self-hosting card grids scale to `xl:grid-cols-4 2xl:grid-cols-5`.
- **DashboardPage**: tile grid may use up to 8 columns (was 4), with the minimum tile width raised 240px → 320px so extra columns never crush tile content.
- **BonkersPage**: the standalone platform-admin shell had its own copy of the cap; dropped too.

Saved dashboard arrangements are untouched — persisted tile geometry still renders verbatim, and Customize → Reset reflows into the wider grid.

## Testing

- `node --test` over all portal conformance suites: 120/120 pass (assertions pinning the old constants updated).
- `vue-tsc -b` clean.
- Verified live against the Tilt dev hub at 2560/1920/1440px: providers page renders 5/5/4 card columns edge to edge; dashboard tiles stay ≥320px wide; settings/workspaces pages stretch cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)