### PR TITLE
Add accessible Kuery topology navigation

### DIFF
--- a/hack/ui-conformance-exceptions.json
+++ b/hack/ui-conformance-exceptions.json
@@ -4,7 +4,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/element.ts",
-      "line": 1079,
+      "line": 1159,
       "column": 44,
       "match": "#888",
       "reference": "design-book §8 Kuery graph",
@@ -94,7 +94,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 242,
+      "line": 324,
       "column": 49,
       "match": "rgba(127,127,127,0.16)",
       "reference": "design-book §8 Kuery graph",
@@ -103,7 +103,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 243,
+      "line": 325,
       "column": 47,
       "match": "rgba(127,127,127,0.45)",
       "reference": "design-book §8 Kuery graph",
@@ -112,7 +112,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 244,
+      "line": 326,
       "column": 43,
       "match": "#e9e9f2",
       "reference": "design-book §8 Kuery graph",
@@ -121,7 +121,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 245,
+      "line": 327,
       "column": 42,
       "match": "#5d5f78",
       "reference": "design-book §8 Kuery graph",
@@ -130,7 +130,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 246,
+      "line": 328,
       "column": 39,
       "match": "#8b6bff",
       "reference": "design-book §8 Kuery graph",

--- a/providers/kuery/portal/package.json
+++ b/providers/kuery/portal/package.json
@@ -9,6 +9,7 @@
     "vendor-cytoscape": "node -e \"require('fs').copyFileSync('node_modules/cytoscape/dist/cytoscape.min.js','dist/cytoscape.min.js')\"",
     "vendor-codemirror": "node vendor-codemirror.cjs",
     "dev": "vite",
