### PR TITLE
fix(providers): enforce backend readiness

### DIFF
--- a/pkg/hub/providers/api.go
+++ b/pkg/hub/providers/api.go
@@ -61,9 +61,13 @@ type providerDTO struct {
 	Description string `json:"description,omitempty"`
 	Version     string `json:"version,omitempty"`
 	Ready       bool   `json:"ready"`
-	HasUI       bool   `json:"hasUI"`
-	HasBackend  bool   `json:"hasBackend"`
-	IconURL     string `json:"iconURL,omitempty"`
+	// ReadinessReason and ReadinessMessage are present only when Ready is
+	// false. Values come from Provider.Readiness and are safe for end users.
+	ReadinessReason  string `json:"readinessReason,omitempty"`
+	ReadinessMessage string `json:"readinessMessage,omitempty"`
+	HasUI            bool   `json:"hasUI"`
+	HasBackend       bool   `json:"hasBackend"`
+	IconURL          string `json:"iconURL,omitempty"`
 	// BuiltinRoute, when set, tells the portal to render the named Vue
 	// route inside its own SPA instead of loading /main.js as a custom
 	// element. Set on first-party providers shipped with the portal (mcp,
@@ -342,6 +346,7 @@ func listHandlerFunc(reg *Registry) http.Handler {
 			if p.OrgUUID != "" {
 				scope = ScopeOrg
 			}
+			ready, readinessReason, readinessMessage := p.Readiness()
 			items = append(items, providerDTO{
 				Name:             p.Name,
 				Scope:            scope,
@@ -349,7 +354,9 @@ func listHandlerFunc(reg *Registry) http.Handler {
 				DisplayName:      displayName,
 				Description:      p.Description,
 				Version:          p.Version,
-				Ready:            p.Ready(),
+				Ready:            ready,
+				ReadinessReason:  readinessReason,
+				ReadinessMessage: readinessMessage,
 				HasUI:            p.UIURL != nil || p.BuiltinRoute != "" || p.LocalUIAssets != nil,
 				HasBackend:       p.BackendURL != nil,
 				IconURL:          iconURL,

--- a/pkg/hub/providers/api_test.go
+++ b/pkg/hub/providers/api_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	providersv1alpha1 "github.com/faroshq/faros/apis/providers/v1alpha1"
@@ -192,6 +193,56 @@ func TestListHandlerProjectsDescription(t *testing.T) {
 	}
 	if _, ok := byName["silent"]["description"]; ok {
 		t.Errorf("silent emitted a description key: %#v", byName["silent"])
+	}
+}
+
+func TestListHandlerProjectsOnlySanitizedFailureReadiness(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{
+		Name:                  "code",
+		DisplayName:           "Code",
+		EndpointsValid:        true,
+		BackendURL:            mustProviderURL(t, "https://secret.internal.invalid"),
+		BackendHealthRequired: true,
+		BackendHealthy:        false,
+	})
+	reg.Upsert(Provider{
+		Name:           "healthy",
+		DisplayName:    "Healthy",
+		EndpointsValid: true,
+		BackendURL:     mustProviderURL(t, "https://healthy.internal.invalid"),
+		BackendHealthy: true,
+	})
+
+	r := httptest.NewRequest(http.MethodGet, PathListProviders, nil)
+	w := httptest.NewRecorder()
+	NewListHandler(reg).ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var raw struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	byName := map[string]map[string]any{}
+	for _, item := range raw.Items {
+		byName[item["name"].(string)] = item
+	}
+	if got := byName["code"]["readinessReason"]; got != "BackendUnhealthy" {
+		t.Fatalf("code readinessReason = %#v", got)
+	}
+	if got := byName["code"]["readinessMessage"]; got != "Provider backend is unavailable." {
+		t.Fatalf("code readinessMessage = %#v", got)
+	}
+	if strings.Contains(w.Body.String(), "secret.internal") {
+		t.Fatalf("provider response leaked backend authority: %s", w.Body.String())
+	}
+	for _, field := range []string{"readinessReason", "readinessMessage"} {
+		if _, ok := byName["healthy"][field]; ok {
+			t.Fatalf("healthy provider emitted %s: %#v", field, byName["healthy"])
+		}
 	}
 }
 

--- a/pkg/hub/providers/controller.go
+++ b/pkg/hub/providers/controller.go
@@ -326,11 +326,17 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 	// through kcp) is unaffected. It just has no reachable backend, which the
 	// proxy reports as 503 rather than dialling an address inside someone
 	// else's cluster.
-	if orgUUID != "" && r.edgeRoutes != nil && entry.Spec.Backend != nil {
-		route, err := r.edgeRoutes.ResolveProviderEdgeRoute(ctx, orgUUID, entry.Name, entry.Spec.Backend.URL)
-		if err != nil {
+	var edgeRouteErr error
+	if orgUUID != "" && entry.Spec.Backend != nil {
+		if r.edgeRoutes == nil {
+			edgeRouteErr = fmt.Errorf("edge route resolver is unavailable")
+		} else if route, err := r.edgeRoutes.ResolveProviderEdgeRoute(ctx, orgUUID, entry.Name, entry.Spec.Backend.URL); err != nil {
+			edgeRouteErr = err
 			logger.Info("Could not resolve edge route for org-owned provider; its backend stays unroutable",
 				"provider", entry.Name, "error", err.Error())
+		} else if !route.Usable() {
+			edgeRouteErr = fmt.Errorf("edge route is not yet usable")
+			logger.Info("Edge route for org-owned provider is not yet usable", "provider", entry.Name)
 		} else {
 			prov.EdgeRoute = route
 		}
@@ -605,6 +611,10 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 		cond.Status = metav1.ConditionFalse
 		cond.Reason = "InvalidEndpoint"
 		cond.Message = fmt.Sprintf("Endpoint parse errors: %v", parseErrs)
+	case edgeRouteErr != nil:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "BackendUnroutable"
+		cond.Message = "Provider backend route is unavailable."
 	case prov.BackendHealthRequired && !prov.BackendHealthy:
 		cond.Status = metav1.ConditionFalse
 		cond.Reason = "BackendUnhealthy"
@@ -629,7 +639,7 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 	} else if requeue {
 		return ctrl.Result{Requeue: true}, nil
 	}
-	if prov.BackendHealthRequired || prov.HeartbeatRequired {
+	if prov.BackendHealthRequired || prov.HeartbeatRequired || edgeRouteErr != nil {
 		return ctrl.Result{RequeueAfter: SweepInterval}, nil
 	}
 	return ctrl.Result{}, nil

--- a/pkg/hub/providers/controller.go
+++ b/pkg/hub/providers/controller.go
@@ -19,8 +19,11 @@ package providers
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -70,6 +73,9 @@ type CatalogReconciler struct {
 	// edgeRoutes resolves an org-owned provider's edge transport. Nil in
 	// registry-only mode and on hubs that predate edge transport.
 	edgeRoutes EdgeRouteResolver
+	// healthClient performs bounded, same-authority readiness probes for
+	// platform-provider backends. Org-owned backends are never sent here.
+	healthClient httpDoer
 
 	// clusterPaths caches logical-cluster-ID → canonical workspace path. The
 	// path is what tells a platform provider apart from an org-owned one and
@@ -82,6 +88,21 @@ type CatalogReconciler struct {
 	// by the number of provider workspaces the hub has observed.
 	clusterPathsMu sync.RWMutex
 	clusterPaths   map[string]string
+}
+
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+const backendHealthTimeout = 3 * time.Second
+
+func defaultBackendHealthClient() *http.Client {
+	return &http.Client{
+		Timeout: backendHealthTimeout,
+		// A provider-controlled redirect cannot move the hub's health probe to
+		// another authority. The 3xx response itself is unhealthy.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
 }
 
 // CatalogReconcilerOptions threads optional extras into the reconciler
@@ -112,6 +133,7 @@ func SetupCatalogWithManager(mgr mcmanager.Manager, reg *Registry, kcpConfig *re
 		hubExternalURL: opts.HubExternalURL,
 		hubInternalURL: opts.HubInternalURL,
 		edgeRoutes:     opts.EdgeRoutes,
+		healthClient:   defaultBackendHealthClient(),
 		clusterPaths:   map[string]string{},
 	}
 	if kcpConfig != nil {
@@ -342,6 +364,7 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 	if entry.Status.LastHeartbeat != nil {
 		prov.LastHeartbeat = entry.Status.LastHeartbeat.Time
 		prov.HeartbeatRequired = true
+		prov.HeartbeatStale = time.Since(prov.LastHeartbeat) > HeartbeatTTL
 		prov.ReportedVersion = entry.Status.ReportedVersion
 	}
 	if entry.Spec.APIExport != nil {
@@ -444,6 +467,7 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 	})
 
 	var parseErrs []string
+	var backendHealthErr error
 	if entry.Spec.UI != nil && entry.Spec.UI.URL != "" {
 		u, err := ParseURL(entry.Spec.UI.URL)
 		if err != nil {
@@ -458,6 +482,22 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 			parseErrs = append(parseErrs, "backend.url: "+err.Error())
 		} else {
 			prov.BackendURL = u
+			// Platform providers are hub-operated and their declared service URL
+			// is an admitted in-cluster route. Org-owned provider URLs name an
+			// address inside a tenant cluster; direct probing would bypass the
+			// hub-owned edge route and turn tenant input into an SSRF primitive.
+			if orgUUID == "" {
+				prov.BackendHealthRequired = true
+				healthClient := r.healthClient
+				if healthClient == nil {
+					healthClient = defaultBackendHealthClient()
+				}
+				if err := probeBackendHealth(ctx, healthClient, u, entry.Spec.Backend.HealthPath); err != nil {
+					backendHealthErr = err
+				} else {
+					prov.BackendHealthy = true
+				}
+			}
 		}
 	}
 	if entry.Spec.VirtualWorkspace != nil {
@@ -534,6 +574,26 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 	if prov.BackendURL != nil {
 		entry.Status.Endpoints.Backend = prov.BackendURL.String()
 	}
+	if !prov.BackendHealthRequired {
+		removeCondition(&entry.Status.Conditions, "BackendHealthy")
+	} else {
+		backendCondition := metav1.Condition{
+			Type:               "BackendHealthy",
+			LastTransitionTime: now,
+			ObservedGeneration: entry.Generation,
+		}
+		if prov.BackendHealthy {
+			backendCondition.Status = metav1.ConditionTrue
+			backendCondition.Reason = "HealthCheckSucceeded"
+			backendCondition.Message = "Provider backend health check succeeded."
+		} else {
+			backendCondition.Status = metav1.ConditionFalse
+			backendCondition.Reason = "HealthCheckFailed"
+			backendCondition.Message = "Provider backend health check failed."
+			logger.Info("Provider backend health check failed", "error", backendHealthErr)
+		}
+		setCondition(&entry.Status.Conditions, backendCondition)
+	}
 
 	cond := metav1.Condition{
 		Type:               "Ready",
@@ -545,10 +605,18 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 		cond.Status = metav1.ConditionFalse
 		cond.Reason = "InvalidEndpoint"
 		cond.Message = fmt.Sprintf("Endpoint parse errors: %v", parseErrs)
+	case prov.BackendHealthRequired && !prov.BackendHealthy:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "BackendUnhealthy"
+		cond.Message = "Provider backend is unavailable."
+	case prov.HeartbeatRequired && prov.HeartbeatStale:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "HeartbeatStale"
+		cond.Message = "Provider heartbeat is stale."
 	case prov.EndpointsValid:
 		cond.Status = metav1.ConditionTrue
-		cond.Reason = "EndpointsResolved"
-		cond.Message = "Provider endpoints registered with the hub routing table."
+		cond.Reason = "Ready"
+		cond.Message = "Provider endpoints and health checks are ready."
 	default:
 		cond.Status = metav1.ConditionFalse
 		cond.Reason = "NoEndpoint"
@@ -561,7 +629,69 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 	} else if requeue {
 		return ctrl.Result{Requeue: true}, nil
 	}
+	if prov.BackendHealthRequired || prov.HeartbeatRequired {
+		return ctrl.Result{RequeueAfter: SweepInterval}, nil
+	}
 	return ctrl.Result{}, nil
+}
+
+// probeBackendHealth builds a same-authority endpoint from backend and the
+// provider's relative healthPath, then requires HTTP 200 within a bounded
+// interval. Absolute URLs and traversal are rejected before any request.
+func probeBackendHealth(ctx context.Context, client httpDoer, backend *url.URL, healthPath string) error {
+	if backend == nil {
+		return fmt.Errorf("backend URL is missing")
+	}
+	if backend.Scheme != "http" && backend.Scheme != "https" {
+		return fmt.Errorf("backend URL must use http or https")
+	}
+	if healthPath == "" {
+		healthPath = "/healthz"
+	}
+	rel, err := url.Parse(healthPath)
+	if err != nil {
+		return fmt.Errorf("invalid healthPath: %w", err)
+	}
+	if rel.IsAbs() || rel.Host != "" || rel.User != nil || rel.Opaque != "" || rel.Fragment != "" {
+		return fmt.Errorf("healthPath must be a local HTTP path")
+	}
+	decodedPath, err := url.PathUnescape(rel.EscapedPath())
+	if err != nil {
+		return fmt.Errorf("invalid healthPath escaping: %w", err)
+	}
+	for _, segment := range strings.Split(decodedPath, "/") {
+		if segment == "." || segment == ".." {
+			return fmt.Errorf("healthPath must not contain traversal segments")
+		}
+	}
+	if decodedPath == "" {
+		return fmt.Errorf("healthPath must not be empty")
+	}
+	if !strings.HasPrefix(decodedPath, "/") {
+		decodedPath = "/" + decodedPath
+	}
+	target := *backend
+	target.Path = singleJoiningSlash(backend.Path, decodedPath)
+	target.RawPath = ""
+	target.RawQuery = rel.RawQuery
+	target.Fragment = ""
+
+	probeCtx, cancel := context.WithTimeout(ctx, backendHealthTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, target.String(), nil)
+	if err != nil {
+		return fmt.Errorf("build health request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("returned HTTP %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // updateStatusIfChanged writes entry's status only when it differs from what
@@ -599,12 +729,24 @@ func urlString(u *url.URL) string {
 func setCondition(conds *[]metav1.Condition, c metav1.Condition) {
 	for i, existing := range *conds {
 		if existing.Type == c.Type {
-			if existing.Status == c.Status && existing.Reason == c.Reason && existing.Message == c.Message {
-				return // no-op
+			if existing.Status == c.Status {
+				c.LastTransitionTime = existing.LastTransitionTime
+			}
+			if equality.Semantic.DeepEqual(existing, c) {
+				return
 			}
 			(*conds)[i] = c
 			return
 		}
 	}
 	*conds = append(*conds, c)
+}
+
+func removeCondition(conds *[]metav1.Condition, conditionType string) {
+	for i, condition := range *conds {
+		if condition.Type == conditionType {
+			*conds = append((*conds)[:i], (*conds)[i+1:]...)
+			return
+		}
+	}
 }

--- a/pkg/hub/providers/controller_test.go
+++ b/pkg/hub/providers/controller_test.go
@@ -18,6 +18,12 @@ package providers
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -29,8 +35,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	providersv1alpha1 "github.com/faroshq/faros/apis/providers/v1alpha1"
+	"github.com/faroshq/faros/pkg/kcppaths"
 	"github.com/faroshq/faros/utils/testfakes"
 )
+
+type httpDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f httpDoerFunc) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+func healthyHTTPDoer() httpDoer {
+	return httpDoerFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     make(http.Header),
+		}, nil
+	})
+}
 
 func newProviderTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -224,7 +245,7 @@ func TestCatalogReconcilerDoesNotRewriteUnchangedStatus(t *testing.T) {
 		WithObjects(entry).
 		Build()
 
-	r := &CatalogReconciler{mgr: testfakes.NewManager(c), reg: reg, noKCP: true}
+	r := &CatalogReconciler{mgr: testfakes.NewManager(c), reg: reg, noKCP: true, healthClient: healthyHTTPDoer()}
 	req := testfakes.NewRequest("cluster", "", "cost")
 	if _, err := r.Reconcile(context.Background(), req); err != nil {
 		t.Fatalf("first reconcile: %v", err)
@@ -271,7 +292,7 @@ func TestCatalogReconcilerAdoptsStatusHeartbeat(t *testing.T) {
 		WithObjects(entry).
 		Build()
 
-	r := &CatalogReconciler{mgr: testfakes.NewManager(c), reg: reg, noKCP: true}
+	r := &CatalogReconciler{mgr: testfakes.NewManager(c), reg: reg, noKCP: true, healthClient: healthyHTTPDoer()}
 	if _, err := r.Reconcile(context.Background(), testfakes.NewRequest("cluster", "", "cost")); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
@@ -286,4 +307,158 @@ func TestCatalogReconcilerAdoptsStatusHeartbeat(t *testing.T) {
 	if !got.Ready() {
 		t.Fatal("provider with a fresh heartbeat should be Ready on every replica")
 	}
+}
+
+func TestCatalogReconcilerBackendHealthGatesReadyAndRecovers(t *testing.T) {
+	reg := NewRegistry()
+	scheme := newProviderTestScheme(t)
+	entry := &providersv1alpha1.CatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "code", Generation: 2},
+		Spec: providersv1alpha1.CatalogEntrySpec{
+			Backend: &providersv1alpha1.ProviderBackend{URL: "http://code.invalid", HealthPath: "/readyz"},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&providersv1alpha1.CatalogEntry{}).
+		WithObjects(entry).
+		Build()
+	r := &CatalogReconciler{
+		mgr: testfakes.NewManager(c), reg: reg, noKCP: true,
+		healthClient: httpDoerFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Body:       io.NopCloser(strings.NewReader("sensitive upstream detail")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	req := testfakes.NewRequest("cluster", "", "code")
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("reconcile unhealthy: %v", err)
+	}
+	if result.RequeueAfter != SweepInterval {
+		t.Fatalf("requeueAfter = %v, want %v", result.RequeueAfter, SweepInterval)
+	}
+	got, ok := reg.Get("code")
+	if !ok || got.Ready() || !got.BackendHealthRequired || got.BackendHealthy {
+		t.Fatalf("unhealthy registry provider = %+v, found=%v", got, ok)
+	}
+
+	var updated providersv1alpha1.CatalogEntry
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "code"}, &updated); err != nil {
+		t.Fatalf("get unhealthy entry: %v", err)
+	}
+	backendCondition := conditionByType(updated.Status.Conditions, "BackendHealthy")
+	readyCondition := conditionByType(updated.Status.Conditions, "Ready")
+	if backendCondition == nil || backendCondition.Status != metav1.ConditionFalse ||
+		readyCondition == nil || readyCondition.Status != metav1.ConditionFalse || readyCondition.Reason != "BackendUnhealthy" {
+		t.Fatalf("unhealthy conditions = %#v", updated.Status.Conditions)
+	}
+	for _, condition := range updated.Status.Conditions {
+		if strings.Contains(condition.Message, "sensitive upstream detail") || strings.Contains(condition.Message, "code.invalid") {
+			t.Fatalf("condition leaked probe detail: %#v", condition)
+		}
+	}
+
+	r.healthClient = healthyHTTPDoer()
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile healthy: %v", err)
+	}
+	if got, _ := reg.Get("code"); !got.Ready() || !got.BackendHealthy {
+		t.Fatalf("healthy registry provider = %+v", got)
+	}
+}
+
+func TestCatalogReconcilerDoesNotDirectlyProbeOrgOwnedBackend(t *testing.T) {
+	reg := NewRegistry()
+	scheme := newProviderTestScheme(t)
+	entry := &providersv1alpha1.CatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "database"},
+		Spec: providersv1alpha1.CatalogEntrySpec{
+			Backend: &providersv1alpha1.ProviderBackend{URL: "http://tenant-controlled.invalid", HealthPath: "/readyz"},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&providersv1alpha1.CatalogEntry{}).
+		WithObjects(entry).
+		Build()
+	probes := 0
+	r := &CatalogReconciler{
+		mgr: testfakes.NewManager(c), reg: reg, prov: &Provisioner{},
+		clusterPaths: map[string]string{"cluster": kcppaths.OrgProviderPath("org-1", "database")},
+		healthClient: httpDoerFunc(func(*http.Request) (*http.Response, error) {
+			probes++
+			return nil, fmt.Errorf("org-owned backend must not be dialled")
+		}),
+	}
+	if _, err := r.Reconcile(context.Background(), testfakes.NewRequest("cluster", "", "database")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if probes != 0 {
+		t.Fatalf("org-owned backend received %d direct probes", probes)
+	}
+	got, ok := reg.GetForOrg("org-1", "database")
+	if !ok || got.BackendHealthRequired || !got.Ready() {
+		t.Fatalf("org-owned registry provider = %+v, found=%v", got, ok)
+	}
+}
+
+func TestProbeBackendHealthUsesSameAuthorityAndBoundedPath(t *testing.T) {
+	var requested string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = r.URL.RequestURI()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	backend, err := url.Parse(server.URL + "/services/provider")
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+	if err := probeBackendHealth(context.Background(), server.Client(), backend, "/readyz?full=1"); err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if requested != "/services/provider/readyz?full=1" {
+		t.Fatalf("request URI = %q", requested)
+	}
+	for _, healthPath := range []string{"https://attacker.invalid/healthz", "//attacker.invalid/healthz", "/../admin", "/%2e%2e/admin"} {
+		if err := probeBackendHealth(context.Background(), server.Client(), backend, healthPath); err == nil {
+			t.Fatalf("healthPath %q was accepted", healthPath)
+		}
+	}
+}
+
+func TestDefaultBackendHealthClientDoesNotFollowRedirects(t *testing.T) {
+	redirectTargetHit := false
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectTargetHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(redirectTarget.Close)
+	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", redirectTarget.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(backendServer.Close)
+	backend, err := url.Parse(backendServer.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+	if err := probeBackendHealth(context.Background(), defaultBackendHealthClient(), backend, "/readyz"); err == nil {
+		t.Fatal("redirecting backend was considered healthy")
+	}
+	if redirectTargetHit {
+		t.Fatal("backend health probe followed a redirect to another authority")
+	}
+}
+
+func conditionByType(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
 }

--- a/pkg/hub/providers/controller_test.go
+++ b/pkg/hub/providers/controller_test.go
@@ -43,6 +43,12 @@ type httpDoerFunc func(*http.Request) (*http.Response, error)
 
 func (f httpDoerFunc) Do(req *http.Request) (*http.Response, error) { return f(req) }
 
+type edgeRouteResolverFunc func(context.Context, string, string, string) (*EdgeRoute, error)
+
+func (f edgeRouteResolverFunc) ResolveProviderEdgeRoute(ctx context.Context, orgUUID, providerName, backendURL string) (*EdgeRoute, error) {
+	return f(ctx, orgUUID, providerName, backendURL)
+}
+
 func healthyHTTPDoer() httpDoer {
 	return httpDoerFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -389,6 +395,9 @@ func TestCatalogReconcilerDoesNotDirectlyProbeOrgOwnedBackend(t *testing.T) {
 	r := &CatalogReconciler{
 		mgr: testfakes.NewManager(c), reg: reg, prov: &Provisioner{},
 		clusterPaths: map[string]string{"cluster": kcppaths.OrgProviderPath("org-1", "database")},
+		edgeRoutes: edgeRouteResolverFunc(func(context.Context, string, string, string) (*EdgeRoute, error) {
+			return &EdgeRoute{Cluster: "tenant-cluster", ServiceName: "provider-database"}, nil
+		}),
 		healthClient: httpDoerFunc(func(*http.Request) (*http.Response, error) {
 			probes++
 			return nil, fmt.Errorf("org-owned backend must not be dialled")
@@ -403,6 +412,60 @@ func TestCatalogReconcilerDoesNotDirectlyProbeOrgOwnedBackend(t *testing.T) {
 	got, ok := reg.GetForOrg("org-1", "database")
 	if !ok || got.BackendHealthRequired || !got.Ready() {
 		t.Fatalf("org-owned registry provider = %+v, found=%v", got, ok)
+	}
+}
+
+func TestCatalogReconcilerRetriesOrgOwnedEdgeRouteAndRecovers(t *testing.T) {
+	reg := NewRegistry()
+	scheme := newProviderTestScheme(t)
+	entry := &providersv1alpha1.CatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "database"},
+		Spec: providersv1alpha1.CatalogEntrySpec{
+			Backend: &providersv1alpha1.ProviderBackend{URL: "http://database.tenant.svc", HealthPath: "/readyz"},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&providersv1alpha1.CatalogEntry{}).
+		WithObjects(entry).
+		Build()
+	routeReady := false
+	r := &CatalogReconciler{
+		mgr: testfakes.NewManager(c), reg: reg, prov: &Provisioner{},
+		clusterPaths: map[string]string{"cluster": kcppaths.OrgProviderPath("org-1", "database")},
+		edgeRoutes: edgeRouteResolverFunc(func(context.Context, string, string, string) (*EdgeRoute, error) {
+			if !routeReady {
+				return nil, fmt.Errorf("temporary route lookup failure")
+			}
+			return &EdgeRoute{Cluster: "tenant-cluster", ServiceName: "provider-database"}, nil
+		}),
+	}
+	req := testfakes.NewRequest("cluster", "", "database")
+	result, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("reconcile unroutable: %v", err)
+	}
+	if result.RequeueAfter != SweepInterval {
+		t.Fatalf("unroutable requeueAfter = %v, want %v", result.RequeueAfter, SweepInterval)
+	}
+	if got, ok := reg.GetForOrg("org-1", "database"); !ok || got.Ready() {
+		t.Fatalf("unroutable registry provider = %+v, found=%v", got, ok)
+	}
+	var updated providersv1alpha1.CatalogEntry
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "database"}, &updated); err != nil {
+		t.Fatalf("get unroutable entry: %v", err)
+	}
+	readyCondition := conditionByType(updated.Status.Conditions, "Ready")
+	if readyCondition == nil || readyCondition.Status != metav1.ConditionFalse || readyCondition.Reason != "BackendUnroutable" {
+		t.Fatalf("unroutable conditions = %#v", updated.Status.Conditions)
+	}
+
+	routeReady = true
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile recovered route: %v", err)
+	}
+	if got, ok := reg.GetForOrg("org-1", "database"); !ok || !got.Ready() || !got.EdgeRoute.Usable() {
+		t.Fatalf("recovered registry provider = %+v, found=%v", got, ok)
 	}
 }
 

--- a/pkg/hub/providers/proxy.go
+++ b/pkg/hub/providers/proxy.go
@@ -292,7 +292,7 @@ func (p *ProviderProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// a provider is an address inside that cluster, and dialling it from here
 	// would either fail or — worse, if it happened to resolve — reach something
 	// else entirely.
-	if prov.EdgeRoute != nil {
+	if prov.OrgUUID != "" {
 		p.serveOverEdge(w, r, prov, rest)
 		return
 	}

--- a/pkg/hub/providers/proxy_edge_test.go
+++ b/pkg/hub/providers/proxy_edge_test.go
@@ -167,6 +167,34 @@ func TestBackendProxyUnusableEdgeRouteIs503(t *testing.T) {
 	}
 }
 
+func TestBackendProxyOrgProviderWithoutEdgeRouteNeverDialsBackendURL(t *testing.T) {
+	hit := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		hit = true
+	}))
+	t.Cleanup(upstream.Close)
+	backendURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+	reg := NewRegistry()
+	reg.Upsert(Provider{
+		Name: "infrastructure", OrgUUID: testOrg, EndpointsValid: true,
+		BackendURL: backendURL,
+	})
+	proxy := NewBackendProxy(reg, logr.Discard())
+	proxy.SetTenantResolver(TenantResolverFunc(func(*http.Request) (string, string, error) {
+		return "alice", "root:faros:tenants:" + testOrg, nil
+	}))
+
+	if w := serveProxy(proxy, "/services/providers/infrastructure/x"); w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+	if hit {
+		t.Fatal("hub directly dialled an org-owned provider's BackendURL")
+	}
+}
+
 // With no platform edges provider there is no transport. Failing closed matters
 // because the alternative — falling through to the org provider's declared
 // BackendURL — is a hub-initiated request at an address the tenant chose.

--- a/pkg/hub/providers/registry.go
+++ b/pkg/hub/providers/registry.go
@@ -71,6 +71,12 @@ type Provider struct {
 	Dependencies []Dependency
 	UIURL        *url.URL // proxy target for /ui/providers/{name}/*; nil → 404
 	BackendURL   *url.URL // proxy target for /services/providers/{name}/*; nil → 404
+	// BackendHealthRequired is set only for platform-operated providers that
+	// declare a backend. BackendHealthy is the latest bounded healthPath probe
+	// result. Org-owned provider backends travel through an edge tunnel and are
+	// deliberately never dialled directly by the hub.
+	BackendHealthRequired bool
+	BackendHealthy        bool
 	// VirtualWorkspaceURL is the provider-declared action transport target.
 	// Provider Actions append /actions/{name}/{version} to this URL; they never
 	// use BackendURL or a provider MCP endpoint.
@@ -193,17 +199,27 @@ func (s *SelfHosting) Installable() bool {
 	return s != nil && s.Supported && s.ChartRepo != "" && s.ChartName != ""
 }
 
-// Ready returns true when the proxy should forward to the provider. The
-// catalog controller's URL parse must have succeeded AND, if the provider
-// has heartbeated at least once, its most recent heartbeat must be fresh.
-func (p Provider) Ready() bool {
+// Readiness returns the aggregate provider verdict and a stable, sanitized
+// explanation suitable for the portal API. Backend response bodies, URLs, and
+// transport errors never cross this boundary.
+func (p Provider) Readiness() (ready bool, reason, message string) {
 	if !p.EndpointsValid {
-		return false
+		return false, "InvalidEndpoint", "Provider endpoint configuration is invalid."
+	}
+	if p.BackendHealthRequired && !p.BackendHealthy {
+		return false, "BackendUnhealthy", "Provider backend is unavailable."
 	}
 	if p.HeartbeatRequired && p.HeartbeatStale {
-		return false
+		return false, "HeartbeatStale", "Provider heartbeat is stale."
 	}
-	return true
+	return true, "", ""
+}
+
+// Ready returns true when the provider's declared endpoints and runtime
+// health signals are all ready.
+func (p Provider) Ready() bool {
+	ready, _, _ := p.Readiness()
+	return ready
 }
 
 // PermissionClaim mirrors CatalogEntry.spec.apiExport.permissionClaims so the
@@ -540,8 +556,7 @@ func (r *Registry) ListForOrg(orgUUID string) []Provider {
 // CatalogEntry status says (the cross-replica signal); the record may already
 // hold a newer beat this replica served directly, or one whose status write was
 // throttled. Taking the later of the two keeps the merge monotone, so neither
-// source can move a provider backwards in time and flip it stale. HeartbeatStale
-// stays a purely local verdict, recomputed by the sweeper from these timestamps.
+// source can move a provider backwards in time and flip it stale.
 func (r *Registry) Upsert(p Provider) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -554,10 +569,14 @@ func (r *Registry) Upsert(p Provider) {
 			if existing.ReportedVersion != "" {
 				p.ReportedVersion = existing.ReportedVersion
 			}
+			p.HeartbeatStale = existing.HeartbeatStale
+		} else if existing.LastHeartbeat.Equal(p.LastHeartbeat) {
+			// Either the sweeper or this reconcile may have observed expiry for
+			// the same beat. Once stale, that timestamp cannot become fresh again.
+			p.HeartbeatStale = p.HeartbeatStale || existing.HeartbeatStale
 		}
 		// A provider that has ever heartbeated is expected to keep doing so.
 		p.HeartbeatRequired = p.HeartbeatRequired || existing.HeartbeatRequired
-		p.HeartbeatStale = existing.HeartbeatStale
 		if p.WorkspaceCluster == "" {
 			// Provisioning sets this after the Upsert in the same reconcile;
 			// don't lose it on the next reconcile's fresh Provider value.

--- a/pkg/hub/providers/registry.go
+++ b/pkg/hub/providers/registry.go
@@ -206,6 +206,13 @@ func (p Provider) Readiness() (ready bool, reason, message string) {
 	if !p.EndpointsValid {
 		return false, "InvalidEndpoint", "Provider endpoint configuration is invalid."
 	}
+	// Org-owned backend URLs name services inside tenant clusters. The proxy
+	// deliberately refuses to dial them directly, so a usable hub-owned edge
+	// route is part of aggregate readiness even though routed health probing is
+	// deferred. This checks route admission only; it never contacts the URL.
+	if p.OrgUUID != "" && p.BackendURL != nil && !p.EdgeRoute.Usable() {
+		return false, "BackendUnroutable", "Provider backend route is unavailable."
+	}
 	if p.BackendHealthRequired && !p.BackendHealthy {
 		return false, "BackendUnhealthy", "Provider backend is unavailable."
 	}

--- a/pkg/hub/providers/registry_test.go
+++ b/pkg/hub/providers/registry_test.go
@@ -19,6 +19,33 @@ import (
 	providersv1alpha1 "github.com/faroshq/faros/apis/providers/v1alpha1"
 )
 
+func TestProviderReadinessAggregatesBackendAndHeartbeat(t *testing.T) {
+	p := Provider{
+		EndpointsValid:        true,
+		BackendHealthRequired: true,
+		BackendHealthy:        false,
+		HeartbeatRequired:     true,
+		HeartbeatStale:        false,
+	}
+	ready, reason, message := p.Readiness()
+	if ready || reason != "BackendUnhealthy" || message != "Provider backend is unavailable." {
+		t.Fatalf("backend readiness = (%v, %q, %q)", ready, reason, message)
+	}
+
+	p.BackendHealthy = true
+	p.HeartbeatStale = true
+	ready, reason, message = p.Readiness()
+	if ready || reason != "HeartbeatStale" || message != "Provider heartbeat is stale." {
+		t.Fatalf("heartbeat readiness = (%v, %q, %q)", ready, reason, message)
+	}
+
+	p.HeartbeatStale = false
+	ready, reason, message = p.Readiness()
+	if !ready || reason != "" || message != "" {
+		t.Fatalf("healthy readiness = (%v, %q, %q)", ready, reason, message)
+	}
+}
+
 func TestParseProviderActionsCanonicalCatalogShape(t *testing.T) {
 	parsed, err := ParseProviderActions([]providersv1alpha1.ProviderActionSpec{{
 		ID: "query_table/v1",

--- a/pkg/hub/providers/registry_test.go
+++ b/pkg/hub/providers/registry_test.go
@@ -10,6 +10,7 @@ package providers
 
 import (
 	"encoding/json"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -43,6 +44,23 @@ func TestProviderReadinessAggregatesBackendAndHeartbeat(t *testing.T) {
 	ready, reason, message = p.Readiness()
 	if !ready || reason != "" || message != "" {
 		t.Fatalf("healthy readiness = (%v, %q, %q)", ready, reason, message)
+	}
+}
+
+func TestProviderReadinessRequiresOrgOwnedBackendRoute(t *testing.T) {
+	p := Provider{
+		Name:           "database",
+		OrgUUID:        "org-1",
+		BackendURL:     &url.URL{Scheme: "http", Host: "database.tenant.svc"},
+		EndpointsValid: true,
+	}
+	ready, reason, message := p.Readiness()
+	if ready || reason != "BackendUnroutable" || message != "Provider backend route is unavailable." {
+		t.Fatalf("unroutable readiness = (%v, %q, %q)", ready, reason, message)
+	}
+	p.EdgeRoute = &EdgeRoute{Cluster: "tenant-cluster", ServiceName: "provider-database"}
+	if ready, reason, message = p.Readiness(); !ready || reason != "" || message != "" {
+		t.Fatalf("routable readiness = (%v, %q, %q)", ready, reason, message)
 	}
 }
 

--- a/portal/src/lib/providerBindingAction.ts
+++ b/portal/src/lib/providerBindingAction.ts
@@ -1,0 +1,17 @@
+export type ProviderBindingAction = 'enable' | 'disable' | null
+
+export interface ProviderBindingState {
+  hasAPIExport: boolean
+  ready: boolean
+  enabled: boolean
+  disabling: boolean
+}
+
+// Binding removal remains available during provider outages, but a provider
+// that was never enabled must not gain a misleading Disable action merely
+// because readiness prevents Enable.
+export function providerBindingAction(state: ProviderBindingState): ProviderBindingAction {
+  if (!state.hasAPIExport || state.disabling) return null
+  if (state.enabled) return 'disable'
+  return state.ready ? 'enable' : null
+}

--- a/portal/src/pages/ProvidersPage.readiness.test.mjs
+++ b/portal/src/pages/ProvidersPage.readiness.test.mjs
@@ -7,5 +7,8 @@ const source = readFileSync(new URL('./ProvidersPage.vue', import.meta.url), 'ut
 test('provider cards distinguish unavailable providers from pending work', () => {
   assert.match(source, /!p\.ready \? 'Not ready'/)
   assert.match(source, /p\.readinessMessage \|\| 'Provider is unavailable\.'/)
+  assert.match(source, /<template v-if="p\.apiExportName">/)
+  assert.match(source, /v-else-if="!providers\.isEnabled\(p\.name\) && p\.ready"/)
+  assert.match(source, /v-else[\s\S]*@click="onDisable\(p\)"/)
   assert.doesNotMatch(source, /Provider is starting/)
 })

--- a/portal/src/pages/ProvidersPage.readiness.test.mjs
+++ b/portal/src/pages/ProvidersPage.readiness.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('./ProvidersPage.vue', import.meta.url), 'utf8')
+
+test('provider cards distinguish unavailable providers from pending work', () => {
+  assert.match(source, /!p\.ready \? 'Not ready'/)
+  assert.match(source, /p\.readinessMessage \|\| 'Provider is unavailable\.'/)
+  assert.doesNotMatch(source, /Provider is starting/)
+})

--- a/portal/src/pages/ProvidersPage.readiness.test.mjs
+++ b/portal/src/pages/ProvidersPage.readiness.test.mjs
@@ -1,14 +1,37 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import test from 'node:test'
+import { createServer } from 'vite'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 
 const source = readFileSync(new URL('./ProvidersPage.vue', import.meta.url), 'utf8')
+const vite = await createServer({
+  appType: 'custom',
+  cacheDir: join(tmpdir(), 'faros-vite-provider-binding-action'),
+  configFile: false,
+  optimizeDeps: { noDiscovery: true },
+  root: new URL('../../', import.meta.url).pathname,
+  server: { middlewareMode: true, hmr: false },
+})
+const { providerBindingAction } = await vite.ssrLoadModule('/src/lib/providerBindingAction.ts')
+test.after(() => vite.close())
 
 test('provider cards distinguish unavailable providers from pending work', () => {
   assert.match(source, /!p\.ready \? 'Not ready'/)
   assert.match(source, /p\.readinessMessage \|\| 'Provider is unavailable\.'/)
   assert.match(source, /<template v-if="p\.apiExportName">/)
-  assert.match(source, /v-else-if="!providers\.isEnabled\(p\.name\) && p\.ready"/)
-  assert.match(source, /v-else[\s\S]*@click="onDisable\(p\)"/)
+  assert.match(source, /v-else-if="bindingAction\(p\) === 'enable'"/)
+  assert.match(source, /v-else-if="bindingAction\(p\) === 'disable'"[\s\S]*@click="onDisable\(p\)"/)
   assert.doesNotMatch(source, /Provider is starting/)
+})
+
+test('provider binding actions cover readiness and enabled state independently', () => {
+  const state = (ready, enabled) => ({ hasAPIExport: true, ready, enabled, disabling: false })
+  assert.equal(providerBindingAction(state(true, false)), 'enable')
+  assert.equal(providerBindingAction(state(false, false)), null)
+  assert.equal(providerBindingAction(state(true, true)), 'disable')
+  assert.equal(providerBindingAction(state(false, true)), 'disable')
+  assert.equal(providerBindingAction({ ...state(true, true), disabling: true }), null)
+  assert.equal(providerBindingAction({ ...state(true, false), hasAPIExport: false }), null)
 })

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -812,8 +812,9 @@ function dependencyNotice(p: ProviderDTO): string {
               <ExternalLink class="h-3 w-3" :stroke-width="2" />
             </router-link>
 
-            <!-- Enable / Disable: only when provider declares an APIExport -->
-            <template v-if="p.apiExportName && p.ready">
+            <!-- Readiness gates new bindings, but never removal of an existing
+                 binding: an outage is exactly when Disable may be needed. -->
+            <template v-if="p.apiExportName">
               <!-- Mid-deletion: neither Enable (name still taken) nor Disable
                    (already deleting) is actionable, so say what's happening. -->
               <span
@@ -824,7 +825,7 @@ function dependencyNotice(p: ProviderDTO): string {
                 Disabling&hellip;
               </span>
               <button
-                v-else-if="!providers.isEnabled(p.name)"
+                v-else-if="!providers.isEnabled(p.name) && p.ready"
                 type="button"
                 class="k-btn k-btn--ghost inline-flex items-center gap-1 px-2.5 py-1 text-[11px] font-medium text-success transition-colors hover:border-success/40 hover:bg-success-subtle disabled:cursor-not-allowed disabled:opacity-60"
                 :disabled="!!busy[p.name] || providers.hasMissingDependencies(p)"

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -7,6 +7,7 @@ import { confirmDialog } from '@/portalkit/confirm'
 import { useProvidersStore, type ProviderDTO, type PermissionClaim } from '@/stores/providers'
 import { useOrgProvidersStore, type OrgProviderRegistration } from '@/stores/orgProviders'
 import { categoryIcons, fallbackCategoryIcon } from '@/lib/categoryIcons'
+import { providerBindingAction } from '@/lib/providerBindingAction'
 import { Puzzle, ExternalLink, AlertCircle, AlertTriangle, ArrowUpCircle, Plus, X, Loader2, Search, Server, Trash2, RefreshCw } from 'lucide-vue-next'
 
 const providers = useProvidersStore()
@@ -52,6 +53,14 @@ function edgeLabel(t: { workspace: string; workspaceDisplayName?: string; name: 
 // button is disabled rather than left to 409.
 const canSelfHost = computed(() => orgProviders.installTargetsEligible && !!selectedEdge.value)
 
+function bindingAction(p: ProviderDTO) {
+  return providerBindingAction({
+    hasAPIExport: !!p.apiExportName,
+    ready: p.ready,
+    enabled: providers.isEnabled(p.name),
+    disabling: providers.isDisabling(p.name),
+  })
+}
 async function selfHost(p: ProviderDTO) {
   const edge = selectedEdge.value
   if (!edge) {
@@ -825,7 +834,7 @@ function dependencyNotice(p: ProviderDTO): string {
                 Disabling&hellip;
               </span>
               <button
-                v-else-if="!providers.isEnabled(p.name) && p.ready"
+                v-else-if="bindingAction(p) === 'enable'"
                 type="button"
                 class="k-btn k-btn--ghost inline-flex items-center gap-1 px-2.5 py-1 text-[11px] font-medium text-success transition-colors hover:border-success/40 hover:bg-success-subtle disabled:cursor-not-allowed disabled:opacity-60"
                 :disabled="!!busy[p.name] || providers.hasMissingDependencies(p)"
@@ -837,7 +846,7 @@ function dependencyNotice(p: ProviderDTO): string {
                 Enable
               </button>
               <button
-                v-else
+                v-else-if="bindingAction(p) === 'disable'"
                 type="button"
                 class="k-btn k-btn--ghost inline-flex items-center gap-1 px-2.5 py-1 text-[11px] font-medium text-text-muted transition-colors hover:border-danger/30 hover:text-danger disabled:cursor-not-allowed disabled:opacity-60"
                 :disabled="!!busy[p.name]"

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -684,7 +684,7 @@ function dependencyNotice(p: ProviderDTO): string {
                   class="rounded-sm px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider"
                   :class="
                     !p.ready
-                      ? 'border border-border-default bg-surface-overlay text-text-muted'
+                      ? 'border border-warning/30 bg-warning-subtle text-warning'
                       : p.builtinRoute
                         ? 'border border-border-default bg-surface-overlay text-text-secondary'
                         : providers.isDisabling(p.name)
@@ -698,7 +698,7 @@ function dependencyNotice(p: ProviderDTO): string {
                                 : 'border border-success/30 bg-success-subtle text-success'
                   "
                 >
-                  {{ !p.ready ? 'Pending' : p.builtinRoute ? 'Built-in' : providers.isDisabling(p.name) ? 'Disabling' : providers.hasStaleClaims(p.name) ? 'Degraded' : providers.isEnabled(p.name) ? 'Enabled' : providers.hasMissingDependencies(p) ? 'Blocked' : 'Available' }}
+                  {{ !p.ready ? 'Not ready' : p.builtinRoute ? 'Built-in' : providers.isDisabling(p.name) ? 'Disabling' : providers.hasStaleClaims(p.name) ? 'Degraded' : providers.isEnabled(p.name) ? 'Enabled' : providers.hasMissingDependencies(p) ? 'Blocked' : 'Available' }}
                 </span>
               </div>
               <p class="mt-0.5 truncate font-mono text-[10px] text-text-muted">{{ p.name }}<span v-if="p.version"> · {{ p.version }}</span></p>
@@ -849,7 +849,7 @@ function dependencyNotice(p: ProviderDTO): string {
             </template>
 
             <span v-if="!p.ready" class="text-[11px] text-text-muted/70">
-              Provider is starting&hellip;
+              {{ p.readinessMessage || 'Provider is unavailable.' }}
             </span>
           </div>
           </li>

--- a/portal/src/stores/providers.ts
+++ b/portal/src/stores/providers.ts
@@ -23,6 +23,10 @@ export interface ProviderDTO {
   description?: string
   version?: string
   ready: boolean
+  // Present only when ready is false. The hub owns and sanitizes these
+  // explanations so provider transport details never reach the browser.
+  readinessReason?: string
+  readinessMessage?: string
   hasUI: boolean
   hasBackend: boolean
   iconURL?: string

--- a/providers/code/portal/src/api.test.ts
+++ b/providers/code/portal/src/api.test.ts
@@ -184,6 +184,32 @@ describe('getRepository health snapshot', () => {
     expect(call?.query).not.toContain('autoInit')
   })
 
+  it.each([
+    { generation: 4, observedGeneration: 4, status: 'False', message: undefined, failed: true },
+    { generation: 4, observedGeneration: 3, status: 'False', message: 'old failure', failed: false },
+    { generation: 4, observedGeneration: 4, status: 'Unknown', message: 'still checking', failed: false },
+  ])('classifies only a current-generation Ready=False condition as failed: %#', async scenario => {
+    setAPIContext({ tenant: `repository-failure-${scenario.status}-${scenario.observedGeneration}`, token: 'repository-failure-token' })
+    vi.stubGlobal('fetch', vi.fn(async () => response({
+      data: {
+        code_faros_sh: {
+          v1alpha1: {
+            Repository: {
+              metadata: { name: 'orders', uid: 'orders-uid', generation: scenario.generation },
+              spec: { connectionRef: 'github', name: 'orders' },
+              status: {
+                observedGeneration: scenario.observedGeneration,
+                conditions: [{ type: 'Ready', status: scenario.status, message: scenario.message }],
+              },
+            },
+          },
+        },
+      },
+    })))
+
+    await expect(api.getRepository('orders')).resolves.toMatchObject({ failed: scenario.failed })
+  })
+
   it.each(['cloneURL', 'sshURL'] as const)('rejects a malformed repository %s status field', async field => {
     setAPIContext({ tenant: `repository-malformed-${field}`, token: `repository-malformed-${field}-token` })
     vi.stubGlobal('fetch', vi.fn(async () => response({

--- a/providers/code/portal/src/api.ts
+++ b/providers/code/portal/src/api.ts
@@ -352,6 +352,9 @@ async function graphqlQuery<T>(query: string, variables: Record<string, unknown>
 function condTrue(cr: RawCR, type: string): boolean {
   return (cr.status?.conditions ?? []).some(c => c.type === type && c.status === 'True')
 }
+function condFalse(cr: RawCR, type: string): boolean {
+  return (cr.status?.conditions ?? []).some(c => c.type === type && c.status === 'False')
+}
 function condMsg(cr: RawCR, type: string): string | undefined {
   return (cr.status?.conditions ?? []).find(c => c.type === type)?.message ?? undefined
 }
@@ -439,6 +442,7 @@ function repoFromCR(cr: RawCR): Repository {
     cloneURL: status.cloneURL ? String(status.cloneURL) : undefined,
     sshURL: status.sshURL ? String(status.sshURL) : undefined,
     ready: reconciliation.reconciled && condTrue(cr, 'Ready'),
+    failed: reconciliation.reconciled && condFalse(cr, 'Ready'),
     message: reconciliation.waitingMessage ?? condMsg(cr, 'Ready'),
   }
 }

--- a/providers/code/portal/src/repositoriesPagination.test.ts
+++ b/providers/code/portal/src/repositoriesPagination.test.ts
@@ -125,8 +125,9 @@ describe('repository table pagination state', () => {
 
   it('distinguishes deleting, not-yet-observed, ready, and failed resources', () => {
     expect(repositoryStatus({ deletionTimestamp: 'now', generation: 1, observedGeneration: 1, ready: true })).toBe('Deleting')
-    expect(repositoryStatus({ generation: 2, observedGeneration: 1, ready: false, message: 'waiting' })).toBe('pending')
+    expect(repositoryStatus({ generation: 2, observedGeneration: 1, ready: false, failed: true })).toBe('pending')
     expect(repositoryStatus({ generation: 1, observedGeneration: 1, ready: true })).toBe('ready')
-    expect(repositoryStatus({ generation: 1, observedGeneration: 1, ready: false, message: 'host rejected request' })).toBe('failed')
+    expect(repositoryStatus({ generation: 1, observedGeneration: 1, ready: false, failed: true })).toBe('failed')
+    expect(repositoryStatus({ generation: 1, observedGeneration: 1, ready: false, failed: false })).toBe('pending')
   })
 })

--- a/providers/code/portal/src/repositoriesPagination.ts
+++ b/providers/code/portal/src/repositoriesPagination.ts
@@ -149,13 +149,13 @@ export function repositoryPageInfo(nextCursor?: string): RepositoryPageInfo {
  * current generation; a controller that has not observed the object yet is
  * still pending even though the API exposes a waiting message.
  */
-export function repositoryStatus(repository: Pick<Repository, 'deletionTimestamp' | 'generation' | 'observedGeneration' | 'ready' | 'message'>): string {
+export function repositoryStatus(repository: Pick<Repository, 'deletionTimestamp' | 'generation' | 'observedGeneration' | 'ready' | 'failed'>): string {
   if (repository.deletionTimestamp) return 'Deleting'
   if (repository.generation !== undefined &&
     (repository.observedGeneration === undefined || repository.observedGeneration < repository.generation)) {
     return 'pending'
   }
   if (repository.ready) return 'ready'
-  if (repository.message) return 'failed'
+  if (repository.failed) return 'failed'
   return 'pending'
 }

--- a/providers/code/portal/src/resource-detail.behavior.test.ts
+++ b/providers/code/portal/src/resource-detail.behavior.test.ts
@@ -326,6 +326,23 @@ afterEach(() => {
 })
 
 describe('mounted resource deletion state', () => {
+  it('shows a current-generation repository controller failure as failed', async () => {
+    mocks.api.getRepository.mockResolvedValue({ ...repository, ready: false, failed: true, message: 'GitHub rejected the request.' })
+    mocks.api.listConnections.mockResolvedValue([])
+    mocks.api.listDeployKeys.mockResolvedValue([])
+    mocks.api.listCollaborators.mockResolvedValue([])
+    mocks.api.listPackagesPage.mockResolvedValue({ items: [], continue: '', resourceVersion: '' })
+
+    const { app, root } = mount(RepoDetailView, {
+      name: repository.name,
+      deletions: createResourceDeletions(),
+    })
+    await settle()
+
+    expect(findNode(root, node => node.type === 'span' && node.props.class === 'status-badge-stub' && textContent(node) === 'failed')).toBeDefined()
+    app.unmount()
+  })
+
   it('keeps the repository snapshot visible and announces Deleting while a delete is pending, then recovers after failure', async () => {
     const connections = deferred<Connection[]>()
     const keys = deferred<DeployKey[]>()

--- a/providers/code/portal/src/types.ts
+++ b/providers/code/portal/src/types.ts
@@ -90,6 +90,9 @@ export interface Repository {
   cloneURL?: string
   sshURL?: string
   ready: boolean
+  // True only when the controller observed the current generation and set
+  // Ready=False. An Unknown condition remains pending even if it has a message.
+  failed?: boolean
   message?: string
 }
 

--- a/providers/code/portal/src/views/RepoDetailView.vue
+++ b/providers/code/portal/src/views/RepoDetailView.vue
@@ -199,11 +199,11 @@ const ownerWillChange = computed(() =>
 const repositoryStatus = computed(() => {
   if (repositoryDeleting.value) return 'Deleting'
   if (!repo.value) return repoLoading.value ? 'Loading' : 'Unavailable'
-  return repo.value.ready ? 'ready' : 'pending'
+  return repo.value.failed ? 'failed' : repo.value.ready ? 'ready' : 'pending'
 })
 const repositoryStatusTone = computed(() => {
   if (repositoryDeleting.value || repositoryStatus.value === 'Loading') return 'warning'
-  if (repositoryStatus.value === 'Unavailable') return 'danger'
+  if (repositoryStatus.value === 'Unavailable' || repositoryStatus.value === 'failed') return 'danger'
   return null
 })
 function providerLabel(provider: string | undefined): string {


### PR DESCRIPTION
Stack 1 of 5 for the Provider UX Repair Program.

Makes platform-provider readiness aggregate backend health and heartbeat freshness. Adds bounded same-authority health probes, sanitized API reasons, CatalogEntry BackendHealthy and Ready conditions, org-provider SSRF protection, and truthful Code repository terminal states.

Verified with provider hub unit tests, root and Code portal suites/builds, a live Code stop/recovery smoke test, and code-generation verification.