### PR TITLE
Bound Quickstart comparison layouts

### DIFF
--- a/providers/quickstart/portal/package.json
+++ b/providers/quickstart/portal/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite",
+    "test": "node --test src/quickstartLayout.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/providers/quickstart/portal/src/element.ts
+++ b/providers/quickstart/portal/src/element.ts
@@ -70,7 +70,7 @@ export class QuickstartElement extends HTMLElement {
             </span>
           </div>
           <p class="quickstart-meta">Context delivered by the shell as a JS property — no postMessage shuttle.</p>
-          <pre class="k-card quickstart-dump ${ctx ? '' : 'quickstart-muted'}" id="ctx-dump">${escapeHTML(ctxDump)}</pre>
+          <pre class="quickstart-dump ${ctx ? '' : 'quickstart-muted'}" id="ctx-dump">${escapeHTML(ctxDump)}</pre>
         </section>
 
         <section class="k-card quickstart-panel">
@@ -79,7 +79,7 @@ export class QuickstartElement extends HTMLElement {
             <span class="k-badge k-badge--warning" id="api-status" role="status">${escapeHTML(apiStateLabel)}</span>
           </div>
           <p class="quickstart-meta">GET <code id="api-url">${escapeHTML(this._apiURL())}</code></p>
-          <pre class="k-card quickstart-dump ${this._apiState ? '' : 'quickstart-muted'}" id="api-dump">${escapeHTML(apiStateDump)}</pre>
+          <pre class="quickstart-dump ${this._apiState ? '' : 'quickstart-muted'}" id="api-dump">${escapeHTML(apiStateDump)}</pre>
         </section>
       </div>
     `

--- a/providers/quickstart/portal/src/quickstartLayout.test.mjs
+++ b/providers/quickstart/portal/src/quickstartLayout.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const read = path => readFile(new URL(path, import.meta.url), 'utf8')
+
+test('Quickstart keeps code dumps flat inside the two card panels', async () => {
+  const source = await read('./element.ts')
+  const panels = source.match(/<section class="k-card quickstart-panel">[\s\S]*?<\/section>/g) ?? []
+
+  assert.equal(panels.length, 2)
+  for (const panel of panels) {
+    assert.equal((panel.match(/<pre\b/g) ?? []).length, 1)
+    assert.match(panel, /<pre class="quickstart-dump(?:\s[^\"]*)?"/)
+    assert.doesNotMatch(panel, /<pre[^>]*\bk-card(?:\s|\")/)
+  }
+})
+
+test('Quickstart comparison geometry is locally bounded and container responsive', async () => {
+  const styles = await read('./style.css')
+  const grid = styles.match(/faros-provider-quickstart \.quickstart-grid\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+  const dump = styles.match(/faros-provider-quickstart \.quickstart-dump\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+
+  assert.match(grid, /width:\s*100%/)
+  assert.match(grid, /max-width:\s*64rem/)
+  assert.match(grid, /margin-inline:\s*auto/)
+  assert.match(grid, /grid-template-columns:\s*minmax\(0, 1fr\)/)
+  assert.match(styles, /container-name:\s*quickstart-provider/)
+  assert.match(styles, /container-type:\s*inline-size/)
+  assert.match(styles, /@container quickstart-provider \(min-width: 46rem\)[\s\S]*?repeat\(2, minmax\(0, 1fr\)\)/)
+  assert.match(styles, /@supports not \(container-type: inline-size\)[\s\S]*?@media \(min-width: 46rem\)[\s\S]*?repeat\(2, minmax\(0, 1fr\)\)/)
+  assert.doesNotMatch(styles, /@supports not \(container-type: inline-size\)[\s\S]*?@media \(min-width: \d+px\)/)
+
+  assert.match(dump, /background:\s*var\(--color-surface-overlay/)
+  assert.match(dump, /border:\s*1px solid var\(--color-border-subtle/)
+  assert.match(dump, /border-radius:\s*4px/)
+  assert.match(dump, /box-shadow:\s*none/)
+})

--- a/providers/quickstart/portal/src/style.css
+++ b/providers/quickstart/portal/src/style.css
@@ -13,21 +13,42 @@
 
 faros-provider-quickstart {
   display: block;
+  container-name: quickstart-provider;
+  container-type: inline-size;
 }
 
 faros-provider-quickstart .quickstart-grid {
   display: grid;
   gap: 12px;
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr);
+  margin-inline: auto;
+  max-width: 64rem;
+  min-width: 0;
+  width: 100%;
 }
 
-@media (min-width: 720px) {
-  faros-provider-quickstart .quickstart-grid {
-    grid-template-columns: 1fr 1fr;
+/* Two panels stay readable at roughly 23rem each, including their inset
+ * padding and the grid gap. Container queries keep this decision tied to the
+ * provider's available column rather than to the browser viewport. */
+@supports (container-type: inline-size) {
+  @container quickstart-provider (min-width: 46rem) {
+    faros-provider-quickstart .quickstart-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+}
+
+/* Keep the same narrow-first layout in browsers without container queries. */
+@supports not (container-type: inline-size) {
+  @media (min-width: 46rem) {
+    faros-provider-quickstart .quickstart-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
   }
 }
 
 faros-provider-quickstart .quickstart-panel {
+  min-width: 0;
   padding: 14px 16px;
   color: var(--color-text-primary, inherit);
 }
@@ -50,10 +71,17 @@ faros-provider-quickstart .quickstart-panel-title {
 }
 
 faros-provider-quickstart .quickstart-dump {
+  min-width: 0;
   margin: 0;
   padding: 10px 12px;
+  background: var(--color-surface-overlay, #171927);
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 4px;
+  box-shadow: none;
+  color: var(--color-text-secondary, #8a8ca6);
   font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace);
   font-size: 11px;
+  line-height: 1.5;
   overflow-x: auto;
 }
 


### PR DESCRIPTION
Stack: 10 of 10 in Fluid-Shell 4K Conformance and Provider UI Hardening.

Depends on the Agents semantics PR.

Summary:
- Removes the nested card from the Quickstart result dump.
- Renders results as flat inset code surfaces.
- Locally bounds the comparison region so two extremely wide panels do not span the full 4K shell.
- Collapses to one column when both panels cannot retain their readable minimum width.

Verification:
- Quickstart layout tests
- Provider tests and production build
- PortalKit and UI conformance gates
- git diff --check