### PR TITLE
Fix Kuery tenant identity for edge engagement

### DIFF
--- a/providers/kuery/engagement/controller.go
+++ b/providers/kuery/engagement/controller.go
@@ -73,6 +73,7 @@ import (
 	"github.com/kcp-dev/multicluster-provider/apiexport"
 	apiskcpv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	apiskcpv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	kcpcore "github.com/kcp-dev/sdk/apis/core"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
@@ -145,10 +146,9 @@ type Controller struct {
 }
 
 // engagedEdge tracks one locally engaged edge. The map key stays
-// cluster-based ("{tenantCluster}/{edgeName}") so it's computable on delete
-// (when the edge — and its status.workspacePath — is already gone), but the
-// tenant identity queries scope by is the workspace PATH the edges provider
-// stamped onto the status, which is what X-Faros-Tenant carries.
+// cluster-based ("{tenantCluster}/{edgeName}") so it's computable on delete.
+// Tenant identity comes from the reconciled kuery APIBinding's kcp-owned
+// workspace metadata, never from an Edge status field.
 type engagedEdge struct {
 	cancel   context.CancelFunc
 	tenant   string // workspace path, used as the kuery cluster label
@@ -298,6 +298,10 @@ func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 		c.dropCluster(ctx, tenantCluster)
 		return ctrl.Result{}, nil
 	}
+	tenantPath, err := c.resolveTenantPath(ctx, binding, tenantCluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	token, err := c.ensureIdentity(ctx, cl.GetClient(), binding)
 	if err != nil {
@@ -323,7 +327,7 @@ func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	for i := range list.Items {
 		edge := &list.Items[i]
 		seen[edge.GetName()] = true
-		if d := c.reconcileEdge(ctx, tenantCluster, edge); d > 0 && d < requeueAfter {
+		if d := c.reconcileEdge(ctx, tenantCluster, tenantPath, edge); d > 0 && d < requeueAfter {
 			requeueAfter = d
 		}
 	}
@@ -334,10 +338,71 @@ func (c *Controller) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
+// resolveTenantPath applies the binding identity guard for a reconcile and
+// tears down any prior engagement when the authoritative identity is no longer
+// usable. Keeping the cleanup on this fail-closed path prevents an old stream
+// from continuing to populate tenant-labelled rows after metadata corruption.
+func (c *Controller) resolveTenantPath(ctx context.Context, binding *apiskcpv1alpha2.APIBinding, tenantCluster string) (string, error) {
+	tenantPath, err := tenantPathFromBinding(binding, tenantCluster)
+	if err != nil {
+		c.dropCluster(ctx, tenantCluster)
+		return "", fmt.Errorf("resolving tenant path in %s: %w", tenantCluster, err)
+	}
+	return tenantPath, nil
+}
+
+// tenantPathFromBinding returns the authoritative workspace path for one
+// consumer of kuery's APIExport. The APIExport virtual workspace decorates the
+// consumer APIBinding with both its logical-cluster ID and canonical kcp path.
+// The cluster match prevents accidentally attributing one workspace's path to
+// another reconcile request; the topology check keeps non-tenant workspaces
+// out of the tenant-labelled query store.
+func tenantPathFromBinding(binding *apiskcpv1alpha2.APIBinding, expectedCluster string) (string, error) {
+	if binding == nil {
+		return "", fmt.Errorf("APIBinding is required")
+	}
+	annotations := binding.GetAnnotations()
+	cluster := strings.TrimSpace(annotations["kcp.io/cluster"])
+	if cluster == "" {
+		return "", fmt.Errorf("APIBinding has no kcp.io/cluster annotation")
+	}
+	if cluster != expectedCluster {
+		return "", fmt.Errorf("APIBinding cluster %q does not match request cluster %q", cluster, expectedCluster)
+	}
+	path := strings.TrimSpace(annotations[kcpcore.LogicalClusterPathAnnotationKey])
+	if path == "" {
+		return "", fmt.Errorf("APIBinding has no %s annotation", kcpcore.LogicalClusterPathAnnotationKey)
+	}
+	if !isTenantWorkspacePath(path) {
+		return "", fmt.Errorf("APIBinding path %q is not a tenant workspace", path)
+	}
+	return path, nil
+}
+
+// isTenantWorkspacePath accepts the two consumer workspace shapes the hub can
+// put in X-Faros-Tenant: an organization workspace or one direct child team
+// workspace. Provider and deeper internal workspaces must never enter Kuery's
+// tenant-labelled store.
+func isTenantWorkspacePath(path string) bool {
+	parts := strings.Split(path, ":")
+	if len(parts) != 4 && len(parts) != 5 {
+		return false
+	}
+	if parts[0] != "root" || parts[1] != "faros" || parts[2] != "tenants" {
+		return false
+	}
+	for _, part := range parts[3:] {
+		if part == "" {
+			return false
+		}
+	}
+	return len(parts) != 5 || parts[4] != "providers"
+}
+
 // reconcileEdge maps one edge's state to Engage/Disengage, returning a
 // shorter requeue when this edge needs a faster re-check than the standard
 // renewal poll (0 means no preference).
-func (c *Controller) reconcileEdge(ctx context.Context, tenantCluster string, edge *unstructured.Unstructured) time.Duration {
+func (c *Controller) reconcileEdge(ctx context.Context, tenantCluster, tenantPath string, edge *unstructured.Unstructured) time.Duration {
 	edgeName := edge.GetName()
 	logger := klog.FromContext(ctx).WithValues("cluster", tenantCluster, "edge", edgeName)
 	key := tenantCluster + "/" + edgeName
@@ -350,19 +415,11 @@ func (c *Controller) reconcileEdge(ctx context.Context, tenantCluster string, ed
 		return 0
 	}
 
-	// Tenant identity is the workspace PATH the edges provider stamps onto
-	// the status. Both the kuery cluster row's NAME and its tenant LABEL are
-	// keyed by it so tenant-scoped queries match — the list query scopes by
-	// label, and the impact query re-pins the path prefix onto the cluster
-	// name (queryapi.ScopeToTenant). Until it is stamped, requeue rather
-	// than engage under the logical-cluster name: that would create a store
-	// row the portal — which only ever sends the path — could never match.
-	tenant, _, _ := unstructured.NestedString(edge.Object, "status", "workspacePath")
-	if tenant == "" {
-		logger.V(4).Info("workspacePath not yet stamped; requeuing")
-		return 5 * time.Second
-	}
-	storeName := tenant + "/" + edgeName
+	// Both the kuery cluster row's name and tenant label use the authoritative
+	// workspace path from kuery's APIBinding. Edge status is deliberately not a
+	// tenant-identity input: it is owned by another provider and may be absent,
+	// stale, or inconsistent with the workspace being reconciled.
+	storeName := tenantPath + "/" + edgeName
 
 	held, err := c.claims.tryAcquire(ctx, storeName)
 	if err != nil {
@@ -378,7 +435,7 @@ func (c *Controller) reconcileEdge(ctx context.Context, tenantCluster string, ed
 		return 0
 	}
 
-	if err := c.engage(ctx, key, tenantCluster, edgeName, tenant); err != nil {
+	if err := c.engage(ctx, key, tenantCluster, edgeName, tenantPath); err != nil {
 		logger.Error(err, "engaging edge")
 		return 30 * time.Second
 	}
@@ -388,7 +445,7 @@ func (c *Controller) reconcileEdge(ctx context.Context, tenantCluster string, ed
 	// previous owner's context ended, and its own upserts wipe the labels
 	// column, so the row must be continuously re-claimed by the syncing
 	// replica or tenant-scoped queries lose the edge.
-	if err := c.assertTenantLabel(ctx, storeName, tenant); err != nil {
+	if err := c.assertTenantLabel(ctx, storeName, tenantPath); err != nil {
 		logger.Error(err, "re-asserting cluster row")
 	}
 	return 0
@@ -458,7 +515,7 @@ func (c *Controller) dropCluster(ctx context.Context, tenantCluster string) {
 // Two distinct identifiers are at play:
 //   - key ("{logicalCluster}/{edge}") is the internal engaged-map key. It's
 //     derived purely from the reconcile request so it stays computable on
-//     delete, when the edge (and its status.workspacePath) is already gone.
+//     delete, when the edge object is already gone.
 //   - storeName ("{workspacePath}/{edge}") is the name kuery records the
 //     cluster under. queryapi.ScopeToTenant rebuilds exactly this form from
 //     the caller's tenant + edge for impact queries, so the store name MUST

--- a/providers/kuery/engagement/controller_test.go
+++ b/providers/kuery/engagement/controller_test.go
@@ -10,12 +10,19 @@ package engagement
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 
+	apiskcpv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	kcpcore "github.com/kcp-dev/sdk/apis/core"
+
 	kuerystore "github.com/faroshq/kuery/pkg/store"
+	kuerysync "github.com/faroshq/kuery/pkg/sync"
 )
 
 // TestEdgeProxyURL keeps the inlined URL pattern in lockstep with the faros
@@ -49,6 +56,130 @@ func TestTenantLabelIsBareIdentifier(t *testing.T) {
 		if !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_') {
 			t.Fatalf("TenantLabel %q contains %q — must stay a bare identifier", TenantLabel, string(c))
 		}
+	}
+}
+
+func TestTenantPathFromBindingUsesAuthoritativeWorkspaceMetadata(t *testing.T) {
+	const cluster = "btykuuy2789iyolq"
+	for _, path := range []string{
+		"root:faros:tenants:org-1",
+		"root:faros:tenants:org-1:workspace-1",
+	} {
+		t.Run(path, func(t *testing.T) {
+			binding := &apiskcpv1alpha2.APIBinding{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"kcp.io/cluster":                        cluster,
+				kcpcore.LogicalClusterPathAnnotationKey: path,
+			}}}
+
+			got, err := tenantPathFromBinding(binding, cluster)
+			if err != nil {
+				t.Fatalf("tenantPathFromBinding: %v", err)
+			}
+			if got != path {
+				t.Fatalf("tenantPathFromBinding = %q, want %q", got, path)
+			}
+		})
+	}
+}
+
+func TestTenantPathFromBindingFailsClosed(t *testing.T) {
+	const cluster = "btykuuy2789iyolq"
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantError   string
+	}{
+		{name: "nil binding", wantError: "APIBinding is required"},
+		{name: "missing cluster", annotations: map[string]string{kcpcore.LogicalClusterPathAnnotationKey: "root:faros:tenants:org-1"}, wantError: "no kcp.io/cluster"},
+		{name: "cluster mismatch", annotations: map[string]string{"kcp.io/cluster": "other", kcpcore.LogicalClusterPathAnnotationKey: "root:faros:tenants:org-1"}, wantError: "does not match"},
+		{name: "missing path", annotations: map[string]string{"kcp.io/cluster": cluster}, wantError: "no kcp.io/path"},
+		{name: "platform provider path", annotations: map[string]string{"kcp.io/cluster": cluster, kcpcore.LogicalClusterPathAnnotationKey: "root:faros:providers:kuery"}, wantError: "not a tenant workspace"},
+		{name: "org provider path", annotations: map[string]string{"kcp.io/cluster": cluster, kcpcore.LogicalClusterPathAnnotationKey: "root:faros:tenants:org-1:providers"}, wantError: "not a tenant workspace"},
+		{name: "org provider child path", annotations: map[string]string{"kcp.io/cluster": cluster, kcpcore.LogicalClusterPathAnnotationKey: "root:faros:tenants:org-1:providers:kuery"}, wantError: "not a tenant workspace"},
+		{name: "nested internal path", annotations: map[string]string{"kcp.io/cluster": cluster, kcpcore.LogicalClusterPathAnnotationKey: "root:faros:tenants:org-1:workspace-1:edge-1"}, wantError: "not a tenant workspace"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var binding *apiskcpv1alpha2.APIBinding
+			if tt.annotations != nil {
+				binding = &apiskcpv1alpha2.APIBinding{ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations}}
+			}
+			_, err := tenantPathFromBinding(binding, cluster)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("tenantPathFromBinding error = %v, want containing %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestResolveTenantPathDropsEngagementOnInvalidBinding(t *testing.T) {
+	ctx := context.Background()
+	const (
+		cluster   = "btykuuy2789iyolq"
+		tenant    = "root:faros:tenants:org-1:workspace-1"
+		edgeName  = "edge-1"
+		storeName = tenant + "/" + edgeName
+	)
+
+	store := testStore(t)
+	now := time.Now()
+	if err := store.UpsertCluster(ctx, &kuerystore.ClusterModel{
+		Name:     storeName,
+		Status:   "active",
+		LastSeen: now,
+		TTL:      clusterTTLSeconds,
+		Labels:   tenantLabelsJSON(tenant),
+	}); err != nil {
+		t.Fatalf("seed active cluster: %v", err)
+	}
+
+	clientset := kubefake.NewClientset()
+	claims := testClaims("replica-a", clientset, time.Now)
+	held, err := claims.tryAcquire(ctx, storeName)
+	if err != nil || !held {
+		t.Fatalf("acquire edge claim = %v/%v, want held", held, err)
+	}
+
+	cancelled := false
+	c := &Controller{
+		cfg: Config{
+			Store: store,
+			Sync:  kuerysync.NewSyncController(kuerysync.Config{Store: store}),
+		},
+		claims: claims,
+		engaged: map[string]engagedEdge{
+			cluster + "/" + edgeName: {
+				cancel:   func() { cancelled = true },
+				tenant:   tenant,
+				edgeName: edgeName,
+			},
+		},
+	}
+
+	binding := &apiskcpv1alpha2.APIBinding{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		"kcp.io/cluster": cluster,
+	}}}
+	_, err = c.resolveTenantPath(ctx, binding, cluster)
+	if err == nil || !strings.Contains(err.Error(), "no kcp.io/path") {
+		t.Fatalf("resolveTenantPath error = %v, want missing-path error", err)
+	}
+	if !cancelled {
+		t.Fatal("invalid binding did not cancel the existing engagement")
+	}
+	if len(c.engaged) != 0 {
+		t.Fatalf("engaged entries = %d, want 0", len(c.engaged))
+	}
+
+	row, err := store.GetCluster(ctx, storeName)
+	if err != nil {
+		t.Fatalf("get disengaged cluster: %v", err)
+	}
+	if row.Status != "stale" {
+		t.Fatalf("cluster status = %q, want stale", row.Status)
+	}
+	if _, err := claims.leases.Get(ctx, claimName(storeName), metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("claim lookup error = %v, want not found after cleanup", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- derive the tenant workspace path from the reflexive Kuery APIBinding kcp metadata instead of Edge status.workspacePath
- verify the binding cluster matches the reconcile request and accept only Faros organization or team workspace paths
- disengage existing streams and release claims if authoritative binding identity becomes invalid
- keep logical-cluster-based internal keys for reliable deletion while using canonical paths for query-facing store names and tenant labels

## Why

Kuery engagement could wait indefinitely when an Edge did not carry status.workspacePath, even though the reconciled APIBinding already provides the authoritative canonical workspace path. This prevented connected edges from becoming queryable.

## Verification

- go test -count=1 ./engagement
- go test -count=1 ./...
- go vet ./...
- go build -buildvcs=false ./...
- git diff --check

The full Kuery test suite was run outside the restricted sandbox because its MCP handler test opens an IPv6 loopback listener.