### PR TITLE
Add shared PortalKit action menus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,10 +263,11 @@ The shared visual authority is `provider-sdk/portalkit/faros-ui.css`. The host
 copy at `portal/src/assets/faros-ui.css` and each vendored
 `src/portalkit/faros-ui.css` are exact sync outputs; the verifier also rejects
 unmanifested canonical files and unexpected copies. Standalone bundles call
-`ensureFarosUIStyles()`, which accepts the host's computed
-`--faros-ui-canonical: 1` marker or an existing `#k-faros-ui` style and otherwise
-appends the exact vendored stylesheet as a fallback. It never overwrites an
-existing style element.
+`ensureFarosUIStyles()`, which accepts the host only when its computed
+`--faros-ui-canonical: 1` marker has a compatible `--faros-ui-version`. If the
+host is stale, the bundle appends its exact vendored stylesheet under a
+versioned fallback ID. It never overwrites an existing style element, and a
+newer host stylesheet always wins.
 
 - **`provider-sdk/portalkit/`** — plain-TS kit for the **string-building
   (vanilla-TS)** portals (`agents`, `kuery`, `quickstart`):

--- a/docs/design-book.md
+++ b/docs/design-book.md
@@ -334,12 +334,12 @@ canonical files, then run `make sync-portalkit`. Never edit the vendored copies
 under `*/src/portalkit/` — CI's `verify-portalkit` fails on drift.
 
 Standalone bundles call `ensureFarosUIStyles()` before rendering. It first
-accepts a host stylesheet whose computed `:root` marker
-`--faros-ui-canonical: 1` is present, or an existing `#k-faros-ui` style. If
-neither exists, it appends the exact vendored stylesheet as a
-`data-faros-ui-source="portalkit-fallback"` fallback. It never replaces or
-mutates an existing style element, so a provider's older fallback cannot
-overwrite the host's canonical CSS.
+accepts a host stylesheet whose computed `:root` markers include
+`--faros-ui-canonical: 1` and a compatible `--faros-ui-version`. A stale host
+or unversioned `#k-faros-ui` style remains untouched while the bundle appends
+its exact vendored stylesheet under a versioned fallback ID with
+`data-faros-ui-source="portalkit-fallback"`. Newer host versions are accepted,
+so a provider's older fallback cannot overwrite or downgrade canonical CSS.
 
 ## 10. Extended component specs
 

--- a/docs/ui-conformance.md
+++ b/docs/ui-conformance.md
@@ -10,9 +10,11 @@ at `portal/src/assets/faros-ui.css` and the byte-synced `src/portalkit/` copies
 are checked separately by `make verify-portalkit`; its manifest canary rejects
 an unmanifested canonical file and its copy checks reject missing, stale, or
 unexpected assets. Standalone bundles use the shared `styles.ts` handoff: the
-computed `:root` marker `--faros-ui-canonical: 1` preserves a host stylesheet;
-only when no marker or existing `#k-faros-ui` style is present is the exact
-vendored CSS appended as a fallback. Existing style elements are not replaced.
+computed `:root` marker `--faros-ui-canonical: 1` preserves a host stylesheet
+only when its `--faros-ui-version` is compatible. A stale or unversioned host
+style remains untouched while the exact vendored CSS is appended under a
+versioned fallback ID. Existing style elements are not replaced, and newer host
+versions are not downgraded.
 
 It scans the canonical `provider-sdk/portalkit` and
 `provider-sdk/portalkit-vue` roots plus `providers/*/portal/src`. Generated

--- a/hack/sync-portalkit.sh
+++ b/hack/sync-portalkit.sh
@@ -32,7 +32,7 @@ VUE_PORTALS=(
   "providers/edges/portal"
   "providers/infrastructure/portal"
 )
-VUE_FILES=(confirm.ts ConditionsPanel.vue ConfirmDialog.vue FormSelect.vue LayoutSelector.vue layoutPreference.ts ResourceBackLink.vue ResourcePage.vue ResourceSectionCard.vue ResourceStatCards.vue ResourceTable.vue ResourceTableFilter.vue table.ts ResourceTableActionButton.vue ResourceTableDeleteButton.vue ResourceTableEditButton.vue StatusBadge.vue Tabs.vue useDelayedLoading.ts)
+VUE_FILES=(ActionMenu.vue confirm.ts ConditionsPanel.vue ConfirmDialog.vue FormSelect.vue LayoutSelector.vue layoutPreference.ts ResourceBackLink.vue ResourcePage.vue ResourceSectionCard.vue ResourceStatCards.vue ResourceTable.vue ResourceTableFilter.vue table.ts ResourceTableActionButton.vue ResourceTableDeleteButton.vue ResourceTableEditButton.vue StatusBadge.vue Tabs.vue useDelayedLoading.ts)
 
 # Plain assets from the vanilla kit are shared by both portal styles.
 VUE_SHARED_FILES=(dashboardtile.ts faros-ui.css icons.ts page-state.ts styles.ts tabs.ts tenant.ts toast.ts)
@@ -43,7 +43,7 @@ HOST_UI="$ROOT/portal/src/assets/faros-ui.css"
 # asset. Every other direct file in the canonical directories must be listed
 # above so adding a new source file cannot silently skip every portal.
 TS_CANONICAL_ONLY=(README.md page-state.ts)
-VUE_CANONICAL_ONLY=()
+VUE_CANONICAL_ONLY=(ActionMenu.conformance.test.mjs)
 
 # These files were visual implementations before faros-ui.css became the sole
 # recipe. Remove only this known migration set; arbitrary unexpected files are

