### PR TITLE
Standardize Code detail actions

### DIFF
--- a/providers/code/portal/src/resource-detail.behavior.test.ts
+++ b/providers/code/portal/src/resource-detail.behavior.test.ts
@@ -24,6 +24,36 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('./api', () => ({ api: mocks.api }))
 vi.mock('./portalkit/confirm', () => ({ confirmDialog: mocks.confirmDialog }))
+vi.mock('./portalkit/ActionMenu.vue', async () => {
+  const { h, ref } = await import('vue')
+  type ActionItem = { id: string; label: string; disabled?: boolean; busy?: boolean }
+  return {
+    default: {
+      props: ['label', 'items', 'disabled'],
+      emits: ['select'],
+      setup: (props: { label: string; items: readonly ActionItem[]; disabled?: boolean }, { emit }: { emit: (event: string, id: string) => void }) => {
+        const open = ref(false)
+        const toggle = () => {
+          if (!props.disabled) open.value = !open.value
+        }
+        const select = (item: ActionItem) => {
+          if (props.disabled || item.disabled || item.busy) return
+          open.value = false
+          emit('select', item.id)
+        }
+        return () => h('div', { class: 'action-menu-stub' }, [
+          h('button', { type: 'button', 'aria-label': props.label, disabled: props.disabled, onClick: toggle }, props.label),
+          open.value ? h('div', { role: 'menu' }, props.items.map(item => h('button', {
+            type: 'button',
+            disabled: item.disabled || item.busy,
+            'aria-busy': item.busy ? 'true' : undefined,
+            onClick: () => select(item),
+          }, item.label))) : null,
+        ])
+      },
+    },
+  }
+})
 vi.mock('./portalkit/ConditionsPanel.vue', async () => {
   const { h } = await import('vue')
   return { default: { setup: () => () => h('div', { class: 'conditions-stub' }) } }
@@ -319,20 +349,27 @@ describe('mounted resource deletion state', () => {
     expect(mocks.api.listCollaborators).toHaveBeenCalled()
     expect(mocks.api.listPackagesPage).toHaveBeenCalled()
     const refreshButton = findNode(root, node => node.type === 'button' && textContent(node).trim() === 'Refresh')
-    const deleteButton = findNode(root, node => node.type === 'button' && textContent(node).trim() === 'Delete repository')
     expect(refreshButton?.props.disabled).toBe(false)
+    const menuTrigger = findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More repository actions')
+    expect(menuTrigger?.props.disabled).toBe(false)
+    click(menuTrigger!)
+    await settle()
+    const deleteButton = findNode(root, node => node.type === 'button' && textContent(node).trim() === 'Delete repository')
     expect(deleteButton?.props.disabled).toBe(false)
-
-    const menu = findNode(root, node => node.type === 'details')
-    expect(menu).toBeDefined()
-    menu!.setAttribute('open', '')
     click(deleteButton!)
     await settle()
 
-    expect(menu!.props.open).toBeUndefined()
+    expect(mocks.confirmDialog).toHaveBeenCalledWith({
+      title: 'Delete repository "orders"?',
+      message: 'This removes the repository on the git host. This cannot be undone.',
+      confirmLabel: 'Delete',
+      danger: true,
+    })
+    expect(findNode(root, node => node.props.role === 'menu')).toBeUndefined()
     expect(textContent(root)).toContain('orders')
     expect(textContent(root)).toContain('Deleting this repository.')
     expect(findNode(root, node => node.props.role === 'status' && node.props['aria-live'] === 'polite' && textContent(node).includes('Deleting this repository.'))).toBeDefined()
+    expect(findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More repository actions')?.props.disabled).toBe(true)
 
     deleteRequest.reject({ reason: 'GraphQLError', message: 'delete failed' })
     await settle()
@@ -341,6 +378,7 @@ describe('mounted resource deletion state', () => {
     expect(textContent(root)).toContain('GraphQLError: delete failed')
     expect(textContent(root)).toContain('orders')
     expect(findNode(root, node => node.type === 'button' && textContent(node).trim() === 'Refresh')?.props.disabled).toBe(false)
+    expect(findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More repository actions')?.props.disabled).toBe(false)
     app.unmount()
   })
 
@@ -356,18 +394,26 @@ describe('mounted resource deletion state', () => {
     })
     await settle()
 
+    const menuTrigger = findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More connection actions')
+    expect(menuTrigger?.props.disabled).toBe(false)
+    click(menuTrigger!)
+    await settle()
     const deleteButton = findNode(root, node => node.type === 'button' && textContent(node).trim() === 'Delete connection')
-    const menu = findNode(root, node => node.type === 'details')
     expect(deleteButton?.props.disabled).toBe(false)
-    expect(menu).toBeDefined()
-    menu!.setAttribute('open', '')
     click(deleteButton!)
     await settle()
 
-    expect(menu!.props.open).toBeUndefined()
+    expect(mocks.confirmDialog).toHaveBeenCalledWith({
+      title: 'Delete connection "github"?',
+      message: 'Repositories using it will stop reconciling.',
+      confirmLabel: 'Delete',
+      danger: true,
+    })
+    expect(findNode(root, node => node.props.role === 'menu')).toBeUndefined()
     expect(textContent(root)).toContain('github')
     expect(textContent(root)).toContain('Deleting this connection.')
     expect(findNode(root, node => node.props.role === 'status' && node.props['aria-live'] === 'polite' && textContent(node).includes('Deleting this connection.'))).toBeDefined()
+    expect(findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More connection actions')?.props.disabled).toBe(true)
 
     deleteRequest.reject({ reason: 'GraphQLError', message: 'delete failed' })
     await settle()
@@ -376,7 +422,31 @@ describe('mounted resource deletion state', () => {
     expect(textContent(root)).toContain('GraphQLError: delete failed')
     expect(textContent(root)).toContain('github')
     expect(back).not.toHaveBeenCalled()
-    expect(findNode(root, node => node.type === 'button' && textContent(node).trim() === 'Delete connection')?.props.disabled).toBe(false)
+    expect(findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More connection actions')?.props.disabled).toBe(false)
+    app.unmount()
+  })
+
+  it('closes the connection menu and leaves the resource actionable when deletion is cancelled', async () => {
+    mocks.confirmDialog.mockResolvedValueOnce(false)
+    const { app, root } = mount(ConnectionDetailView, {
+      name: connection.name,
+      deletions: createResourceDeletions(),
+    })
+    await settle()
+
+    const menuTrigger = findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More connection actions')
+    expect(menuTrigger?.props.disabled).toBe(false)
+    click(menuTrigger!)
+    await settle()
+    const deleteButton = findNode(root, node => node.type === 'button' && textContent(node).trim() === 'Delete connection')
+    click(deleteButton!)
+    await settle()
+
+    expect(mocks.confirmDialog).toHaveBeenCalledTimes(1)
+    expect(mocks.api.deleteConnection).not.toHaveBeenCalled()
+    expect(findNode(root, node => node.props.role === 'menu')).toBeUndefined()
+    expect(textContent(root)).not.toContain('Deleting this connection.')
+    expect(findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More connection actions')?.props.disabled).toBe(false)
     app.unmount()
   })
 

--- a/providers/code/portal/src/resource-detail.structure.test.mjs
+++ b/providers/code/portal/src/resource-detail.structure.test.mjs
@@ -68,7 +68,11 @@ describe('Code repository resource detail cards', () => {
     expect(detail).toMatch(/<div class="repo-detail__actions" role="group" aria-label="Repository actions">/)
     expect(detail).toMatch(/Open repository[\s\S]*k-btn--primary/)
     expect(detail).toMatch(/class="k-btn k-btn--ghost"[\s\S]*@click="loadAll"/)
-    expect(detail).toMatch(/<details ref="actionsMenu" class="repo-detail__menu">[\s\S]*Delete repository/)
+    expect(detail).toContain("import ActionMenu, { type ActionMenuItem } from '../portalkit/ActionMenu.vue'")
+    expect(detail).toContain('const actionItems = computed<ActionMenuItem[]>(() =>')
+    expect(detail).toMatch(/<ActionMenu[\s\S]*label="More repository actions"[\s\S]*:items="actionItems"[\s\S]*:disabled="!repo \|\| repositoryActionBusy"[\s\S]*@select="selectAction"/)
+    expect(detail).not.toContain('<details')
+    expect(detail).not.toContain('repo-detail__menu')
     expect(detail).toMatch(/@retry="loadRepository"/)
     expect(detail).toMatch(/async function deleteRepository\(\)/)
     expect(detail).toMatch(/confirmDialog\(\{[\s\S]*danger: true/)
@@ -78,11 +82,13 @@ describe('Code repository resource detail cards', () => {
     expect(detail).toMatch(/<p v-if="repositoryDeleting" class="repo-detail__deleting" role="status" aria-live="polite">[\s\S]*Deleting this repository\./)
   })
 
-  it('keeps overflow action menus wider than their icon triggers', () => {
-    expect(style).toMatch(/\.repo-detail \.repo-detail__menu-popover\s*\{[\s\S]*width:\s*max-content;[\s\S]*min-width:\s*170px;[\s\S]*max-width:\s*min\(240px, calc\(100vw - 32px\)\)/)
-    expect(style).toMatch(/\.repo-detail__menu-item\s*\{[\s\S]*width:\s*100%;[\s\S]*white-space:\s*nowrap/)
-    expect(style).toMatch(/\.connection-detail \.connection-detail__menu-popover\s*\{[\s\S]*width:\s*max-content;[\s\S]*min-width:\s*170px;[\s\S]*max-width:\s*min\(240px, calc\(100vw - 32px\)\)/)
-    expect(style).toMatch(/\.connection-detail__menu-item\s*\{[\s\S]*width:\s*100%;[\s\S]*white-space:\s*nowrap/)
+  it('uses shared overflow action styling and a complete warning hint border', () => {
+    expect(style).not.toMatch(/__menu-popover|__menu-item/)
+    const hintRule = style.match(/\.connection-detail__hint\s*\{([\s\S]*?)\}/)?.[1] ?? ''
+    expect(hintRule).toContain('border: 1px solid color-mix(in srgb, var(--color-warning, #f0a63a) 35%, transparent);')
+    expect(hintRule).toContain('border-radius: 6px;')
+    expect(hintRule).toContain('background: var(--color-warning-subtle, rgba(240, 166, 58, 0.12));')
+    expect(hintRule).not.toContain('border-left')
   })
 
   it('uses compact provider-owned stat cards and canonical section cards', () => {
@@ -169,7 +175,13 @@ describe('Code connection resource detail cards', () => {
       page.indexOf('<template #status>'),
     ]
     expect(headerOrder).toEqual([...headerOrder].sort((a, b) => a - b))
-    expect(connectionDetail).toMatch(/<template #actions>[\s\S]*Refresh[\s\S]*More connection actions[\s\S]*Delete connection/)
+    expect(connectionDetail).toMatch(/<template #actions>[\s\S]*Refresh[\s\S]*<ActionMenu[\s\S]*More connection actions/)
+    expect(connectionDetail).toContain("import ActionMenu, { type ActionMenuItem } from '../portalkit/ActionMenu.vue'")
+    expect(connectionDetail).toContain('const actionItems = computed<ActionMenuItem[]>(() =>')
+    expect(connectionDetail).toContain("label: deleting.value ? 'Deleting connection…' : 'Delete connection'")
+    expect(connectionDetail).toMatch(/<ActionMenu[\s\S]*label="More connection actions"[\s\S]*:items="actionItems"[\s\S]*:disabled="connectionActionBusy"[\s\S]*@select="selectAction"/)
+    expect(connectionDetail).not.toContain('<details')
+    expect(connectionDetail).not.toContain('connection-detail__menu')
     expect(connectionDetail).toContain(':loaded="connectionReadState"')
     expect(connectionDetail).toContain(':stale="loaded && !!error"')
     expect(connectionDetail).toContain('@retry="load"')

--- a/providers/code/portal/src/style.css
+++ b/providers/code/portal/src/style.css
@@ -182,58 +182,6 @@ faros-provider-code .repo-detail__actions {
   justify-content: flex-end;
   gap: 8px;
 }
-faros-provider-code .repo-detail__menu {
-  position: relative;
-}
-faros-provider-code .repo-detail__menu summary {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 32px;
-  list-style: none;
-  padding: 7px 8px;
-}
-faros-provider-code .repo-detail__menu summary::-webkit-details-marker {
-  display: none;
-}
-faros-provider-code .repo-detail__menu summary::marker {
-  display: none;
-}
-faros-provider-code .repo-detail .repo-detail__menu-popover {
-  position: absolute;
-  z-index: 5;
-  top: calc(100% + 6px);
-  right: 0;
-  width: max-content;
-  min-width: 170px;
-  max-width: min(240px, calc(100vw - 32px));
-  border: 1px solid var(--color-border-default, rgba(255,255,255,.11));
-  border-radius: 6px;
-  background: var(--color-surface-overlay, #171927);
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--color-surface, #0a0b12) 65%, transparent);
-  padding: 4px;
-}
-faros-provider-code .repo-detail__menu-item {
-  display: block;
-  width: 100%;
-  border: 0;
-  border-radius: 3px;
-  background: transparent;
-  color: var(--color-danger, #ff5d5d);
-  cursor: pointer;
-  font: inherit;
-  font-size: 12px;
-  padding: 8px 10px;
-  text-align: left;
-  white-space: nowrap;
-}
-faros-provider-code .repo-detail__menu-item:hover:not(:disabled) {
-  background: var(--color-danger-subtle, rgba(255, 93, 93, 0.12));
-}
-faros-provider-code .repo-detail__menu-item:disabled {
-  cursor: default;
-  opacity: .5;
-}
 faros-provider-code .repo-detail__sections {
   display: flex;
   min-width: 0;
@@ -425,49 +373,6 @@ faros-provider-code .connection-detail__actions {
   justify-content: flex-end;
   gap: 8px;
 }
-faros-provider-code .connection-detail__menu { position: relative; }
-faros-provider-code .connection-detail__menu summary {
-  display: inline-flex;
-  min-width: 32px;
-  align-items: center;
-  justify-content: center;
-  list-style: none;
-  padding: 7px 8px;
-}
-faros-provider-code .connection-detail__menu summary::-webkit-details-marker,
-faros-provider-code .connection-detail__menu summary::marker { display: none; }
-faros-provider-code .connection-detail .connection-detail__menu-popover {
-  position: absolute;
-  z-index: 5;
-  top: calc(100% + 6px);
-  right: 0;
-  width: max-content;
-  min-width: 170px;
-  max-width: min(240px, calc(100vw - 32px));
-  border: 1px solid var(--color-border-default, rgba(255, 255, 255, .11));
-  border-radius: 6px;
-  background: var(--color-surface-overlay, #171927);
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--color-surface, #0a0b12) 65%, transparent);
-  padding: 4px;
-}
-faros-provider-code .connection-detail__menu-item {
-  display: block;
-  width: 100%;
-  border: 0;
-  border-radius: 3px;
-  background: transparent;
-  color: var(--color-danger, #ff5d5d);
-  cursor: pointer;
-  font: inherit;
-  font-size: 12px;
-  padding: 8px 10px;
-  text-align: left;
-  white-space: nowrap;
-}
-faros-provider-code .connection-detail__menu-item:hover:not(:disabled) {
-  background: var(--color-danger-subtle, rgba(255, 93, 93, .12));
-}
-faros-provider-code .connection-detail__menu-item:disabled { cursor: default; opacity: .5; }
 faros-provider-code .connection-detail__sections {
   display: flex;
   min-width: 0;
@@ -491,8 +396,9 @@ faros-provider-code .connection-detail__facts dd {
 }
 faros-provider-code .connection-detail__hint {
   margin-bottom: 18px;
-  border-left: 2px solid var(--color-warning, #f0a63a);
-  background: var(--color-warning-subtle);
+  border: 1px solid color-mix(in srgb, var(--color-warning, #f0a63a) 35%, transparent);
+  border-radius: 6px;
+  background: var(--color-warning-subtle, rgba(240, 166, 58, 0.12));
   padding: 10px 12px;
 }
 faros-provider-code .connection-detail__hint-title {

--- a/providers/code/portal/src/views/ConnectionDetailView.vue
+++ b/providers/code/portal/src/views/ConnectionDetailView.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
-import { Ellipsis, GitBranch, KeyRound, Link2, Plug, RefreshCw, User } from 'lucide-vue-next'
+import { GitBranch, KeyRound, Link2, Plug, RefreshCw, User } from 'lucide-vue-next'
 import { api } from '../api'
 import type { ConnectionDetail, ErrorResponse } from '../types'
+import ActionMenu, { type ActionMenuItem } from '../portalkit/ActionMenu.vue'
 import ConditionsPanel from '../portalkit/ConditionsPanel.vue'
 import ResourcePage from '../portalkit/ResourcePage.vue'
 import ResourceBackLink from '../portalkit/ResourceBackLink.vue'
@@ -31,7 +32,6 @@ const error = ref<string | null>(null)
 const mutationError = ref<string | null>(null)
 const loading = ref(true)
 const loaded = ref(false)
-const actionsMenu = ref<HTMLDetailsElement | null>(null)
 const operations = createOperationLocks()
 let mounted = false
 let refresh!: LatestRefreshController
@@ -89,6 +89,13 @@ const connectionActionBusy = computed(() =>
   deleting.value ||
   operations.isLocked(operationKey('connection', conn.value?.name || props.name)),
 )
+const actionItems = computed<ActionMenuItem[]>(() => [{
+  id: 'delete',
+  label: deleting.value ? 'Deleting connection…' : 'Delete connection',
+  tone: 'danger',
+  disabled: !conn.value || connectionActionBusy.value,
+  busy: deleting.value,
+}])
 // ResourcePage distinguishes an explicit first read from the expected
 // TenantMissing/no-context state while the host changes workspaces. Keep the
 // null sentinel for that no-context state so the body is not replaced by a
@@ -185,9 +192,8 @@ async function deleteConnection() {
   }
 }
 
-function deleteFromMenu() {
-  actionsMenu.value?.removeAttribute('open')
-  void deleteConnection()
+function selectAction(action: string): void {
+  if (action === 'delete') void deleteConnection()
 }
 
 refresh = createLatestRefreshController(async (requestID, mode) => {
@@ -289,22 +295,12 @@ onUnmounted(() => {
               <RefreshCw :size="14" :class="{ spin: foregroundRefreshing }" aria-hidden="true" />
               {{ foregroundRefreshing ? 'Refreshing…' : 'Refresh' }}
             </button>
-            <details ref="actionsMenu" class="connection-detail__menu">
-              <summary class="k-btn k-btn--ghost" aria-label="More connection actions">
-                <Ellipsis :size="16" aria-hidden="true" />
-                <span class="sr-only">More actions</span>
-              </summary>
-              <div class="connection-detail__menu-popover">
-                <button
-                  type="button"
-                  class="connection-detail__menu-item"
-                  :disabled="connectionActionBusy"
-                  @click="deleteFromMenu"
-                >
-                  Delete connection
-                </button>
-              </div>
-            </details>
+            <ActionMenu
+              label="More connection actions"
+              :items="actionItems"
+              :disabled="connectionActionBusy"
+              @select="selectAction"
+            />
           </div>
         </template>
 

--- a/providers/code/portal/src/views/RepoDetailView.vue
+++ b/providers/code/portal/src/views/RepoDetailView.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { AlertTriangle, ArrowLeftRight, Ellipsis, ExternalLink, Eye, GitBranch, Github, Package as PackageIcon, PackageOpen, Plug, RefreshCw, User, Users, X } from 'lucide-vue-next'
+import { AlertTriangle, ArrowLeftRight, ExternalLink, Eye, GitBranch, Github, Package as PackageIcon, PackageOpen, Plug, RefreshCw, User, Users, X } from 'lucide-vue-next'
 import { api } from '../api'
 import type { Collaborator, Connection, DeployKey, ErrorResponse, Package, RepositoryDetail } from '../types'
+import ActionMenu, { type ActionMenuItem } from '../portalkit/ActionMenu.vue'
 import ConditionsPanel from '../portalkit/ConditionsPanel.vue'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
@@ -50,7 +51,6 @@ const repoLoading = ref(true)
 const repoLoaded = ref(false)
 const repoError = ref<string | null>(null)
 const repositoryMutationError = ref<string | null>(null)
-const actionsMenu = ref<HTMLDetailsElement | null>(null)
 const connectionExpanded = ref(false)
 const accessExpanded = ref(false)
 const packagesExpanded = ref(false)
@@ -138,6 +138,13 @@ const packageRefreshMode = ref<ResourceRefreshMode>('foreground')
 const repositoryRefreshing = computed(() => repoLoading.value)
 const repositoryForegroundRefreshing = computed(() => repoLoading.value && repositoryRefreshMode.value === 'foreground')
 const repositoryActionBusy = computed(() => repositoryForegroundRefreshing.value || repositoryDeleting.value || operations.isLocked(operationKey('repository', props.name)))
+const actionItems = computed<ActionMenuItem[]>(() => [{
+  id: 'delete',
+  label: repositoryDeleting.value ? 'Deleting repository…' : 'Delete repository',
+  tone: 'danger',
+  disabled: !repo.value || repositoryActionBusy.value,
+  busy: repositoryDeleting.value,
+}])
 const keyRows = computed<Array<Record<string, unknown>>>(() => keys.value
   .map(key => {
     const deleting = isDeleting(keyScope, key)
@@ -390,9 +397,8 @@ async function deleteRepository() {
   }
 }
 
-function deleteFromMenu() {
-  actionsMenu.value?.removeAttribute('open')
-  void deleteRepository()
+function selectAction(action: string): void {
+  if (action === 'delete') void deleteRepository()
 }
 
 function toggleConnectionEditor() {
@@ -842,17 +848,12 @@ onUnmounted(() => {
             <RefreshCw :size="14" :class="{ spin: repositoryForegroundRefreshing }" aria-hidden="true" />
           {{ repositoryForegroundRefreshing ? 'Refreshing…' : 'Refresh' }}
         </button>
-        <details ref="actionsMenu" class="repo-detail__menu">
-          <summary class="k-btn k-btn--ghost" aria-label="More repository actions">
-            <Ellipsis :size="16" aria-hidden="true" />
-            <span class="sr-only">More actions</span>
-          </summary>
-          <div class="repo-detail__menu-popover">
-            <button type="button" class="repo-detail__menu-item" :disabled="!repo || repositoryActionBusy" @click="deleteFromMenu">
-              Delete repository
-            </button>
-          </div>
-        </details>
+        <ActionMenu
+          label="More repository actions"
+          :items="actionItems"
+          :disabled="!repo || repositoryActionBusy"
+          @select="selectAction"
+        />
       </div>
     </template>
 


### PR DESCRIPTION
Stack: 7 of 10 in Fluid-Shell 4K Conformance and Provider UI Hardening.

Depends on the App Studio controls PR.

Summary:
- Keeps Code data tables full width while inheriting the bounded shared search field.
- Migrates repository and connection overflow actions to ActionMenu.
- Replaces the warning side stripe with a complete warning border and subtle warning surface.
- Preserves canonical table row-action sizing.

Verification:
- Code portal tests, including menu behavior
- Typecheck and production build
- PortalKit and UI conformance gates
- git diff --check