### PR TITLE
fix(portal): make self-hosting prerequisites actionable

### DIFF
--- a/portal/src/pages/ProvidersPage.self-hosting.test.mjs
+++ b/portal/src/pages/ProvidersPage.self-hosting.test.mjs
@@ -1,0 +1,44 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const source = await readFile(new URL('./ProvidersPage.vue', import.meta.url), 'utf8')
+
+test('self-hosting Edges prerequisite uses catalog-owned availability states', () => {
+  assert.match(source, /const edgesProvider = computed\(\(\) => providers\.byName\('edges'\)\)/)
+  assert.match(source, /if \(!edges\) return 'absent'/)
+  assert.match(source, /return edges\.ready && edges\.hasUI \? 'ready' : 'unready'/)
+})
+
+test('only a ready Edges portal receives the provider deep link', () => {
+  assert.match(
+    source,
+    /<router-link\s+v-if="edgesSelfHostState === 'ready'"\s+to="\/providers\/edges"/,
+  )
+  assert.match(source, /v-else-if="edgesSelfHostState === 'unready'"/)
+  assert.match(source, /v-else-if="edgesSelfHostState === 'absent'"/)
+  assert.match(source, /View Edges in catalog/)
+  assert.match(source, /Edges is not installed in this catalog\./)
+})
+
+test('unready Edges returns to a filtered catalog instead of navigating to a dead route', () => {
+  assert.match(
+    source,
+    /function showEdgesCatalogEntry\(\) \{\s+tab\.value = 'catalog'\s+selectedCategory\.value = null\s+search\.value = 'edges'\s+\}/,
+  )
+  assert.match(source, /@click="showEdgesCatalogEntry"/)
+})

