### PR TITLE
Harden Agents interaction semantics

### DIFF
--- a/hack/create-flow-conformance.test.mjs
+++ b/hack/create-flow-conformance.test.mjs
@@ -63,7 +63,7 @@ test('Vue route-owned create flows use the shared skeleton', async () => {
   }
 })
 
-test('Agents route-owned create flows use the shared skeleton while dialogs remain contextual', async () => {
+test('Agents route-owned create flows use the shared skeleton without obsolete modal fallbacks', async () => {
   const cases = [
     ['agent', 'providers/agents/portal/src/views/agent-create.ts'],
     ['connection', 'providers/agents/portal/src/views/connections.ts'],
@@ -79,8 +79,8 @@ test('Agents route-owned create flows use the shared skeleton while dialogs rema
     source('providers/agents/portal/src/views/agent-create.ts'),
     source('providers/agents/portal/src/views/assisted-search.ts'),
   ])
-  assert.match(agent, /agents-dialog/)
-  assert.match(assistedSearch, /agents-dialog/)
+  assert.doesNotMatch(agent, /agents-dialog/)
+  assert.doesNotMatch(assistedSearch, /agents-dialog/)
 })
 
 test('App Studio removes collection tabs and nested settings chrome from model creation', async () => {

--- a/providers/agents/portal/src/element.ts
+++ b/providers/agents/portal/src/element.ts
@@ -297,7 +297,7 @@ export class AgentsElement extends LightElement {
     const render = (view: TemplateResult): TemplateResult | DirectiveResult => keyed(this.createSession, view)
     switch (route.resource) {
       case 'agent':
-        return render(html`<agents-agent-create .createSession=${this.createSession} .store=${bind.store} .api=${bind.api} .routeOwned=${true}></agents-agent-create>`)
+        return render(html`<agents-agent-create .createSession=${this.createSession} .store=${bind.store} .api=${bind.api}></agents-agent-create>`)
       case 'connection':
         return render(html`<agents-connections
           .createSession=${this.createSession}

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -49,10 +49,10 @@ faros-provider-agents .agents-back:hover { background: var(--color-surface-hover
 faros-provider-agents :focus-visible { outline: 2px solid var(--color-accent, #8b6bff); outline-offset: 2px; }
 
 /* --- agent card grid --- */
-faros-provider-agents .agents-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 18px; }
+faros-provider-agents .agents-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr)); gap: 18px; }
 faros-provider-agents .agents-card {
   display: flex; flex-direction: column; gap: 10px; min-height: 160px; padding: 18px;
-  cursor: pointer; text-align: left;
+  text-align: left;
   transition: border-color 0.12s, background 0.12s, transform 0.06s;
 }
 faros-provider-agents .agents-card:hover {
@@ -60,6 +60,10 @@ faros-provider-agents .agents-card:hover {
   background: var(--color-surface-overlay, #171927);
 }
 faros-provider-agents .agents-card:active { transform: translateY(1px); }
+faros-provider-agents .agents-card-link {
+  display: flex; flex: 1; min-width: 0; flex-direction: column; gap: 10px;
+  color: inherit; text-decoration: none;
+}
 faros-provider-agents .agents-card-glyph {
   width: 42px; height: 42px; display: flex; align-items: center; justify-content: center;
   font-size: 22px; border-radius: 6px; background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14));
@@ -172,11 +176,9 @@ faros-provider-agents .agents-fieldset-legend { font-size: 12px; font-weight: 60
 faros-provider-agents .agents-addselect { align-self: flex-start; font-size: 12.5px; }
 faros-provider-agents .agents-chiprow { display: flex; flex-wrap: wrap; gap: 5px; }
 faros-provider-agents .agents-chip-x {
-  padding: 0; margin-left: 3px; width: 14px; height: 14px; border-radius: 50%; background: transparent;
-  color: inherit; display: inline-flex; align-items: center; justify-content: center;
+  flex: 0 0 auto; margin-inline-start: 3px;
 }
 faros-provider-agents .agents-chip-x:hover { background: var(--color-danger-subtle); color: var(--color-danger, #ff5d5d); }
-faros-provider-agents .agents-chip-x svg { width: 11px; height: 11px; }
 
 /* autonomy: radio cards, because the choice now has real consequences */
 faros-provider-agents .agents-radiocards { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 10px; }
@@ -246,25 +248,6 @@ faros-provider-agents .agents-spinner {
   faros-provider-agents .agents-spinner, faros-provider-agents .agents-offline svg { animation: none; }
 }
 
-/* --- modal-style overlay dialog (create wizard) --- */
-faros-provider-agents .agents-overlay {
-  position: fixed; inset: 0; z-index: 2147481000; display: grid; place-items: center; padding: 24px;
-  background: color-mix(in srgb, var(--color-surface, #0a0b12) 55%, transparent); backdrop-filter: blur(2px);
-}
-faros-provider-agents .agents-dialog {
-  width: min(520px, 100%); max-height: 88vh; overflow-y: auto;
-  display: flex; flex-direction: column; gap: 14px; padding: 20px; border-radius: 6px;
-  background: var(--color-surface-raised, #111320);
-  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
-  box-shadow: 0 1px 2px var(--color-surface), 0 24px 70px var(--color-surface);
-}
-faros-provider-agents .agents-dialog-head { display: flex; align-items: center; gap: 11px; }
-faros-provider-agents .agents-dialog-head h3 { margin: 0; font-size: 16px; font-weight: 650; }
-faros-provider-agents .agents-dialog-ic {
-  width: 34px; height: 34px; flex: none; display: grid; place-items: center; border-radius: 6px;
-  background: var(--color-accent-subtle); color: var(--color-accent, #8b6bff);
-}
-
 /* --- capability toggles (create wizard) --- */
 faros-provider-agents .agents-cap-fs { margin: 0; padding: 0; border: 0; display: flex; flex-direction: column; gap: 8px; }
 faros-provider-agents .agents-cap-fs legend {
@@ -322,11 +305,8 @@ faros-provider-agents .agents-kv > span { font-size: 10.5px; text-transform: upp
 faros-provider-agents .agents-timeline { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
 faros-provider-agents .agents-step {
   border-radius: 6px; overflow: hidden; border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
-  border-left: 3px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); background: var(--color-surface-raised, #111320);
+  background: var(--color-surface-raised, #111320);
 }
-faros-provider-agents .agents-step.is-ok { border-left-color: var(--color-success, #2fd6a0); }
-faros-provider-agents .agents-step.is-err { border-left-color: var(--color-danger, #ff5d5d); }
-faros-provider-agents .agents-step.is-wait { border-left-color: var(--color-warning, #f0a63a); }
 faros-provider-agents .agents-step-head {
   width: 100%; display: flex; align-items: center; gap: 10px; padding: 9px 12px; text-align: left;
   background: transparent; color: inherit; font: inherit; font-weight: 500; border-radius: 0;
@@ -403,10 +383,7 @@ faros-provider-agents .agents-toolcards { display: flex; flex-direction: column;
 faros-provider-agents .agents-toolcard {
   border-radius: 6px; overflow: hidden; background: var(--color-surface, #0a0b12);
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
-  border-left: 3px solid var(--color-accent, #8b6bff);
 }
-faros-provider-agents .agents-toolcard.is-ok { border-left-color: var(--color-success, #2fd6a0); }
-faros-provider-agents .agents-toolcard.is-err { border-left-color: var(--color-danger, #ff5d5d); }
 faros-provider-agents .agents-toolcard-head {
   width: 100%; display: flex; align-items: center; gap: 8px; padding: 6px 10px; text-align: left; border-radius: 0;
   background: transparent; color: var(--color-text-secondary, inherit); font: inherit; font-size: 12px; font-weight: 500;

--- a/providers/agents/portal/src/test/activity.test.ts
+++ b/providers/agents/portal/src/test/activity.test.ts
@@ -66,6 +66,26 @@ describe('activity list', () => {
     expect(text(row)).toContain('$0.0042')
   })
 
+  it('keeps run-row activation keyboard accessible without stealing nested controls', async () => {
+    const listRuns = vi.fn().mockResolvedValue({ items: [run()], nextCursor: '' })
+    const api = stubApi({ listRuns })
+    const el = await mount<Activity>('agents-activity', { store: makeStore(api), api })
+    const row = el.querySelector<HTMLElement>('.agents-run-row')!
+    const navigations: unknown[] = []
+    el.addEventListener('agents-navigate', (event) => navigations.push((event as CustomEvent).detail))
+
+    expect(row.getAttribute('role')).toBeNull()
+    row.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
+    expect(navigations).toEqual([{ kind: 'run', id: 'r1' }])
+
+    const nested = document.createElement('button')
+    nested.type = 'button'
+    row.querySelector('td')!.append(nested)
+    nested.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
+    nested.click()
+    expect(navigations).toEqual([{ kind: 'run', id: 'r1' }])
+  })
+
   it('reports a load failure instead of an empty state', async () => {
     const api = stubApi({ listRuns: () => Promise.reject(new Error('502 upstream error')) })
     const el = await mount<Activity>('agents-activity', { store: makeStore(api), api })
@@ -284,6 +304,27 @@ describe('run detail', () => {
     expect(text(el)).toContain('1 spawned worker')
     expect(text(el)).toContain('delegated')
     expect(text(el)).toContain('worker')
+  })
+
+  it('keeps child-row keyboard activation separate from nested controls', async () => {
+    const api = stubApi({
+      getRun: () => Promise.resolve(detail({ children: [run({ id: 'c1', agent: 'researcher' })] })),
+    })
+    const el = await mount<RunDetailView>('agents-run-detail', { store: makeStore(api), api, runID: 'r5' })
+    const row = el.querySelector<HTMLElement>('.agents-run-row')!
+    const navigations: unknown[] = []
+    el.addEventListener('agents-navigate', (event) => navigations.push((event as CustomEvent).detail))
+
+    expect(row.getAttribute('role')).toBeNull()
+    row.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }))
+    expect(navigations).toEqual([{ kind: 'run', id: 'c1' }])
+
+    const nested = document.createElement('button')
+    nested.type = 'button'
+    row.querySelector('td')!.append(nested)
+    nested.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }))
+    nested.click()
+    expect(navigations).toEqual([{ kind: 'run', id: 'c1' }])
   })
 
   it('shows the run answer and its sources', async () => {

--- a/providers/agents/portal/src/test/agents-list.test.ts
+++ b/providers/agents/portal/src/test/agents-list.test.ts
@@ -1,9 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import '../views/agents-list'
 import { agentFixture, makeStore, mount, settle, stubApi, text } from './helpers'
 
-describe('agents list card keyboard behavior', () => {
-  it('does not let nested action keys activate the card route', async () => {
+describe('agents list card semantics', () => {
+  it('uses a native primary link and keeps explicit actions independent', async () => {
     const api = stubApi()
     const store = makeStore(api)
     store.agents.data = [agentFixture('scout')]
@@ -16,10 +18,23 @@ describe('agents list card keyboard behavior', () => {
     })
 
     const card = el.querySelector<HTMLElement>('.agents-card')
+    const link = el.querySelector<HTMLAnchorElement>('.agents-card-link')
     const runs = [...el.querySelectorAll<HTMLButtonElement>('button')]
       .find((button) => button.textContent?.includes('Runs'))
     expect(card).toBeTruthy()
+    expect(link).toBeTruthy()
     expect(runs).toBeTruthy()
+    const remove = el.querySelector<HTMLButtonElement>('button[aria-label="Delete agent scout"]')
+    expect(card!.getAttribute('role')).toBeNull()
+    expect(card!.getAttribute('tabindex')).toBeNull()
+    expect(link!.getAttribute('href')).toBe('#/agents/scout/config')
+    expect(remove).not.toBeNull()
+    expect(remove!.classList.contains('k-icon-action')).toBe(true)
+    // Keep the provider-local 28px icon recipe off this control: it would
+    // override PortalKit's square action and its 44px coarse-pointer target.
+    expect(remove!.classList.contains('agents-iconbtn')).toBe(false)
+    const sharedStyles = readFileSync(resolve(process.cwd(), 'src/portalkit/faros-ui.css'), 'utf8')
+    expect(sharedStyles).toMatch(/@media \(pointer: coarse\), \(any-pointer: coarse\)[\s\S]*?\.k-icon-action\s*\{[\s\S]*?flex-basis:\s*44px;[\s\S]*?height:\s*44px;[\s\S]*?width:\s*44px;/)
 
     runs!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
     expect(navigations).toEqual([])
@@ -28,8 +43,10 @@ describe('agents list card keyboard behavior', () => {
     await settle(el)
     expect(navigations).toEqual([{ kind: 'agent', name: 'scout', tab: 'runs' }])
 
+    // The card itself is a structural container now; only its real link owns
+    // primary navigation, so keyboard events on the article cannot trigger it.
     card!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }))
-    expect(navigations.at(-1)).toEqual({ kind: 'agent', name: 'scout', tab: 'config' })
+    expect(navigations).toEqual([{ kind: 'agent', name: 'scout', tab: 'runs' }])
   })
 })
 

--- a/providers/agents/portal/src/test/assisted-setup.test.ts
+++ b/providers/agents/portal/src/test/assisted-setup.test.ts
@@ -25,8 +25,20 @@ async function mountConnections(caps: Capabilities, agents = [agentFixture('scou
   // The assist card waits for connections before deciding whether to show, so
   // an unloaded slice means "not yet", not "none".
   store.connections.loaded = true
-  const el = await mount<Connections>('agents-connections', { store, api })
+  const el = await mount<Connections>('agents-connections', { store, api, routeOwned: true })
   return { el, store, api }
+}
+
+async function mountAssistedPage(
+  caps: Capabilities,
+  agents = [agentFixture('scout')],
+  extra: Record<string, unknown> = {},
+) {
+  const result = await mountConnections(caps, agents, extra)
+  result.el.createRoute = true
+  result.el.createType = 'assisted-search'
+  await settle(result.el, 3)
+  return result
 }
 
 // localStorage carries the manual dismissal, and jsdom keeps it between tests.
@@ -178,22 +190,31 @@ describe('composed prompt', () => {
 })
 
 describe('assisted setup flow', () => {
+  it('renders setup as a route-owned page with no modal fallback', async () => {
+    const { el } = await mountAssistedPage({ providers: ['infrastructure'] })
+
+    expect(el.querySelector('.agents-create-page')).not.toBeNull()
+    expect(el.querySelector('.agents-conn-form')).not.toBeNull()
+    expect(el.querySelector('.agents-overlay')).toBeNull()
+    expect(el.querySelector('[role="dialog"]')).toBeNull()
+  })
+
   it('creates the connection naming the instance, hands off the prompt and navigates to the agent', async () => {
     const createConnection = vi.fn().mockResolvedValue({ metadata: { name: 'search' }, spec: { type: 'websearch' } })
-    const { el, store } = await mountConnections({ providers: ['infrastructure'] }, [agentFixture('scout')], { createConnection })
-    const routes: Route[] = []
-    document.addEventListener('agents-navigate', (e) => routes.push((e as CustomEvent<Route>).detail))
+    const { el, store } = await mountAssistedPage({ providers: ['infrastructure'] }, [agentFixture('scout')], { createConnection })
+    let destination: Route | undefined
+    el.addEventListener('agents-create-success', (e) => {
+      destination = (e as CustomEvent<{ destination?: Route }>).detail.destination
+    })
 
-    el.querySelector<HTMLButtonElement>('.agents-assist button')!.click()
-    await settle(el, 4)
-    const dialog = el.querySelector<HTMLFormElement>('.agents-dialog')!
+    const form = el.querySelector<HTMLFormElement>('.agents-conn-form')!
     // A single agent means no picker at all.
-    expect(dialog.querySelector('select')).toBeNull()
-    expect(dialog.querySelector<HTMLInputElement>('input[name=connName]')!.value).toBe('search')
+    expect(form.querySelector('select')).toBeNull()
+    expect(form.querySelector<HTMLInputElement>('input[name=connName]')!.value).toBe('search')
     // The instance name defaults to the connection name.
-    expect(dialog.querySelector<HTMLInputElement>('input[name=instance]')!.value).toBe('search')
+    expect(form.querySelector<HTMLInputElement>('input[name=instance]')!.value).toBe('search')
 
-    dialog.dispatchEvent(new Event('submit', { cancelable: true }))
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
     await settle(el, 6)
 
     expect(createConnection).toHaveBeenCalledTimes(1)
@@ -204,7 +225,7 @@ describe('assisted setup flow', () => {
     expect(body.baseURL).toBeUndefined()
     expect(body.secret).toBeUndefined()
 
-    expect(routes).toEqual([{ kind: 'agent', name: 'scout', tab: 'config' }])
+    expect(destination).toEqual({ kind: 'agent', name: 'scout', tab: 'config' })
     const handed = store.takePendingPrompt('scout')
     expect(handed).toContain('name: `search`')
   })
@@ -216,11 +237,9 @@ describe('assisted setup flow', () => {
     const patchAgent = vi.fn().mockResolvedValue({ metadata: { name: 'scout' }, spec: {} })
     const agent = agentFixture('scout')
     agent.spec.tools = { interactive: { connections: ['gh'] } }
-    const { el } = await mountConnections({ providers: ['infrastructure'] }, [agent], { createConnection, patchAgent })
+    const { el } = await mountAssistedPage({ providers: ['infrastructure'] }, [agent], { createConnection, patchAgent })
 
-    el.querySelector<HTMLButtonElement>('.agents-assist button')!.click()
-    await settle(el, 4)
-    el.querySelector<HTMLFormElement>('.agents-dialog')!.dispatchEvent(new Event('submit', { cancelable: true }))
+    el.querySelector<HTMLFormElement>('.agents-conn-form')!.dispatchEvent(new Event('submit', { cancelable: true }))
     await settle(el, 6)
 
     expect(patchAgent).toHaveBeenCalledTimes(1)
@@ -238,14 +257,12 @@ describe('assisted setup flow', () => {
   it('still hands off when wiring the agent fails', async () => {
     const createConnection = vi.fn().mockResolvedValue({ metadata: { name: 'search' }, spec: { type: 'websearch' } })
     const patchAgent = vi.fn().mockRejectedValue(new Error('nope'))
-    const { el, store } = await mountConnections({ providers: ['infrastructure'] }, [agentFixture('scout')], {
+    const { el, store } = await mountAssistedPage({ providers: ['infrastructure'] }, [agentFixture('scout')], {
       createConnection,
       patchAgent,
     })
 
-    el.querySelector<HTMLButtonElement>('.agents-assist button')!.click()
-    await settle(el, 4)
-    el.querySelector<HTMLFormElement>('.agents-dialog')!.dispatchEvent(new Event('submit', { cancelable: true }))
+    el.querySelector<HTMLFormElement>('.agents-conn-form')!.dispatchEvent(new Event('submit', { cancelable: true }))
     await settle(el, 6)
 
     expect(store.takePendingPrompt('scout')).toContain('searxng')
@@ -253,14 +270,12 @@ describe('assisted setup flow', () => {
 
   it('rejects names that are not DNS labels before touching the API', async () => {
     const createConnection = vi.fn()
-    const { el } = await mountConnections({ providers: ['infrastructure'] }, [agentFixture('scout')], { createConnection })
-    el.querySelector<HTMLButtonElement>('.agents-assist button')!.click()
-    await settle(el, 4)
+    const { el } = await mountAssistedPage({ providers: ['infrastructure'] }, [agentFixture('scout')], { createConnection })
 
     const input = el.querySelector<HTMLInputElement>('input[name=connName]')!
     input.value = 'Search Me'
     input.dispatchEvent(new Event('input'))
-    el.querySelector<HTMLFormElement>('.agents-dialog')!.dispatchEvent(new Event('submit', { cancelable: true }))
+    el.querySelector<HTMLFormElement>('.agents-conn-form')!.dispatchEvent(new Event('submit', { cancelable: true }))
     await settle(el, 4)
 
     expect(createConnection).not.toHaveBeenCalled()

--- a/providers/agents/portal/src/test/authority-races.test.ts
+++ b/providers/agents/portal/src/test/authority-races.test.ts
@@ -136,13 +136,19 @@ describe('assisted-search authority capture', () => {
     store.capabilities.data = { providers: ['infrastructure'] }
     store.capabilities.loaded = true
     store.connections.loaded = true
-    const el = await mount('agents-connections', { store, api })
-    const routes: unknown[] = []
-    document.addEventListener('agents-navigate', (e) => routes.push((e as CustomEvent).detail), { once: true })
+    const el = await mount('agents-connections', {
+      store,
+      api,
+      routeOwned: true,
+      createRoute: true,
+      createType: 'assisted-search',
+    })
+    let destination: unknown
+    el.addEventListener('agents-create-success', (e) => {
+      destination = (e as CustomEvent<{ destination?: unknown }>).detail.destination
+    })
 
-    el.querySelector<HTMLButtonElement>('.agents-assist button')!.click()
-    await settle(el)
-    const form = el.querySelector<HTMLFormElement>('.agents-dialog')!
+    const form = el.querySelector<HTMLFormElement>('.agents-conn-form')!
     const agent = form.querySelector<HTMLSelectElement>('select')!
     const conn = form.querySelector<HTMLInputElement>('input[name=connName]')!
     const instance = form.querySelector<HTMLInputElement>('input[name=instance]')!
@@ -182,7 +188,7 @@ describe('assisted-search authority capture', () => {
     expect(patchAgent).toHaveBeenCalledTimes(1)
     expect(patchAgent.mock.calls[0][0]).toBe('scout')
     expect(patchAgent.mock.calls[0][1].interactiveConnections).toEqual(['search-old'])
-    expect(routes).toEqual([{ kind: 'agent', name: 'scout', tab: 'config' }])
+    expect(destination).toEqual({ kind: 'agent', name: 'scout', tab: 'config' })
     expect(store.takePendingPrompt('scout')).toContain('name: `searxng-old`')
     expect(store.takePendingPrompt('scout')).toBeNull()
     expect(store.takePendingPrompt('rover')).toBeNull()

--- a/providers/agents/portal/src/test/config.test.ts
+++ b/providers/agents/portal/src/test/config.test.ts
@@ -26,6 +26,16 @@ function sectionButton(el: AgentConfig, label: string): HTMLButtonElement {
 }
 
 describe('agent config', () => {
+  it('uses the canonical square action for removing a model fallback', async () => {
+    const { el } = await mountConfig({ models: { chat: 'main' }, modelFallbacks: ['backup'] })
+    const remove = el.querySelector<HTMLButtonElement>('.agents-chip-x')!
+
+    expect(remove).not.toBeNull()
+    expect(remove.classList.contains('k-icon-action')).toBe(true)
+    expect(remove.type).toBe('button')
+    expect(remove.getAttribute('aria-label')).toBe('Remove fallback backup')
+  })
+
   it('saves an editable description with the persona section', async () => {
     const { el, patchAgent } = await mountConfig({ description: 'watches the deploy queue' })
     const inputs = [...el.querySelectorAll<HTMLInputElement>('input')]
@@ -216,18 +226,19 @@ describe('web + fan-out capability warnings', () => {
 // two toggles and the same words.
 describe('agent creation capabilities', () => {
   async function mountCreate() {
-    const api = stubApi({})
+    const createAgent = vi.fn().mockResolvedValue({ metadata: { name: 'scout' }, spec: {} })
+    const api = stubApi({ createAgent })
     const store = makeStore(api)
     store.credentials.data = [{ name: 'main', model: 'gpt-5' }] as never
     const el = await mount<AgentCreateWizard>('agents-agent-create', { store, api })
     await settle(el, 3)
-    return el
+    return { el, createAgent }
   }
 
   const caps = (el: AgentCreateWizard) => [...el.querySelectorAll<HTMLInputElement>('.agents-cap input[type=checkbox]')]
 
   it('offers capabilities, not agent templates', async () => {
-    const el = await mountCreate()
+    const { el } = await mountCreate()
     expect(text(el)).not.toContain('Research agent')
     expect(text(el)).not.toContain('Blank agent')
     expect(text(el)).toContain('Read the web')
@@ -239,12 +250,12 @@ describe('agent creation capabilities', () => {
   // job is the prompt field's own label. If that ever goes back to asking for
   // mechanics, the capability has stopped being self-sufficient.
   it('asks the prompt for persona, not mechanics', async () => {
-    const el = await mountCreate()
+    const { el } = await mountCreate()
     expect(text(el)).toContain('not mechanics')
   })
 
   it('puts capabilities last, after the fields you must fill in', async () => {
-    const el = await mountCreate()
+    const { el } = await mountCreate()
     const body = text(el)
     // Name and model are required; capabilities are optional extras and should
     // not lead the form.
@@ -253,9 +264,7 @@ describe('agent creation capabilities', () => {
   })
 
   it('sends only the families that were ticked', async () => {
-    const el = await mountCreate()
-    let sent: Record<string, unknown> | null = null
-    el.addEventListener('agents-create', (e) => (sent = (e as CustomEvent).detail))
+    const { el, createAgent } = await mountCreate()
 
     const nameInput = el.querySelector<HTMLInputElement>('input[name=name]')!
     nameInput.value = 'scout'
@@ -274,16 +283,14 @@ describe('agent creation capabilities', () => {
     el.querySelector<HTMLFormElement>('form')!.dispatchEvent(new Event('submit'))
     await settle(el, 3)
 
-    expect(sent).toBeTruthy()
-    expect(sent!.interactiveFamilies).toEqual(['core', 'web', 'spawn'])
+    const sent = createAgent.mock.calls[0][0] as Record<string, unknown>
+    expect(sent.interactiveFamilies).toEqual(['core', 'web', 'spawn'])
     // No prompt is invented on the user's behalf.
     expect(sent!.systemPrompt).toBeUndefined()
   })
 
   it('omits families entirely when nothing is ticked', async () => {
-    const el = await mountCreate()
-    let sent: Record<string, unknown> | null = null
-    el.addEventListener('agents-create', (e) => (sent = (e as CustomEvent).detail))
+    const { el, createAgent } = await mountCreate()
     const nameInput = el.querySelector<HTMLInputElement>('input[name=name]')!
     nameInput.value = 'plain'
     nameInput.dispatchEvent(new Event('input'))
@@ -293,6 +300,7 @@ describe('agent creation capabilities', () => {
     await settle(el, 3)
     el.querySelector<HTMLFormElement>('form')!.dispatchEvent(new Event('submit'))
     await settle(el, 3)
+    const sent = createAgent.mock.calls[0][0] as Record<string, unknown>
     expect(sent!.interactiveFamilies).toBeUndefined()
   })
 })

--- a/providers/agents/portal/src/test/create-routes.test.ts
+++ b/providers/agents/portal/src/test/create-routes.test.ts
@@ -16,12 +16,13 @@ describe('route-owned creation surfaces', () => {
     const api = stubApi({ createAgent })
     const store = makeStore(api)
     store.credentials.data = [{ name: 'main', model: 'gpt-5' }]
-    const el = await mount<AgentCreateWizard>('agents-agent-create', { store, api, routeOwned: true })
+    const el = await mount<AgentCreateWizard>('agents-agent-create', { store, api })
     let result: unknown
     el.addEventListener('agents-create-success', (e) => (result = (e as CustomEvent).detail))
 
     expect(el.querySelector('.agents-overlay')).toBeNull()
     expect(el.querySelector('.agents-create-page')).not.toBeNull()
+    expect(el.querySelector('[role="dialog"]')).toBeNull()
     el.querySelector<HTMLInputElement>('input[name=name]')!.value = 'nova'
     el.querySelector<HTMLInputElement>('input[name=name]')!.dispatchEvent(new Event('input'))
     const model = el.querySelector('select') as HTMLSelectElement

--- a/providers/agents/portal/src/views/activity.ts
+++ b/providers/agents/portal/src/views/activity.ts
@@ -308,13 +308,23 @@ export class Activity extends StoreElement {
 
   private row(r: RunSummary): TemplateResult {
     const open = (): void => this.navigate({ kind: 'run', id: r.id })
+    const isNestedControl = (event: Event): boolean => {
+      const currentTarget = event.currentTarget as Element | null
+      const target = event.target as Element | null
+      const control = target?.closest?.(
+        'a, button, input, select, textarea, summary, [contenteditable="true"], [role="button"], [role="link"]',
+      )
+      return Boolean(control && control !== currentTarget)
+    }
     return html`<tr
       class="agents-run-row"
       tabindex="0"
-      role="link"
       aria-label="Open run ${r.id}"
-      @click=${open}
+      @click=${(e: Event) => {
+        if (!isNestedControl(e)) open()
+      }}
       @keydown=${(e: KeyboardEvent) => {
+        if (isNestedControl(e)) return
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
           open()

--- a/providers/agents/portal/src/views/agent-config.ts
+++ b/providers/agents/portal/src/views/agent-config.ts
@@ -179,8 +179,9 @@ export class AgentConfig extends StoreElement {
                 (f, i) => html`<span class="agents-chip"
                   >${f}
                   <button
-                    class="k-btn k-btn--ghost agents-chip-x"
+                    class="k-icon-action agents-chip-x"
                     aria-label="Remove fallback ${f}"
+                    type="button"
                     @click=${() => (this.fallbacks = this.fallbacks.filter((_, j) => j !== i))}
                   >
                     ${icon('x')}

--- a/providers/agents/portal/src/views/agent-create.ts
+++ b/providers/agents/portal/src/views/agent-create.ts
@@ -5,7 +5,7 @@
 // things everyone sets.
 
 import { html, nothing, type TemplateResult } from 'lit'
-import { property, state } from 'lit/decorators.js'
+import { state } from 'lit/decorators.js'
 import { StoreElement } from '../ui/base'
 import { icon } from '../ui/icon'
 import { mutate } from '../mutate'
@@ -15,10 +15,6 @@ import type { AgentCreate } from '../types'
 const NAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 
 export class AgentCreateWizard extends StoreElement {
-  // Route-owned creation renders as a normal page surface. The default keeps
-  // the standalone element compatible with older embedders/tests that still
-  // open the compact dialog directly.
-  @property({ type: Boolean }) routeOwned = false
   @state() private name = ''
   @state() private modelCredential = ''
   @state() private systemPrompt = ''
@@ -56,11 +52,6 @@ export class AgentCreateWizard extends StoreElement {
     if (this.web) fams.push('web')
     if (this.fanOut) fams.push('spawn')
     if (fams.length > 1) body.interactiveFamilies = fams
-    if (!this.routeOwned) {
-      this.dispatchEvent(new CustomEvent<AgentCreate>('agents-create', { detail: body }))
-      return
-    }
-
     this.busy = true
     const res = await mutate(this.store, {
       run: () => this.api.createAgent(body),
@@ -80,29 +71,18 @@ export class AgentCreateWizard extends StoreElement {
   }
 
   private cancel(): void {
-    if (this.routeOwned) {
-      this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
-      return
-    }
-    this.dispatchEvent(new CustomEvent('agents-cancel'))
+    this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
   }
 
   render(): TemplateResult {
     const creds = this.store.credentials.data
     const channels = this.store.channelConnections()
     const form = html`<form
-      class=${this.routeOwned ? 'agents-create-form k-create-surface' : 'agents-dialog'}
-      role=${this.routeOwned ? nothing : 'dialog'}
-      aria-modal=${this.routeOwned ? nothing : 'true'}
+      class="agents-create-form k-create-surface"
       aria-label="Create agent"
       @submit=${(e: Event) => void this.submit(e)}
     >
-        ${this.routeOwned ? nothing : html`<header class="agents-dialog-head">
-          <span class="agents-dialog-ic">${icon('bot')}</span>
-          <h3>New agent</h3>
-        </header>`}
-
-        <div class=${this.routeOwned ? 'k-create-body' : ''}>
+        <div class="k-create-body">
         <label>
           Name *
           <input class="k-input"
@@ -176,22 +156,16 @@ export class AgentCreateWizard extends StoreElement {
         </fieldset>
         </div>
 
-        <div class=${this.routeOwned ? 'k-create-actions' : 'agents-form-actions'}>
+        <div class="k-create-actions">
           <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancel()}>Cancel</button>
           <button class="k-btn k-btn--primary" type="submit">${icon('check')} Create agent</button>
         </div>
       </form>`
-    return this.routeOwned
-      ? html`<div class="agents-create-page k-create-page">
-          <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancel()}>${icon('arrow-left')} Agents</button>
-          <header class="k-create-header"><h1 class="k-create-title">Create agent</h1><p class="k-create-description">Choose the model, instructions, and optional channel this agent starts with.</p></header>
-          ${form}
-        </div>`
-      : html`<div
-          class="agents-overlay"
-          @click=${(e: Event) => e.target === e.currentTarget && this.cancel()}
-          @keydown=${(e: KeyboardEvent) => e.key === 'Escape' && this.cancel()}
-        >${form}</div>`
+    return html`<div class="agents-create-page k-create-page">
+      <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancel()}>${icon('arrow-left')} Agents</button>
+      <header class="k-create-header"><h1 class="k-create-title">Create agent</h1><p class="k-create-description">Choose the model, instructions, and optional channel this agent starts with.</p></header>
+      ${form}
+    </div>`
   }
 }
 

--- a/providers/agents/portal/src/views/agents-list.ts
+++ b/providers/agents/portal/src/views/agents-list.ts
@@ -11,10 +11,7 @@ import { sliceView } from '../ui/states'
 import { confirmModal } from '../portalkit/modal'
 import { mutate } from '../mutate'
 import type { Agent } from '../types'
-
-// Keep the element registration available to standalone consumers that import
-// only the list view; the shell also imports the route surface explicitly.
-import './agent-create'
+import { hashFor } from '../router'
 
 export class AgentsList extends StoreElement {
   private async del(name: string): Promise<void> {
@@ -67,46 +64,27 @@ export class AgentsList extends StoreElement {
     const chans = a.spec?.channels || []
     const primary = chans.find((ch) => ch.primary) || chans[0]
     const chan = primary ? primary.connectionRef + (chans.length > 1 ? ` +${chans.length - 1}` : '') : ''
-    const open = (): void => this.navigate({ kind: 'agent', name, tab: 'config' })
-    const isNestedControl = (event: KeyboardEvent): boolean => {
-      const currentTarget = event.currentTarget as Element | null
-      const target = event.target as Element | null
-      const control = target?.closest?.(
-        'a, button, input, select, textarea, summary, [contenteditable="true"], [role="button"], [role="link"]',
-      )
-      return Boolean(control && control !== currentTarget)
-    }
+    const agentRoute = hashFor({ kind: 'agent', name, tab: 'config' })
     return html`
-      <article
-        class="agents-card k-card"
-        tabindex="0"
-        role="link"
-        aria-label="Open agent ${a.spec?.displayName || name}"
-        @click=${open}
-        @keydown=${(e: KeyboardEvent) => {
-          if (isNestedControl(e)) return
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            open()
-          }
-        }}
-      >
-        <div class="agents-card-glyph">${icon('bot')}</div>
-        <div class="agents-card-body">
-          <h3>${a.spec?.displayName || name}</h3>
-          <p class="agents-card-model ${model ? '' : 'warn'}">${model || 'no model — pick one in Config'}</p>
-        </div>
-        <div class="agents-card-foot">
-          <span>${nsched} schedule${nsched === 1 ? '' : 's'}</span>
-          <span>${ntrig} trigger${ntrig === 1 ? '' : 's'}</span>
-          <span>${chan ? html`${icon('megaphone')} ${chan}` : 'no channel'}</span>
-        </div>
+      <article class="agents-card k-card">
+        <a class="agents-card-link" href=${agentRoute} aria-label="Open agent ${a.spec?.displayName || name}">
+          <div class="agents-card-glyph">${icon('bot')}</div>
+          <div class="agents-card-body">
+            <h3>${a.spec?.displayName || name}</h3>
+            <p class="agents-card-model ${model ? '' : 'warn'}">${model || 'no model — pick one in Config'}</p>
+          </div>
+          <div class="agents-card-foot">
+            <span>${nsched} schedule${nsched === 1 ? '' : 's'}</span>
+            <span>${ntrig} trigger${ntrig === 1 ? '' : 's'}</span>
+            <span>${chan ? html`${icon('megaphone')} ${chan}` : 'no channel'}</span>
+          </div>
+        </a>
         <div class="agents-card-actions">
           <button
             class="k-btn k-btn--ghost agents-card-chat"
             @click=${(e: Event) => {
               e.stopPropagation()
-              open()
+              this.navigate({ kind: 'agent', name, tab: 'config' })
             }}
           >
             ${icon('message')} Open
@@ -121,7 +99,7 @@ export class AgentsList extends StoreElement {
             ${icon('gauge')} Runs
           </button>
           <button
-            class="k-btn k-btn--ghost agents-iconbtn agents-iconbtn-danger"
+            class="k-icon-action agents-iconbtn-danger"
             aria-label="Delete agent ${name}"
             title="Delete agent"
             @click=${(e: Event) => {

--- a/providers/agents/portal/src/views/assisted-search.ts
+++ b/providers/agents/portal/src/views/assisted-search.ts
@@ -33,9 +33,7 @@ import { familiesForConns } from '../conn-defs'
 import type { ConnectionWrite } from '../types'
 
 export class AssistedSearch extends StoreElement {
-  @property({ type: Boolean }) routeOwned = false
   @property({ type: Boolean }) page = false
-  @state() private open = false
   @state() private agent = ''
   @state() private connName = 'search'
   @state() private instance = ''
@@ -47,23 +45,9 @@ export class AssistedSearch extends StoreElement {
   // they do it mirrors the connection name, which is the default the two share.
   private instanceTouched = false
 
-  private start(): void {
-    this.open = true
-    this.agent = this.store.agents.data[0]?.metadata.name || ''
-    this.connName = 'search'
-    this.instance = ''
-    this.instanceTouched = false
-    this.size = 'small'
-    this.errors = {}
-  }
-
   private cancel(): void {
     if (this.busy) return
-    if (this.routeOwned || this.page) {
-      this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
-      return
-    }
-    this.open = false
+    this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
   }
 
   private selectedAgent(): string {
@@ -125,28 +109,21 @@ export class AssistedSearch extends StoreElement {
       if (!this.authorityIsCurrent(authority)) return
 
       authority.store.setPendingPrompt(agent, searxngSetupPrompt({ connection: conn, instance: inst, size }))
-      if (this.routeOwned || this.page) {
-        this.dispatchEvent(
-          new CustomEvent<CreateSuccessDetail>('agents-create-success', {
-            detail: {
-              resource: 'connection',
-              name: conn,
-              item: res,
-              // Assisted setup intentionally keeps its existing handoff: the
-              // agent's Config/chat surface is where the provisioning prompt is
-              // actionable and visible.
-              destination: { kind: 'agent', name: agent, tab: 'config' },
-            },
-            bubbles: true,
-            composed: true,
-          }),
-        )
-      } else {
-        this.open = false
-        // The chat playground lives in the agent's Config pane (right-hand split),
-        // so that is where "go to its chat" lands.
-        this.navigate({ kind: 'agent', name: agent, tab: 'config' })
-      }
+      this.dispatchEvent(
+        new CustomEvent<CreateSuccessDetail>('agents-create-success', {
+          detail: {
+            resource: 'connection',
+            name: conn,
+            item: res,
+            // Assisted setup intentionally keeps its existing handoff: the
+            // agent's Config/chat surface is where the provisioning prompt is
+            // actionable and visible.
+            destination: { kind: 'agent', name: agent, tab: 'config' },
+          },
+          bubbles: true,
+          composed: true,
+        }),
+      )
     } finally {
       this.busy = false
     }
@@ -190,7 +167,7 @@ export class AssistedSearch extends StoreElement {
       if (selfHostedSearchConfigured(this.store.connections.data)) {
         return html`<div class="agents-panel k-card agents-route-panel"><p class="muted">Self-hosted search is already configured in this workspace.</p></div>`
       }
-      return this.dialog()
+      return this.createPage()
     }
     // Both gates matter: no infrastructure tools means the agent cannot
     // provision anything, no agents means there is nobody to ask.
@@ -201,7 +178,7 @@ export class AssistedSearch extends StoreElement {
     if (!this.store.connections.loaded) return html`${nothing}`
     if (selfHostedSearchConfigured(this.store.connections.data)) return html`${nothing}`
     if (this.dismissed) return html`${nothing}`
-    return html`${this.card()}${this.open ? this.dialog() : nothing}`
+    return html`${this.card()}`
   }
 
   // dismissed mirrors the stored flag. Held in @state so dismissing re-renders
@@ -225,7 +202,7 @@ export class AssistedSearch extends StoreElement {
       <button
         type="button"
         class="k-btn k-btn--ghost secondary"
-        @click=${() => (this.routeOwned ? this.navigate({ kind: 'create', resource: 'connection', type: 'assisted-search' }) : this.start())}
+        @click=${() => this.navigate({ kind: 'create', resource: 'connection', type: 'assisted-search' })}
       >Set it up</button>
       <button
         type="button"
@@ -239,21 +216,15 @@ export class AssistedSearch extends StoreElement {
     </div>`
   }
 
-  private dialog(): TemplateResult {
+  private createPage(): TemplateResult {
     const agents = this.store.agents.data
     const selected = this.selectedAgent()
     const form = html`<form
-        class=${this.page ? 'agents-conn-form k-create-surface' : 'agents-dialog'}
-        role=${this.page ? nothing : 'dialog'}
-        aria-modal=${this.page ? nothing : 'true'}
+        class="agents-conn-form k-create-surface"
         aria-label="Assisted search setup"
         @submit=${(e: Event) => void this.submit(e)}
       >
-        ${this.page ? nothing : html`<header class="agents-dialog-head">
-          <span class="agents-dialog-ic">${icon('sparkles')}</span>
-          <h3>Self-hosted search, set up for you</h3>
-        </header>`}
-        <div class=${this.page ? 'k-create-body' : ''}>
+        <div class="k-create-body">
         <p class="muted">
           We create the web-search connection pointing at an instance name, then your agent provisions the <code>searxng</code>
           instance itself. Nothing to paste back: agents reach it over the platform's internal path, so it is never published and
@@ -331,22 +302,16 @@ export class AssistedSearch extends StoreElement {
         </label>
         </div>
 
-        <div class=${this.page ? 'k-create-actions' : 'agents-form-actions'}>
+        <div class="k-create-actions">
           <button type="button" ?disabled=${this.busy} class="k-btn k-btn--ghost secondary" @click=${() => this.cancel()}>Cancel</button>
           <button class="k-btn k-btn--primary" type="submit" ?disabled=${this.busy}>${icon('sparkles')} Create and hand off</button>
         </div>
       </form>`
-    return this.page
-      ? html`<div class="agents-create-page k-create-page">
-          <button type="button" ?disabled=${this.busy} class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancel()}>${icon('arrow-left')} Connections</button>
-          <header class="k-create-header"><h1 class="k-create-title">Set up assisted search</h1><p class="k-create-description">Create a private search connection and let an agent provision the supporting service.</p></header>
-          ${form}
-        </div>`
-      : html`<div
-          class="agents-overlay"
-          @click=${(e: Event) => e.target === e.currentTarget && this.cancel()}
-          @keydown=${(e: KeyboardEvent) => e.key === 'Escape' && this.cancel()}
-        >${form}</div>`
+    return html`<div class="agents-create-page k-create-page">
+      <button type="button" ?disabled=${this.busy} class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancel()}>${icon('arrow-left')} Connections</button>
+      <header class="k-create-header"><h1 class="k-create-title">Set up assisted search</h1><p class="k-create-description">Create a private search connection and let an agent provision the supporting service.</p></header>
+      ${form}
+    </div>`
   }
 }
 

--- a/providers/agents/portal/src/views/connections.ts
+++ b/providers/agents/portal/src/views/connections.ts
@@ -191,7 +191,7 @@ export class Connections extends StoreElement {
           ${this.routeOwned
             ? this.editing
               ? this.editorArea()
-              : html`<agents-assisted-search .store=${this.store} .api=${this.api} .routeOwned=${true}></agents-assisted-search>`
+              : html`<agents-assisted-search .store=${this.store} .api=${this.api}></agents-assisted-search>`
             : this.editorArea()}
         </div>
         <agents-toolsets .store=${this.store} .api=${this.api} .routeOwned=${this.routeOwned}></agents-toolsets>
@@ -211,7 +211,7 @@ export class Connections extends StoreElement {
     }
     if (this.createType === 'assisted-search') {
       return html`<div class="agents-menu agents-create-page">
-        <agents-assisted-search .store=${this.store} .api=${this.api} .routeOwned=${true} .page=${true}></agents-assisted-search>
+        <agents-assisted-search .store=${this.store} .api=${this.api} .page=${true}></agents-assisted-search>
       </div>`
     }
     const def = CONN_DEFS.find((d) => d.id === this.createType)
@@ -352,7 +352,7 @@ export class Connections extends StoreElement {
           <h5 class="agents-conn-grouphead">${icon(m.icon)} ${m.label}s <span class="muted">— ${m.blurb}</span></h5>
           <div class="agents-conn-types">${defs.map(tile)}</div>
           ${cat === 'tool'
-            ? html`<agents-assisted-search .store=${this.store} .api=${this.api} .routeOwned=${this.routeOwned}></agents-assisted-search>`
+            ? html`<agents-assisted-search .store=${this.store} .api=${this.api}></agents-assisted-search>`
             : nothing}
         </div>`
       })}

--- a/providers/agents/portal/src/views/run-detail.ts
+++ b/providers/agents/portal/src/views/run-detail.ts
@@ -17,6 +17,15 @@ import { phaseChip } from './activity'
 
 const LIVE_PHASES = new Set(['Pending', 'Running', 'PendingApproval'])
 
+function isNestedControl(event: Event): boolean {
+  const currentTarget = event.currentTarget as Element | null
+  const target = event.target as Element | null
+  const control = target?.closest?.(
+    'a, button, input, select, textarea, summary, [contenteditable="true"], [role="button"], [role="link"]',
+  )
+  return Boolean(control && control !== currentTarget)
+}
+
 export class RunDetailView extends StoreElement {
   @property({ type: String }) runID = ''
 
@@ -357,9 +366,12 @@ export class RunDetailView extends StoreElement {
             <tr><th>Agent</th><th>Kind</th><th>Input</th><th>Phase</th><th>Duration</th><th>Usage</th></tr>
           </thead>
           <tbody>
-            ${r.children.map((c: RunSummary) => html`<tr class="agents-run-row" tabindex="0" role="link" aria-label="Open run ${c.id}"
-              @click=${() => this.navigate({ kind: 'run', id: c.id })}
+            ${r.children.map((c: RunSummary) => html`<tr class="agents-run-row" tabindex="0" aria-label="Open run ${c.id}"
+              @click=${(e: Event) => {
+                if (!isNestedControl(e)) this.navigate({ kind: 'run', id: c.id })
+              }}
               @keydown=${(e: KeyboardEvent) => {
+                if (isNestedControl(e)) return
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault()
                   this.navigate({ kind: 'run', id: c.id })


### PR DESCRIPTION
Stack: 9 of 10 in Fluid-Shell 4K Conformance and Provider UI Hardening.

Depends on the Databricks detail-actions PR.

Summary:
- Removes unused modal creation fallbacks and retains route-owned creation.
- Replaces pseudo-link cards and role-link rows with native links and explicit controls.
- Standardizes chip removal and semantic status treatments.
- Keeps the collection grid fluid with a deliberate 20rem minimum card width.

Verification:
- Agents portal tests
- Typecheck and production build
- Creation-flow and UI conformance gates
- git diff --check