### PR TITLE
Give bootstrap-provisioned default workspaces a human-readable name

### DIFF
--- a/pkg/hub/controllers/organization/controller.go
+++ b/pkg/hub/controllers/organization/controller.go
@@ -106,6 +106,13 @@ type WorkspaceProvisioner interface {
 	// Idempotent (per O-11).
 	EnsureChildWorkspace(ctx context.Context, orgUUID, wsUUID string) error
 
+	// EnsureChildWorkspaceDisplayName stamps the display-name
+	// annotation on the child Workspace when none is set yet, so the
+	// default workspace surfaces under a human-readable name instead
+	// of its UUID. Never overwrites an existing name — a user rename
+	// must survive reconciles. Idempotent.
+	EnsureChildWorkspaceDisplayName(ctx context.Context, orgUUID, wsUUID, displayName string) error
+
 	// EnsureChildWorkspaceFarosBinding materializes an APIBinding to
 	// root:faros:providers.core.faros.sh inside the child team
 	// Workspace, with the permission claims faros controllers need.
@@ -464,6 +471,17 @@ func (r *Reconciler) reconcileOrganizationStatus(ctx context.Context, user *tena
 	default:
 		if err := r.provisioner.EnsureChildWorkspace(ctx, org.Name, wsUUID); err != nil {
 			logger.Error(err, "Provisioning default child Workspace failed; will retry")
+			childCond = metav1.Condition{
+				Type:    tenancyv1alpha1.OrganizationConditionDefaultWorkspaceReady,
+				Status:  metav1.ConditionFalse,
+				Reason:  reasonDefaultWorkspaceProvisioningFailed,
+				Message: err.Error(),
+			}
+		} else if err := r.provisioner.EnsureChildWorkspaceDisplayName(ctx, org.Name, wsUUID, defaultWorkspaceDisplayName); err != nil {
+			// The workspace exists but is still surfacing under its UUID.
+			// Keep the condition False so the reconcile retries: the UMI
+			// entry below advertises "default" and the two must agree.
+			logger.Error(err, "Stamping default child Workspace displayName failed; will retry")
 			childCond = metav1.Condition{
 				Type:    tenancyv1alpha1.OrganizationConditionDefaultWorkspaceReady,
 				Status:  metav1.ConditionFalse,

--- a/pkg/hub/controllers/organization/controller_test.go
+++ b/pkg/hub/controllers/organization/controller_test.go
@@ -41,6 +41,7 @@ type fakeProvisioner struct {
 	wsCalls        []string
 	memCalls       []membershipCall
 	childCalls     []childWorkspaceCall
+	nameCalls      []displayNameCall
 	farosBindCalls []childWorkspaceCall
 	adminCalls     []workspaceAdminCall
 	mcpCalls       []childWorkspaceCall
@@ -48,6 +49,7 @@ type fakeProvisioner struct {
 	wsErr          error
 	memErr         error
 	childErr       error
+	nameErr        error
 	farosBindErr   error
 	adminErr       error
 	mcpErr         error
@@ -66,6 +68,12 @@ type membershipCall struct {
 type childWorkspaceCall struct {
 	OrgUUID string
 	WSUUID  string
+}
+
+type displayNameCall struct {
+	OrgUUID     string
+	WSUUID      string
+	DisplayName string
 }
 
 type workspaceAdminCall struct {
@@ -93,6 +101,13 @@ func (f *fakeProvisioner) EnsureChildWorkspace(_ context.Context, orgUUID, wsUUI
 	defer f.mu.Unlock()
 	f.childCalls = append(f.childCalls, childWorkspaceCall{OrgUUID: orgUUID, WSUUID: wsUUID})
 	return f.childErr
+}
+
+func (f *fakeProvisioner) EnsureChildWorkspaceDisplayName(_ context.Context, orgUUID, wsUUID, displayName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nameCalls = append(f.nameCalls, displayNameCall{OrgUUID: orgUUID, WSUUID: wsUUID, DisplayName: displayName})
+	return f.nameErr
 }
 
 func (f *fakeProvisioner) EnsureChildWorkspaceFarosBinding(_ context.Context, orgUUID, wsUUID string) error {
@@ -150,6 +165,14 @@ func (f *fakeProvisioner) ChildWorkspaceCalls() []childWorkspaceCall {
 	defer f.mu.Unlock()
 	out := make([]childWorkspaceCall, len(f.childCalls))
 	copy(out, f.childCalls)
+	return out
+}
+
+func (f *fakeProvisioner) DisplayNameCalls() []displayNameCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]displayNameCall, len(f.nameCalls))
+	copy(out, f.nameCalls)
 	return out
 }
 
@@ -280,6 +303,10 @@ func TestReconciler_CreatesPersonalOrgForNewUser(t *testing.T) {
 	childCalls := prov.ChildWorkspaceCalls()
 	if len(childCalls) != 1 || childCalls[0].OrgUUID != org.Name || childCalls[0].WSUUID != wsUUID {
 		t.Errorf("expected exactly one EnsureChildWorkspace call for %s/%s, got %v", org.Name, wsUUID, childCalls)
+	}
+	nameCalls := prov.DisplayNameCalls()
+	if len(nameCalls) != 1 || nameCalls[0].OrgUUID != org.Name || nameCalls[0].WSUUID != wsUUID || nameCalls[0].DisplayName != defaultWorkspaceDisplayName {
+		t.Errorf("expected exactly one EnsureChildWorkspaceDisplayName call for %s/%s with %q, got %v", org.Name, wsUUID, defaultWorkspaceDisplayName, nameCalls)
 	}
 	farosCalls := prov.FarosBindCalls()
 	if len(farosCalls) != 1 || farosCalls[0].OrgUUID != org.Name || farosCalls[0].WSUUID != wsUUID {
@@ -483,6 +510,48 @@ func TestReconciler_ChildWorkspaceFailureSurfacesInStatus(t *testing.T) {
 	// Heal and re-reconcile.
 	prov.childErr = nil
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "frank"}}); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: org.Name}, &org); err != nil {
+		t.Fatalf("re-get organization: %v", err)
+	}
+	if !hasCondition(org.Status.Conditions, tenancyv1alpha1.OrganizationConditionReady, metav1.ConditionTrue, reasonAllStepsReady) {
+		t.Errorf("expected Ready=True/OrganizationReady after recovery; got %#v", org.Status.Conditions)
+	}
+}
+
+func TestReconciler_DisplayNameFailureSurfacesInStatus(t *testing.T) {
+	scheme := newTestScheme(t)
+	user := newUser("grace", "Grace")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(user).
+		WithStatusSubresource(&tenancyv1alpha1.User{}, &tenancyv1alpha1.Organization{}, &tenancyv1alpha1.UserMembershipIndex{}).
+		Build()
+
+	prov := &fakeProvisioner{nameErr: errors.New("annotation write denied")}
+	r := &Reconciler{client: c, provisioner: prov}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "grace"}}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var got tenancyv1alpha1.User
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "grace"}, &got); err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	var org tenancyv1alpha1.Organization
+	if err := c.Get(context.Background(), types.NamespacedName{Name: got.Status.PersonalOrg}, &org); err != nil {
+		t.Fatalf("get organization: %v", err)
+	}
+	// The workspace itself provisioned, but it would surface under its
+	// UUID — the step must not report Ready until the name is stamped.
+	if !hasCondition(org.Status.Conditions, tenancyv1alpha1.OrganizationConditionDefaultWorkspaceReady, metav1.ConditionFalse, reasonDefaultWorkspaceProvisioningFailed) {
+		t.Errorf("expected DefaultWorkspaceReady=False/DefaultWorkspaceProvisioningFailed; got %#v", org.Status.Conditions)
+	}
+
+	// Heal and re-reconcile.
+	prov.nameErr = nil
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "grace"}}); err != nil {
 		t.Fatalf("second reconcile: %v", err)
 	}
 	if err := c.Get(context.Background(), types.NamespacedName{Name: org.Name}, &org); err != nil {

--- a/pkg/hub/kcp/bootstrap.go
+++ b/pkg/hub/kcp/bootstrap.go
@@ -936,16 +936,10 @@ func (b *Bootstrapper) SetWorkspaceDisplayName(ctx context.Context, orgUUID, wsU
 // EnsureChildWorkspaceDisplayName stamps the display-name annotation
 // only when the Workspace does not carry one yet. Reconcilers use this
 // to give bootstrap-provisioned workspaces a human-readable default
-// without clobbering a rename the user made since.
+// without clobbering a rename the user made since — the absence check
+// runs inside the update loop, so a rename that lands mid-flight wins.
 func (b *Bootstrapper) EnsureChildWorkspaceDisplayName(ctx context.Context, orgUUID, wsUUID, displayName string) error {
-	current, err := b.GetWorkspaceDisplayName(ctx, orgUUID, wsUUID)
-	if err != nil {
-		return err
-	}
-	if current != "" {
-		return nil
-	}
-	return b.patchWorkspaceAnnotation(ctx, orgUUID, wsUUID, WorkspaceDisplayNameAnnotation, displayName)
+	return b.patchWorkspaceAnnotationIfAbsent(ctx, orgUUID, wsUUID, WorkspaceDisplayNameAnnotation, displayName)
 }
 
 // GetWorkspaceDisplayName reads the display-name annotation. Empty
@@ -1022,8 +1016,18 @@ func (b *Bootstrapper) patchWorkspaceAnnotation(ctx context.Context, orgUUID, ws
 // request. The conditional read is repeated after conflicts and treats any
 // existing value (including an older or malformed value) as authoritative.
 func (b *Bootstrapper) patchWorkspaceDeletionAnnotationIfAbsent(ctx context.Context, orgUUID, wsUUID, value string) error {
+	return b.patchWorkspaceAnnotationIfAbsent(ctx, orgUUID, wsUUID, WorkspaceDeletionAnnotation, value)
+}
+
+// patchWorkspaceAnnotationIfAbsent writes an annotation only while the
+// Workspace carries no non-empty value for it. Unlike
+// patchWorkspaceAnnotation, the absence check runs on every attempt of
+// the get/modify/update loop: a competing writer that lands first —
+// either before the first read or via a conflict retry — is treated as
+// authoritative and the write is dropped.
+func (b *Bootstrapper) patchWorkspaceAnnotationIfAbsent(ctx context.Context, orgUUID, wsUUID, key, value string) error {
 	if orgUUID == "" || wsUUID == "" {
-		return fmt.Errorf("patchWorkspaceDeletionAnnotationIfAbsent: orgUUID and wsUUID are required")
+		return fmt.Errorf("patchWorkspaceAnnotationIfAbsent: orgUUID and wsUUID are required")
 	}
 	orgConfig := configForPath(b.config, kcppaths.OrgPath(orgUUID))
 	orgClient, err := dynamic.NewForConfig(orgConfig)
@@ -1039,13 +1043,13 @@ func (b *Bootstrapper) patchWorkspaceDeletionAnnotationIfAbsent(ctx context.Cont
 			return err
 		}
 		annos, _, _ := unstructured.NestedStringMap(ws.Object, "metadata", "annotations")
-		if existing, present := annos[WorkspaceDeletionAnnotation]; present && existing != "" {
+		if existing, present := annos[key]; present && existing != "" {
 			return nil
 		}
 		if annos == nil {
 			annos = map[string]string{}
 		}
-		annos[WorkspaceDeletionAnnotation] = value
+		annos[key] = value
 		if err := unstructured.SetNestedStringMap(ws.Object, annos, "metadata", "annotations"); err != nil {
 			return fmt.Errorf("setting annotations: %w", err)
 		}

--- a/pkg/hub/kcp/bootstrap.go
+++ b/pkg/hub/kcp/bootstrap.go
@@ -933,6 +933,21 @@ func (b *Bootstrapper) SetWorkspaceDisplayName(ctx context.Context, orgUUID, wsU
 	return b.patchWorkspaceAnnotation(ctx, orgUUID, wsUUID, WorkspaceDisplayNameAnnotation, displayName)
 }
 
+// EnsureChildWorkspaceDisplayName stamps the display-name annotation
+// only when the Workspace does not carry one yet. Reconcilers use this
+// to give bootstrap-provisioned workspaces a human-readable default
+// without clobbering a rename the user made since.
+func (b *Bootstrapper) EnsureChildWorkspaceDisplayName(ctx context.Context, orgUUID, wsUUID, displayName string) error {
+	current, err := b.GetWorkspaceDisplayName(ctx, orgUUID, wsUUID)
+	if err != nil {
+		return err
+	}
+	if current != "" {
+		return nil
+	}
+	return b.patchWorkspaceAnnotation(ctx, orgUUID, wsUUID, WorkspaceDisplayNameAnnotation, displayName)
+}
+
 // GetWorkspaceDisplayName reads the display-name annotation. Empty
 // string if absent. Workspace-not-found surfaces as IsNotFound.
 func (b *Bootstrapper) GetWorkspaceDisplayName(ctx context.Context, orgUUID, wsUUID string) (string, error) {


### PR DESCRIPTION
## Summary

Every workspace a user creates through the portal or REST API already requires a human-readable `displayName`, and orgs get one at creation too. The one path that didn't: the org bootstrap controller. It provisioned each user's default workspace without stamping the display-name annotation, so the settings page and workspace lists rendered the raw UUID (`bd6dd2e5-402a-…`) — even though the membership index simultaneously advertised the same workspace as `"default"`.

- **organization controller (Step E)**: after the default child workspace provisions, ensure the display-name annotation is set to `default` (the same constant already written into the UMI entry). A stamping failure keeps `DefaultWorkspaceReady` False so the reconcile retries; the two sources can no longer disagree.
- **kcp Bootstrapper**: new `EnsureChildWorkspaceDisplayName` that writes the annotation only when none is present — a rename the user made later is never clobbered by subsequent reconciles.
- Existing orgs pick the name up on their next reconcile; no migration needed.

## Testing

- Extended the happy-path bootstrap test to assert exactly one display-name stamp with `"default"` for the new workspace.
- New `TestReconciler_DisplayNameFailureSurfacesInStatus`: a failed stamp surfaces as `DefaultWorkspaceReady=False` and the org recovers to `Ready=True` once the write succeeds.
- `go test ./pkg/hub/controllers/organization/ ./pkg/hub/kcp/ ./pkg/hub/restapi/` pass; `go build ./...` and `go vet ./pkg/hub/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)