### PR TITLE
Document the fluid portal shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -540,20 +540,28 @@ When a provider needs something not in the portalkit or `portal/src/components/`
 prefer adding it to the canonical kit (§5.7) over inventing a provider-local
 variant — consistency across the embedded micro-frontends is the whole point.
 
-### Page content width — one column, set centrally
+### Page content width — fluid shell, local readability
 
-Page content width is owned by **`AppLayout`**, not by pages. The layout slot
-renders every non-full-bleed page in one centered `mx-auto w-full max-w-7xl`
-column, so the content doesn't resize or shift when navigating between pages.
+Page width is owned by **`AppLayout`**, not by pages. Every ordinary page
+inherits one fluid `w-full` content column and the same layout padding. This is
+intentional: tables, visualizations, workbenches, and responsive collections
+may use the available viewport instead of leaving ultrawide screens empty.
 
-- **Do NOT add your own `mx-auto` / `max-w-*` wrapper** to a page or provider
-  micro-frontend — that reintroduces per-page width drift (the bug that made the
-  MCP and edges tables different widths). Just render your content; it inherits
-  the shared column.
-- A page that genuinely needs full width passes `<AppLayout full-bleed>` and
-  manages its own width/scroll (e.g. `app-studio`). Use this sparingly.
-- Horizontal/vertical page padding also comes from `AppLayout` (`px-8 py-5`) —
-  don't re-pad the top-level page wrapper.
+- **Do NOT add a page-level `mx-auto` / `max-w-*` wrapper** to a page or provider
+  micro-frontend. That reintroduces route-to-route width drift. Bound the
+  specific task region that needs a readable measure instead.
+- Prose should stay near 65–75 characters per line. Simple forms and search
+  controls should normally stop around `42rem`. Dense provisioning forms may
+  fill the page, but must reflow into responsive columns with roughly `20rem`
+  minimum field width and no more than three columns.
+- Tables and data visualizations may fill the fluid column and should own their
+  internal overflow. Collection grids own a deliberate minimum card width and
+  responsive column strategy rather than inheriting one global page cap.
+- A page that needs to own the viewport itself passes `<AppLayout full-bleed>`
+  and manages its own padding and scrolling (for example, the App Studio
+  workbench). Use this for viewport-owned tools, not merely wide content.
+- Horizontal and vertical page padding comes from `AppLayout`
+  (`px-4 py-5 sm:px-8`); do not re-pad the top-level page wrapper.
 
 ### Provider portals that ship their own stylesheet
 

--- a/docs/design-book.md
+++ b/docs/design-book.md
@@ -170,6 +170,28 @@ texture (login, empty states — sparingly), `.island` floating dock card,
 
 ## 6. Component patterns
 
+### Fluid page composition
+
+`AppLayout` owns one fluid `w-full` column for ordinary routes. Providers do
+not add page-level centering or `max-w-*` wrappers: navigation between routes
+must not change the shell geometry, and wide tables, visualizations, and
+responsive collections are allowed to use the viewport.
+
+Readability is local to the content that needs it. Keep prose near 65–75
+characters per line and simple forms or search controls at no more than about
+`42rem`. Dense provisioning forms may fill the shell, but should use responsive
+columns with a roughly `20rem` minimum field width and no more than three
+columns. A fieldset, validation summary, or nested structural group spans those
+columns rather than being squeezed into one track. Collection grids choose a
+minimum card width and column strategy appropriate to their content. Tables own
+horizontal overflow inside their canvas while their surrounding controls stay
+reachable.
+
+`<AppLayout full-bleed>` is a separate viewport-ownership contract: it removes
+the ordinary page padding and delegates scrolling to the surface, as the App
+Studio workbench does. Do not use full-bleed merely because a table or grid is
+wide, and do not use a local readable region as a competing page shell.
+
 - **Buttons.** One solid-accent primary per view, and it glows
   (`0 0 16px var(--color-accent-glow)`, 22px on hover). Everything else is
   ghost (overlay bg + hairline) or text-level. Danger actions use the
@@ -746,7 +768,9 @@ Before merging any UI change:
       routing, `aria-current="page"`, and no tab glow/shadow.
 - [ ] Works in BOTH themes (toggle it — don't trust the default).
 - [ ] Uses `k-*` / portalkit primitives instead of re-derived markup.
-- [ ] No per-page `max-w-*` wrapper (width is owned by `AppLayout`).
+- [ ] Ordinary routes use the fluid `AppLayout` column with no competing
+      page-level `max-w-*` wrapper; prose, simple forms/search, and dense forms
+      apply the local readability rules in §6.
 - [ ] The creation surface matches the task: focused and route-owned for
       independently managed resources; contextual for compact, parent-dependent
       additions. Route-owned flows use the canonical creation skeleton, and

--- a/portal/src/components/AppLayout.sidenav.test.mjs
+++ b/portal/src/components/AppLayout.sidenav.test.mjs
@@ -58,7 +58,7 @@ const { clampDockPosition } = clampDockPositionModule
 test('ordinary pages use the shared fluid desktop column without becoming full bleed', () => {
   assert.match(appLayout, /'relative z-10 min-h-0 min-w-0 flex-1'/)
   assert.match(appLayout, /layoutProps\.fullBleed \? 'h-full min-h-0' : 'w-full'/)
-  assert.doesNotMatch(appLayout, /max-w-5xl/)
+  assert.doesNotMatch(appLayout, /max-w-(?:5xl|7xl)/)
 })
 
 test('flat shell modes flatten provider children with qualified labels', () => {


### PR DESCRIPTION
Stack: 1 of 10 in Fluid-Shell 4K Conformance and Provider UI Hardening.

Summary:
- Documents AppLayout as the single owner of the fluid page shell.
- Replaces the stale page-level max-width guidance with local readability rules for prose, forms, dense forms, tables, visualizations, and collections.
- Strengthens layout conformance coverage against reintroducing max-w-5xl or max-w-7xl.

Production layout behavior remains unchanged in this PR.

Verification:
- UI conformance tests
- Root portal tests and production build
- git diff --check