--- a/portal/src/assets/faros-ui.css
+++ b/portal/src/assets/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/portal/src/portalkit/ActionMenu.vue
+++ b/portal/src/portalkit/ActionMenu.vue
@@ -1,0 +1,290 @@
+<!-- CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+     under providers/*/portal/src/portalkit/; edit here and run
+     `make sync-portalkit`.
+
+     ActionMenu owns the compact overflow trigger and menu keyboard behavior.
+     Callers own the action mutation and map the emitted id to their behavior. -->
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
+import { Ellipsis, Loader2 } from 'lucide-vue-next'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+export type ActionMenuTone = 'neutral' | 'accent' | 'warning' | 'danger'
+
+export interface ActionMenuItem {
+  id: string
+  label: string
+  tone?: ActionMenuTone
+  disabled?: boolean
+  busy?: boolean
+}
+
+const props = withDefaults(defineProps<{
+  /** Accessible name for the overflow trigger and menu. */
+  label: string
+  items: readonly ActionMenuItem[]
+  disabled?: boolean
+}>(), {
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  select: [id: string]
+}>()
+
+// Standalone provider portals load the exact canonical recipe through the
+// shared helper; the host portal already imports the same faros-ui.css file.
+ensureFarosUIStyles()
+
+const instanceID = useId()
+const triggerID = `k-action-menu-trigger-${instanceID}`
+const menuID = `k-action-menu-${instanceID}`
+const root = ref<HTMLElement | null>(null)
+const trigger = ref<HTMLButtonElement | null>(null)
+const menu = ref<HTMLElement | null>(null)
+const open = ref(false)
+const activeIndex = ref(-1)
+let deferredCloseTimer: ReturnType<typeof setTimeout> | undefined
+
+const selectableIndexes = computed(() => props.items.reduce<number[]>((indexes, item, index) => {
+  if (!item.disabled && !item.busy) indexes.push(index)
+  return indexes
+}, []))
+
+function isSelectable(index: number): boolean {
+  const item = props.items[index]
+  return !!item && !item.disabled && !item.busy
+}
+
+function firstSelectableIndex(): number {
+  return selectableIndexes.value[0] ?? -1
+}
+
+function lastSelectableIndex(): number {
+  const indexes = selectableIndexes.value
+  return indexes[indexes.length - 1] ?? -1
+}
+
+function menuItems(): HTMLButtonElement[] {
+  return menu.value ? [...menu.value.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')] : []
+}
+
+function focusItem(index: number): void {
+  activeIndex.value = index
+  void nextTick(() => menuItems()[index]?.focus())
+}
+
+function setInitialActive(): void {
+  activeIndex.value = firstSelectableIndex()
+}
+
+function openMenu(index = firstSelectableIndex()): void {
+  if (props.disabled || open.value || !props.items.length) return
+  open.value = true
+  activeIndex.value = index
+  if (index >= 0) void nextTick(() => menuItems()[index]?.focus())
+}
+
+function clearDeferredClose(): void {
+  if (deferredCloseTimer === undefined) return
+  clearTimeout(deferredCloseTimer)
+  deferredCloseTimer = undefined
+}
+
+function closeMenu(restoreFocus = false): void {
+  clearDeferredClose()
+  if (!open.value) return
+  open.value = false
+  activeIndex.value = -1
+  if (restoreFocus) void nextTick(() => trigger.value?.focus())
+}
+
+function closeMenuAfterTab(): void {
+  if (deferredCloseTimer !== undefined) return
+  // Keep the focused menu item mounted while the browser performs its native
+  // Tab move. The focusin listener closes the menu when focus leaves it; this
+  // fallback also covers hosts that do not emit focusin for an unavailable
+  // next focus target.
+  deferredCloseTimer = setTimeout(() => {
+    deferredCloseTimer = undefined
+    closeMenu()
+  }, 0)
+}
+
+function toggleMenu(): void {
+  if (open.value) closeMenu()
+  else openMenu()
+}
+
+function select(id: string): void {
+  const item = props.items.find(candidate => candidate.id === id)
+  if (!item || props.disabled || item.disabled || item.busy) return
+  closeMenu(true)
+  emit('select', id)
+}
+
+function selectActive(): void {
+  const item = props.items[activeIndex.value]
+  if (item) select(item.id)
+}
+
+function moveActive(direction: 1 | -1): void {
+  const count = props.items.length
+  if (count === 0 || selectableIndexes.value.length === 0) return
+
+  let index = activeIndex.value
+  for (let attempts = 0; attempts < count; attempts += 1) {
+    index = (index + direction + count) % count
+    if (isSelectable(index)) {
+      focusItem(index)
+      return
+    }
+  }
+}
+
+function handleTriggerKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    if (!open.value) return
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    if (open.value) closeMenuAfterTab()
+    return
+  }
+  if (open.value) return
+
+  if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    openMenu(firstSelectableIndex())
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    openMenu(lastSelectableIndex())
+  }
+}
+
+function handleMenuKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    closeMenuAfterTab()
+    return
+  }
+  if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+    event.preventDefault()
+    selectActive()
+    return
+  }
+
+  if (event.key === 'Home') {
+    event.preventDefault()
+    focusItem(firstSelectableIndex())
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    focusItem(lastSelectableIndex())
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveActive(1)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveActive(-1)
+  }
+}
+
+function closeFromOutsidePointer(event: PointerEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function closeFromOutsideFocus(event: FocusEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function focusTrigger(): void {
+  trigger.value?.focus()
+}
+
+defineExpose({ focus: focusTrigger })
+
+watch(() => props.items, () => {
+  if (!open.value) return
+  if (!isSelectable(activeIndex.value)) {
+    setInitialActive()
+    if (activeIndex.value >= 0) void nextTick(() => menuItems()[activeIndex.value]?.focus())
+  } else if (activeIndex.value >= props.items.length) {
+    setInitialActive()
+  }
+}, { deep: true })
+
+watch(() => props.disabled, disabled => {
+  if (disabled) closeMenu()
+})
+
+onMounted(() => {
+  document.addEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.addEventListener('focusin', closeFromOutsideFocus)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.removeEventListener('focusin', closeFromOutsideFocus)
+  clearDeferredClose()
+})
+</script>
+
+<template>
+  <div ref="root" class="k-action-menu">
+    <button
+      :id="triggerID"
+      ref="trigger"
+      type="button"
+      class="k-icon-action k-action-menu__trigger"
+      :data-k-tip="label"
+      :aria-label="label"
+      :aria-controls="menuID"
+      aria-haspopup="menu"
+      :aria-expanded="open"
+      :disabled="disabled"
+      @click="toggleMenu"
+      @keydown="handleTriggerKeydown"
+    >
+      <Ellipsis :size="16" :stroke-width="1.75" aria-hidden="true" />
+    </button>
+
+    <div
+      v-if="open"
+      :id="menuID"
+      ref="menu"
+      class="k-menu k-action-menu__menu"
+      role="menu"
+      :aria-label="label"
+      :aria-labelledby="triggerID"
+      @keydown="handleMenuKeydown"
+    >
+      <button
+        v-for="(item, index) in items"
+        :key="item.id"
+        type="button"
+        class="k-menu-item k-action-menu__item"
+        :class="item.tone ? `k-menu-item--${item.tone}` : undefined"
+        role="menuitem"
+        :disabled="item.disabled || item.busy"
+        :aria-disabled="item.disabled || item.busy ? 'true' : undefined"
+        :aria-busy="item.busy ? 'true' : undefined"
+        :tabindex="index === activeIndex && isSelectable(index) ? 0 : -1"
+        @focus="activeIndex = index"
+        @click="select(item.id)"
+      >
+        <Loader2 v-if="item.busy" class="k-action-menu__busy" :size="14" :stroke-width="1.75" aria-hidden="true" />
+        <span>{{ item.label }}</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/portal/src/portalkit/faros-ui.css
+++ b/portal/src/portalkit/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/portal/src/portalkit/styles.ts
+++ b/portal/src/portalkit/styles.ts
@@ -13,6 +13,13 @@ import farosUIStyles from './faros-ui.css?raw'
 export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
+export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
+export const FAROS_UI_VERSION = 3
+
+function hasRequiredVersion(value: string): boolean {
+  const version = Number(value.trim())
+  return Number.isFinite(version) && version >= FAROS_UI_VERSION
+}
 
 function hostStylesAreLoaded(): boolean {
   const root = document.documentElement
@@ -22,22 +29,33 @@ function hostStylesAreLoaded(): boolean {
   // computed-style check works for both Vite style tags and production CSS
   // links, where there is no stable DOM id to inspect.
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    return window.getComputedStyle(root).getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    const styles = window.getComputedStyle(root)
+    return styles.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+      && hasRequiredVersion(styles.getPropertyValue(FAROS_UI_VERSION_MARKER))
   }
   return root.style?.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    && hasRequiredVersion(root.style?.getPropertyValue(FAROS_UI_VERSION_MARKER) || '')
 }
 
 export function ensureFarosUIStyles(): void {
   if (typeof document === 'undefined') return
 
-  // Never mutate an existing style element.  It may be the host's canonical
-  // stylesheet or a fallback installed by another provider bundle; replacing
-  // it here would let a stale bundle win the cascade.
-  if (document.getElementById(FAROS_UI_STYLE_ID) || hostStylesAreLoaded()) return
+  // Never mutate an existing style element. It may be the host's canonical
+  // stylesheet or an older fallback installed by another provider bundle;
+  // replacing it here would let a stale bundle win the cascade. A stale
+  // stylesheet is detected by its missing version marker and gets a new,
+  // versioned fallback appended instead.
+  if (hostStylesAreLoaded()) return
+
+  const fallbackStyleID = document.getElementById(FAROS_UI_STYLE_ID)
+    ? `${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`
+    : FAROS_UI_STYLE_ID
+  if (document.getElementById(fallbackStyleID)) return
 
   const style = document.createElement('style')
-  style.id = FAROS_UI_STYLE_ID
+  style.id = fallbackStyleID
   style.setAttribute('data-faros-ui-source', 'portalkit-fallback')
+  style.setAttribute('data-faros-ui-version', String(FAROS_UI_VERSION))
   style.textContent = farosUIStyles
   document.head?.appendChild(style)
 }

--- a/provider-sdk/portalkit-vue/ActionMenu.conformance.test.mjs
+++ b/provider-sdk/portalkit-vue/ActionMenu.conformance.test.mjs
@@ -1,0 +1,256 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { runInNewContext } from 'node:vm'
+import test from 'node:test'
+
+const component = readFileSync(new URL('./ActionMenu.vue', import.meta.url), 'utf8')
+const stylesheet = readFileSync(new URL('../portalkit/faros-ui.css', import.meta.url), 'utf8')
+const styles = readFileSync(new URL('../portalkit/styles.ts', import.meta.url), 'utf8')
+const resourceTable = readFileSync(new URL('./ResourceTable.vue', import.meta.url), 'utf8')
+
+function sourceBlock(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker)
+  assert.notEqual(start, -1, `source contains ${startMarker}`)
+  const end = endMarker ? source.indexOf(endMarker, start) : source.length
+  assert.notEqual(end, -1, `source contains ${endMarker}`)
+  return source.slice(start, end)
+}
+
+function templateBlock(source, marker) {
+  const start = source.indexOf(marker)
+  assert.notEqual(start, -1, `template contains ${marker}`)
+  const end = source.indexOf('</button>', start)
+  assert.notEqual(end, -1, `template button closes after ${marker}`)
+  return source.slice(start, end + '</button>'.length)
+}
+
+function styleNode(id, textContent = '') {
+  const attributes = new Map()
+  return {
+    id,
+    textContent,
+    setAttribute(name, value) {
+      attributes.set(name, value)
+    },
+    getAttribute(name) {
+      return attributes.get(name) ?? null
+    },
+  }
+}
+
+function executableStylesHelper({ canonical = '1', version = '', existingNodes = [] } = {}) {
+  const computedValues = new Map([
+    ['--faros-ui-canonical', canonical],
+    ['--faros-ui-version', version],
+  ])
+  const nodes = new Map(existingNodes.map(node => [node.id, node]))
+  const document = {
+    documentElement: {
+      style: {
+        getPropertyValue(name) {
+          return computedValues.get(name) ?? ''
+        },
+      },
+    },
+    getElementById(id) {
+      return nodes.get(id) ?? null
+    },
+    createElement(tagName) {
+      assert.equal(tagName, 'style')
+      return styleNode('')
+    },
+    head: {
+      children: [],
+      appendChild(node) {
+        this.children.push(node)
+        nodes.set(node.id, node)
+        // A real browser incorporates the newly appended stylesheet into the
+        // computed root style before a second provider bundle can run.
+        computedValues.set('--faros-ui-canonical', '1')
+        computedValues.set('--faros-ui-version', node.getAttribute('data-faros-ui-version') ?? '')
+        return node
+      },
+    },
+  }
+  const context = { document, window: { getComputedStyle: () => ({ getPropertyValue: name => computedValues.get(name) ?? '' }) } }
+  const executable = styles
+    .replace(/^import farosUIStyles.*$/m, "const farosUIStyles = 'current-faros-ui';")
+    .replaceAll('export const ', 'const ')
+    .replaceAll('export function ', 'function ')
+    .replaceAll(': string', '')
+    .replaceAll(': boolean', '')
+    .replaceAll(': void', '')
+    + '\n;globalThis.__styles = { ensureFarosUIStyles, FAROS_UI_STYLE_ID, FAROS_UI_VERSION };'
+  runInNewContext(executable, context)
+  return { ...context.__styles, document }
+}
+
+test('ActionMenu exposes a typed action and accessible menu contract', () => {
+  assert.match(component, /export interface ActionMenuItem\s*\{[\s\S]*id: string[\s\S]*label: string[\s\S]*tone\?: ActionMenuTone[\s\S]*disabled\?: boolean[\s\S]*busy\?: boolean/)
+  assert.match(component, /const emit = defineEmits<[\s\S]*select: \[id: string\]/)
+  assert.match(component, /function select\(id: string\)/)
+  assert.match(component, /aria-haspopup="menu"/)
+  assert.match(component, /:aria-expanded="open"/)
+  assert.match(component, /:aria-controls="menuID"/)
+  assert.match(component, /role="menu"/)
+  assert.match(component, /role="menuitem"/)
+  assert.match(component, /:aria-disabled="item\.disabled \|\| item\.busy \? 'true' : undefined"/)
+  assert.match(component, /:aria-busy="item\.busy \? 'true' : undefined"/)
+  assert.match(component, /:tabindex="index === activeIndex && isSelectable\(index\) \? 0 : -1"/)
+})
+
+test('ActionMenu owns complete keyboard and dismissal behavior', () => {
+  for (const key of ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter', ' ', 'Spacebar', 'Escape', 'Tab']) {
+    assert.match(component, new RegExp(`event\\.key === '${key === ' ' ? ' ' : key}'`), `handles ${key}`)
+  }
+  assert.match(component, /function moveActive\(direction: 1 \| -1\)/)
+  assert.match(component, /function closeMenuAfterTab\(\)/)
+  assert.match(component, /document\.addEventListener\('pointerdown', closeFromOutsidePointer, true\)/)
+  assert.match(component, /document\.addEventListener\('focusin', closeFromOutsideFocus\)/)
+  assert.match(component, /closeMenu\(true\)/)
+})
+
+test('ActionMenu renders tones and keeps disabled or busy items out of the roving set', () => {
+  assert.match(component, /export type ActionMenuTone = 'neutral' \| 'accent' \| 'warning' \| 'danger'/)
+  const itemType = sourceBlock(component, 'export interface ActionMenuItem', '}\n\nconst props')
+  for (const field of ['id: string', 'label: string', 'tone\\?: ActionMenuTone', 'disabled\\?: boolean', 'busy\\?: boolean']) {
+    assert.match(itemType, new RegExp(field), `typed item field ${field}`)
+  }
+
+  const itemTemplate = templateBlock(component, '<button\n        v-for="(item, index)')
+  assert.match(itemTemplate, /:class="item\.tone \? `k-menu-item--\$\{item\.tone\}` : undefined"/)
+  assert.match(itemTemplate, /:disabled="item\.disabled \|\| item\.busy"/)
+  assert.match(itemTemplate, /:aria-disabled="item\.disabled \|\| item\.busy \? 'true' : undefined"/)
+  assert.match(itemTemplate, /:aria-busy="item\.busy \? 'true' : undefined"/)
+  assert.match(itemTemplate, /<Loader2 v-if="item\.busy"/)
+  assert.match(component, /if \(!item\.disabled && !item\.busy\) indexes\.push\(index\)/)
+  assert.match(component, /if \(!item \|\| props\.disabled \|\| item\.disabled \|\| item\.busy\) return/)
+})
+
+test('ActionMenu keyboard paths activate, wrap, restore focus, and dismiss', () => {
+  const triggerHandler = sourceBlock(component, 'function handleTriggerKeydown', 'function handleMenuKeydown')
+  const menuHandler = sourceBlock(component, 'function handleMenuKeydown', 'function closeFromOutsidePointer')
+
+  assert.match(triggerHandler, /event\.key === 'ArrowDown' \|\| event\.key === 'Enter' \|\| event\.key === ' '/)
+  assert.match(triggerHandler, /event\.key === 'ArrowUp'/)
+  assert.match(triggerHandler, /openMenu\(firstSelectableIndex\(\)\)/)
+  assert.match(triggerHandler, /openMenu\(lastSelectableIndex\(\)\)/)
+  assert.match(menuHandler, /event\.key === 'Home'/)
+  assert.match(menuHandler, /event\.key === 'End'/)
+  assert.match(menuHandler, /event\.key === 'ArrowDown'/)
+  assert.match(menuHandler, /event\.key === 'ArrowUp'/)
+  assert.match(menuHandler, /focusItem\(firstSelectableIndex\(\)\)/)
+  assert.match(menuHandler, /focusItem\(lastSelectableIndex\(\)\)/)
+  assert.match(menuHandler, /moveActive\(1\)/)
+  assert.match(menuHandler, /moveActive\(-1\)/)
+  assert.match(component, /const selectableIndexes = computed\(\(\) => props\.items\.reduce<number\[\]>/)
+  assert.match(component, /const count = props\.items\.length[\s\S]*?\(index \+ direction \+ count\) % count/)
+
+  assert.match(menuHandler, /event\.key === 'Enter' \|\| event\.key === ' ' \|\| event\.key === 'Spacebar'/)
+  assert.match(menuHandler, /event\.preventDefault\(\)[\s\S]*?selectActive\(\)/)
+  assert.match(component, /function selectActive\(\): void \{[\s\S]*?select\(item\.id\)/)
+  assert.match(component, /function select\(id: string\): void \{[\s\S]*?closeMenu\(true\)[\s\S]*?emit\('select', id\)/)
+  assert.match(component, /if \(restoreFocus\) void nextTick\(\(\) => trigger\.value\?\.focus\(\)\)/)
+
+  assert.match(menuHandler, /if \(event\.key === 'Escape'\)[\s\S]*?closeMenu\(true\)/)
+  assert.match(triggerHandler, /if \(event\.key === 'Escape'\)[\s\S]*?closeMenu\(true\)/)
+  assert.match(triggerHandler, /if \(event\.key === 'Tab'\)[\s\S]*?closeMenuAfterTab\(\)/)
+  assert.match(menuHandler, /if \(event\.key === 'Tab'\)[\s\S]*?closeMenuAfterTab\(\)/)
+  assert.match(component, /deferredCloseTimer = setTimeout\(\(\) => \{[\s\S]*?closeMenu\(\)[\s\S]*?\}, 0\)/)
+})
+
+test('ActionMenu exposes the trigger/menu ARIA relationship and outside dismissal guards', () => {
+  const triggerTemplate = templateBlock(component, '<button\n      :id="triggerID"')
+  assert.match(triggerTemplate, /:aria-label="label"/)
+  assert.match(triggerTemplate, /:aria-controls="menuID"/)
+  assert.match(triggerTemplate, /aria-haspopup="menu"/)
+  assert.match(triggerTemplate, /:aria-expanded="open"/)
+  assert.match(triggerTemplate, /:disabled="disabled"/)
+
+  const menuTemplate = sourceBlock(component, '<div\n      v-if="open"', '      <button\n        v-for="(item, index)')
+  assert.match(menuTemplate, /role="menu"/)
+  assert.match(menuTemplate, /:aria-label="label"/)
+  assert.match(menuTemplate, /:aria-labelledby="triggerID"/)
+  assert.match(component, /role="menuitem"/)
+  assert.match(component, /:tabindex="index === activeIndex && isSelectable\(index\) \? 0 : -1"/)
+
+  assert.match(component, /document\.addEventListener\('pointerdown', closeFromOutsidePointer, true\)/)
+  assert.match(component, /document\.addEventListener\('focusin', closeFromOutsideFocus\)/)
+  for (const handler of ['closeFromOutsidePointer', 'closeFromOutsideFocus']) {
+    const block = sourceBlock(component, `function ${handler}`, 'function focusTrigger')
+    assert.match(block, /if \(!open\.value \|\| \(target && root\.value\?\.contains\(target\)\)\) return/)
+    assert.match(block, /closeMenu\(\)/)
+  }
+})
+
+test('canonical icon action, layer, and bounded search recipes remain intact', () => {
+  assert.match(stylesheet, /\.k-icon-action\s*\{[\s\S]*?height: 32px;[\s\S]*?width: 32px;/)
+  assert.match(stylesheet, /\.k-icon-action:focus-visible\s*\{[\s\S]*?outline: 2px solid var\(--color-accent/)
+  assert.match(stylesheet, /@media \(pointer: coarse\), \(any-pointer: coarse\)\s*\{[\s\S]*?\.k-icon-action\s*\{[\s\S]*?height: 44px;[\s\S]*?width: 44px;/)
+  const layers = Object.fromEntries([...stylesheet.matchAll(/--k-layer-(menu|fullscreen|modal|toast):\s*(\d+)/g)].map(match => [match[1], Number(match[2])]))
+  assert.deepEqual(Object.keys(layers).sort(), ['fullscreen', 'menu', 'modal', 'toast'])
+  assert.ok(layers.menu < layers.fullscreen && layers.fullscreen < layers.modal && layers.modal < layers.toast)
+  assert.match(stylesheet, /\.k-table__search\s*\{[\s\S]*?max-width: 42rem;/)
+  assert.match(stylesheet, /\.k-table__search-input\s*\{[\s\S]*?max-width: 42rem;/)
+  assert.match(resourceTable, /class="k-table__scroll"/)
+
+  const tableShell = stylesheet.match(/\.k-table\.k-table--resource\s*\{[\s\S]*?\n\}/)?.[0]
+  assert.ok(tableShell)
+  assert.match(tableShell, /max-width: 100%/)
+  assert.match(tableShell, /width: 100%/)
+  assert.doesNotMatch(tableShell, /max-width: 42rem/)
+  assert.match(stylesheet, /\.k-table__scroll\s*\{[\s\S]*?max-width: 100%;[\s\S]*?overflow-x: auto;/)
+})
+
+test('ActionMenu geometry survives broad provider descendant constraints', () => {
+  const menuRule = stylesheet.match(/\.k-action-menu\s*>\s*\.k-action-menu__menu\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+  assert.match(menuRule, /max-width:\s*calc\(100vw - 16px\)/)
+  assert.match(menuRule, /min-width:\s*180px/)
+
+  const tooltipRule = stylesheet.match(/\.k-action-menu__trigger\[data-k-tip\]::after\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+  assert.match(tooltipRule, /inset-inline-start:\s*auto/)
+  assert.match(tooltipRule, /inset-inline-end:\s*0/)
+  assert.match(tooltipRule, /transform:\s*none/)
+  assert.match(tooltipRule, /max-width:\s*min\(260px, calc\(100vw - 16px\)\)/)
+  assert.match(tooltipRule, /width:\s*max-content/)
+
+  const expandedTooltipRule = stylesheet.match(/\.k-action-menu__trigger\[aria-expanded="true"\]\[data-k-tip\]::after\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+  assert.match(expandedTooltipRule, /opacity:\s*0/)
+  assert.match(expandedTooltipRule, /visibility:\s*hidden/)
+})
+
+test('standalone style recovery distinguishes a stale host stylesheet', () => {
+  assert.match(styles, /export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'/)
+  assert.match(styles, /export const FAROS_UI_VERSION = 3/)
+  assert.match(styles, /getPropertyValue\(FAROS_UI_CANONICAL_MARKER\)\.trim\(\) === FAROS_UI_CANONICAL_VALUE/)
+  assert.match(styles, /function hasRequiredVersion\(value: string\): boolean/)
+  assert.match(styles, /Number\.isFinite\(version\) && version >= FAROS_UI_VERSION/)
+  assert.match(styles, /hasRequiredVersion\(styles\.getPropertyValue\(FAROS_UI_VERSION_MARKER\)\)/)
+  assert.doesNotMatch(styles, /if \(document\.getElementById\(FAROS_UI_STYLE_ID\) \|\| hostStylesAreLoaded\(\)\) return/)
+  assert.match(styles, /const fallbackStyleID = document\.getElementById\(FAROS_UI_STYLE_ID\)/)
+  assert.match(styles, /`\$\{FAROS_UI_STYLE_ID\}-v\$\{FAROS_UI_VERSION\}`/)
+  assert.match(styles, /style\.setAttribute\('data-faros-ui-version', String\(FAROS_UI_VERSION\)\)/)
+})
+
+test('standalone style recovery executes the stale/current/newer host matrix', () => {
+  const staleHost = styleNode('k-faros-ui', 'stale-host-css')
+  const stale = executableStylesHelper({ existingNodes: [staleHost] })
+  stale.ensureFarosUIStyles()
+  assert.equal(stale.document.head.children.length, 1)
+  assert.equal(stale.document.head.children[0].id, 'k-faros-ui-v3')
+  assert.equal(stale.document.head.children[0].textContent, 'current-faros-ui')
+  assert.equal(stale.document.head.children[0].getAttribute('data-faros-ui-version'), '3')
+  assert.equal(staleHost.textContent, 'stale-host-css')
+  assert.equal(staleHost.getAttribute('data-faros-ui-version'), null)
+  stale.ensureFarosUIStyles()
+  assert.equal(stale.document.head.children.length, 1)
+
+  const current = executableStylesHelper({ version: '3' })
+  current.ensureFarosUIStyles()
+  assert.equal(current.document.head.children.length, 0)
+
+  const newerHost = executableStylesHelper({ version: '4', existingNodes: [styleNode('k-faros-ui', 'future-host-css')] })
+  newerHost.ensureFarosUIStyles()
+  assert.equal(newerHost.document.head.children.length, 0)
+  assert.equal(newerHost.document.getElementById('k-faros-ui').textContent, 'future-host-css')
+})

--- a/provider-sdk/portalkit-vue/ActionMenu.vue
+++ b/provider-sdk/portalkit-vue/ActionMenu.vue
@@ -1,0 +1,290 @@
+<!-- CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+     under providers/*/portal/src/portalkit/; edit here and run
+     `make sync-portalkit`.
+
+     ActionMenu owns the compact overflow trigger and menu keyboard behavior.
+     Callers own the action mutation and map the emitted id to their behavior. -->
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
+import { Ellipsis, Loader2 } from 'lucide-vue-next'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+export type ActionMenuTone = 'neutral' | 'accent' | 'warning' | 'danger'
+
+export interface ActionMenuItem {
+  id: string
+  label: string
+  tone?: ActionMenuTone
+  disabled?: boolean
+  busy?: boolean
+}
+
+const props = withDefaults(defineProps<{
+  /** Accessible name for the overflow trigger and menu. */
+  label: string
+  items: readonly ActionMenuItem[]
+  disabled?: boolean
+}>(), {
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  select: [id: string]
+}>()
+
+// Standalone provider portals load the exact canonical recipe through the
+// shared helper; the host portal already imports the same faros-ui.css file.
+ensureFarosUIStyles()
+
+const instanceID = useId()
+const triggerID = `k-action-menu-trigger-${instanceID}`
+const menuID = `k-action-menu-${instanceID}`
+const root = ref<HTMLElement | null>(null)
+const trigger = ref<HTMLButtonElement | null>(null)
+const menu = ref<HTMLElement | null>(null)
+const open = ref(false)
+const activeIndex = ref(-1)
+let deferredCloseTimer: ReturnType<typeof setTimeout> | undefined
+
+const selectableIndexes = computed(() => props.items.reduce<number[]>((indexes, item, index) => {
+  if (!item.disabled && !item.busy) indexes.push(index)
+  return indexes
+}, []))
+
+function isSelectable(index: number): boolean {
+  const item = props.items[index]
+  return !!item && !item.disabled && !item.busy
+}
+
+function firstSelectableIndex(): number {
+  return selectableIndexes.value[0] ?? -1
+}
+
+function lastSelectableIndex(): number {
+  const indexes = selectableIndexes.value
+  return indexes[indexes.length - 1] ?? -1
+}
+
+function menuItems(): HTMLButtonElement[] {
+  return menu.value ? [...menu.value.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')] : []
+}
+
+function focusItem(index: number): void {
+  activeIndex.value = index
+  void nextTick(() => menuItems()[index]?.focus())
+}
+
+function setInitialActive(): void {
+  activeIndex.value = firstSelectableIndex()
+}
+
+function openMenu(index = firstSelectableIndex()): void {
+  if (props.disabled || open.value || !props.items.length) return
+  open.value = true
+  activeIndex.value = index
+  if (index >= 0) void nextTick(() => menuItems()[index]?.focus())
+}
+
+function clearDeferredClose(): void {
+  if (deferredCloseTimer === undefined) return
+  clearTimeout(deferredCloseTimer)
+  deferredCloseTimer = undefined
+}
+
+function closeMenu(restoreFocus = false): void {
+  clearDeferredClose()
+  if (!open.value) return
+  open.value = false
+  activeIndex.value = -1
+  if (restoreFocus) void nextTick(() => trigger.value?.focus())
+}
+
+function closeMenuAfterTab(): void {
+  if (deferredCloseTimer !== undefined) return
+  // Keep the focused menu item mounted while the browser performs its native
+  // Tab move. The focusin listener closes the menu when focus leaves it; this
+  // fallback also covers hosts that do not emit focusin for an unavailable
+  // next focus target.
+  deferredCloseTimer = setTimeout(() => {
+    deferredCloseTimer = undefined
+    closeMenu()
+  }, 0)
+}
+
+function toggleMenu(): void {
+  if (open.value) closeMenu()
+  else openMenu()
+}
+
+function select(id: string): void {
+  const item = props.items.find(candidate => candidate.id === id)
+  if (!item || props.disabled || item.disabled || item.busy) return
+  closeMenu(true)
+  emit('select', id)
+}
+
+function selectActive(): void {
+  const item = props.items[activeIndex.value]
+  if (item) select(item.id)
+}
+
+function moveActive(direction: 1 | -1): void {
+  const count = props.items.length
+  if (count === 0 || selectableIndexes.value.length === 0) return
+
+  let index = activeIndex.value
+  for (let attempts = 0; attempts < count; attempts += 1) {
+    index = (index + direction + count) % count
+    if (isSelectable(index)) {
+      focusItem(index)
+      return
+    }
+  }
+}
+
+function handleTriggerKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    if (!open.value) return
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    if (open.value) closeMenuAfterTab()
+    return
+  }
+  if (open.value) return
+
+  if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    openMenu(firstSelectableIndex())
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    openMenu(lastSelectableIndex())
+  }
+}
+
+function handleMenuKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    closeMenuAfterTab()
+    return
+  }
+  if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+    event.preventDefault()
+    selectActive()
+    return
+  }
+
+  if (event.key === 'Home') {
+    event.preventDefault()
+    focusItem(firstSelectableIndex())
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    focusItem(lastSelectableIndex())
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveActive(1)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveActive(-1)
+  }
+}
+
+function closeFromOutsidePointer(event: PointerEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function closeFromOutsideFocus(event: FocusEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function focusTrigger(): void {
+  trigger.value?.focus()
+}
+
+defineExpose({ focus: focusTrigger })
+
+watch(() => props.items, () => {
+  if (!open.value) return
+  if (!isSelectable(activeIndex.value)) {
+    setInitialActive()
+    if (activeIndex.value >= 0) void nextTick(() => menuItems()[activeIndex.value]?.focus())
+  } else if (activeIndex.value >= props.items.length) {
+    setInitialActive()
+  }
+}, { deep: true })
+
+watch(() => props.disabled, disabled => {
+  if (disabled) closeMenu()
+})
+
+onMounted(() => {
+  document.addEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.addEventListener('focusin', closeFromOutsideFocus)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.removeEventListener('focusin', closeFromOutsideFocus)
+  clearDeferredClose()
+})
+</script>
+
+<template>
+  <div ref="root" class="k-action-menu">
+    <button
+      :id="triggerID"
+      ref="trigger"
+      type="button"
+      class="k-icon-action k-action-menu__trigger"
+      :data-k-tip="label"
+      :aria-label="label"
+      :aria-controls="menuID"
+      aria-haspopup="menu"
+      :aria-expanded="open"
+      :disabled="disabled"
+      @click="toggleMenu"
+      @keydown="handleTriggerKeydown"
+    >
+      <Ellipsis :size="16" :stroke-width="1.75" aria-hidden="true" />
+    </button>
+
+    <div
+      v-if="open"
+      :id="menuID"
+      ref="menu"
+      class="k-menu k-action-menu__menu"
+      role="menu"
+      :aria-label="label"
+      :aria-labelledby="triggerID"
+      @keydown="handleMenuKeydown"
+    >
+      <button
+        v-for="(item, index) in items"
+        :key="item.id"
+        type="button"
+        class="k-menu-item k-action-menu__item"
+        :class="item.tone ? `k-menu-item--${item.tone}` : undefined"
+        role="menuitem"
+        :disabled="item.disabled || item.busy"
+        :aria-disabled="item.disabled || item.busy ? 'true' : undefined"
+        :aria-busy="item.busy ? 'true' : undefined"
+        :tabindex="index === activeIndex && isSelectable(index) ? 0 : -1"
+        @focus="activeIndex = index"
+        @click="select(item.id)"
+      >
+        <Loader2 v-if="item.busy" class="k-action-menu__busy" :size="14" :stroke-width="1.75" aria-hidden="true" />
+        <span>{{ item.label }}</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/provider-sdk/portalkit/README.md
+++ b/provider-sdk/portalkit/README.md
@@ -33,10 +33,11 @@ package boundaries.
 must remain byte-identical. `make verify-portalkit` checks the manifest, the
 host copy, every portal copy, and unexpected files. Standalone helpers call
 `ensureFarosUIStyles()`: a computed `:root` marker
-`--faros-ui-canonical: 1` or an existing `#k-faros-ui` means the host/style is
-already present and is left untouched; otherwise the exact vendored stylesheet
-is appended with `data-faros-ui-source="portalkit-fallback"`. Existing style
-elements are never replaced.
+`--faros-ui-canonical: 1` is accepted only when its `--faros-ui-version` is at
+least the bundle's required version. Otherwise the exact vendored stylesheet
+is appended under a versioned fallback ID with
+`data-faros-ui-source="portalkit-fallback"`. Existing style elements are never
+replaced, and a newer host stylesheet is never downgraded.
 
 ## Editing
 

--- a/provider-sdk/portalkit/faros-ui.css
+++ b/provider-sdk/portalkit/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/provider-sdk/portalkit/styles.ts
+++ b/provider-sdk/portalkit/styles.ts
@@ -13,6 +13,13 @@ import farosUIStyles from './faros-ui.css?raw'
 export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
+export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
+export const FAROS_UI_VERSION = 3
+
+function hasRequiredVersion(value: string): boolean {
+  const version = Number(value.trim())
+  return Number.isFinite(version) && version >= FAROS_UI_VERSION
+}
 
 function hostStylesAreLoaded(): boolean {
   const root = document.documentElement
@@ -22,22 +29,33 @@ function hostStylesAreLoaded(): boolean {
   // computed-style check works for both Vite style tags and production CSS
   // links, where there is no stable DOM id to inspect.
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    return window.getComputedStyle(root).getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    const styles = window.getComputedStyle(root)
+    return styles.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+      && hasRequiredVersion(styles.getPropertyValue(FAROS_UI_VERSION_MARKER))
   }
   return root.style?.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    && hasRequiredVersion(root.style?.getPropertyValue(FAROS_UI_VERSION_MARKER) || '')
 }
 
 export function ensureFarosUIStyles(): void {
   if (typeof document === 'undefined') return
 
-  // Never mutate an existing style element.  It may be the host's canonical
-  // stylesheet or a fallback installed by another provider bundle; replacing
-  // it here would let a stale bundle win the cascade.
-  if (document.getElementById(FAROS_UI_STYLE_ID) || hostStylesAreLoaded()) return
+  // Never mutate an existing style element. It may be the host's canonical
+  // stylesheet or an older fallback installed by another provider bundle;
+  // replacing it here would let a stale bundle win the cascade. A stale
+  // stylesheet is detected by its missing version marker and gets a new,
+  // versioned fallback appended instead.
+  if (hostStylesAreLoaded()) return
+
+  const fallbackStyleID = document.getElementById(FAROS_UI_STYLE_ID)
+    ? `${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`
+    : FAROS_UI_STYLE_ID
+  if (document.getElementById(fallbackStyleID)) return
 
   const style = document.createElement('style')
-  style.id = FAROS_UI_STYLE_ID
+  style.id = fallbackStyleID
   style.setAttribute('data-faros-ui-source', 'portalkit-fallback')
+  style.setAttribute('data-faros-ui-version', String(FAROS_UI_VERSION))
   style.textContent = farosUIStyles
   document.head?.appendChild(style)
 }

--- a/providers/agents/portal/src/portalkit/faros-ui.css
+++ b/providers/agents/portal/src/portalkit/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/providers/agents/portal/src/portalkit/styles.ts
+++ b/providers/agents/portal/src/portalkit/styles.ts
@@ -13,6 +13,13 @@ import farosUIStyles from './faros-ui.css?raw'
 export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
+export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
+export const FAROS_UI_VERSION = 3
+
+function hasRequiredVersion(value: string): boolean {
+  const version = Number(value.trim())
+  return Number.isFinite(version) && version >= FAROS_UI_VERSION
+}
 
 function hostStylesAreLoaded(): boolean {
   const root = document.documentElement
@@ -22,22 +29,33 @@ function hostStylesAreLoaded(): boolean {
   // computed-style check works for both Vite style tags and production CSS
   // links, where there is no stable DOM id to inspect.
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    return window.getComputedStyle(root).getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    const styles = window.getComputedStyle(root)
+    return styles.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+      && hasRequiredVersion(styles.getPropertyValue(FAROS_UI_VERSION_MARKER))
   }
   return root.style?.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    && hasRequiredVersion(root.style?.getPropertyValue(FAROS_UI_VERSION_MARKER) || '')
 }
 
 export function ensureFarosUIStyles(): void {
   if (typeof document === 'undefined') return
 
-  // Never mutate an existing style element.  It may be the host's canonical
-  // stylesheet or a fallback installed by another provider bundle; replacing
-  // it here would let a stale bundle win the cascade.
-  if (document.getElementById(FAROS_UI_STYLE_ID) || hostStylesAreLoaded()) return
+  // Never mutate an existing style element. It may be the host's canonical
+  // stylesheet or an older fallback installed by another provider bundle;
+  // replacing it here would let a stale bundle win the cascade. A stale
+  // stylesheet is detected by its missing version marker and gets a new,
+  // versioned fallback appended instead.
+  if (hostStylesAreLoaded()) return
+
+  const fallbackStyleID = document.getElementById(FAROS_UI_STYLE_ID)
+    ? `${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`
+    : FAROS_UI_STYLE_ID
+  if (document.getElementById(fallbackStyleID)) return
 
   const style = document.createElement('style')
-  style.id = FAROS_UI_STYLE_ID
+  style.id = fallbackStyleID
   style.setAttribute('data-faros-ui-source', 'portalkit-fallback')
+  style.setAttribute('data-faros-ui-version', String(FAROS_UI_VERSION))
   style.textContent = farosUIStyles
   document.head?.appendChild(style)
 }

--- a/providers/app-studio/portal/src/portalkit/ActionMenu.vue
+++ b/providers/app-studio/portal/src/portalkit/ActionMenu.vue
@@ -1,0 +1,290 @@
+<!-- CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+     under providers/*/portal/src/portalkit/; edit here and run
+     `make sync-portalkit`.
+
+     ActionMenu owns the compact overflow trigger and menu keyboard behavior.
+     Callers own the action mutation and map the emitted id to their behavior. -->
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
+import { Ellipsis, Loader2 } from 'lucide-vue-next'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+export type ActionMenuTone = 'neutral' | 'accent' | 'warning' | 'danger'
+
+export interface ActionMenuItem {
+  id: string
+  label: string
+  tone?: ActionMenuTone
+  disabled?: boolean
+  busy?: boolean
+}
+
+const props = withDefaults(defineProps<{
+  /** Accessible name for the overflow trigger and menu. */
+  label: string
+  items: readonly ActionMenuItem[]
+  disabled?: boolean
+}>(), {
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  select: [id: string]
+}>()
+
+// Standalone provider portals load the exact canonical recipe through the
+// shared helper; the host portal already imports the same faros-ui.css file.
+ensureFarosUIStyles()
+
+const instanceID = useId()
+const triggerID = `k-action-menu-trigger-${instanceID}`
+const menuID = `k-action-menu-${instanceID}`
+const root = ref<HTMLElement | null>(null)
+const trigger = ref<HTMLButtonElement | null>(null)
+const menu = ref<HTMLElement | null>(null)
+const open = ref(false)
+const activeIndex = ref(-1)
+let deferredCloseTimer: ReturnType<typeof setTimeout> | undefined
+
+const selectableIndexes = computed(() => props.items.reduce<number[]>((indexes, item, index) => {
+  if (!item.disabled && !item.busy) indexes.push(index)
+  return indexes
+}, []))
+
+function isSelectable(index: number): boolean {
+  const item = props.items[index]
+  return !!item && !item.disabled && !item.busy
+}
+
+function firstSelectableIndex(): number {
+  return selectableIndexes.value[0] ?? -1
+}
+
+function lastSelectableIndex(): number {
+  const indexes = selectableIndexes.value
+  return indexes[indexes.length - 1] ?? -1
+}
+
+function menuItems(): HTMLButtonElement[] {
+  return menu.value ? [...menu.value.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')] : []
+}
+
+function focusItem(index: number): void {
+  activeIndex.value = index
+  void nextTick(() => menuItems()[index]?.focus())
+}
+
+function setInitialActive(): void {
+  activeIndex.value = firstSelectableIndex()
+}
+
+function openMenu(index = firstSelectableIndex()): void {
+  if (props.disabled || open.value || !props.items.length) return
+  open.value = true
+  activeIndex.value = index
+  if (index >= 0) void nextTick(() => menuItems()[index]?.focus())
+}
+
+function clearDeferredClose(): void {
+  if (deferredCloseTimer === undefined) return
+  clearTimeout(deferredCloseTimer)
+  deferredCloseTimer = undefined
+}
+
+function closeMenu(restoreFocus = false): void {
+  clearDeferredClose()
+  if (!open.value) return
+  open.value = false
+  activeIndex.value = -1
+  if (restoreFocus) void nextTick(() => trigger.value?.focus())
+}
+
+function closeMenuAfterTab(): void {
+  if (deferredCloseTimer !== undefined) return
+  // Keep the focused menu item mounted while the browser performs its native
+  // Tab move. The focusin listener closes the menu when focus leaves it; this
+  // fallback also covers hosts that do not emit focusin for an unavailable
+  // next focus target.
+  deferredCloseTimer = setTimeout(() => {
+    deferredCloseTimer = undefined
+    closeMenu()
+  }, 0)
+}
+
+function toggleMenu(): void {
+  if (open.value) closeMenu()
+  else openMenu()
+}
+
+function select(id: string): void {
+  const item = props.items.find(candidate => candidate.id === id)
+  if (!item || props.disabled || item.disabled || item.busy) return
+  closeMenu(true)
+  emit('select', id)
+}
+
+function selectActive(): void {
+  const item = props.items[activeIndex.value]
+  if (item) select(item.id)
+}
+
+function moveActive(direction: 1 | -1): void {
+  const count = props.items.length
+  if (count === 0 || selectableIndexes.value.length === 0) return
+
+  let index = activeIndex.value
+  for (let attempts = 0; attempts < count; attempts += 1) {
+    index = (index + direction + count) % count
+    if (isSelectable(index)) {
+      focusItem(index)
+      return
+    }
+  }
+}
+
+function handleTriggerKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    if (!open.value) return
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    if (open.value) closeMenuAfterTab()
+    return
+  }
+  if (open.value) return
+
+  if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    openMenu(firstSelectableIndex())
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    openMenu(lastSelectableIndex())
+  }
+}
+
+function handleMenuKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    closeMenuAfterTab()
+    return
+  }
+  if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+    event.preventDefault()
+    selectActive()
+    return
+  }
+
+  if (event.key === 'Home') {
+    event.preventDefault()
+    focusItem(firstSelectableIndex())
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    focusItem(lastSelectableIndex())
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveActive(1)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveActive(-1)
+  }
+}
+
+function closeFromOutsidePointer(event: PointerEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function closeFromOutsideFocus(event: FocusEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function focusTrigger(): void {
+  trigger.value?.focus()
+}
+
+defineExpose({ focus: focusTrigger })
+
+watch(() => props.items, () => {
+  if (!open.value) return
+  if (!isSelectable(activeIndex.value)) {
+    setInitialActive()
+    if (activeIndex.value >= 0) void nextTick(() => menuItems()[activeIndex.value]?.focus())
+  } else if (activeIndex.value >= props.items.length) {
+    setInitialActive()
+  }
+}, { deep: true })
+
+watch(() => props.disabled, disabled => {
+  if (disabled) closeMenu()
+})
+
+onMounted(() => {
+  document.addEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.addEventListener('focusin', closeFromOutsideFocus)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.removeEventListener('focusin', closeFromOutsideFocus)
+  clearDeferredClose()
+})
+</script>
+
+<template>
+  <div ref="root" class="k-action-menu">
+    <button
+      :id="triggerID"
+      ref="trigger"
+      type="button"
+      class="k-icon-action k-action-menu__trigger"
+      :data-k-tip="label"
+      :aria-label="label"
+      :aria-controls="menuID"
+      aria-haspopup="menu"
+      :aria-expanded="open"
+      :disabled="disabled"
+      @click="toggleMenu"
+      @keydown="handleTriggerKeydown"
+    >
+      <Ellipsis :size="16" :stroke-width="1.75" aria-hidden="true" />
+    </button>
+
+    <div
+      v-if="open"
+      :id="menuID"
+      ref="menu"
+      class="k-menu k-action-menu__menu"
+      role="menu"
+      :aria-label="label"
+      :aria-labelledby="triggerID"
+      @keydown="handleMenuKeydown"
+    >
+      <button
+        v-for="(item, index) in items"
+        :key="item.id"
+        type="button"
+        class="k-menu-item k-action-menu__item"
+        :class="item.tone ? `k-menu-item--${item.tone}` : undefined"
+        role="menuitem"
+        :disabled="item.disabled || item.busy"
+        :aria-disabled="item.disabled || item.busy ? 'true' : undefined"
+        :aria-busy="item.busy ? 'true' : undefined"
+        :tabindex="index === activeIndex && isSelectable(index) ? 0 : -1"
+        @focus="activeIndex = index"
+        @click="select(item.id)"
+      >
+        <Loader2 v-if="item.busy" class="k-action-menu__busy" :size="14" :stroke-width="1.75" aria-hidden="true" />
+        <span>{{ item.label }}</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/providers/app-studio/portal/src/portalkit/faros-ui.css
+++ b/providers/app-studio/portal/src/portalkit/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/providers/app-studio/portal/src/portalkit/styles.ts
+++ b/providers/app-studio/portal/src/portalkit/styles.ts
@@ -13,6 +13,13 @@ import farosUIStyles from './faros-ui.css?raw'
 export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
+export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
+export const FAROS_UI_VERSION = 3
+
+function hasRequiredVersion(value: string): boolean {
+  const version = Number(value.trim())
+  return Number.isFinite(version) && version >= FAROS_UI_VERSION
+}
 
 function hostStylesAreLoaded(): boolean {
   const root = document.documentElement
@@ -22,22 +29,33 @@ function hostStylesAreLoaded(): boolean {
   // computed-style check works for both Vite style tags and production CSS
   // links, where there is no stable DOM id to inspect.
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    return window.getComputedStyle(root).getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    const styles = window.getComputedStyle(root)
+    return styles.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+      && hasRequiredVersion(styles.getPropertyValue(FAROS_UI_VERSION_MARKER))
   }
   return root.style?.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    && hasRequiredVersion(root.style?.getPropertyValue(FAROS_UI_VERSION_MARKER) || '')
 }
 
 export function ensureFarosUIStyles(): void {
   if (typeof document === 'undefined') return
 
-  // Never mutate an existing style element.  It may be the host's canonical
-  // stylesheet or a fallback installed by another provider bundle; replacing
-  // it here would let a stale bundle win the cascade.
-  if (document.getElementById(FAROS_UI_STYLE_ID) || hostStylesAreLoaded()) return
+  // Never mutate an existing style element. It may be the host's canonical
+  // stylesheet or an older fallback installed by another provider bundle;
+  // replacing it here would let a stale bundle win the cascade. A stale
+  // stylesheet is detected by its missing version marker and gets a new,
+  // versioned fallback appended instead.
+  if (hostStylesAreLoaded()) return
+
+  const fallbackStyleID = document.getElementById(FAROS_UI_STYLE_ID)
+    ? `${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`
+    : FAROS_UI_STYLE_ID
+  if (document.getElementById(fallbackStyleID)) return
 
   const style = document.createElement('style')
-  style.id = FAROS_UI_STYLE_ID
+  style.id = fallbackStyleID
   style.setAttribute('data-faros-ui-source', 'portalkit-fallback')
+  style.setAttribute('data-faros-ui-version', String(FAROS_UI_VERSION))
   style.textContent = farosUIStyles
   document.head?.appendChild(style)
 }

--- a/providers/code/portal/src/portalkit/ActionMenu.vue
+++ b/providers/code/portal/src/portalkit/ActionMenu.vue
@@ -1,0 +1,290 @@
+<!-- CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+     under providers/*/portal/src/portalkit/; edit here and run
+     `make sync-portalkit`.
+
+     ActionMenu owns the compact overflow trigger and menu keyboard behavior.
+     Callers own the action mutation and map the emitted id to their behavior. -->
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
+import { Ellipsis, Loader2 } from 'lucide-vue-next'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+export type ActionMenuTone = 'neutral' | 'accent' | 'warning' | 'danger'
+
+export interface ActionMenuItem {
+  id: string
+  label: string
+  tone?: ActionMenuTone
+  disabled?: boolean
+  busy?: boolean
+}
+
+const props = withDefaults(defineProps<{
+  /** Accessible name for the overflow trigger and menu. */
+  label: string
+  items: readonly ActionMenuItem[]
+  disabled?: boolean
+}>(), {
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  select: [id: string]
+}>()
+
+// Standalone provider portals load the exact canonical recipe through the
+// shared helper; the host portal already imports the same faros-ui.css file.
+ensureFarosUIStyles()
+
+const instanceID = useId()
+const triggerID = `k-action-menu-trigger-${instanceID}`
+const menuID = `k-action-menu-${instanceID}`
+const root = ref<HTMLElement | null>(null)
+const trigger = ref<HTMLButtonElement | null>(null)
+const menu = ref<HTMLElement | null>(null)
+const open = ref(false)
+const activeIndex = ref(-1)
+let deferredCloseTimer: ReturnType<typeof setTimeout> | undefined
+
+const selectableIndexes = computed(() => props.items.reduce<number[]>((indexes, item, index) => {
+  if (!item.disabled && !item.busy) indexes.push(index)
+  return indexes
+}, []))
+
+function isSelectable(index: number): boolean {
+  const item = props.items[index]
+  return !!item && !item.disabled && !item.busy
+}
+
+function firstSelectableIndex(): number {
+  return selectableIndexes.value[0] ?? -1
+}
+
+function lastSelectableIndex(): number {
+  const indexes = selectableIndexes.value
+  return indexes[indexes.length - 1] ?? -1
+}
+
+function menuItems(): HTMLButtonElement[] {
+  return menu.value ? [...menu.value.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')] : []
+}
+
+function focusItem(index: number): void {
+  activeIndex.value = index
+  void nextTick(() => menuItems()[index]?.focus())
+}
+
+function setInitialActive(): void {
+  activeIndex.value = firstSelectableIndex()
+}
+
+function openMenu(index = firstSelectableIndex()): void {
+  if (props.disabled || open.value || !props.items.length) return
+  open.value = true
+  activeIndex.value = index
+  if (index >= 0) void nextTick(() => menuItems()[index]?.focus())
+}
+
+function clearDeferredClose(): void {
+  if (deferredCloseTimer === undefined) return
+  clearTimeout(deferredCloseTimer)
+  deferredCloseTimer = undefined
+}
+
+function closeMenu(restoreFocus = false): void {
+  clearDeferredClose()
+  if (!open.value) return
+  open.value = false
+  activeIndex.value = -1
+  if (restoreFocus) void nextTick(() => trigger.value?.focus())
+}
+
+function closeMenuAfterTab(): void {
+  if (deferredCloseTimer !== undefined) return
+  // Keep the focused menu item mounted while the browser performs its native
+  // Tab move. The focusin listener closes the menu when focus leaves it; this
+  // fallback also covers hosts that do not emit focusin for an unavailable
+  // next focus target.
+  deferredCloseTimer = setTimeout(() => {
+    deferredCloseTimer = undefined
+    closeMenu()
+  }, 0)
+}
+
+function toggleMenu(): void {
+  if (open.value) closeMenu()
+  else openMenu()
+}
+
+function select(id: string): void {
+  const item = props.items.find(candidate => candidate.id === id)
+  if (!item || props.disabled || item.disabled || item.busy) return
+  closeMenu(true)
+  emit('select', id)
+}
+
+function selectActive(): void {
+  const item = props.items[activeIndex.value]
+  if (item) select(item.id)
+}
+
+function moveActive(direction: 1 | -1): void {
+  const count = props.items.length
+  if (count === 0 || selectableIndexes.value.length === 0) return
+
+  let index = activeIndex.value
+  for (let attempts = 0; attempts < count; attempts += 1) {
+    index = (index + direction + count) % count
+    if (isSelectable(index)) {
+      focusItem(index)
+      return
+    }
+  }
+}
+
+function handleTriggerKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    if (!open.value) return
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    if (open.value) closeMenuAfterTab()
+    return
+  }
+  if (open.value) return
+
+  if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    openMenu(firstSelectableIndex())
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    openMenu(lastSelectableIndex())
+  }
+}
+
+function handleMenuKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    closeMenuAfterTab()
+    return
+  }
+  if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+    event.preventDefault()
+    selectActive()
+    return
+  }
+
+  if (event.key === 'Home') {
+    event.preventDefault()
+    focusItem(firstSelectableIndex())
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    focusItem(lastSelectableIndex())
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveActive(1)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveActive(-1)
+  }
+}
+
+function closeFromOutsidePointer(event: PointerEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function closeFromOutsideFocus(event: FocusEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function focusTrigger(): void {
+  trigger.value?.focus()
+}
+
+defineExpose({ focus: focusTrigger })
+
+watch(() => props.items, () => {
+  if (!open.value) return
+  if (!isSelectable(activeIndex.value)) {
+    setInitialActive()
+    if (activeIndex.value >= 0) void nextTick(() => menuItems()[activeIndex.value]?.focus())
+  } else if (activeIndex.value >= props.items.length) {
+    setInitialActive()
+  }
+}, { deep: true })
+
+watch(() => props.disabled, disabled => {
+  if (disabled) closeMenu()
+})
+
+onMounted(() => {
+  document.addEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.addEventListener('focusin', closeFromOutsideFocus)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.removeEventListener('focusin', closeFromOutsideFocus)
+  clearDeferredClose()
+})
+</script>
+
+<template>
+  <div ref="root" class="k-action-menu">
+    <button
+      :id="triggerID"
+      ref="trigger"
+      type="button"
+      class="k-icon-action k-action-menu__trigger"
+      :data-k-tip="label"
+      :aria-label="label"
+      :aria-controls="menuID"
+      aria-haspopup="menu"
+      :aria-expanded="open"
+      :disabled="disabled"
+      @click="toggleMenu"
+      @keydown="handleTriggerKeydown"
+    >
+      <Ellipsis :size="16" :stroke-width="1.75" aria-hidden="true" />
+    </button>
+
+    <div
+      v-if="open"
+      :id="menuID"
+      ref="menu"
+      class="k-menu k-action-menu__menu"
+      role="menu"
+      :aria-label="label"
+      :aria-labelledby="triggerID"
+      @keydown="handleMenuKeydown"
+    >
+      <button
+        v-for="(item, index) in items"
+        :key="item.id"
+        type="button"
+        class="k-menu-item k-action-menu__item"
+        :class="item.tone ? `k-menu-item--${item.tone}` : undefined"
+        role="menuitem"
+        :disabled="item.disabled || item.busy"
+        :aria-disabled="item.disabled || item.busy ? 'true' : undefined"
+        :aria-busy="item.busy ? 'true' : undefined"
+        :tabindex="index === activeIndex && isSelectable(index) ? 0 : -1"
+        @focus="activeIndex = index"
+        @click="select(item.id)"
+      >
+        <Loader2 v-if="item.busy" class="k-action-menu__busy" :size="14" :stroke-width="1.75" aria-hidden="true" />
+        <span>{{ item.label }}</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/providers/code/portal/src/portalkit/faros-ui.css
+++ b/providers/code/portal/src/portalkit/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/providers/code/portal/src/portalkit/styles.ts
+++ b/providers/code/portal/src/portalkit/styles.ts
@@ -13,6 +13,13 @@ import farosUIStyles from './faros-ui.css?raw'
 export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
+export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
+export const FAROS_UI_VERSION = 3
+
+function hasRequiredVersion(value: string): boolean {
+  const version = Number(value.trim())
+  return Number.isFinite(version) && version >= FAROS_UI_VERSION
+}
 
 function hostStylesAreLoaded(): boolean {
   const root = document.documentElement
@@ -22,22 +29,33 @@ function hostStylesAreLoaded(): boolean {
   // computed-style check works for both Vite style tags and production CSS
   // links, where there is no stable DOM id to inspect.
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    return window.getComputedStyle(root).getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    const styles = window.getComputedStyle(root)
+    return styles.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+      && hasRequiredVersion(styles.getPropertyValue(FAROS_UI_VERSION_MARKER))
   }
   return root.style?.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    && hasRequiredVersion(root.style?.getPropertyValue(FAROS_UI_VERSION_MARKER) || '')
 }
 
 export function ensureFarosUIStyles(): void {
   if (typeof document === 'undefined') return
 
-  // Never mutate an existing style element.  It may be the host's canonical
-  // stylesheet or a fallback installed by another provider bundle; replacing
-  // it here would let a stale bundle win the cascade.
-  if (document.getElementById(FAROS_UI_STYLE_ID) || hostStylesAreLoaded()) return
+  // Never mutate an existing style element. It may be the host's canonical
+  // stylesheet or an older fallback installed by another provider bundle;
+  // replacing it here would let a stale bundle win the cascade. A stale
+  // stylesheet is detected by its missing version marker and gets a new,
+  // versioned fallback appended instead.
+  if (hostStylesAreLoaded()) return
+
+  const fallbackStyleID = document.getElementById(FAROS_UI_STYLE_ID)
+    ? `${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`
+    : FAROS_UI_STYLE_ID
+  if (document.getElementById(fallbackStyleID)) return
 
   const style = document.createElement('style')
-  style.id = FAROS_UI_STYLE_ID
+  style.id = fallbackStyleID
   style.setAttribute('data-faros-ui-source', 'portalkit-fallback')
+  style.setAttribute('data-faros-ui-version', String(FAROS_UI_VERSION))
   style.textContent = farosUIStyles
   document.head?.appendChild(style)
 }

--- a/providers/code/portal/src/styles.behavior.test.ts
+++ b/providers/code/portal/src/styles.behavior.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ensureFarosUIStyles,
+  FAROS_UI_CANONICAL_MARKER,
+  FAROS_UI_CANONICAL_VALUE,
+  FAROS_UI_STYLE_ID,
+  FAROS_UI_VERSION,
+  FAROS_UI_VERSION_MARKER,
+} from './portalkit/styles'
+
+interface FakeStyle {
+  id: string
+  textContent: string
+  attributes: Record<string, string>
+  setAttribute(name: string, value: string): void
+}
+
+function fakeStyle(id: string): FakeStyle {
+  return {
+    id,
+    textContent: 'stale host stylesheet',
+    attributes: {},
+    setAttribute(name, value) {
+      this.attributes[name] = value
+    },
+  }
+}
+
+function installFakeHost(initialVersion = ''): {
+  stale: FakeStyle
+  appended: FakeStyle[]
+  setVersion(version: string): void
+  restore(): void
+} {
+  const stale = fakeStyle(FAROS_UI_STYLE_ID)
+  const appended: FakeStyle[] = []
+  let version = initialVersion
+  const document = {
+    documentElement: {},
+    getElementById(id: string): FakeStyle | null {
+      if (id === stale.id) return stale
+      return appended.find(style => style.id === id) ?? null
+    },
+    createElement(): FakeStyle {
+      return fakeStyle('')
+    },
+    head: {
+      appendChild(style: FakeStyle): void {
+        appended.push(style)
+      },
+    },
+  }
+  const window = {
+    getComputedStyle: () => ({
+      getPropertyValue(name: string): string {
+        if (name === FAROS_UI_CANONICAL_MARKER) return FAROS_UI_CANONICAL_VALUE
+        if (name === FAROS_UI_VERSION_MARKER) return version
+        return ''
+      },
+    }),
+  }
+  const previousDocument = globalThis.document
+  const previousWindow = globalThis.window
+  Object.assign(globalThis, { document, window })
+
+  return {
+    stale,
+    appended,
+    setVersion(nextVersion) {
+      version = nextVersion
+    },
+    restore() {
+      if (previousDocument === undefined) delete (globalThis as { document?: unknown }).document
+      else globalThis.document = previousDocument
+      if (previousWindow === undefined) delete (globalThis as { window?: unknown }).window
+      else globalThis.window = previousWindow
+    },
+  }
+}
+
+describe('PortalKit stylesheet compatibility', () => {
+  it('recovers from a stale canonical host without replacing its style node', () => {
+    const host = installFakeHost()
+
+    try {
+      ensureFarosUIStyles()
+
+      expect(host.stale.textContent).toBe('stale host stylesheet')
+      expect(host.appended).toHaveLength(1)
+      expect(host.appended[0].id).toBe(`${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`)
+      expect(host.appended[0].attributes['data-faros-ui-source']).toBe('portalkit-fallback')
+      expect(host.appended[0].attributes['data-faros-ui-version']).toBe(String(FAROS_UI_VERSION))
+
+      host.setVersion(String(FAROS_UI_VERSION))
+      ensureFarosUIStyles()
+      expect(host.appended).toHaveLength(1)
+    } finally {
+      host.restore()
+    }
+  })
+
+  it.each([String(FAROS_UI_VERSION), String(FAROS_UI_VERSION + 1)])(
+    'accepts a current or newer host stylesheet version (%s)',
+    version => {
+      const host = installFakeHost(version)
+
+      try {
+        ensureFarosUIStyles()
+        expect(host.appended).toHaveLength(0)
+      } finally {
+        host.restore()
+      }
+    },
+  )
+})

--- a/providers/databricks/portal/src/portalkit/ActionMenu.vue
+++ b/providers/databricks/portal/src/portalkit/ActionMenu.vue
@@ -1,0 +1,290 @@
+<!-- CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+     under providers/*/portal/src/portalkit/; edit here and run
+     `make sync-portalkit`.
+
+     ActionMenu owns the compact overflow trigger and menu keyboard behavior.
+     Callers own the action mutation and map the emitted id to their behavior. -->
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
+import { Ellipsis, Loader2 } from 'lucide-vue-next'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+export type ActionMenuTone = 'neutral' | 'accent' | 'warning' | 'danger'
+
+export interface ActionMenuItem {
+  id: string
+  label: string
+  tone?: ActionMenuTone
+  disabled?: boolean
+  busy?: boolean
+}
+
+const props = withDefaults(defineProps<{
+  /** Accessible name for the overflow trigger and menu. */
+  label: string
+  items: readonly ActionMenuItem[]
+  disabled?: boolean
+}>(), {
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  select: [id: string]
+}>()
+
+// Standalone provider portals load the exact canonical recipe through the
+// shared helper; the host portal already imports the same faros-ui.css file.
+ensureFarosUIStyles()
+
+const instanceID = useId()
+const triggerID = `k-action-menu-trigger-${instanceID}`
+const menuID = `k-action-menu-${instanceID}`
+const root = ref<HTMLElement | null>(null)
+const trigger = ref<HTMLButtonElement | null>(null)
+const menu = ref<HTMLElement | null>(null)
+const open = ref(false)
+const activeIndex = ref(-1)
+let deferredCloseTimer: ReturnType<typeof setTimeout> | undefined
+
+const selectableIndexes = computed(() => props.items.reduce<number[]>((indexes, item, index) => {
+  if (!item.disabled && !item.busy) indexes.push(index)
+  return indexes
+}, []))
+
+function isSelectable(index: number): boolean {
+  const item = props.items[index]
+  return !!item && !item.disabled && !item.busy
+}
+
+function firstSelectableIndex(): number {
+  return selectableIndexes.value[0] ?? -1
+}
+
+function lastSelectableIndex(): number {
+  const indexes = selectableIndexes.value
+  return indexes[indexes.length - 1] ?? -1
+}
+
+function menuItems(): HTMLButtonElement[] {
+  return menu.value ? [...menu.value.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')] : []
+}
+
+function focusItem(index: number): void {
+  activeIndex.value = index
+  void nextTick(() => menuItems()[index]?.focus())
+}
+
+function setInitialActive(): void {
+  activeIndex.value = firstSelectableIndex()
+}
+
+function openMenu(index = firstSelectableIndex()): void {
+  if (props.disabled || open.value || !props.items.length) return
+  open.value = true
+  activeIndex.value = index
+  if (index >= 0) void nextTick(() => menuItems()[index]?.focus())
+}
+
+function clearDeferredClose(): void {
+  if (deferredCloseTimer === undefined) return
+  clearTimeout(deferredCloseTimer)
+  deferredCloseTimer = undefined
+}
+
+function closeMenu(restoreFocus = false): void {
+  clearDeferredClose()
+  if (!open.value) return
+  open.value = false
+  activeIndex.value = -1
+  if (restoreFocus) void nextTick(() => trigger.value?.focus())
+}
+
+function closeMenuAfterTab(): void {
+  if (deferredCloseTimer !== undefined) return
+  // Keep the focused menu item mounted while the browser performs its native
+  // Tab move. The focusin listener closes the menu when focus leaves it; this
+  // fallback also covers hosts that do not emit focusin for an unavailable
+  // next focus target.
+  deferredCloseTimer = setTimeout(() => {
+    deferredCloseTimer = undefined
+    closeMenu()
+  }, 0)
+}
+
+function toggleMenu(): void {
+  if (open.value) closeMenu()
+  else openMenu()
+}
+
+function select(id: string): void {
+  const item = props.items.find(candidate => candidate.id === id)
+  if (!item || props.disabled || item.disabled || item.busy) return
+  closeMenu(true)
+  emit('select', id)
+}
+
+function selectActive(): void {
+  const item = props.items[activeIndex.value]
+  if (item) select(item.id)
+}
+
+function moveActive(direction: 1 | -1): void {
+  const count = props.items.length
+  if (count === 0 || selectableIndexes.value.length === 0) return
+
+  let index = activeIndex.value
+  for (let attempts = 0; attempts < count; attempts += 1) {
+    index = (index + direction + count) % count
+    if (isSelectable(index)) {
+      focusItem(index)
+      return
+    }
+  }
+}
+
+function handleTriggerKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    if (!open.value) return
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    if (open.value) closeMenuAfterTab()
+    return
+  }
+  if (open.value) return
+
+  if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    openMenu(firstSelectableIndex())
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    openMenu(lastSelectableIndex())
+  }
+}
+
+function handleMenuKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    closeMenuAfterTab()
+    return
+  }
+  if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+    event.preventDefault()
+    selectActive()
+    return
+  }
+
+  if (event.key === 'Home') {
+    event.preventDefault()
+    focusItem(firstSelectableIndex())
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    focusItem(lastSelectableIndex())
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveActive(1)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveActive(-1)
+  }
+}
+
+function closeFromOutsidePointer(event: PointerEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function closeFromOutsideFocus(event: FocusEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function focusTrigger(): void {
+  trigger.value?.focus()
+}
+
+defineExpose({ focus: focusTrigger })
+
+watch(() => props.items, () => {
+  if (!open.value) return
+  if (!isSelectable(activeIndex.value)) {
+    setInitialActive()
+    if (activeIndex.value >= 0) void nextTick(() => menuItems()[activeIndex.value]?.focus())
+  } else if (activeIndex.value >= props.items.length) {
+    setInitialActive()
+  }
+}, { deep: true })
+
+watch(() => props.disabled, disabled => {
+  if (disabled) closeMenu()
+})
+
+onMounted(() => {
+  document.addEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.addEventListener('focusin', closeFromOutsideFocus)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.removeEventListener('focusin', closeFromOutsideFocus)
+  clearDeferredClose()
+})
+</script>
+
+<template>
+  <div ref="root" class="k-action-menu">
+    <button
+      :id="triggerID"
+      ref="trigger"
+      type="button"
+      class="k-icon-action k-action-menu__trigger"
+      :data-k-tip="label"
+      :aria-label="label"
+      :aria-controls="menuID"
+      aria-haspopup="menu"
+      :aria-expanded="open"
+      :disabled="disabled"
+      @click="toggleMenu"
+      @keydown="handleTriggerKeydown"
+    >
+      <Ellipsis :size="16" :stroke-width="1.75" aria-hidden="true" />
+    </button>
+
+    <div
+      v-if="open"
+      :id="menuID"
+      ref="menu"
+      class="k-menu k-action-menu__menu"
+      role="menu"
+      :aria-label="label"
+      :aria-labelledby="triggerID"
+      @keydown="handleMenuKeydown"
+    >
+      <button
+        v-for="(item, index) in items"
+        :key="item.id"
+        type="button"
+        class="k-menu-item k-action-menu__item"
+        :class="item.tone ? `k-menu-item--${item.tone}` : undefined"
+        role="menuitem"
+        :disabled="item.disabled || item.busy"
+        :aria-disabled="item.disabled || item.busy ? 'true' : undefined"
+        :aria-busy="item.busy ? 'true' : undefined"
+        :tabindex="index === activeIndex && isSelectable(index) ? 0 : -1"
+        @focus="activeIndex = index"
+        @click="select(item.id)"
+      >
+        <Loader2 v-if="item.busy" class="k-action-menu__busy" :size="14" :stroke-width="1.75" aria-hidden="true" />
+        <span>{{ item.label }}</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/providers/databricks/portal/src/portalkit/faros-ui.css
+++ b/providers/databricks/portal/src/portalkit/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/providers/databricks/portal/src/portalkit/styles.ts
+++ b/providers/databricks/portal/src/portalkit/styles.ts
@@ -13,6 +13,13 @@ import farosUIStyles from './faros-ui.css?raw'
 export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
+export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
+export const FAROS_UI_VERSION = 3
+
+function hasRequiredVersion(value: string): boolean {
+  const version = Number(value.trim())
+  return Number.isFinite(version) && version >= FAROS_UI_VERSION
+}
 
 function hostStylesAreLoaded(): boolean {
   const root = document.documentElement
@@ -22,22 +29,33 @@ function hostStylesAreLoaded(): boolean {
   // computed-style check works for both Vite style tags and production CSS
   // links, where there is no stable DOM id to inspect.
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    return window.getComputedStyle(root).getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    const styles = window.getComputedStyle(root)
+    return styles.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+      && hasRequiredVersion(styles.getPropertyValue(FAROS_UI_VERSION_MARKER))
   }
   return root.style?.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    && hasRequiredVersion(root.style?.getPropertyValue(FAROS_UI_VERSION_MARKER) || '')
 }
 
 export function ensureFarosUIStyles(): void {
   if (typeof document === 'undefined') return
 
-  // Never mutate an existing style element.  It may be the host's canonical
-  // stylesheet or a fallback installed by another provider bundle; replacing
-  // it here would let a stale bundle win the cascade.
-  if (document.getElementById(FAROS_UI_STYLE_ID) || hostStylesAreLoaded()) return
+  // Never mutate an existing style element. It may be the host's canonical
+  // stylesheet or an older fallback installed by another provider bundle;
+  // replacing it here would let a stale bundle win the cascade. A stale
+  // stylesheet is detected by its missing version marker and gets a new,
+  // versioned fallback appended instead.
+  if (hostStylesAreLoaded()) return
+
+  const fallbackStyleID = document.getElementById(FAROS_UI_STYLE_ID)
+    ? `${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`
+    : FAROS_UI_STYLE_ID
+  if (document.getElementById(fallbackStyleID)) return
 
   const style = document.createElement('style')
-  style.id = FAROS_UI_STYLE_ID
+  style.id = fallbackStyleID
   style.setAttribute('data-faros-ui-source', 'portalkit-fallback')
+  style.setAttribute('data-faros-ui-version', String(FAROS_UI_VERSION))
   style.textContent = farosUIStyles
   document.head?.appendChild(style)
 }

--- a/providers/edges/portal/src/portalkit/ActionMenu.vue
+++ b/providers/edges/portal/src/portalkit/ActionMenu.vue
@@ -1,0 +1,290 @@
+<!-- CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+     under providers/*/portal/src/portalkit/; edit here and run
+     `make sync-portalkit`.
+
+     ActionMenu owns the compact overflow trigger and menu keyboard behavior.
+     Callers own the action mutation and map the emitted id to their behavior. -->
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
+import { Ellipsis, Loader2 } from 'lucide-vue-next'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+export type ActionMenuTone = 'neutral' | 'accent' | 'warning' | 'danger'
+
+export interface ActionMenuItem {
+  id: string
+  label: string
+  tone?: ActionMenuTone
+  disabled?: boolean
+  busy?: boolean
+}
+
+const props = withDefaults(defineProps<{
+  /** Accessible name for the overflow trigger and menu. */
+  label: string
+  items: readonly ActionMenuItem[]
+  disabled?: boolean
+}>(), {
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  select: [id: string]
+}>()
+
+// Standalone provider portals load the exact canonical recipe through the
+// shared helper; the host portal already imports the same faros-ui.css file.
+ensureFarosUIStyles()
+
+const instanceID = useId()
+const triggerID = `k-action-menu-trigger-${instanceID}`
+const menuID = `k-action-menu-${instanceID}`
+const root = ref<HTMLElement | null>(null)
+const trigger = ref<HTMLButtonElement | null>(null)
+const menu = ref<HTMLElement | null>(null)
+const open = ref(false)
+const activeIndex = ref(-1)
+let deferredCloseTimer: ReturnType<typeof setTimeout> | undefined
+
+const selectableIndexes = computed(() => props.items.reduce<number[]>((indexes, item, index) => {
+  if (!item.disabled && !item.busy) indexes.push(index)
+  return indexes
+}, []))
+
+function isSelectable(index: number): boolean {
+  const item = props.items[index]
+  return !!item && !item.disabled && !item.busy
+}
+
+function firstSelectableIndex(): number {
+  return selectableIndexes.value[0] ?? -1
+}
+
+function lastSelectableIndex(): number {
+  const indexes = selectableIndexes.value
+  return indexes[indexes.length - 1] ?? -1
+}
+
+function menuItems(): HTMLButtonElement[] {
+  return menu.value ? [...menu.value.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')] : []
+}
+
+function focusItem(index: number): void {
+  activeIndex.value = index
+  void nextTick(() => menuItems()[index]?.focus())
+}
+
+function setInitialActive(): void {
+  activeIndex.value = firstSelectableIndex()
+}
+
+function openMenu(index = firstSelectableIndex()): void {
+  if (props.disabled || open.value || !props.items.length) return
+  open.value = true
+  activeIndex.value = index
+  if (index >= 0) void nextTick(() => menuItems()[index]?.focus())
+}
+
+function clearDeferredClose(): void {
+  if (deferredCloseTimer === undefined) return
+  clearTimeout(deferredCloseTimer)
+  deferredCloseTimer = undefined
+}
+
+function closeMenu(restoreFocus = false): void {
+  clearDeferredClose()
+  if (!open.value) return
+  open.value = false
+  activeIndex.value = -1
+  if (restoreFocus) void nextTick(() => trigger.value?.focus())
+}
+
+function closeMenuAfterTab(): void {
+  if (deferredCloseTimer !== undefined) return
+  // Keep the focused menu item mounted while the browser performs its native
+  // Tab move. The focusin listener closes the menu when focus leaves it; this
+  // fallback also covers hosts that do not emit focusin for an unavailable
+  // next focus target.
+  deferredCloseTimer = setTimeout(() => {
+    deferredCloseTimer = undefined
+    closeMenu()
+  }, 0)
+}
+
+function toggleMenu(): void {
+  if (open.value) closeMenu()
+  else openMenu()
+}
+
+function select(id: string): void {
+  const item = props.items.find(candidate => candidate.id === id)
+  if (!item || props.disabled || item.disabled || item.busy) return
+  closeMenu(true)
+  emit('select', id)
+}
+
+function selectActive(): void {
+  const item = props.items[activeIndex.value]
+  if (item) select(item.id)
+}
+
+function moveActive(direction: 1 | -1): void {
+  const count = props.items.length
+  if (count === 0 || selectableIndexes.value.length === 0) return
+
+  let index = activeIndex.value
+  for (let attempts = 0; attempts < count; attempts += 1) {
+    index = (index + direction + count) % count
+    if (isSelectable(index)) {
+      focusItem(index)
+      return
+    }
+  }
+}
+
+function handleTriggerKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    if (!open.value) return
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    if (open.value) closeMenuAfterTab()
+    return
+  }
+  if (open.value) return
+
+  if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    openMenu(firstSelectableIndex())
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    openMenu(lastSelectableIndex())
+  }
+}
+
+function handleMenuKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    closeMenuAfterTab()
+    return
+  }
+  if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+    event.preventDefault()
+    selectActive()
+    return
+  }
+
+  if (event.key === 'Home') {
+    event.preventDefault()
+    focusItem(firstSelectableIndex())
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    focusItem(lastSelectableIndex())
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveActive(1)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveActive(-1)
+  }
+}
+
+function closeFromOutsidePointer(event: PointerEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function closeFromOutsideFocus(event: FocusEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function focusTrigger(): void {
+  trigger.value?.focus()
+}
+
+defineExpose({ focus: focusTrigger })
+
+watch(() => props.items, () => {
+  if (!open.value) return
+  if (!isSelectable(activeIndex.value)) {
+    setInitialActive()
+    if (activeIndex.value >= 0) void nextTick(() => menuItems()[activeIndex.value]?.focus())
+  } else if (activeIndex.value >= props.items.length) {
+    setInitialActive()
+  }
+}, { deep: true })
+
+watch(() => props.disabled, disabled => {
+  if (disabled) closeMenu()
+})
+
+onMounted(() => {
+  document.addEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.addEventListener('focusin', closeFromOutsideFocus)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.removeEventListener('focusin', closeFromOutsideFocus)
+  clearDeferredClose()
+})
+</script>
+
+<template>
+  <div ref="root" class="k-action-menu">
+    <button
+      :id="triggerID"
+      ref="trigger"
+      type="button"
+      class="k-icon-action k-action-menu__trigger"
+      :data-k-tip="label"
+      :aria-label="label"
+      :aria-controls="menuID"
+      aria-haspopup="menu"
+      :aria-expanded="open"
+      :disabled="disabled"
+      @click="toggleMenu"
+      @keydown="handleTriggerKeydown"
+    >
+      <Ellipsis :size="16" :stroke-width="1.75" aria-hidden="true" />
+    </button>
+
+    <div
+      v-if="open"
+      :id="menuID"
+      ref="menu"
+      class="k-menu k-action-menu__menu"
+      role="menu"
+      :aria-label="label"
+      :aria-labelledby="triggerID"
+      @keydown="handleMenuKeydown"
+    >
+      <button
+        v-for="(item, index) in items"
+        :key="item.id"
+        type="button"
+        class="k-menu-item k-action-menu__item"
+        :class="item.tone ? `k-menu-item--${item.tone}` : undefined"
+        role="menuitem"
+        :disabled="item.disabled || item.busy"
+        :aria-disabled="item.disabled || item.busy ? 'true' : undefined"
+        :aria-busy="item.busy ? 'true' : undefined"
+        :tabindex="index === activeIndex && isSelectable(index) ? 0 : -1"
+        @focus="activeIndex = index"
+        @click="select(item.id)"
+      >
+        <Loader2 v-if="item.busy" class="k-action-menu__busy" :size="14" :stroke-width="1.75" aria-hidden="true" />
+        <span>{{ item.label }}</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/providers/edges/portal/src/portalkit/faros-ui.css
+++ b/providers/edges/portal/src/portalkit/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/providers/edges/portal/src/portalkit/styles.ts
+++ b/providers/edges/portal/src/portalkit/styles.ts
@@ -13,6 +13,13 @@ import farosUIStyles from './faros-ui.css?raw'
 export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
+export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
+export const FAROS_UI_VERSION = 3
+
+function hasRequiredVersion(value: string): boolean {
+  const version = Number(value.trim())
+  return Number.isFinite(version) && version >= FAROS_UI_VERSION
+}
 
 function hostStylesAreLoaded(): boolean {
   const root = document.documentElement
@@ -22,22 +29,33 @@ function hostStylesAreLoaded(): boolean {
   // computed-style check works for both Vite style tags and production CSS
   // links, where there is no stable DOM id to inspect.
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    return window.getComputedStyle(root).getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    const styles = window.getComputedStyle(root)
+    return styles.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+      && hasRequiredVersion(styles.getPropertyValue(FAROS_UI_VERSION_MARKER))
   }
   return root.style?.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    && hasRequiredVersion(root.style?.getPropertyValue(FAROS_UI_VERSION_MARKER) || '')
 }
 
 export function ensureFarosUIStyles(): void {
   if (typeof document === 'undefined') return
 
-  // Never mutate an existing style element.  It may be the host's canonical
-  // stylesheet or a fallback installed by another provider bundle; replacing
-  // it here would let a stale bundle win the cascade.
-  if (document.getElementById(FAROS_UI_STYLE_ID) || hostStylesAreLoaded()) return
+  // Never mutate an existing style element. It may be the host's canonical
+  // stylesheet or an older fallback installed by another provider bundle;
+  // replacing it here would let a stale bundle win the cascade. A stale
+  // stylesheet is detected by its missing version marker and gets a new,
+  // versioned fallback appended instead.
+  if (hostStylesAreLoaded()) return
+
+  const fallbackStyleID = document.getElementById(FAROS_UI_STYLE_ID)
+    ? `${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`
+    : FAROS_UI_STYLE_ID
+  if (document.getElementById(fallbackStyleID)) return
 
   const style = document.createElement('style')
-  style.id = FAROS_UI_STYLE_ID
+  style.id = fallbackStyleID
   style.setAttribute('data-faros-ui-source', 'portalkit-fallback')
+  style.setAttribute('data-faros-ui-version', String(FAROS_UI_VERSION))
   style.textContent = farosUIStyles
   document.head?.appendChild(style)
 }

--- a/providers/infrastructure/portal/src/portalkit/ActionMenu.vue
+++ b/providers/infrastructure/portal/src/portalkit/ActionMenu.vue
@@ -1,0 +1,290 @@
+<!-- CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+     under providers/*/portal/src/portalkit/; edit here and run
+     `make sync-portalkit`.
+
+     ActionMenu owns the compact overflow trigger and menu keyboard behavior.
+     Callers own the action mutation and map the emitted id to their behavior. -->
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
+import { Ellipsis, Loader2 } from 'lucide-vue-next'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+export type ActionMenuTone = 'neutral' | 'accent' | 'warning' | 'danger'
+
+export interface ActionMenuItem {
+  id: string
+  label: string
+  tone?: ActionMenuTone
+  disabled?: boolean
+  busy?: boolean
+}
+
+const props = withDefaults(defineProps<{
+  /** Accessible name for the overflow trigger and menu. */
+  label: string
+  items: readonly ActionMenuItem[]
+  disabled?: boolean
+}>(), {
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  select: [id: string]
+}>()
+
+// Standalone provider portals load the exact canonical recipe through the
+// shared helper; the host portal already imports the same faros-ui.css file.
+ensureFarosUIStyles()
+
+const instanceID = useId()
+const triggerID = `k-action-menu-trigger-${instanceID}`
+const menuID = `k-action-menu-${instanceID}`
+const root = ref<HTMLElement | null>(null)
+const trigger = ref<HTMLButtonElement | null>(null)
+const menu = ref<HTMLElement | null>(null)
+const open = ref(false)
+const activeIndex = ref(-1)
+let deferredCloseTimer: ReturnType<typeof setTimeout> | undefined
+
+const selectableIndexes = computed(() => props.items.reduce<number[]>((indexes, item, index) => {
+  if (!item.disabled && !item.busy) indexes.push(index)
+  return indexes
+}, []))
+
+function isSelectable(index: number): boolean {
+  const item = props.items[index]
+  return !!item && !item.disabled && !item.busy
+}
+
+function firstSelectableIndex(): number {
+  return selectableIndexes.value[0] ?? -1
+}
+
+function lastSelectableIndex(): number {
+  const indexes = selectableIndexes.value
+  return indexes[indexes.length - 1] ?? -1
+}
+
+function menuItems(): HTMLButtonElement[] {
+  return menu.value ? [...menu.value.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')] : []
+}
+
+function focusItem(index: number): void {
+  activeIndex.value = index
+  void nextTick(() => menuItems()[index]?.focus())
+}
+
+function setInitialActive(): void {
+  activeIndex.value = firstSelectableIndex()
+}
+
+function openMenu(index = firstSelectableIndex()): void {
+  if (props.disabled || open.value || !props.items.length) return
+  open.value = true
+  activeIndex.value = index
+  if (index >= 0) void nextTick(() => menuItems()[index]?.focus())
+}
+
+function clearDeferredClose(): void {
+  if (deferredCloseTimer === undefined) return
+  clearTimeout(deferredCloseTimer)
+  deferredCloseTimer = undefined
+}
+
+function closeMenu(restoreFocus = false): void {
+  clearDeferredClose()
+  if (!open.value) return
+  open.value = false
+  activeIndex.value = -1
+  if (restoreFocus) void nextTick(() => trigger.value?.focus())
+}
+
+function closeMenuAfterTab(): void {
+  if (deferredCloseTimer !== undefined) return
+  // Keep the focused menu item mounted while the browser performs its native
+  // Tab move. The focusin listener closes the menu when focus leaves it; this
+  // fallback also covers hosts that do not emit focusin for an unavailable
+  // next focus target.
+  deferredCloseTimer = setTimeout(() => {
+    deferredCloseTimer = undefined
+    closeMenu()
+  }, 0)
+}
+
+function toggleMenu(): void {
+  if (open.value) closeMenu()
+  else openMenu()
+}
+
+function select(id: string): void {
+  const item = props.items.find(candidate => candidate.id === id)
+  if (!item || props.disabled || item.disabled || item.busy) return
+  closeMenu(true)
+  emit('select', id)
+}
+
+function selectActive(): void {
+  const item = props.items[activeIndex.value]
+  if (item) select(item.id)
+}
+
+function moveActive(direction: 1 | -1): void {
+  const count = props.items.length
+  if (count === 0 || selectableIndexes.value.length === 0) return
+
+  let index = activeIndex.value
+  for (let attempts = 0; attempts < count; attempts += 1) {
+    index = (index + direction + count) % count
+    if (isSelectable(index)) {
+      focusItem(index)
+      return
+    }
+  }
+}
+
+function handleTriggerKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    if (!open.value) return
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    if (open.value) closeMenuAfterTab()
+    return
+  }
+  if (open.value) return
+
+  if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    openMenu(firstSelectableIndex())
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    openMenu(lastSelectableIndex())
+  }
+}
+
+function handleMenuKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeMenu(true)
+    return
+  }
+  if (event.key === 'Tab') {
+    closeMenuAfterTab()
+    return
+  }
+  if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+    event.preventDefault()
+    selectActive()
+    return
+  }
+
+  if (event.key === 'Home') {
+    event.preventDefault()
+    focusItem(firstSelectableIndex())
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    focusItem(lastSelectableIndex())
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveActive(1)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveActive(-1)
+  }
+}
+
+function closeFromOutsidePointer(event: PointerEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function closeFromOutsideFocus(event: FocusEvent): void {
+  const target = event.target as Node | null
+  if (!open.value || (target && root.value?.contains(target))) return
+  closeMenu()
+}
+
+function focusTrigger(): void {
+  trigger.value?.focus()
+}
+
+defineExpose({ focus: focusTrigger })
+
+watch(() => props.items, () => {
+  if (!open.value) return
+  if (!isSelectable(activeIndex.value)) {
+    setInitialActive()
+    if (activeIndex.value >= 0) void nextTick(() => menuItems()[activeIndex.value]?.focus())
+  } else if (activeIndex.value >= props.items.length) {
+    setInitialActive()
+  }
+}, { deep: true })
+
+watch(() => props.disabled, disabled => {
+  if (disabled) closeMenu()
+})
+
+onMounted(() => {
+  document.addEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.addEventListener('focusin', closeFromOutsideFocus)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', closeFromOutsidePointer, true)
+  document.removeEventListener('focusin', closeFromOutsideFocus)
+  clearDeferredClose()
+})
+</script>
+
+<template>
+  <div ref="root" class="k-action-menu">
+    <button
+      :id="triggerID"
+      ref="trigger"
+      type="button"
+      class="k-icon-action k-action-menu__trigger"
+      :data-k-tip="label"
+      :aria-label="label"
+      :aria-controls="menuID"
+      aria-haspopup="menu"
+      :aria-expanded="open"
+      :disabled="disabled"
+      @click="toggleMenu"
+      @keydown="handleTriggerKeydown"
+    >
+      <Ellipsis :size="16" :stroke-width="1.75" aria-hidden="true" />
+    </button>
+
+    <div
+      v-if="open"
+      :id="menuID"
+      ref="menu"
+      class="k-menu k-action-menu__menu"
+      role="menu"
+      :aria-label="label"
+      :aria-labelledby="triggerID"
+      @keydown="handleMenuKeydown"
+    >
+      <button
+        v-for="(item, index) in items"
+        :key="item.id"
+        type="button"
+        class="k-menu-item k-action-menu__item"
+        :class="item.tone ? `k-menu-item--${item.tone}` : undefined"
+        role="menuitem"
+        :disabled="item.disabled || item.busy"
+        :aria-disabled="item.disabled || item.busy ? 'true' : undefined"
+        :aria-busy="item.busy ? 'true' : undefined"
+        :tabindex="index === activeIndex && isSelectable(index) ? 0 : -1"
+        @focus="activeIndex = index"
+        @click="select(item.id)"
+      >
+        <Loader2 v-if="item.busy" class="k-action-menu__busy" :size="14" :stroke-width="1.75" aria-hidden="true" />
+        <span>{{ item.label }}</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/providers/infrastructure/portal/src/portalkit/faros-ui.css
+++ b/providers/infrastructure/portal/src/portalkit/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/providers/infrastructure/portal/src/portalkit/styles.ts
+++ b/providers/infrastructure/portal/src/portalkit/styles.ts
@@ -13,6 +13,13 @@ import farosUIStyles from './faros-ui.css?raw'
 export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
+export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
+export const FAROS_UI_VERSION = 3
+
+function hasRequiredVersion(value: string): boolean {
+  const version = Number(value.trim())
+  return Number.isFinite(version) && version >= FAROS_UI_VERSION
+}
 
 function hostStylesAreLoaded(): boolean {
   const root = document.documentElement
@@ -22,22 +29,33 @@ function hostStylesAreLoaded(): boolean {
   // computed-style check works for both Vite style tags and production CSS
   // links, where there is no stable DOM id to inspect.
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    return window.getComputedStyle(root).getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    const styles = window.getComputedStyle(root)
+    return styles.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+      && hasRequiredVersion(styles.getPropertyValue(FAROS_UI_VERSION_MARKER))
   }
   return root.style?.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    && hasRequiredVersion(root.style?.getPropertyValue(FAROS_UI_VERSION_MARKER) || '')
 }
 
 export function ensureFarosUIStyles(): void {
   if (typeof document === 'undefined') return
 
-  // Never mutate an existing style element.  It may be the host's canonical
-  // stylesheet or a fallback installed by another provider bundle; replacing
-  // it here would let a stale bundle win the cascade.
-  if (document.getElementById(FAROS_UI_STYLE_ID) || hostStylesAreLoaded()) return
+  // Never mutate an existing style element. It may be the host's canonical
+  // stylesheet or an older fallback installed by another provider bundle;
+  // replacing it here would let a stale bundle win the cascade. A stale
+  // stylesheet is detected by its missing version marker and gets a new,
+  // versioned fallback appended instead.
+  if (hostStylesAreLoaded()) return
+
+  const fallbackStyleID = document.getElementById(FAROS_UI_STYLE_ID)
+    ? `${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`
+    : FAROS_UI_STYLE_ID
+  if (document.getElementById(fallbackStyleID)) return
 
   const style = document.createElement('style')
-  style.id = FAROS_UI_STYLE_ID
+  style.id = fallbackStyleID
   style.setAttribute('data-faros-ui-source', 'portalkit-fallback')
+  style.setAttribute('data-faros-ui-version', String(FAROS_UI_VERSION))
   style.textContent = farosUIStyles
   document.head?.appendChild(style)
 }

--- a/providers/kuery/portal/src/portalkit/faros-ui.css
+++ b/providers/kuery/portal/src/portalkit/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/providers/kuery/portal/src/portalkit/styles.ts
+++ b/providers/kuery/portal/src/portalkit/styles.ts
@@ -13,6 +13,13 @@ import farosUIStyles from './faros-ui.css?raw'
 export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
+export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
+export const FAROS_UI_VERSION = 3
+
+function hasRequiredVersion(value: string): boolean {
+  const version = Number(value.trim())
+  return Number.isFinite(version) && version >= FAROS_UI_VERSION
+}
 
 function hostStylesAreLoaded(): boolean {
   const root = document.documentElement
@@ -22,22 +29,33 @@ function hostStylesAreLoaded(): boolean {
   // computed-style check works for both Vite style tags and production CSS
   // links, where there is no stable DOM id to inspect.
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    return window.getComputedStyle(root).getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    const styles = window.getComputedStyle(root)
+    return styles.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+      && hasRequiredVersion(styles.getPropertyValue(FAROS_UI_VERSION_MARKER))
   }
   return root.style?.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    && hasRequiredVersion(root.style?.getPropertyValue(FAROS_UI_VERSION_MARKER) || '')
 }
 
 export function ensureFarosUIStyles(): void {
   if (typeof document === 'undefined') return
 
-  // Never mutate an existing style element.  It may be the host's canonical
-  // stylesheet or a fallback installed by another provider bundle; replacing
-  // it here would let a stale bundle win the cascade.
-  if (document.getElementById(FAROS_UI_STYLE_ID) || hostStylesAreLoaded()) return
+  // Never mutate an existing style element. It may be the host's canonical
+  // stylesheet or an older fallback installed by another provider bundle;
+  // replacing it here would let a stale bundle win the cascade. A stale
+  // stylesheet is detected by its missing version marker and gets a new,
+  // versioned fallback appended instead.
+  if (hostStylesAreLoaded()) return
+
+  const fallbackStyleID = document.getElementById(FAROS_UI_STYLE_ID)
+    ? `${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`
+    : FAROS_UI_STYLE_ID
+  if (document.getElementById(fallbackStyleID)) return
 
   const style = document.createElement('style')
-  style.id = FAROS_UI_STYLE_ID
+  style.id = fallbackStyleID
   style.setAttribute('data-faros-ui-source', 'portalkit-fallback')
+  style.setAttribute('data-faros-ui-version', String(FAROS_UI_VERSION))
   style.textContent = farosUIStyles
   document.head?.appendChild(style)
 }

--- a/providers/quickstart/portal/src/portalkit/faros-ui.css
+++ b/providers/quickstart/portal/src/portalkit/faros-ui.css
@@ -19,13 +19,23 @@
  */
 
 /*
- * This marker is intentionally part of the canonical stylesheet.  The
- * standalone injector checks the computed root value before adding a local
- * fallback, so a provider bundle can never replace a host-loaded stylesheet
- * with an older vendored copy.
+ * These markers are intentionally part of the canonical stylesheet. The
+ * standalone injector checks both computed root values before adding a local
+ * fallback, so a provider bundle can recover from an older host stylesheet
+ * without replacing it or letting an older vendored copy win.
  */
 :root {
   --faros-ui-canonical: 1;
+  /* Bump this when a standalone primitive requires a newer stylesheet than
+   * the generic canonical marker can describe. Provider bundles use it to
+   * recover from a host stylesheet served from an older deployment. */
+  --faros-ui-version: 3;
+  /* Shared stacking contract: menus sit above page content, fullscreen
+   * surfaces above menus, and global modal/toast layers remain topmost. */
+  --k-layer-menu: 1000;
+  --k-layer-fullscreen: 2000;
+  --k-layer-modal: 2147483000;
+  --k-layer-toast: 2147483001;
 }
 
 /* ── Eyebrow / KPI ────────────────────────────────────────────────────────
@@ -382,6 +392,7 @@ html.light .k-create-surface {
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
   padding: 4px;
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-surface, #0a0b12) 40%, transparent);
+  z-index: var(--k-layer-menu, 1000);
 }
 html.light .k-menu {
   box-shadow: 0 12px 34px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 14%, transparent);
@@ -431,6 +442,96 @@ html.light .k-menu {
   background: var(--color-border-subtle, rgba(255, 255, 255, 0.07));
 }
 
+/* ── Action menu / icon action ────────────────────────────────────────────
+ * Compact overflow controls use one square target on desktop and the shared
+ * 44px coarse-pointer target. The trigger is tooltip-compatible through the
+ * global [data-k-tip] recipe above; the menu keeps the ordinary k-menu item
+ * language so callers do not need a provider-local variant. */
+.k-icon-action {
+  align-items: center;
+  aspect-ratio: 1;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: var(--color-text-secondary, #8a8ca6);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 32px;
+  height: 32px;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  width: 32px;
+}
+.k-icon-action:hover {
+  background: var(--color-surface-hover, #1e2033);
+  color: var(--color-text-primary, #e9e9f2);
+}
+.k-icon-action:focus {
+  outline: none;
+  box-shadow: none;
+}
+.k-icon-action:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-icon-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.k-icon-action > svg {
+  flex: 0 0 auto;
+  height: 16px;
+  width: 16px;
+}
+.k-action-menu {
+  display: inline-flex;
+  position: relative;
+}
+.k-action-menu > .k-action-menu__menu {
+  /* Keep the panel readable when a provider applies a broad max-width rule
+   * to every descendant (for example, a detail-page flex safety reset). */
+  max-height: min(28rem, calc(100vh - 16px));
+  max-width: calc(100vw - 16px);
+  min-width: 180px;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 5px);
+}
+.k-action-menu__item {
+  min-width: 168px;
+}
+.k-menu-item--accent { color: var(--color-accent, #8b6bff); }
+.k-menu-item--warning { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger { color: var(--color-danger, #ff5d5d); }
+.k-menu-item--accent:hover { color: var(--color-accent-hover, #a18aff); }
+.k-menu-item--warning:hover { color: var(--color-warning, #f0a63a); }
+.k-menu-item--danger:hover { background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12)); color: var(--color-danger, #ff5d5d); }
+.k-action-menu__item[aria-busy="true"] { cursor: wait; }
+.k-action-menu__busy {
+  animation: k-action-menu-spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes k-action-menu-spin { to { transform: rotate(360deg); } }
+.k-fullscreen {
+  inset: 0;
+  position: fixed;
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+:fullscreen {
+  z-index: var(--k-layer-fullscreen, 2000);
+}
+@media (pointer: coarse), (any-pointer: coarse) {
+  .k-icon-action {
+    flex-basis: 44px;
+    height: 44px;
+    width: 44px;
+  }
+}
+
 /* ── Form select ──────────────────────────────────────────────────────────
  * FormSelect composes the input and menu recipes above. The panel is
  * teleported to body, so k-form-select__portal is an explicit generic scope
@@ -475,7 +576,7 @@ html.light .k-menu {
   overflow-y: auto;
   overscroll-behavior: contain;
   position: fixed;
-  z-index: 1000;
+  z-index: var(--k-layer-menu, 1000);
 }
 .k-form-select__portal .k-form-select__option {
   justify-content: space-between;
@@ -545,7 +646,7 @@ html.light .k-menu {
 }
 .k-layout-selector__menu {
   position: absolute;
-  z-index: 80;
+  z-index: var(--k-layer-menu, 1000);
   top: calc(100% + 5px);
   right: 0;
   width: 154px;
@@ -635,6 +736,25 @@ html.light .k-menu {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
+}
+/* ActionMenu's trigger tooltip must keep its intrinsic measure even when an
+ * embedding provider constrains all descendants and pseudo-elements to their
+ * containing block. */
+.k-action-menu__trigger[data-k-tip]::after {
+  /* Action menus already pin their panel to the inline end of the trigger.
+   * Pinning the tooltip to that same edge keeps its intrinsic measure inside
+   * the viewport when the trigger is in a right-aligned action group. */
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  transform: none;
+  max-width: min(260px, calc(100vw - 16px));
+  width: max-content;
+}
+.k-action-menu__trigger[aria-expanded="true"][data-k-tip]::after {
+  /* The open menu is the active disclosure; avoid a competing tooltip over it. */
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 html.light [data-k-tip]::after {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--color-text-primary, #e9e9f2) 10%, transparent);
@@ -869,7 +989,7 @@ html.light [data-k-tip]::after {
 .k-modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 2147483000;
+  z-index: var(--k-layer-modal, 2147483000);
   display: grid;
   place-items: center;
   padding: 24px;
@@ -981,7 +1101,7 @@ html.light [data-k-tip]::after {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 2147483001;
+  z-index: var(--k-layer-toast, 2147483001);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -1144,6 +1264,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__loading-control--search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
 }
 .k-table__loading-control--filter { flex: 0 0 132px; }
@@ -1153,6 +1274,7 @@ html.light [data-k-tip]::after {
 }
 .k-table__search {
   flex: 1 1 220px;
+  max-width: 42rem;
   min-width: 180px;
   position: relative;
 }
@@ -1176,6 +1298,7 @@ html.light [data-k-tip]::after {
   height: 32px;
 }
 .k-table__search-input {
+  max-width: 42rem;
   padding: 0 30px;
   width: 100%;
 }
@@ -2202,6 +2325,7 @@ html.light [data-k-tip]::after {
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
   .k-resource-technical__chevron { transition: none; }
+  .k-action-menu__busy { animation: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/providers/quickstart/portal/src/portalkit/styles.ts
+++ b/providers/quickstart/portal/src/portalkit/styles.ts
@@ -13,6 +13,13 @@ import farosUIStyles from './faros-ui.css?raw'
 export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
+export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
+export const FAROS_UI_VERSION = 3
+
+function hasRequiredVersion(value: string): boolean {
+  const version = Number(value.trim())
+  return Number.isFinite(version) && version >= FAROS_UI_VERSION
+}
 
 function hostStylesAreLoaded(): boolean {
   const root = document.documentElement
@@ -22,22 +29,33 @@ function hostStylesAreLoaded(): boolean {
   // computed-style check works for both Vite style tags and production CSS
   // links, where there is no stable DOM id to inspect.
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    return window.getComputedStyle(root).getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    const styles = window.getComputedStyle(root)
+    return styles.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+      && hasRequiredVersion(styles.getPropertyValue(FAROS_UI_VERSION_MARKER))
   }
   return root.style?.getPropertyValue(FAROS_UI_CANONICAL_MARKER).trim() === FAROS_UI_CANONICAL_VALUE
+    && hasRequiredVersion(root.style?.getPropertyValue(FAROS_UI_VERSION_MARKER) || '')
 }
 
 export function ensureFarosUIStyles(): void {
   if (typeof document === 'undefined') return
 
-  // Never mutate an existing style element.  It may be the host's canonical
-  // stylesheet or a fallback installed by another provider bundle; replacing
-  // it here would let a stale bundle win the cascade.
-  if (document.getElementById(FAROS_UI_STYLE_ID) || hostStylesAreLoaded()) return
+  // Never mutate an existing style element. It may be the host's canonical
+  // stylesheet or an older fallback installed by another provider bundle;
+  // replacing it here would let a stale bundle win the cascade. A stale
+  // stylesheet is detected by its missing version marker and gets a new,
+  // versioned fallback appended instead.
+  if (hostStylesAreLoaded()) return
+
+  const fallbackStyleID = document.getElementById(FAROS_UI_STYLE_ID)
+    ? `${FAROS_UI_STYLE_ID}-v${FAROS_UI_VERSION}`
+    : FAROS_UI_STYLE_ID
+  if (document.getElementById(fallbackStyleID)) return
 
   const style = document.createElement('style')
-  style.id = FAROS_UI_STYLE_ID
+  style.id = fallbackStyleID
   style.setAttribute('data-faros-ui-source', 'portalkit-fallback')
+  style.setAttribute('data-faros-ui-version', String(FAROS_UI_VERSION))
   style.textContent = farosUIStyles
   document.head?.appendChild(style)
 }


### PR DESCRIPTION
Stack: 2 of 10 in Fluid-Shell 4K Conformance and Provider UI Hardening.

Depends on the fluid-shell guidance PR.

Summary:
- Adds the shared Vue ActionMenu interaction contract with keyboard navigation, focus restoration, busy and disabled states, and labeled menu items.
- Adds canonical icon-action sizing, named layer tokens, and a bounded ResourceTable search field.
- Adds stylesheet version negotiation so provider bundles recover from stale host CSS without replacing or downgrading it.
- Keeps ActionMenu dropdowns readable and their tooltips inside the supported right-aligned header placement, including hiding the tooltip while the menu is open.
- Synchronizes every vendored PortalKit copy.

Verification:
- ActionMenu conformance and stale/current/newer stylesheet matrix
- make verify-portalkit verify-ui-conformance
- Code portal tests, typecheck, and production build
- git diff --check