--- a/portal/src/pages/ProvidersPage.self-hosting.test.mjs
+++ b/portal/src/pages/ProvidersPage.self-hosting.test.mjs
@@ -27,12 +27,18 @@ test('self-hosting Edges prerequisite uses catalog-owned availability states', (
 test('only a ready Edges portal receives the provider deep link', () => {
   assert.match(
     source,
-    /<router-link\s+v-if="edgesSelfHostState === 'ready'"\s+to="\/providers\/edges"/,
+    /<router-link\s+v-else-if="edgesSelfHostState === 'ready'"\s+to="\/providers\/edges"/,
   )
   assert.match(source, /v-else-if="edgesSelfHostState === 'unready'"/)
   assert.match(source, /v-else-if="edgesSelfHostState === 'absent'"/)
   assert.match(source, /View Edges in catalog/)
   assert.match(source, /Edges is not installed in this catalog\./)
+})
+
+test('a failed install-target check is visible and retryable', () => {
+  assert.match(source, /v-if="orgProviders\.installTargetsError"/)
+  assert.match(source, /@click="orgProviders\.loadInstallTargets"/)
+  assert.match(source, /Retry check/)
 })
 
 test('unready Edges returns to a filtered catalog instead of navigating to a dead route', () => {

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -53,6 +53,25 @@ function edgeLabel(t: { workspace: string; workspaceDisplayName?: string; name: 
 // button is disabled rather than left to 409.
 const canSelfHost = computed(() => orgProviders.installTargetsEligible && !!selectedEdge.value)
 
+// The hub-owned catalog is authoritative for whether the Edges prerequisite
+// exists and is ready to open. Do not manufacture a provider route when the
+// entry is absent: ProviderFrame can explain a known-but-unready provider, but
+// it cannot make an unavailable catalog entry actionable.
+type EdgesSelfHostState = 'absent' | 'unready' | 'ready'
+
+const edgesProvider = computed(() => providers.byName('edges'))
+const edgesSelfHostState = computed<EdgesSelfHostState>(() => {
+  const edges = edgesProvider.value
+  if (!edges) return 'absent'
+  return edges.ready && edges.hasUI ? 'ready' : 'unready'
+})
+
+function showEdgesCatalogEntry() {
+  tab.value = 'catalog'
+  selectedCategory.value = null
+  search.value = 'edges'
+}
+
 function bindingAction(p: ProviderDTO) {
   return providerBindingAction({
     hasAPIExport: !!p.apiExportName,
@@ -61,6 +80,7 @@ function bindingAction(p: ProviderDTO) {
     disabling: providers.isDisabling(p.name),
   })
 }
+
 async function selfHost(p: ProviderDTO) {
   const edge = selectedEdge.value
   if (!edge) {
@@ -398,12 +418,26 @@ function dependencyNotice(p: ProviderDTO): string {
           <div class="min-w-0">
             <p>{{ orgProviders.installTargetsReason || 'no connected cluster to install into' }}</p>
             <router-link
+              v-if="edgesSelfHostState === 'ready'"
               to="/providers/edges"
               class="mt-1 inline-flex items-center gap-1 text-[11px] font-medium underline"
             >
               Connect a Kubernetes cluster
               <ExternalLink class="h-3 w-3" :stroke-width="2" />
             </router-link>
+            <div v-else-if="edgesSelfHostState === 'unready'" class="mt-1 text-[11px] leading-relaxed">
+              <p>Edges is installed but is not ready. Open its catalog entry for status, or ask a platform administrator to repair it.</p>
+              <button
+                type="button"
+                class="mt-1 font-medium underline"
+                @click="showEdgesCatalogEntry"
+              >
+                View Edges in catalog
+              </button>
+            </div>
+            <p v-else-if="edgesSelfHostState === 'absent'" class="mt-1 text-[11px] leading-relaxed">
+              Edges is not installed in this catalog. Ask a platform administrator to install it before self-hosting a provider.
+            </p>
           </div>
         </div>
 

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -417,8 +417,18 @@ function dependencyNotice(p: ProviderDTO): string {
           <AlertTriangle class="h-4 w-4 flex-shrink-0 mt-0.5" :stroke-width="1.75" />
           <div class="min-w-0">
             <p>{{ orgProviders.installTargetsReason || 'no connected cluster to install into' }}</p>
+            <button
+              v-if="orgProviders.installTargetsError"
+              type="button"
+              class="mt-1 inline-flex items-center gap-1 font-medium underline disabled:cursor-wait disabled:opacity-60"
+              :disabled="orgProviders.installTargetsLoading"
+              @click="orgProviders.loadInstallTargets"
+            >
+              <RefreshCw class="h-3 w-3" :class="{ 'animate-spin': orgProviders.installTargetsLoading }" :stroke-width="2" />
+              Retry check
+            </button>
             <router-link
-              v-if="edgesSelfHostState === 'ready'"
+              v-else-if="edgesSelfHostState === 'ready'"
               to="/providers/edges"
               class="mt-1 inline-flex items-center gap-1 text-[11px] font-medium underline"
             >

--- a/portal/src/stores/orgProviders-install-targets.test.mjs
+++ b/portal/src/stores/orgProviders-install-targets.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import ts from 'typescript'
+
+const root = path.resolve(new URL('../../../', import.meta.url).pathname)
+const storeSource = fs.readFileSync(path.join(root, 'portal', 'src', 'stores', 'orgProviders.ts'), 'utf8')
+const sourceWithoutImports = storeSource
+  .replace("import { defineStore } from 'pinia'\n", '')
+  .replace("import { computed, ref } from 'vue'\n", '')
+  .replace("import { authFetch } from '@/auth/session'\n", '')
+const harness = `
+const ref = (value) => ({ value })
+const computed = (getter) => ({ get value() { return getter() } })
+const defineStore = (_name, setup) => () => {
+  const state = setup()
+  return new Proxy(state, {
+    get(target, key) {
+      const value = Reflect.get(target, key)
+      return value && typeof value === 'object' && 'value' in value ? value.value : value
+    },
+  })
+}
+const authFetch = (...args) => globalThis.__orgProviderAuthFetch(...args)
+`
+const { outputText } = ts.transpileModule(`${harness}\n${sourceWithoutImports}`, {
+  compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+})
+const storeModule = await import(`data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`)
+
+globalThis.localStorage = {
+  getItem: () => JSON.stringify({ orgUUID: 'org-a' }),
+}
+
+test('a rejected initial install-target request settles in a retryable error state', async () => {
+  const store = storeModule.useOrgProvidersStore()
+  let attempts = 0
+  globalThis.__orgProviderAuthFetch = async () => {
+    attempts += 1
+    if (attempts === 1) throw new Error('temporary gateway failure')
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ eligible: true, items: [{ workspace: 'ws', name: 'edge', eligible: true, connected: true }] }),
+    }
+  }
+
+  await store.loadInstallTargets()
+  assert.equal(store.installTargetsLoaded, true)
+  assert.equal(store.installTargetsEligible, false)
+  assert.equal(store.installTargetsReason, 'could not check for a connected cluster')
+  assert.equal(store.installTargetsError, 'temporary gateway failure')
+
+  await store.loadInstallTargets()
+  assert.equal(store.installTargetsEligible, true)
+  assert.equal(store.installTargetsError, null)
+  assert.equal(store.eligibleInstallTargets.length, 1)
+})

--- a/portal/src/stores/orgProviders.ts
+++ b/portal/src/stores/orgProviders.ts
@@ -128,6 +128,7 @@ export const useOrgProvidersStore = defineStore('orgProviders', () => {
   const installTargets = ref<EdgeInstallTarget[]>([])
   const installTargetsEligible = ref(false)
   const installTargetsReason = ref<string | null>(null)
+  const installTargetsError = ref<string | null>(null)
   const installTargetsLoading = ref(false)
   const installTargetsLoaded = ref(false)
 
@@ -182,6 +183,7 @@ export const useOrgProvidersStore = defineStore('orgProviders', () => {
     const url = orgURL('/install-targets')
     if (!url || installTargetsLoading.value) return
     installTargetsLoading.value = true
+    installTargetsError.value = null
     try {
       const res = await authFetch(url, { tenant: true })
       if (res.status === 501) {
@@ -195,12 +197,13 @@ export const useOrgProvidersStore = defineStore('orgProviders', () => {
       installTargetsReason.value = body.reason ?? null
       installTargetsLoaded.value = true
     } catch (e) {
-      // Surfaced through the same error slot as the rest of the surface; the
-      // caller renders self-hosting as unavailable rather than guessing it is
-      // fine, because guessing "fine" produces a 409 on click.
-      error.value = e instanceof Error ? e.message : String(e)
+      // Keep this failure local to the preflight surface. The caller renders
+      // self-hosting as unavailable rather than guessing it is fine, because
+      // guessing "fine" produces a 409 on click.
+      installTargetsError.value = e instanceof Error ? e.message : String(e)
       installTargetsEligible.value = false
       installTargetsReason.value = 'could not check for a connected cluster'
+      installTargetsLoaded.value = true
     } finally {
       installTargetsLoading.value = false
     }
@@ -278,6 +281,7 @@ export const useOrgProvidersStore = defineStore('orgProviders', () => {
     eligibleInstallTargets,
     installTargetsEligible,
     installTargetsReason,
+    installTargetsError,
     installTargetsLoading,
     installTargetsLoaded,
     loadInstallTargets,


### PR DESCRIPTION
Stack 2 of 5 for the Provider UX Repair Program. Depends on PR 1.

Replaces the unconditional Edges portal CTA with explicit absent, unavailable, and ready prerequisite states. Unavailable Edges routes to its catalog entry; absent Edges explains the administrator action; ready Edges preserves the connect-cluster path. Server authority for eligibility and credentials is unchanged.

Verified with focused self-hosting component tests and the full root portal suite/build.