### PR TITLE
Prevent Databricks create action flashes

### DIFF
--- a/providers/databricks/portal/src/resourceTable.ssr.test.mjs
+++ b/providers/databricks/portal/src/resourceTable.ssr.test.mjs
@@ -1956,8 +1956,19 @@ function resourceListStubComponents() {
       }, props.rows?.length ? 'Rows' : 'Table')
     },
   }
+  const SplitCreateButtonStub = {
+    props: { kind: String },
+    setup(props) {
+      return () => h('div', { class: 'split-create', 'data-kind': props.kind }, `New ${props.kind}`)
+    },
+  }
   const StatusBadgeStub = { setup: () => () => h('span') }
-  return { DatabricksEmptyState: EmptyStateStub, ResourceTable: ResourceTableStub, StatusBadge: StatusBadgeStub }
+  return {
+    DatabricksEmptyState: EmptyStateStub,
+    ResourceTable: ResourceTableStub,
+    SplitCreateButton: SplitCreateButtonStub,
+    StatusBadge: StatusBadgeStub,
+  }
 }
 
 function resourceListPendingRead(pendingReads, kind) {
@@ -1976,7 +1987,13 @@ async function settleResourceListPage(pendingReads, pageKind, result) {
   await flushVue()
 }
 
-test('known-empty collection surfaces stay mounted while foreground refreshes settle', async () => {
+function resourceListCreateControl(mounted, kind) {
+  return mounted.find(node => kind === 'connections'
+    ? node.type === 'button' && hostText(node).includes('Add connection')
+    : className(node).split(/\s+/).includes('split-create'))
+}
+
+test('collection create controls wait for authority and known-empty surfaces stay mounted during refresh', async () => {
   const ConnectionsView = await loadMountedSFC('/src/views/ConnectionsView.vue')
   const WarehousesView = await loadMountedSFC('/src/views/WarehousesView.vue')
   const TablesView = await loadMountedSFC('/src/views/TablesView.vue')
@@ -2020,11 +2037,14 @@ test('known-empty collection surfaces stay mounted while foreground refreshes se
         assert.equal(pendingReads.filter(read => testCase.supportKinds.includes(read.kind)).length, testCase.supportKinds.length, `${testCase.kind} support reads are pending`)
         assert.equal(pendingReads.filter(read => read.kind === testCase.pageKind).length, testCase.supportKinds.length ? 0 : 1, `${testCase.kind} initial page read follows support initialization`)
         assert.equal(mounted.find(node => className(node).includes('k-table'))?.props?.['data-loading'], 'true', `${testCase.kind} initial read shows the table loading state`)
+        assert.equal(resourceListCreateControl(mounted, testCase.kind), null, `${testCase.kind} withholds create controls while initial authority is unknown`)
 
         await settleResourceListSupport(pendingReads, testCase.supportKinds)
         assert.equal(pendingReads.filter(read => read.kind === testCase.pageKind).length, 1, `${testCase.kind} initial page read is pending`)
+        assert.equal(resourceListCreateControl(mounted, testCase.kind), null, `${testCase.kind} withholds create controls until its collection page settles`)
         await settleResourceListPage(pendingReads, testCase.pageKind, { items: [], continue: null })
         assert.ok(mounted.find(node => className(node).includes('databricks-first-run')), `${testCase.kind} shows onboarding after an authoritative empty result`)
+        assert.equal(resourceListCreateControl(mounted, testCase.kind), null, `${testCase.kind} onboarding owns the empty-state action`)
 
         mounted.instance.setupState.load()
         await nextTick()
@@ -2042,6 +2062,7 @@ test('known-empty collection surfaces stay mounted while foreground refreshes se
         const table = mounted.find(node => className(node).includes('k-table'))
         assert.equal(table?.props?.['data-row-count'], '1', `${testCase.kind} rows replace onboarding directly after refresh`)
         assert.equal(mounted.find(node => className(node).includes('databricks-first-run')), null, `${testCase.kind} removes onboarding once rows are authoritative`)
+        assert.ok(resourceListCreateControl(mounted, testCase.kind), `${testCase.kind} shows create controls once non-empty authority is established`)
 
         if (testCase.kind === 'connections') {
           apiModule.api.deleteConnection = async () => {}

--- a/providers/databricks/portal/src/views/ConnectionsView.vue
+++ b/providers/databricks/portal/src/views/ConnectionsView.vue
@@ -403,7 +403,7 @@ onUnmounted(() => {
         <h2 class="page-title">Connections</h2>
         <p class="page-meta">Databricks workspaces available to tables in this faros workspace.</p>
       </div>
-      <div v-if="!showFirstRun" class="actions">
+      <div v-if="loaded && !showFirstRun" class="actions">
         <button class="k-btn k-btn--primary" type="button" @click="emit('create')">Add connection</button>
       </div>
     </header>

--- a/providers/databricks/portal/src/views/TablesView.vue
+++ b/providers/databricks/portal/src/views/TablesView.vue
@@ -420,7 +420,7 @@ onUnmounted(() => {
           <RefreshCw class="button-icon" :class="{ spin: loading }" :stroke-width="1.75" />
           {{ loading ? 'Refreshing…' : 'Refresh' }}
         </button>
-        <SplitCreateButton v-if="!showFirstRun" kind="table" @manual="emit('create', 'manual')" @browse="emit('create', 'browse')" />
+        <SplitCreateButton v-if="loaded && !showFirstRun" kind="table" @manual="emit('create', 'manual')" @browse="emit('create', 'browse')" />
       </div>
     </header>
 

--- a/providers/databricks/portal/src/views/WarehousesView.vue
+++ b/providers/databricks/portal/src/views/WarehousesView.vue
@@ -440,7 +440,7 @@ onUnmounted(() => {
         <h2 class="page-title">Warehouses</h2>
         <p class="page-meta">SQL warehouses available to imported Databricks tables. Click one to inspect status and defaults.</p>
       </div>
-      <SplitCreateButton v-if="!showFirstRun" kind="warehouse" @manual="emit('create', 'manual')" @browse="emit('create', 'browse')" />
+      <SplitCreateButton v-if="loaded && !showFirstRun" kind="warehouse" @manual="emit('create', 'manual')" @browse="emit('create', 'browse')" />
     </header>
 
     <div v-if="mutationError" class="error mutation-error" role="alert" aria-live="assertive">


### PR DESCRIPTION
## Summary
- hide Databricks collection create actions until the initial resource state is authoritative
- keep first-run onboarding as the sole action surface for authoritative empty collections
- cover pending, empty, refresh, and populated transitions across Connections, Warehouses, and Tables

## Testing
- npm run test:portal
- npm run typecheck
- npm run build
- make verify-ui-conformance
- Impeccable detector: zero findings
- live Tilt Databricks bundle matched the built artifact and reported Ready