+    "test": "node --test --test-concurrency=1 *.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/providers/kuery/portal/src/element.ts
+++ b/providers/kuery/portal/src/element.ts
@@ -11,6 +11,7 @@ import { ic } from './portalkit/icons'
 import { tabClass, tabsClass } from './portalkit/tabs'
 import {
   buildElements,
+  deriveTopologyTree,
   buildTopologyElements,
   relationElements,
   themeStyle,
@@ -18,7 +19,11 @@ import {
   RELATION_COLORS,
   RELATION_LABELS,
   RELATION_DIR,
+  graphKeyAction,
+  graphOwnsFocus,
   type GraphHandle,
+  type TopologyEdgeGroup,
+  type TopologyResourceRow,
 } from './graph'
 import { loadCodeMirror, collectSchemaWords, createEditor, EXAMPLES, type EditorHandle } from './playground'
 
@@ -91,6 +96,7 @@ export class KueryElement extends HTMLElement {
 
   // Topology graph controls — all client-side (no refetch): layout + facet
   // filters re-render from the cached _topology. Edge filter does refetch.
+  private _topoView: 'graph' | 'list' = 'graph'
   private _topoLayout: 'breadthfirst' | 'concentric' | 'circle' | 'cose' = 'breadthfirst'
   private _topoKind = ''
   private _topoNamespace = ''
@@ -125,6 +131,9 @@ export class KueryElement extends HTMLElement {
   // can query that object's relations) and which taps are in flight.
   private _graphObjects = new Map<string, ObjectResult>()
   private _expanding = new Set<string>()
+  // The accessible topology list uses stable row keys rather than positional
+  // indexes so a button always activates the exact object it labels.
+  private _topologyListObjects = new Map<string, ObjectResult>()
 
   // Filter state survives re-renders.
   private _fEdge = ''
@@ -484,7 +493,7 @@ export class KueryElement extends HTMLElement {
     if (this._view === 'topology') {
       this.innerHTML = this._renderTopology()
       this._bindTopology()
-      if (this._topology.length && !this._topologyError && !this._loading) void this._mountTopologyGraph()
+      if (this._topoView === 'graph' && this._topology.length && !this._topologyError && !this._loading) void this._mountTopologyGraph()
       return
     }
     if (this._view === 'playground') {
@@ -647,6 +656,50 @@ export class KueryElement extends HTMLElement {
     return { kinds: [...kinds].sort(), namespaces: [...namespaces].sort() }
   }
 
+  private _topologyViewToggle(): string {
+    const btn = (view: 'graph' | 'list', label: string) =>
+      `<button class="k-btn k-btn--ghost kuery-view-btn" type="button" data-topology-view="${view}" aria-pressed="${this._topoView === view}">${label}</button>`
+    return `<div class="kuery-view-switch" role="group" aria-label="Topology representation">${btn('graph', 'Graph')}${btn('list', 'List')}</div>`
+  }
+
+  private _topologyResourceButton(row: TopologyResourceRow): string {
+    this._topologyListObjects.set(row.key, row.object)
+    const resourceName = row.namespace ? `${row.namespace}/${row.name}` : row.name
+    const label = `Inspect ${row.kind} ${resourceName} on ${row.edge}`
+    return `<button class="kuery-topology-resource" type="button" data-topology-resource="${esc(row.key)}" aria-label="${esc(label)}"><span class="kuery-topology-resource-kind">${esc(row.kind)}</span><span class="kuery-topology-resource-name">${esc(resourceName)}</span></button>`
+  }
+
+  private _renderTopologyList(tree = deriveTopologyTree(this._topology, { kind: this._topoKind, namespace: this._topoNamespace })): string {
+    this._topologyListObjects = new Map()
+
+    const resourceItem = (row: TopologyResourceRow) => `<li class="kuery-topology-resource-item">${this._topologyResourceButton(row)}</li>`
+    const resourceList = (rows: TopologyResourceRow[]) =>
+      rows.length ? `<ul class="kuery-topology-resources">${rows.map(resourceItem).join('')}</ul>` : ''
+    const countLabel = (count: number) => `${count} resource${count === 1 ? '' : 's'}`
+
+    const namespaceItem = (group: TopologyEdgeGroup['namespaces'][number]) => {
+      const count = group.resources.length + (group.resource ? 1 : 0)
+      const namespace = group.resource
+        ? this._topologyResourceButton(group.resource)
+        : `<span class="kuery-topology-namespace-name">Namespace <code>${esc(group.name)}</code></span>`
+      return `<li class="kuery-topology-namespace"><div class="kuery-topology-group-label"><span>${namespace}</span><span class="meta">${countLabel(count)}</span></div>${resourceList(group.resources)}</li>`
+    }
+
+    const edgeItem = (group: TopologyEdgeGroup) => {
+      const namespaceCount = group.namespaces.reduce((total, ns) => total + ns.resources.length + (ns.resource ? 1 : 0), 0)
+      const count = group.resources.length + namespaceCount
+      const clusterResources = group.resources.length
+        ? `<li class="kuery-topology-namespace"><div class="kuery-topology-group-label"><span class="kuery-topology-namespace-name">Cluster-scoped</span><span class="meta">${countLabel(group.resources.length)}</span></div>${resourceList(group.resources)}</li>`
+        : ''
+      return `<li class="kuery-topology-edge"><div class="kuery-topology-group-label kuery-topology-edge-label"><span><span class="kuery-topology-edge-name">Edge <code>${esc(group.name)}</code></span></span><span class="meta">${countLabel(count)}</span></div><ul class="kuery-topology-namespaces">${group.namespaces.map(namespaceItem).join('')}${clusterResources}</ul></li>`
+    }
+
+    if (!tree.edges.length) {
+      return '<p class="k-card kuery-read-state muted" role="status">no resources match the current topology filters</p>'
+    }
+    return `<div id="kuery-topology-list" class="kuery-topology-list" role="region" aria-label="Fleet topology list"><ul class="kuery-topology-tree">${tree.edges.map(edgeItem).join('')}</ul></div>`
+  }
+
   private _renderTopology(): string {
     const opt = (value: string, label: string, sel: string) =>
       `<option value="${esc(value)}"${value === sel ? ' selected' : ''}>${esc(label)}</option>`
@@ -669,6 +722,10 @@ export class KueryElement extends HTMLElement {
     const nsOptions = [opt('', 'All namespaces', this._topoNamespace)]
       .concat(facets.namespaces.map((n) => opt(n, n, this._topoNamespace)))
       .join('')
+    const topologyTree = this._topology.length
+      ? deriveTopologyTree(this._topology, { kind: this._topoKind, namespace: this._topoNamespace })
+      : null
+    const hasTopologyRows = !!topologyTree?.edges.length
 
     let body: string
     if (this._loading) {
@@ -677,8 +734,12 @@ export class KueryElement extends HTMLElement {
       body = `<p class="k-card kuery-read-state kuery-error" role="alert">${esc(this._topologyError)}</p>`
     } else if (this._topology.length === 0) {
       body = `<p class="k-card kuery-read-state muted" role="status">no clusters engaged — connect a kubernetes edge to see its tree</p>`
+    } else if (!hasTopologyRows) {
+      body = '<p class="k-card kuery-read-state muted" role="status">no resources match the current topology filters</p>'
+    } else if (this._topoView === 'list') {
+      body = this._renderTopologyList(topologyTree ?? undefined)
     } else {
-      body = `<div id="kuery-graph" class="kuery-graph"></div>`
+      body = `<div id="kuery-graph" class="kuery-graph" role="region" aria-label="Fleet topology graph" aria-describedby="kuery-graph-help" tabindex="0"></div>`
     }
 
     return `
@@ -687,10 +748,12 @@ export class KueryElement extends HTMLElement {
           <h2 class="kuery-panel-title">Fleet topology</h2>
           <div class="head-actions">
             ${this._viewToggle()}
+            ${this._topologyViewToggle()}
             <span class="k-badge ${this._edges.length ? 'k-badge--success' : 'k-badge--warning'}">${this._edges.length} edge${this._edges.length === 1 ? '' : 's'} engaged</span>
           </div>
         </div>
-        <p class="meta">Click a node to expand, again to collapse; <b>Expand all</b> walks the whole net. Arrows show impact flow: <b>A→B</b> means deleting A breaks B — so a Namespace/owner points <i>into</i> its pods, not out. Pan with arrows/WASD, zoom +/−, <b>F</b> full screen.</p>
+        <p class="meta">Activate a graph node to expand, again to collapse; <b>Expand all</b> walks the whole net. Arrows show impact flow: <b>A→B</b> means deleting A breaks B — so a Namespace/owner points <i>into</i> its pods, not out.</p>
+        ${this._topoView === 'graph' ? '<p id="kuery-graph-help" class="meta">Focus the graph to use Arrow keys or W/A/S/D to pan, +/− to zoom, F for full screen, and Escape to exit full screen.</p>' : '<p class="meta">Use Tab to reach a resource, then press Enter or Space to inspect its declared impact.</p>'}
         <div class="kuery-toolbar">
           <select class="k-input kuery-control" id="t-layout" title="Layout" aria-label="Layout">${layoutOptions}</select>
           <select class="k-input kuery-control" id="f-edge" title="Edge" aria-label="Edge">${edgeOptions}</select>
@@ -708,6 +771,21 @@ export class KueryElement extends HTMLElement {
 
   private _bindTopology(): void {
     this._bindViewToggle()
+    this.querySelectorAll('[data-topology-view]').forEach((button) =>
+      button.addEventListener('click', () => {
+        const view = (button as HTMLElement).dataset.topologyView as 'graph' | 'list' | undefined
+        if (!view || view === this._topoView) return
+        this._topoView = view
+        this._render()
+      }),
+    )
+    this.querySelectorAll('[data-topology-resource]').forEach((button) =>
+      button.addEventListener('click', () => {
+        const key = (button as HTMLElement).dataset.topologyResource || ''
+        const row = this._topologyListObjects.get(key)
+        if (row) void this._runImpact(row)
+      }),
+    )
     // Edge change refetches (it scopes the server query); layout/kind/namespace
     // are pure client-side re-renders off the cached _topology.
     this.querySelector('#f-edge')?.addEventListener('change', () => {
@@ -786,23 +864,25 @@ export class KueryElement extends HTMLElement {
   }
 
   // _onKeyDown gives the topology graph keyboard navigation: arrows/WASD pan,
-  // +/- zoom, F toggles full screen, Esc exits it. Ignored while typing in a
-  // form control or when the graph isn't the active view.
+  // +/- zoom, F toggles full screen, Esc exits it. The handler is installed on
+  // window because the Cytoscape canvas is not a native control, but it only
+  // acts while the labeled graph region owns focus.
   private _onKeyDown(ev: KeyboardEvent): void {
     if (this._view !== 'topology' || this._impactOf || !this._cy) return
-    const t = ev.target as HTMLElement | null
-    if (t && /^(INPUT|SELECT|TEXTAREA)$/.test(t.tagName)) return
+    const graph = this.querySelector('#kuery-graph') as HTMLElement | null
+    if (!graphOwnsFocus(graph, document.activeElement)) return
     const PAN = 70
+    const action = graphKeyAction(ev.key)
     let handled = true
-    switch (ev.key) {
-      case 'ArrowUp': case 'w': case 'W': this._cy.panBy(0, PAN); break
-      case 'ArrowDown': case 's': case 'S': this._cy.panBy(0, -PAN); break
-      case 'ArrowLeft': case 'a': case 'A': this._cy.panBy(PAN, 0); break
-      case 'ArrowRight': case 'd': case 'D': this._cy.panBy(-PAN, 0); break
-      case '+': case '=': this._cy.zoomBy(1.15); break
-      case '-': case '_': this._cy.zoomBy(1 / 1.15); break
-      case 'f': case 'F': this._toggleFull(); break
-      case 'Escape': if (this._topoFull) this._toggleFull(); else handled = false; break
+    switch (action) {
+      case 'pan-up': this._cy.panBy(0, PAN); break
+      case 'pan-down': this._cy.panBy(0, -PAN); break
+      case 'pan-left': this._cy.panBy(PAN, 0); break
+      case 'pan-right': this._cy.panBy(-PAN, 0); break
+      case 'zoom-in': this._cy.zoomBy(1.15); break
+      case 'zoom-out': this._cy.zoomBy(1 / 1.15); break
+      case 'fullscreen': this._toggleFull(); break
+      case 'escape': if (this._topoFull) this._toggleFull(); else handled = false; break
       default: handled = false
     }
     if (handled) ev.preventDefault()
@@ -1040,7 +1120,7 @@ export class KueryElement extends HTMLElement {
       body = '<p class="k-card kuery-read-state muted" role="status">no declared coupling found — nothing references, selects, or descends from this object (network-level dependencies are not visible to kuery)</p>'
     } else if (this._impactView === 'graph') {
       // The graph mounts into this container after render (see _mountGraph).
-      body = `${this._renderLegend()}<div id="kuery-graph" class="kuery-graph"></div>`
+      body = `${this._renderLegend()}<div id="kuery-graph" class="kuery-graph" role="region" aria-label="Impact graph for ${esc(title)}" tabindex="0"></div>`
     } else {
       body = this._renderImpactList()
     }

--- a/providers/kuery/portal/src/graph.ts
+++ b/providers/kuery/portal/src/graph.ts
@@ -119,15 +119,130 @@ export function buildElements(anchor: ObjectResult): BuildResult {
   return { elements, nodeIndex }
 }
 
+export interface TopologyResourceRow {
+  // Stable key used by the accessible list to route activation back to the
+  // exact ObjectResult. The API id is preferred, with a deterministic fallback
+  // for older sync records that did not include one.
+  key: string
+  object: ObjectResult
+  edge: string
+  namespace: string
+  kind: string
+  name: string
+}
+
+export interface TopologyNamespaceGroup {
+  key: string
+  name: string
+  // A synced Namespace is the actual tier node in the graph. The list keeps
+  // that same object available as an inspectable resource button without
+  // duplicating it as a child row.
+  resource?: TopologyResourceRow
+  resources: TopologyResourceRow[]
+}
+
+export interface TopologyEdgeGroup {
+  key: string
+  // Full cluster key, including the tenant prefix. Graph node ids use this so
+  // two edges with the same display name cannot collide.
+  cluster: string
+  name: string
+  namespaces: TopologyNamespaceGroup[]
+  resources: TopologyResourceRow[]
+}
+
+export interface TopologyTree {
+  edges: TopologyEdgeGroup[]
+}
+
+function topologyResource(
+  object: ObjectResult,
+  edge: string,
+  clusterKey: string,
+): TopologyResourceRow {
+  const metadata = object.object?.metadata ?? {}
+  const kind = object.object?.kind || '?'
+  const name = metadata.name || '?'
+  const namespace = metadata.namespace || ''
+  return {
+    key: object.id || `${clusterKey}/${kind}/${namespace}/${name}`,
+    object,
+    edge,
+    namespace,
+    kind,
+    name,
+  }
+}
+
+// deriveTopologyTree is the pointer-free representation of the same topology
+// query used by buildTopologyElements. It is deliberately pure: filters are
+// applied to the cached API result and the returned Edge → Namespace → Resource
+// hierarchy carries only rows that are actually visible in that view.
+//
+// A Namespace object is the real namespace tier (and remains an inspectable
+// resource button in the list). When no Namespace object was synced, a
+// namespace group is synthesized from a namespaced member, matching the graph
+// fallback. Cluster-scoped members remain directly under their Edge.
+export function deriveTopologyTree(
+  clusters: ObjectResult[],
+  opts?: { kind?: string; namespace?: string },
+): TopologyTree {
+  const wantKind = opts?.kind || ''
+  const wantNs = opts?.namespace || ''
+  const edges: TopologyEdgeGroup[] = []
+
+  clusters.forEach((cluster, clusterIndex) => {
+    const clusterName = cluster.cluster || cluster.object?.metadata?.name || 'cluster'
+    const edge = edgeOf(clusterName)
+    const edgeKey = `${clusterName}:${clusterIndex}`
+    const edgeGroup: TopologyEdgeGroup = { key: edgeKey, cluster: clusterName, name: edge, namespaces: [], resources: [] }
+    const namespaceByName = new Map<string, TopologyNamespaceGroup>()
+    const members = cluster.relations?.members ?? []
+
+    const ensureNamespace = (name: string): TopologyNamespaceGroup => {
+      const existing = namespaceByName.get(name)
+      if (existing) return existing
+      const group: TopologyNamespaceGroup = { key: `${edgeKey}/namespace/${name}`, name, resources: [] }
+      namespaceByName.set(name, group)
+      edgeGroup.namespaces.push(group)
+      return group
+    }
+
+    // Preserve the graph's rule that real Namespace objects establish visible
+    // namespace tiers before ordinary members are attached to them.
+    members.forEach((member) => {
+      const object = member.object ?? {}
+      if (object.kind !== 'Namespace') return
+      const name = object.metadata?.name || ''
+      if (!name || (wantKind && wantKind !== 'Namespace') || (wantNs && wantNs !== name)) return
+      const group = ensureNamespace(name)
+      group.resource = topologyResource(member, edge, clusterName)
+    })
+
+    members.forEach((member) => {
+      const object = member.object ?? {}
+      const kind = object.kind || '?'
+      if (kind === 'Namespace') return
+      const namespace = object.metadata?.namespace || ''
+      if ((wantKind && wantKind !== kind) || (wantNs && wantNs !== namespace)) return
+      const row = topologyResource(member, edge, clusterName)
+      if (namespace) ensureNamespace(namespace).resources.push(row)
+      else edgeGroup.resources.push(row)
+    })
+
+    // A cluster with no matching rows should not produce an empty Edge item in
+    // the list. The graph also only creates namespace tiers when it has a row.
+    if (edgeGroup.resources.length || edgeGroup.namespaces.length) edges.push(edgeGroup)
+  })
+
+  return { edges }
+}
+
 // buildTopologyElements turns a clusters-rooted query result (each cluster
 // with its `members` relation) into a fleet tree: Edge → Namespace → object,
 // with cluster-scoped objects hanging straight off the Edge. Structural edges
-// all use rel "namespace" so they share the containment color.
-//
-// A namespace's tier node IS the real `Namespace` object when one was synced
-// (so it carries children AND is clickable → its `namespaced` impact), rather
-// than rendering the Namespace both as a synthetic group and a childless leaf.
-// Falls back to a synthetic tier when the Namespace object isn't in the set.
+// all use rel "namespace" so they share the containment color. Both graph and
+// list views consume deriveTopologyTree so filtering cannot make the two drift.
 export function buildTopologyElements(
   clusters: ObjectResult[],
   opts?: { kind?: string; namespace?: string },
@@ -136,8 +251,6 @@ export function buildTopologyElements(
   const nodeIndex: Record<string, ObjectResult> = {}
   const nodes = new Set<string>()
   const edges = new Set<string>()
-  const wantKind = opts?.kind || ''
-  const wantNs = opts?.namespace || ''
 
   const addNode = (id: string, data: Record<string, unknown>) => {
     if (nodes.has(id)) return
@@ -151,57 +264,26 @@ export function buildTopologyElements(
     elements.push({ data: { id, source, target, rel: 'namespace' } })
   }
 
-  for (const c of clusters) {
-    const cname = c.cluster || c.object?.metadata?.name || 'cluster'
-    const cid = `cluster:${cname}`
-    addNode(cid, { label: edgeOf(cname), tier: 'cluster', anchor: 'true', kind: 'Cluster', name: edgeOf(cname) })
+  for (const edgeGroup of deriveTopologyTree(clusters, opts).edges) {
+    const cid = `cluster:${edgeGroup.cluster}`
+    addNode(cid, { label: edgeGroup.name, tier: 'cluster', anchor: 'true', kind: 'Cluster', name: edgeGroup.name })
 
-    const members = c.relations?.members ?? []
-
-    // Index the real Namespace objects so a tier can adopt one as its node.
-    const nsObjByName = new Map<string, ObjectResult>()
-    for (const mem of members) {
-      if (mem.object?.kind === 'Namespace') nsObjByName.set(mem.object.metadata?.name || '', mem)
-    }
-    // ensureNs returns the tier node id for a namespace, creating it (and the
-    // Edge→Namespace edge) on first use. Uses the real Namespace object's id
-    // when available so the tier is the object itself.
-    const ensureNs = (nsName: string): string => {
-      const real = nsObjByName.get(nsName)
-      const nid = real?.id || `ns:${cname}/${nsName}`
-      if (!nodes.has(nid)) {
-        addNode(nid, { label: nsName, tier: 'namespace', kind: 'Namespace', name: nsName })
-        if (real) nodeIndex[nid] = real
-        addEdge(cid, nid)
-      }
-      return nid
-    }
-
-    // Show every namespace as a tier — even empty ones — unless filtering to a
-    // different kind.
-    if (!wantKind || wantKind === 'Namespace') {
-      for (const nsName of nsObjByName.keys()) {
-        if (!nsName) continue
-        if (wantNs && nsName !== wantNs) continue
-        ensureNs(nsName)
+    for (const namespaceGroup of edgeGroup.namespaces) {
+      const namespaceId = namespaceGroup.resource?.object.id || `ns:${edgeGroup.cluster}/${namespaceGroup.name}`
+      addNode(namespaceId, { label: namespaceGroup.name, tier: 'namespace', kind: 'Namespace', name: namespaceGroup.name })
+      if (namespaceGroup.resource) nodeIndex[namespaceId] = namespaceGroup.resource.object
+      addEdge(cid, namespaceId)
+      for (const row of namespaceGroup.resources) {
+        addNode(row.key, { label: `${row.kind}\n${row.name}`, tier: 'object', kind: row.kind, name: row.name, edge: row.edge })
+        nodeIndex[row.key] = row.object
+        addEdge(namespaceId, row.key)
       }
     }
 
-    for (const mem of members) {
-      const o = mem.object ?? {}
-      const kind = o.kind || '?'
-      if (kind === 'Namespace') continue // already represented as a tier node
-      const name = o.metadata?.name || '?'
-      const ns = o.metadata?.namespace || ''
-      // Client-side facet filters. Namespace "" (cluster-scoped) is excluded
-      // when a specific namespace is selected.
-      if (wantKind && kind !== wantKind) continue
-      if (wantNs && ns !== wantNs) continue
-      const oid = mem.id || `${cname}/${kind}/${ns}/${name}`
-      const parent = ns ? ensureNs(ns) : cid
-      addNode(oid, { label: `${kind}\n${name}`, tier: 'object', kind, name, edge: edgeOf(mem.cluster) })
-      nodeIndex[oid] = mem
-      addEdge(parent, oid)
+    for (const row of edgeGroup.resources) {
+      addNode(row.key, { label: `${row.kind}\n${row.name}`, tier: 'object', kind: row.kind, name: row.name, edge: row.edge })
+      nodeIndex[row.key] = row.object
+      addEdge(cid, row.key)
     }
   }
   return { elements, nodeIndex }
@@ -336,6 +418,29 @@ export interface GraphHandle {
   nodeCount(): number
 }
 
+export type GraphKeyAction = 'pan-up' | 'pan-down' | 'pan-left' | 'pan-right' | 'zoom-in' | 'zoom-out' | 'fullscreen' | 'escape'
+
+// Keep keyboard routing deterministic and separate from Cytoscape so the
+// portal can prove that global arrow keys remain untouched until the graph is
+// the active focus owner.
+export function graphKeyAction(key: string): GraphKeyAction | null {
+  switch (key) {
+    case 'ArrowUp': case 'w': case 'W': return 'pan-up'
+    case 'ArrowDown': case 's': case 'S': return 'pan-down'
+    case 'ArrowLeft': case 'a': case 'A': return 'pan-left'
+    case 'ArrowRight': case 'd': case 'D': return 'pan-right'
+    case '+': case '=': return 'zoom-in'
+    case '-': case '_': return 'zoom-out'
+    case 'f': case 'F': return 'fullscreen'
+    case 'Escape': return 'escape'
+    default: return null
+  }
+}
+
+export function graphOwnsFocus(graph: Element | null, activeElement: Element | null): boolean {
+  return !!graph && (graph === activeElement || (!!activeElement && graph.contains(activeElement)))
+}
+
 // relationElements builds the child nodes/edges for one already-placed node
 // (anchorId) from an impact result's relations. It does NOT emit the anchor
 // itself. Child node ids are the objects' stable kuery ids, so re-expanding or
@@ -421,9 +526,16 @@ export async function mountGraph(
   // Every node is tappable; the caller decides what (if anything) to do — for
   // the explorer that's expand/collapse, for the impact view it re-anchors.
   cy.on('tap', 'node', (evt: cytoscape.EventObject) => onNodeTap(evt.target.id()))
+  // Cytoscape's canvas is not itself a keyboard control. Let a pointer user
+  // opt into the same graph shortcuts without making the shortcuts global.
+  const focusGraph = () => container.focus()
+  container.addEventListener('pointerdown', focusGraph)
 
   return {
-    destroy: () => cy.destroy(),
+    destroy: () => {
+      container.removeEventListener('pointerdown', focusGraph)
+      cy.destroy()
+    },
     hasNode: (id) => cy.getElementById(id).nonempty(),
     isExpanded: (id) => cy.getElementById(id).data('expanded') === 'true',
     markExpanded: (id, expanded) => {

--- a/providers/kuery/portal/src/style.css
+++ b/providers/kuery/portal/src/style.css
@@ -177,6 +177,11 @@ faros-provider-kuery .kuery-view-btn[aria-pressed="true"] {
   color: var(--color-accent, #8b6bff);
 }
 
+faros-provider-kuery .kuery-view-btn:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: -2px;
+}
+
 faros-provider-kuery .kuery-view-btn:hover {
   filter: none;
   color: var(--color-text-primary, inherit);
@@ -192,11 +197,115 @@ faros-provider-kuery .kuery-graph {
   outline: none;
 }
 
+faros-provider-kuery .kuery-graph:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+
+/* Pointer-free topology fallback. The nested list mirrors the graph's Edge →
+   Namespace → Resource structure; only actual synced objects are buttons. */
+faros-provider-kuery .kuery-topology-list {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  background: var(--color-surface-raised);
+  padding: 12px;
+}
+
+faros-provider-kuery .kuery-topology-tree,
+faros-provider-kuery .kuery-topology-namespaces,
+faros-provider-kuery .kuery-topology-resources {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+faros-provider-kuery .kuery-topology-edge + .kuery-topology-edge {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+faros-provider-kuery .kuery-topology-namespace {
+  margin: 8px 0 0 14px;
+  padding-left: 12px;
+  border-left: 1px solid var(--color-border-subtle);
+}
+
+faros-provider-kuery .kuery-topology-group-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 28px;
+  color: var(--color-text-primary, inherit);
+  font-size: 12px;
+}
+
+faros-provider-kuery .kuery-topology-edge-label {
+  min-height: 32px;
+  padding: 0 4px;
+  font-weight: 600;
+}
+
+faros-provider-kuery .kuery-topology-edge-name,
+faros-provider-kuery .kuery-topology-namespace-name {
+  color: var(--color-text-secondary, inherit);
+}
+
+faros-provider-kuery .kuery-topology-resource-item {
+  margin-top: 4px;
+}
+
+faros-provider-kuery .kuery-topology-resource {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 32px;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-primary, inherit);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+faros-provider-kuery .kuery-topology-resource:hover {
+  border-color: var(--color-border-subtle);
+  background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14));
+}
+
+faros-provider-kuery .kuery-topology-resource:focus-visible {
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 1px;
+}
+
+faros-provider-kuery .kuery-topology-resource-kind {
+  flex: none;
+  min-width: 84px;
+  color: var(--color-text-muted, inherit);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+faros-provider-kuery .kuery-topology-resource-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 12px;
+}
+
 /* Fullscreen: the panel fills the viewport and the graph grows to match. */
 faros-provider-kuery .kuery-panel.kuery-full {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--k-layer-fullscreen, 2000);
   margin: 0;
   border-radius: 0;
   overflow: auto;

--- a/providers/kuery/portal/topology.contract.test.mjs
+++ b/providers/kuery/portal/topology.contract.test.mjs
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import ts from 'typescript'
+
+const graphSource = readFileSync(new URL('./src/graph.ts', import.meta.url), 'utf8')
+const graphModule = await import(`data:text/javascript,${encodeURIComponent(ts.transpileModule(graphSource, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+}).outputText)}`)
+
+const member = (id, kind, name, namespace = '', cluster = 'org/edge-a') => ({
+  id,
+  cluster,
+  object: { kind, apiVersion: 'apps/v1', metadata: { name, ...(namespace ? { namespace } : {}) } },
+})
+
+const topology = [
+  {
+    cluster: 'org/edge-a',
+    relations: {
+      members: [
+        member('ns-apps', 'Namespace', 'apps'),
+        member('deploy-web', 'Deployment', 'web', 'apps'),
+        member('pod-web', 'Pod', 'web-1', 'apps'),
+        member('node-a', 'Node', 'worker-a'),
+      ],
+    },
+  },
+  {
+    cluster: 'org/edge-b',
+    relations: { members: [member('deploy-api', 'Deployment', 'api', 'backend', 'org/edge-b')] },
+  },
+]
+
+test('topology derivation preserves Edge → Namespace → Resource hierarchy', () => {
+  const tree = graphModule.deriveTopologyTree(topology)
+
+  assert.deepEqual(tree.edges.map((edge) => edge.name), ['edge-a', 'edge-b'])
+  assert.equal(tree.edges[0].namespaces[0].name, 'apps')
+  assert.equal(tree.edges[0].namespaces[0].resource.object.id, 'ns-apps')
+  assert.deepEqual(tree.edges[0].namespaces[0].resources.map((row) => row.name), ['web', 'web-1'])
+  assert.deepEqual(tree.edges[0].resources.map((row) => row.name), ['worker-a'])
+  assert.deepEqual(tree.edges[1].namespaces.map((group) => group.name), ['backend'])
+})
+
+test('topology filters are pure and match visible resource rows', () => {
+  const deployments = graphModule.deriveTopologyTree(topology, { kind: 'Deployment' })
+  assert.deepEqual(deployments.edges.map((edge) => edge.name), ['edge-a', 'edge-b'])
+  assert.equal(deployments.edges[0].namespaces[0].resource, undefined)
+  assert.deepEqual(deployments.edges[0].namespaces[0].resources.map((row) => row.name), ['web'])
+  assert.deepEqual(deployments.edges[1].namespaces[0].resources.map((row) => row.name), ['api'])
+
+  const apps = graphModule.deriveTopologyTree(topology, { namespace: 'apps' })
+  assert.deepEqual(apps.edges.map((edge) => edge.name), ['edge-a'])
+  assert.equal(apps.edges[0].namespaces[0].resource.object.id, 'ns-apps')
+  assert.deepEqual(apps.edges[0].namespaces[0].resources.map((row) => row.name), ['web', 'web-1'])
+
+  const namespaces = graphModule.deriveTopologyTree(topology, { kind: 'Namespace' })
+  assert.deepEqual(namespaces.edges.map((edge) => edge.name), ['edge-a'])
+  assert.deepEqual(namespaces.edges[0].namespaces.map((group) => group.resource.object.id), ['ns-apps'])
+
+  const none = graphModule.deriveTopologyTree(topology, { kind: 'Service' })
+  assert.deepEqual(none.edges, [], 'a filter with no matches must not leave empty Edge groups')
+})
+
+test('topology graph elements mirror the filtered tree and keep cluster-scoped rows at Edge', () => {
+  const filtered = graphModule.buildTopologyElements(topology, { kind: 'Deployment' })
+  const nodes = filtered.elements
+    .filter((element) => !element.data.source)
+    .map((element) => element.data.id)
+
+  assert.deepEqual(nodes, [
+    'cluster:org/edge-a',
+    'ns:org/edge-a/apps',
+    'deploy-web',
+    'cluster:org/edge-b',
+    'ns:org/edge-b/backend',
+    'deploy-api',
+  ])
+  assert.equal(filtered.nodeIndex['deploy-web'].object.metadata.namespace, 'apps')
+  assert.equal(filtered.nodeIndex['deploy-api'].object.metadata.namespace, 'backend')
+
+  const apps = graphModule.buildTopologyElements(topology, { namespace: 'apps' })
+  const appNodeIds = apps.elements.filter((element) => !element.data.source).map((element) => element.data.id)
+  assert.ok(appNodeIds.includes('ns-apps'))
+  assert.ok(appNodeIds.includes('deploy-web'))
+  assert.ok(appNodeIds.includes('pod-web'))
+  assert.ok(!appNodeIds.includes('node-a'), 'namespace filtering must exclude cluster-scoped rows')
+})
+
+test('graph key actions and focus ownership are deterministic', () => {
+  assert.equal(graphModule.graphKeyAction('ArrowUp'), 'pan-up')
+  assert.equal(graphModule.graphKeyAction('d'), 'pan-right')
+  assert.equal(graphModule.graphKeyAction('='), 'zoom-in')
+  assert.equal(graphModule.graphKeyAction('Escape'), 'escape')
+  assert.equal(graphModule.graphKeyAction('Tab'), null)
+
+  const child = {}
+  const other = {}
+  const graph = { contains: (node) => node === child }
+  assert.equal(graphModule.graphOwnsFocus(graph, graph), true)
+  assert.equal(graphModule.graphOwnsFocus(graph, child), true)
+  assert.equal(graphModule.graphOwnsFocus(graph, other), false)
+  assert.equal(graphModule.graphOwnsFocus(graph, null), false)
+})
+
+test('mountGraph focuses the labeled container on pointer use and removes the listener on destroy', async () => {
+  const previousWindow = globalThis.window
+  let focusCount = 0
+  let destroyed = 0
+  let pointerListener
+  const container = {
+    focus: () => { focusCount += 1 },
+    addEventListener: (type, listener) => { if (type === 'pointerdown') pointerListener = listener },
+    removeEventListener: (type, listener) => {
+      if (type === 'pointerdown' && listener === pointerListener) pointerListener = undefined
+    },
+  }
+  const fakeCytoscape = () => ({
+    on: () => {},
+    destroy: () => { destroyed += 1 },
+  })
+
+  try {
+    globalThis.window = { cytoscape: fakeCytoscape }
+    const handle = await graphModule.mountGraph(container, [], [], () => {}, '/cytoscape.min.js')
+    assert.equal(typeof pointerListener, 'function')
+    pointerListener()
+    assert.equal(focusCount, 1)
+    handle.destroy()
+    assert.equal(pointerListener, undefined)
+    assert.equal(destroyed, 1)
+  } finally {
+    globalThis.window = previousWindow
+  }
+})
+
+test('topology switch and resource activation are native, labeled controls', () => {
+  const elementSource = readFileSync(new URL('./src/element.ts', import.meta.url), 'utf8')
+  assert.match(elementSource, /data-topology-view=/u)
+  assert.match(elementSource, /role="group" aria-label="Topology representation"/u)
+  assert.match(elementSource, /aria-pressed="\$\{this\._topoView === view\}"/u)
+  assert.match(elementSource, /this\._topoView = view[\s\S]{0,120}this\._render\(\)/u)
+  assert.match(elementSource, /data-topology-resource=/u)
+  assert.match(elementSource, /const row = this\._topologyListObjects\.get\(key\)/u)
+  assert.match(elementSource, /button\.addEventListener\('click'/u)
+  assert.match(elementSource, /if \(row\) void this\._runImpact\(row\)/u)
+  assert.match(elementSource, /role="region" aria-label="Fleet topology graph"[^>]*tabindex="0"/u)
+})
+
+test('filtered-empty topology renders a status before either representation', () => {
+  const elementSource = readFileSync(new URL('./src/element.ts', import.meta.url), 'utf8')
+  assert.match(elementSource, /const topologyTree = this\._topology\.length[\s\S]{0,180}deriveTopologyTree\(this\._topology/u)
+  assert.match(elementSource, /else if \(!hasTopologyRows\)[\s\S]{0,180}no resources match the current topology filters/u)
+  assert.match(elementSource, /else if \(this\._topology\.length === 0\) \{\s*body = `[^`]*no clusters engaged/u)
+  assert.match(elementSource, /else if \(!hasTopologyRows\)[\s\S]{0,240}else if \(this\._topoView === 'list'\)/u)
+})
+
+test('graph keyboard routing is focus-scoped and fullscreen uses the shared layer token', () => {
+  const elementSource = readFileSync(new URL('./src/element.ts', import.meta.url), 'utf8')
+  const graphSource = readFileSync(new URL('./src/graph.ts', import.meta.url), 'utf8')
+  const styleSource = readFileSync(new URL('./src/style.css', import.meta.url), 'utf8')
+  const sharedStyleSource = readFileSync(new URL('./src/portalkit/faros-ui.css', import.meta.url), 'utf8')
+
+  assert.match(elementSource, /if \(!graphOwnsFocus\(graph, document\.activeElement\)\) return/u)
+  assert.match(elementSource, /if \(handled\) ev\.preventDefault\(\)/u)
+  assert.match(graphSource, /const focusGraph = \(\) => container\.focus\(\)/u)
+  assert.match(graphSource, /container\.addEventListener\('pointerdown', focusGraph\)/u)
+  assert.match(graphSource, /container\.removeEventListener\('pointerdown', focusGraph\)/u)
+  assert.match(elementSource, /panel\.requestFullscreen\(\)\.catch\(\(\) => this\._toggleFullCSS\(panel\)\)/u)
+  assert.match(elementSource, /this\._toggleFullCSS\(panel\)/u)
+  assert.match(styleSource, /z-index: var\(--k-layer-fullscreen, 2000\)/u)
+  assert.match(sharedStyleSource, /--k-layer-fullscreen: 2000/u)
+})


### PR DESCRIPTION
Stack: 4 of 10 in Fluid-Shell 4K Conformance and Provider UI Hardening.

Depends on the Infrastructure composition PR.

Summary:
- Adds a visible Graph and List selector.
- Builds a semantic Edge to Namespace to Resource list from the same topology and filter state.
- Makes resources keyboard-operable buttons that open the existing detail and impact workflow.
- Scopes graph pan, zoom, fullscreen, and Escape handling to the focused labeled graph region.

Verification:
- Kuery topology contract tests
- Provider tests and production build
- UI conformance gate
- git diff --check