### PR TITLE
Standardize provider create journeys

### DIFF
--- a/docs/design-book.md
+++ b/docs/design-book.md
@@ -570,6 +570,19 @@ Simple forms are constrained; dense provisioning forms may use the full content
 column. Wizards keep this page skeleton and place progress inside it rather than
 retaining dialog chrome.
 
+For an authoritative first-use empty collection, use PortalKit's
+`FirstRunGuide.vue` (or the matching `k-first-run*` semantic markup in a vanilla
+portal). It explains the value, offers the immediate primary action, and shows
+the shortest meaningful resource journey. Missing prerequisites change the
+current step and action; they do not leave users at an inert empty table.
+
+When a route-owned form benefits from domain help, use `CreateGuidance.vue`
+beside a `k-create-fields` region inside `k-create-surface--guided`. The rail
+contains only timely prerequisites, a live and non-secret summary of what Faros
+will create, and controller-owned next steps. Provider copy and value derivation
+remain local. The shared container query keeps fields before guidance on narrow
+surfaces and both regions fluid at desktop and 4K widths.
+
 After creation, navigate to the resource when it owns status or recovery;
 otherwise return to the collection with the result clearly visible.
 

--- a/hack/create-flow-conformance.test.mjs
+++ b/hack/create-flow-conformance.test.mjs
@@ -20,7 +20,7 @@ function expectSkeleton(name, text, { wide = false } = {}) {
   ]) {
     assert.match(text, new RegExp(className), `${name} is missing ${className}`)
   }
-  if (wide) assert.match(text, /k-create-surface--wide/, `${name} should use the wide provisioning surface`)
+  if (wide) assert.match(text, /k-create-surface--(?:wide|guided)/, `${name} should use a wide provisioning surface`)
   assert.match(text, /Cancel[\s\S]*k-btn--primary/, `${name} must order Cancel before its primary action`)
 }
 
@@ -42,6 +42,57 @@ test('the canonical create-page vocabulary defines one shared hierarchy', async 
   assert.match(css, /\.k-create-surface\s*\{[\s\S]*overflow: clip/)
   assert.match(css, /\.k-create-actions\s*\{[\s\S]*justify-content: flex-end/)
   assert.match(css, /@media \(max-width: 620px\)[\s\S]*\.k-create-actions\s*\{[\s\S]*position: sticky/)
+})
+
+test('PortalKit defines shared first-run and guided-create widgets', async () => {
+  const [css, firstRun, guidance, sync] = await Promise.all([
+    source('provider-sdk/portalkit/faros-ui.css'),
+    source('provider-sdk/portalkit-vue/FirstRunGuide.vue'),
+    source('provider-sdk/portalkit-vue/CreateGuidance.vue'),
+    source('hack/sync-portalkit.sh'),
+  ])
+
+  for (const selector of [
+    '.k-first-run',
+    '.k-first-run__journey',
+    '.k-create-surface--guided',
+    '.k-create-body--guided',
+    '.k-create-fields',
+    '.k-create-guidance',
+  ]) {
+    assert.match(css, new RegExp(selector.replace('.', '\\.')), `shared CSS is missing ${selector}`)
+  }
+  assert.match(css, /@container k-create-surface \(max-width: 960px\)[\s\S]*\.k-create-guidance[\s\S]*grid-row: 2/)
+  assert.match(css, /@media \(max-width: 620px\)[\s\S]*\.k-first-run__journey/)
+
+  assert.match(firstRun, /<section class="k-first-run" :aria-labelledby="titleID">/)
+  assert.match(firstRun, /ensureFarosUIStyles\(\)/)
+  assert.match(firstRun, /<ol v-if="steps\.length" class="k-first-run__journey"/)
+  assert.match(firstRun, /:aria-current="index === boundedCurrentStep \? 'step' : undefined"/)
+  assert.match(firstRun, /class="k-first-run__step-status"/)
+  assert.match(firstRun, /index < boundedCurrentStep \? 'Completed step'/)
+  assert.match(css, /\.k-first-run__step-status\s*\{[\s\S]*clip-path: inset\(50%\)[\s\S]*position: absolute/)
+  assert.match(guidance, /<aside class="k-create-guidance" :aria-labelledby="titleID">/)
+  assert.match(guidance, /ensureFarosUIStyles\(\)/)
+  assert.match(guidance, /<dl class="k-create-guidance__values">/)
+  assert.match(guidance, /<ol>[\s\S]*v-for="step in nextSteps"/)
+  assert.match(sync, /CreateGuidance\.vue FirstRunGuide\.vue/)
+})
+
+test('provider create journeys adopt the shared first-run and guidance vocabulary', async () => {
+  const vueProviders = [
+    ['Databricks', 'providers/databricks/portal/src/components/DatabricksEmptyState.vue', 'providers/databricks/portal/src/components/ManualCreateGuidance.vue'],
+    ['Code', 'providers/code/portal/src/views/ConnectionsView.vue', 'providers/code/portal/src/views/ConnectionCreateView.vue'],
+    ['Edges', 'providers/edges/portal/src/EdgeCollection.vue', 'providers/edges/portal/src/ServiceCreate.vue'],
+  ]
+  for (const [name, emptyPath, createPath] of vueProviders) {
+    assert.match(await source(emptyPath), /FirstRunGuide/, `${name} must use the shared first-run component`)
+    assert.match(await source(createPath), /CreateGuidance/, `${name} must use the shared create-guidance component`)
+  }
+
+  const agents = await source('providers/agents/portal/src/ui/create-flow.ts')
+  assert.match(agents, /class="k-first-run(?:\s|\")/, 'Agents must render the shared first-run vocabulary')
+  assert.match(agents, /class="k-create-guidance"/, 'Agents must render the shared create-guidance vocabulary')
 })
 
 test('Vue route-owned create flows use the shared skeleton', async () => {

--- a/hack/sync-portalkit.sh
+++ b/hack/sync-portalkit.sh
@@ -32,7 +32,7 @@ VUE_PORTALS=(
   "providers/edges/portal"
   "providers/infrastructure/portal"
 )
-VUE_FILES=(ActionMenu.vue confirm.ts ConditionsPanel.vue ConfirmDialog.vue FormSelect.vue LayoutSelector.vue layoutPreference.ts ResourceBackLink.vue ResourcePage.vue ResourceSectionCard.vue ResourceStatCards.vue ResourceTable.vue ResourceTableFilter.vue table.ts ResourceTableActionButton.vue ResourceTableDeleteButton.vue ResourceTableEditButton.vue StatusBadge.vue Tabs.vue useDelayedLoading.ts)
+VUE_FILES=(ActionMenu.vue confirm.ts ConditionsPanel.vue ConfirmDialog.vue CreateGuidance.vue FirstRunGuide.vue FormSelect.vue LayoutSelector.vue layoutPreference.ts ResourceBackLink.vue ResourcePage.vue ResourceSectionCard.vue ResourceStatCards.vue ResourceTable.vue ResourceTableFilter.vue table.ts ResourceTableActionButton.vue ResourceTableDeleteButton.vue ResourceTableEditButton.vue StatusBadge.vue Tabs.vue useDelayedLoading.ts)
 
 # Plain assets from the vanilla kit are shared by both portal styles.
 VUE_SHARED_FILES=(dashboardtile.ts faros-ui.css icons.ts page-state.ts styles.ts tabs.ts tenant.ts toast.ts)

--- a/portal/src/assets/faros-ui.css
+++ b/portal/src/assets/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/portal/src/portalkit/CreateGuidance.vue
+++ b/portal/src/portalkit/CreateGuidance.vue
@@ -1,0 +1,72 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { Info } from 'lucide-vue-next'
+import { useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface CreateGuidanceValue {
+  label: string
+  value: string
+  technical?: boolean
+}
+
+withDefaults(defineProps<{
+  title: string
+  description: string
+  prerequisites?: string[]
+  values?: CreateGuidanceValue[]
+  nextSteps?: string[]
+  valuesHeading?: string
+}>(), {
+  prerequisites: () => [],
+  values: () => [],
+  nextSteps: () => [],
+  valuesHeading: 'What Faros will create',
+})
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-create-guidance-${id}-title`
+const prerequisiteID = `k-create-guidance-${id}-prerequisites`
+const valuesID = `k-create-guidance-${id}-values`
+const nextStepsID = `k-create-guidance-${id}-next-steps`
+</script>
+
+<template>
+  <aside class="k-create-guidance" :aria-labelledby="titleID">
+    <div class="k-create-guidance__heading">
+      <Info :size="16" :stroke-width="1.75" aria-hidden="true" />
+      <h3 :id="titleID">{{ title }}</h3>
+    </div>
+    <p class="k-create-guidance__description">{{ description }}</p>
+
+    <section v-if="prerequisites.length" class="k-create-guidance__section" :aria-labelledby="prerequisiteID">
+      <h4 :id="prerequisiteID">Prerequisites</h4>
+      <ul>
+        <li v-for="prerequisite in prerequisites" :key="prerequisite">{{ prerequisite }}</li>
+      </ul>
+    </section>
+
+    <section v-if="values.length" class="k-create-guidance__section" :aria-labelledby="valuesID">
+      <h4 :id="valuesID">{{ valuesHeading }}</h4>
+      <dl class="k-create-guidance__values">
+        <template v-for="item in values" :key="item.label">
+          <dt>{{ item.label }}</dt>
+          <dd><code v-if="item.technical">{{ item.value }}</code><span v-else>{{ item.value }}</span></dd>
+        </template>
+      </dl>
+    </section>
+
+    <section v-if="nextSteps.length" class="k-create-guidance__section" :aria-labelledby="nextStepsID">
+      <h4 :id="nextStepsID">Next steps</h4>
+      <ol>
+        <li v-for="step in nextSteps" :key="step">{{ step }}</li>
+      </ol>
+    </section>
+  </aside>
+</template>

--- a/portal/src/portalkit/FirstRunGuide.vue
+++ b/portal/src/portalkit/FirstRunGuide.vue
@@ -1,0 +1,85 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { ArrowRight, Check, CircleDot } from 'lucide-vue-next'
+import { computed, useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface FirstRunStep {
+  label: string
+  description: string
+}
+
+const props = withDefaults(defineProps<{
+  title: string
+  description: string
+  primaryLabel: string
+  secondaryLabel?: string
+  steps: readonly FirstRunStep[]
+  currentStep?: number
+  journeyLabel?: string
+}>(), {
+  secondaryLabel: '',
+  currentStep: 0,
+  journeyLabel: 'Getting started',
+})
+
+const emit = defineEmits<{
+  (event: 'primary'): void
+  (event: 'secondary'): void
+}>()
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-first-run-${id}-title`
+const boundedCurrentStep = computed(() => Math.max(0, Math.min(props.currentStep, props.steps.length - 1)))
+</script>
+
+<template>
+  <section class="k-first-run" :aria-labelledby="titleID">
+    <div class="k-first-run__lead">
+      <span class="k-first-run__icon" aria-hidden="true"><slot name="icon" /></span>
+      <div class="k-first-run__copy">
+        <h3 :id="titleID">{{ title }}</h3>
+        <p>{{ description }}</p>
+      </div>
+      <div class="k-first-run__actions">
+        <button class="k-btn k-btn--primary" type="button" @click="emit('primary')">
+          {{ primaryLabel }} <ArrowRight :stroke-width="1.75" aria-hidden="true" />
+        </button>
+        <button v-if="secondaryLabel" class="k-btn k-btn--ghost" type="button" @click="emit('secondary')">
+          {{ secondaryLabel }}
+        </button>
+      </div>
+    </div>
+
+    <ol v-if="steps.length" class="k-first-run__journey" :aria-label="journeyLabel">
+      <li
+        v-for="(step, index) in steps"
+        :key="`${index}-${step.label}`"
+        :class="['k-first-run__step', {
+          'is-complete': index < boundedCurrentStep,
+          'is-current': index === boundedCurrentStep,
+        }]"
+        :aria-current="index === boundedCurrentStep ? 'step' : undefined"
+      >
+        <span class="k-first-run__marker" aria-hidden="true">
+          <Check v-if="index < boundedCurrentStep" :stroke-width="2" />
+          <CircleDot v-else-if="index === boundedCurrentStep" :stroke-width="1.75" />
+          <span v-else>{{ index + 1 }}</span>
+        </span>
+        <span class="k-first-run__step-copy">
+          <span class="k-first-run__step-status">
+            {{ index < boundedCurrentStep ? 'Completed step' : index === boundedCurrentStep ? 'Current step' : 'Upcoming step' }}:
+          </span>
+          <strong>{{ step.label }}</strong>
+          <small>{{ step.description }}</small>
+        </span>
+      </li>
+    </ol>
+  </section>
+</template>

--- a/portal/src/portalkit/faros-ui.css
+++ b/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/portal/src/portalkit/styles.ts
+++ b/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 3
+export const FAROS_UI_VERSION = 4
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/provider-sdk/portalkit-vue/CreateGuidance.vue
+++ b/provider-sdk/portalkit-vue/CreateGuidance.vue
@@ -1,0 +1,72 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { Info } from 'lucide-vue-next'
+import { useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface CreateGuidanceValue {
+  label: string
+  value: string
+  technical?: boolean
+}
+
+withDefaults(defineProps<{
+  title: string
+  description: string
+  prerequisites?: string[]
+  values?: CreateGuidanceValue[]
+  nextSteps?: string[]
+  valuesHeading?: string
+}>(), {
+  prerequisites: () => [],
+  values: () => [],
+  nextSteps: () => [],
+  valuesHeading: 'What Faros will create',
+})
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-create-guidance-${id}-title`
+const prerequisiteID = `k-create-guidance-${id}-prerequisites`
+const valuesID = `k-create-guidance-${id}-values`
+const nextStepsID = `k-create-guidance-${id}-next-steps`
+</script>
+
+<template>
+  <aside class="k-create-guidance" :aria-labelledby="titleID">
+    <div class="k-create-guidance__heading">
+      <Info :size="16" :stroke-width="1.75" aria-hidden="true" />
+      <h3 :id="titleID">{{ title }}</h3>
+    </div>
+    <p class="k-create-guidance__description">{{ description }}</p>
+
+    <section v-if="prerequisites.length" class="k-create-guidance__section" :aria-labelledby="prerequisiteID">
+      <h4 :id="prerequisiteID">Prerequisites</h4>
+      <ul>
+        <li v-for="prerequisite in prerequisites" :key="prerequisite">{{ prerequisite }}</li>
+      </ul>
+    </section>
+
+    <section v-if="values.length" class="k-create-guidance__section" :aria-labelledby="valuesID">
+      <h4 :id="valuesID">{{ valuesHeading }}</h4>
+      <dl class="k-create-guidance__values">
+        <template v-for="item in values" :key="item.label">
+          <dt>{{ item.label }}</dt>
+          <dd><code v-if="item.technical">{{ item.value }}</code><span v-else>{{ item.value }}</span></dd>
+        </template>
+      </dl>
+    </section>
+
+    <section v-if="nextSteps.length" class="k-create-guidance__section" :aria-labelledby="nextStepsID">
+      <h4 :id="nextStepsID">Next steps</h4>
+      <ol>
+        <li v-for="step in nextSteps" :key="step">{{ step }}</li>
+      </ol>
+    </section>
+  </aside>
+</template>

--- a/provider-sdk/portalkit-vue/FirstRunGuide.vue
+++ b/provider-sdk/portalkit-vue/FirstRunGuide.vue
@@ -1,0 +1,85 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { ArrowRight, Check, CircleDot } from 'lucide-vue-next'
+import { computed, useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface FirstRunStep {
+  label: string
+  description: string
+}
+
+const props = withDefaults(defineProps<{
+  title: string
+  description: string
+  primaryLabel: string
+  secondaryLabel?: string
+  steps: readonly FirstRunStep[]
+  currentStep?: number
+  journeyLabel?: string
+}>(), {
+  secondaryLabel: '',
+  currentStep: 0,
+  journeyLabel: 'Getting started',
+})
+
+const emit = defineEmits<{
+  (event: 'primary'): void
+  (event: 'secondary'): void
+}>()
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-first-run-${id}-title`
+const boundedCurrentStep = computed(() => Math.max(0, Math.min(props.currentStep, props.steps.length - 1)))
+</script>
+
+<template>
+  <section class="k-first-run" :aria-labelledby="titleID">
+    <div class="k-first-run__lead">
+      <span class="k-first-run__icon" aria-hidden="true"><slot name="icon" /></span>
+      <div class="k-first-run__copy">
+        <h3 :id="titleID">{{ title }}</h3>
+        <p>{{ description }}</p>
+      </div>
+      <div class="k-first-run__actions">
+        <button class="k-btn k-btn--primary" type="button" @click="emit('primary')">
+          {{ primaryLabel }} <ArrowRight :stroke-width="1.75" aria-hidden="true" />
+        </button>
+        <button v-if="secondaryLabel" class="k-btn k-btn--ghost" type="button" @click="emit('secondary')">
+          {{ secondaryLabel }}
+        </button>
+      </div>
+    </div>
+
+    <ol v-if="steps.length" class="k-first-run__journey" :aria-label="journeyLabel">
+      <li
+        v-for="(step, index) in steps"
+        :key="`${index}-${step.label}`"
+        :class="['k-first-run__step', {
+          'is-complete': index < boundedCurrentStep,
+          'is-current': index === boundedCurrentStep,
+        }]"
+        :aria-current="index === boundedCurrentStep ? 'step' : undefined"
+      >
+        <span class="k-first-run__marker" aria-hidden="true">
+          <Check v-if="index < boundedCurrentStep" :stroke-width="2" />
+          <CircleDot v-else-if="index === boundedCurrentStep" :stroke-width="1.75" />
+          <span v-else>{{ index + 1 }}</span>
+        </span>
+        <span class="k-first-run__step-copy">
+          <span class="k-first-run__step-status">
+            {{ index < boundedCurrentStep ? 'Completed step' : index === boundedCurrentStep ? 'Current step' : 'Upcoming step' }}:
+          </span>
+          <strong>{{ step.label }}</strong>
+          <small>{{ step.description }}</small>
+        </span>
+      </li>
+    </ol>
+  </section>
+</template>

--- a/provider-sdk/portalkit/README.md
+++ b/provider-sdk/portalkit/README.md
@@ -20,6 +20,11 @@ too, alongside the SFC kit in `provider-sdk/portalkit-vue`.
   uses the shared stylesheet rather than injecting a second visual language.
 - `styles.ts` — the standalone handoff for the exact canonical
   `provider-sdk/portalkit/faros-ui.css` bytes.
+- `FirstRunGuide.vue` — Vue first-use value, action, and ordered journey
+  surface. Vanilla portals emit the same `k-first-run*` classes.
+- `CreateGuidance.vue` — Vue prerequisites, live output summary, and next-step
+  rail for route-owned forms. Vanilla portals emit the same
+  `k-create-guidance*` classes.
 
 ## Why vendored, not imported
 

--- a/provider-sdk/portalkit/faros-ui.css
+++ b/provider-sdk/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/provider-sdk/portalkit/styles.ts
+++ b/provider-sdk/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 3
+export const FAROS_UI_VERSION = 4
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/agents/portal/src/portalkit/faros-ui.css
+++ b/providers/agents/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/providers/agents/portal/src/portalkit/styles.ts
+++ b/providers/agents/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 3
+export const FAROS_UI_VERSION = 4
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -125,6 +125,8 @@ faros-provider-agents .agents-panel > p { margin: 0; }
 faros-provider-agents .agents-panel form, faros-provider-agents .agents-obj-form, faros-provider-agents .agents-toolset-form {
   display: flex; flex-direction: column; gap: 12px; padding: 16px;
 }
+/* PortalKit owns the body and footer spacing on route-owned creation surfaces. */
+faros-provider-agents form.agents-guided-form { gap: 0; padding: 0; }
 faros-provider-agents label { display: flex; flex-direction: column; gap: 5px; font-size: 13px; }
 faros-provider-agents .agents-grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
 faros-provider-agents .agents-check { flex-direction: row !important; align-items: center; gap: 8px !important; font-size: 13px; }

--- a/providers/agents/portal/src/test/agents-list.test.ts
+++ b/providers/agents/portal/src/test/agents-list.test.ts
@@ -71,10 +71,40 @@ describe('agents list refresh resilience', () => {
     store.agents.loaded = true
     store.agents.hasSnapshot = true
     store.agents.error = 'temporarily unavailable'
+    store.credentials.loaded = true
+    store.credentials.hasSnapshot = true
 
     const el = await mount('agents-agents-list', { store, api })
 
-    expect(text(el.querySelector('.agents-state-empty'))).toContain('No agents yet')
+    expect(el.querySelector('.agents-state-empty.k-first-run')).not.toBeNull()
+    expect(text(el.querySelector('.agents-state-empty'))).toContain('Connect a model before creating your first agent')
     expect(text(el.querySelector('.agents-state-error'))).toContain('Showing the last loaded data')
+  })
+
+  it('waits for authoritative model credentials before offering an agent journey', async () => {
+    const api = stubApi()
+    const store = makeStore(api)
+    store.agents.loaded = true
+    store.agents.hasSnapshot = true
+
+    const el = await mount('agents-agents-list', { store, api })
+
+    expect(text(el.querySelector('.agents-state-loading'))).toContain('Loading model credentials')
+    expect(el.querySelector('.k-first-run')).toBeNull()
+  })
+
+  it('surfaces a retryable model-credential error instead of assuming a model exists', async () => {
+    const api = stubApi()
+    const store = makeStore(api)
+    store.agents.loaded = true
+    store.agents.hasSnapshot = true
+    store.credentials.error = 'credential API unavailable'
+
+    const el = await mount('agents-agents-list', { store, api })
+
+    expect(text(el.querySelector('.agents-state-error'))).toContain('Could not load model credentials')
+    expect(text(el.querySelector('.agents-state-error'))).toContain('credential API unavailable')
+    expect(el.querySelector('.agents-state-error button')).not.toBeNull()
+    expect(el.querySelector('.k-first-run')).toBeNull()
   })
 })

--- a/providers/agents/portal/src/test/config.test.ts
+++ b/providers/agents/portal/src/test/config.test.ts
@@ -230,6 +230,10 @@ describe('agent creation capabilities', () => {
     const api = stubApi({ createAgent })
     const store = makeStore(api)
     store.credentials.data = [{ name: 'main', model: 'gpt-5' }] as never
+    store.credentials.loaded = true
+    store.credentials.hasSnapshot = true
+    store.agents.loaded = true
+    store.agents.hasSnapshot = true
     const el = await mount<AgentCreateWizard>('agents-agent-create', { store, api })
     await settle(el, 3)
     return { el, createAgent }

--- a/providers/agents/portal/src/test/create-routes.test.ts
+++ b/providers/agents/portal/src/test/create-routes.test.ts
@@ -10,12 +10,26 @@ import '../views/models'
 import '../views/toolsets'
 import { agentFixture, makeStore, mount, settle, stubApi } from './helpers'
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => (resolve = resolvePromise))
+  return { promise, resolve }
+}
+
+function markAuthoritative(store: ReturnType<typeof makeStore>, ...keys: Array<'agents' | 'credentials' | 'connections' | 'toolsets'>): void {
+  for (const key of keys) {
+    store[key].loaded = true
+    store[key].hasSnapshot = true
+  }
+}
+
 describe('route-owned creation surfaces', () => {
   it('renders agent creation as a page and emits its result after the API succeeds', async () => {
     const createAgent = vi.fn().mockResolvedValue({ metadata: { name: 'nova' }, spec: { displayName: 'nova' } })
     const api = stubApi({ createAgent })
     const store = makeStore(api)
     store.credentials.data = [{ name: 'main', model: 'gpt-5' }]
+    markAuthoritative(store, 'agents', 'credentials')
     const el = await mount<AgentCreateWizard>('agents-agent-create', { store, api })
     let result: unknown
     el.addEventListener('agents-create-success', (e) => (result = (e as CustomEvent).detail))
@@ -23,6 +37,8 @@ describe('route-owned creation surfaces', () => {
     expect(el.querySelector('.agents-overlay')).toBeNull()
     expect(el.querySelector('.agents-create-page')).not.toBeNull()
     expect(el.querySelector('[role="dialog"]')).toBeNull()
+    expect(el.querySelector('.k-create-surface--guided')).not.toBeNull()
+    expect(el.querySelector('.k-create-guidance')).not.toBeNull()
     el.querySelector<HTMLInputElement>('input[name=name]')!.value = 'nova'
     el.querySelector<HTMLInputElement>('input[name=name]')!.dispatchEvent(new Event('input'))
     const model = el.querySelector('select') as HTMLSelectElement
@@ -33,6 +49,93 @@ describe('route-owned creation surfaces', () => {
 
     expect(createAgent).toHaveBeenCalledWith(expect.objectContaining({ name: 'nova', modelCredential: 'main' }))
     expect(result).toEqual(expect.objectContaining({ resource: 'agent', name: 'nova', item: expect.anything() }))
+  })
+
+  it('announces agent validation and locks the create surface while submitting', async () => {
+    const request = deferred<{ metadata: { name: string }; spec: { displayName: string } }>()
+    const createAgent = vi.fn(() => request.promise)
+    const api = stubApi({ createAgent })
+    const store = makeStore(api)
+    store.credentials.data = [{ name: 'main', model: 'gpt-5' }]
+    markAuthoritative(store, 'agents', 'credentials')
+    const el = await mount<AgentCreateWizard>('agents-agent-create', { store, api })
+    const form = el.querySelector<HTMLFormElement>('form')!
+
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await settle(el)
+    expect(el.querySelector('#agent-create-name-error[role="alert"]')?.textContent).toContain('required')
+    expect(el.querySelector('#agent-create-name')?.getAttribute('aria-invalid')).toBe('true')
+    expect(el.querySelector('#agent-create-model')?.getAttribute('aria-describedby')).toContain('agent-create-model-error')
+
+    const name = el.querySelector<HTMLInputElement>('#agent-create-name')!
+    name.value = 'nova'
+    name.dispatchEvent(new Event('input'))
+    const model = el.querySelector<HTMLSelectElement>('#agent-create-model')!
+    model.value = 'main'
+    model.dispatchEvent(new Event('change'))
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await settle(el)
+    expect(form.getAttribute('aria-busy')).toBe('true')
+    expect([...form.querySelectorAll('input, select, textarea, button')].every((control) => (control as HTMLInputElement).disabled)).toBe(true)
+
+    request.resolve({ metadata: { name: 'nova' }, spec: { displayName: 'Nova' } })
+    await settle(el, 5)
+    expect(form.getAttribute('aria-busy')).toBe('false')
+  })
+
+  it('waits for authoritative agent and credential snapshots before rendering the agent form', async () => {
+    const api = stubApi()
+    const store = makeStore(api)
+    store.credentials.data = [{ name: 'main', model: 'gpt-5' }]
+    markAuthoritative(store, 'credentials')
+
+    const el = await mount<AgentCreateWizard>('agents-agent-create', { store, api })
+
+    expect(el.querySelector('form')).toBeNull()
+    expect(el.querySelector('.agents-state-loading')?.textContent).toContain('Loading existing agents and model credentials')
+    expect(el.textContent).not.toContain('No model credentials yet')
+  })
+
+  it('shows retryable first-load errors instead of treating missing agent prerequisites as empty', async () => {
+    const api = stubApi()
+    const credentialStore = makeStore(api)
+    markAuthoritative(credentialStore, 'agents')
+    credentialStore.credentials.loaded = true
+    credentialStore.credentials.error = 'credential API unavailable'
+    const credentialLoad = vi.spyOn(credentialStore, 'load').mockResolvedValue()
+    const credentialError = await mount<AgentCreateWizard>('agents-agent-create', { store: credentialStore, api })
+
+    expect(credentialError.querySelector('form')).toBeNull()
+    expect(credentialError.querySelector('.agents-state-error')?.textContent).toContain('Could not load model credentials')
+    credentialError.querySelector<HTMLButtonElement>('.agents-state-error button')!.click()
+    expect(credentialLoad).toHaveBeenCalledWith('credentials')
+
+    const agentStore = makeStore(api)
+    markAuthoritative(agentStore, 'credentials')
+    agentStore.agents.loaded = true
+    agentStore.agents.error = 'agent API unavailable'
+    const agentLoad = vi.spyOn(agentStore, 'load').mockResolvedValue()
+    const agentError = await mount<AgentCreateWizard>('agents-agent-create', { store: agentStore, api })
+
+    expect(agentError.querySelector('form')).toBeNull()
+    expect(agentError.querySelector('.agents-state-error')?.textContent).toContain('Could not load existing agents')
+    agentError.querySelector<HTMLButtonElement>('.agents-state-error button')!.click()
+    expect(agentLoad).toHaveBeenCalledWith('agents')
+  })
+
+  it('renders an authoritative empty credential state with recovery to model creation', async () => {
+    const api = stubApi()
+    const store = makeStore(api)
+    markAuthoritative(store, 'agents', 'credentials')
+    const el = await mount<AgentCreateWizard>('agents-agent-create', { store, api })
+    const routes: unknown[] = []
+    el.addEventListener('agents-navigate', (event) => routes.push((event as CustomEvent).detail))
+
+    expect(el.querySelector('form')).not.toBeNull()
+    expect(el.textContent).toContain('No model credentials yet')
+    expect(el.querySelector<HTMLButtonElement>('button[type=submit]')?.disabled).toBe(true)
+    el.querySelector<HTMLButtonElement>('.agents-linkbtn')!.click()
+    expect(routes).toEqual([{ kind: 'create', resource: 'model' }])
   })
 
   it('keeps connection type selection and creation in hash-owned surfaces', async () => {
@@ -49,6 +152,7 @@ describe('route-owned creation surfaces', () => {
 
     const formSurface = await mount<Connections>('agents-connections', { store, api, routeOwned: true, createRoute: true, createType: 'github' })
     expect(formSurface.querySelector('.agents-conn-form')).not.toBeNull()
+    expect(formSurface.querySelector('.k-create-surface--guided .k-create-guidance')).not.toBeNull()
     const name = formSurface.querySelector<HTMLInputElement>('input[name=name]')!
     name.value = 'gh'
     const token = formSurface.querySelector<HTMLInputElement>('input[name=token]')!
@@ -63,8 +167,10 @@ describe('route-owned creation surfaces', () => {
     const api = stubApi({ createToolset })
     const store = makeStore(api)
     store.connections.data = [{ metadata: { name: 'gh' }, spec: { type: 'github' } }]
+    markAuthoritative(store, 'connections')
     const el = await mount<Toolsets>('agents-toolsets', { store, api, routeOwned: true, createRoute: true })
     expect(el.querySelector('table')).toBeNull()
+    expect(el.querySelector('.k-create-surface--guided .k-create-guidance')).not.toBeNull()
     const name = el.querySelector<HTMLInputElement>('input[name=name]')!
     name.value = 'dev-tools'
     el.querySelector<HTMLFormElement>('form')!.dispatchEvent(new Event('submit', { cancelable: true }))
@@ -78,6 +184,7 @@ describe('route-owned creation surfaces', () => {
     const store = makeStore(api)
     const el = await mount<Models>('agents-models', { store, api, routeOwned: true, createRoute: true })
     expect(el.querySelector('.agents-model-create')).not.toBeNull()
+    expect(el.querySelector('.k-create-surface--guided .k-create-guidance')).not.toBeNull()
     const values: Record<string, string> = { name: 'main', model: 'gpt-5', apiKey: 'secret' }
     for (const [field, value] of Object.entries(values)) {
       const input = el.querySelector<HTMLInputElement>(`[name=${field}]`)!
@@ -90,6 +197,97 @@ describe('route-owned creation surfaces', () => {
 })
 
 describe('route-owned collection affordances', () => {
+  it('shows guided first-run journeys only after each collection is authoritative', async () => {
+    const usage = {
+      windowDays: 30,
+      total: { key: 'total', runs: 0, errors: 0, inputTokens: 0, outputTokens: 0, usdMicros: 0, latencyP50MS: 0, latencyP95MS: 0 },
+      byAgent: [],
+      byModel: [],
+      series: [],
+    }
+    const api = stubApi({ catalog: () => Promise.resolve([]), usage: () => Promise.resolve(usage) })
+
+    const pendingStore = makeStore(api)
+    const pendingAgents = await mount('agents-agents-list', { store: pendingStore, api })
+    expect(pendingAgents.querySelector('.k-first-run')).toBeNull()
+
+    const agentsStore = makeStore(api)
+    agentsStore.agents.loaded = true
+    agentsStore.agents.hasSnapshot = true
+    agentsStore.credentials.loaded = true
+    agentsStore.credentials.hasSnapshot = true
+    const agents = await mount('agents-agents-list', { store: agentsStore, api })
+    expect(agents.querySelector('.k-first-run')).not.toBeNull()
+
+    const modelsStore = makeStore(api)
+    modelsStore.credentials.loaded = true
+    modelsStore.credentials.hasSnapshot = true
+    const models = await mount<Models>('agents-models', { store: modelsStore, api, routeOwned: true })
+    expect(models.querySelector('.k-first-run')).not.toBeNull()
+
+    const connectionsStore = makeStore(api)
+    connectionsStore.connections.loaded = true
+    connectionsStore.connections.hasSnapshot = true
+    const connections = await mount<Connections>('agents-connections', { store: connectionsStore, api, routeOwned: true })
+    expect(connections.querySelector('.k-first-run')).not.toBeNull()
+
+    const toolsetsStore = makeStore(api)
+    toolsetsStore.toolsets.loaded = true
+    toolsetsStore.toolsets.hasSnapshot = true
+    const toolsets = await mount<Toolsets>('agents-toolsets', { store: toolsetsStore, api, routeOwned: true })
+    expect(toolsets.querySelector('.k-first-run')).not.toBeNull()
+    expect([...toolsets.querySelectorAll('.k-first-run__step-status')].map(step => step.textContent?.trim()))
+      .toEqual(['Current step:', 'Upcoming step:', 'Upcoming step:'])
+  })
+
+  it('keeps core and edge-only toolset creation available when there are no connections', async () => {
+    const api = stubApi()
+    const store = makeStore(api)
+    markAuthoritative(store, 'toolsets', 'connections')
+    const el = await mount<Toolsets>('agents-toolsets', { store, api, routeOwned: true })
+    const routes: unknown[] = []
+    el.addEventListener('agents-navigate', (event) => routes.push((event as CustomEvent).detail))
+
+    expect(el.textContent).toContain('Start with core and edge capabilities now')
+    const createToolset = [...el.querySelectorAll<HTMLButtonElement>('button')].find((button) => button.textContent?.includes('Create toolset'))!
+    const createConnection = [...el.querySelectorAll<HTMLButtonElement>('button')].find((button) => button.textContent?.includes('Create connection'))!
+    expect(createToolset).toBeTruthy()
+    expect(createConnection).toBeTruthy()
+    createToolset.click()
+    createConnection.click()
+    expect(routes).toEqual([
+      { kind: 'create', resource: 'toolset' },
+      { kind: 'create', resource: 'connection' },
+    ])
+  })
+
+  it('does not infer missing tool connections before their slice is authoritative', async () => {
+    const api = stubApi()
+    const store = makeStore(api)
+    markAuthoritative(store, 'toolsets')
+    const el = await mount<Toolsets>('agents-toolsets', { store, api, routeOwned: true })
+
+    expect(el.querySelector('.agents-state-loading')?.textContent).toContain('Loading optional tool connections')
+    expect(el.textContent).not.toContain('External tool connections are optional')
+    expect(el.textContent).toContain('Available external tool connections will appear after they finish loading')
+    expect([...el.querySelectorAll('button')].some((button) => button.textContent?.includes('Create toolset'))).toBe(true)
+  })
+
+  it('keeps toolset creation available when optional connection discovery fails', async () => {
+    const api = stubApi()
+    const store = makeStore(api)
+    markAuthoritative(store, 'toolsets')
+    store.connections.loaded = true
+    store.connections.error = 'connection API unavailable'
+    const load = vi.spyOn(store, 'load').mockResolvedValue()
+    const el = await mount<Toolsets>('agents-toolsets', { store, api, routeOwned: true })
+
+    expect(el.querySelector('.agents-state-error')?.textContent).toContain('Could not load optional tool connections')
+    expect([...el.querySelectorAll('button')].some((button) => button.textContent?.includes('Create toolset'))).toBe(true)
+    el.querySelector<HTMLButtonElement>('.agents-state-error button')!.click()
+    expect(load).toHaveBeenCalledWith('connections')
+  })
+
   it('navigates New agent instead of opening collection-local state', async () => {
     const api = stubApi()
     const store = makeStore(api)

--- a/providers/agents/portal/src/test/element-router.test.ts
+++ b/providers/agents/portal/src/test/element-router.test.ts
@@ -74,7 +74,7 @@ const waitForHistory = async (): Promise<void> => {
 
 describe('AgentsElement hash-owned creation navigation', () => {
   it('pushes create, replaces on cancel, and leaves the page form in the route', async () => {
-    const el = await mountShell()
+    const el = await mountShell('#/agents', { agents: [{ metadata: { name: 'scout' }, spec: { displayName: 'Scout' } }] })
     const before = history.length
     const newAgent = [...el.querySelectorAll('button')].find((button) => button.textContent?.includes('New agent'))!
     newAgent.click()
@@ -93,7 +93,7 @@ describe('AgentsElement hash-owned creation navigation', () => {
   })
 
   it('replaces the create entry with the new agent detail and keeps the result visible', async () => {
-    const el = await mountShell()
+    const el = await mountShell('#/agents', { agents: [{ metadata: { name: 'scout' }, spec: { displayName: 'Scout' } }] })
     const api = (el as unknown as { api: ApiClient }).api
     ;(el as unknown as { store: { credentials: { data: unknown[] } } }).store.credentials.data = [{ name: 'main', model: 'gpt-5' }]
     const created = { metadata: { name: 'nova' }, spec: { displayName: 'Nova', models: { chat: 'main' } } }
@@ -124,7 +124,7 @@ describe('AgentsElement hash-owned creation navigation', () => {
     expect(location.hash).toBe('#/connections')
     expect(history.length).toBe(before + 1)
 
-    const create = [...el.querySelectorAll('button')].find((button) => button.textContent?.includes('New connection'))!
+    const create = [...el.querySelectorAll('button')].find((button) => button.textContent?.includes('Create connection'))!
     create.click()
     await settle(el)
     expect(location.hash).toBe('#/create/connection')
@@ -152,7 +152,7 @@ describe('AgentsElement hash-owned creation navigation', () => {
     try {
       pushState.mockClear()
       replaceState.mockClear()
-      ;[...el.querySelectorAll<HTMLButtonElement>('button')].find((button) => button.textContent?.includes('New connection'))!.click()
+      ;[...el.querySelectorAll<HTMLButtonElement>('button')].find((button) => button.textContent?.includes('Create connection'))!.click()
       await settle(el)
       expect(location.hash).toBe('#/create/connection')
       expect(pushState).toHaveBeenCalledTimes(1)
@@ -196,7 +196,7 @@ describe('AgentsElement hash-owned creation navigation', () => {
     const api = (el as unknown as { api: ApiClient }).api
     const created = { name: 'main', provider: 'openai-compatible', model: 'gpt-5' }
     api.saveCredential = (() => Promise.resolve(created)) as ApiClient['saveCredential']
-    ;[...el.querySelectorAll<HTMLButtonElement>('button')].find((button) => button.textContent?.includes('New model'))!.click()
+    ;[...el.querySelectorAll<HTMLButtonElement>('button')].find((button) => button.textContent?.includes('Add model credential'))!.click()
     await settle(el)
     expect(location.hash).toBe('#/create/model')
     const createEntryLength = history.length
@@ -291,6 +291,11 @@ describe('AgentsElement hash-owned creation navigation', () => {
       const oldStore = (el as unknown as { store: AppStore }).store
       const oldApi = (el as unknown as { api: ApiClient }).api
       oldStore.credentials.data = [{ name: 'main', model: 'gpt-5' }]
+      oldStore.credentials.loaded = true
+      oldStore.credentials.hasSnapshot = true
+      oldStore.agents.loaded = true
+      oldStore.agents.hasSnapshot = true
+      oldStore.dispatchEvent(new Event('change'))
       await settle(el)
       oldApi.createAgent = (() => pending.promise) as ApiClient['createAgent']
 

--- a/providers/agents/portal/src/ui/create-flow.ts
+++ b/providers/agents/portal/src/ui/create-flow.ts
@@ -1,0 +1,99 @@
+import { html, nothing, type TemplateResult } from 'lit'
+import { icon, type IconName } from './icon'
+
+export interface FirstRunStep {
+  label: string
+  description: string
+}
+
+export interface FirstRunOptions {
+  icon: IconName
+  title: string
+  description: string
+  primaryLabel: string
+  primary: () => void
+  secondaryLabel?: string
+  secondary?: () => void
+  steps: readonly FirstRunStep[]
+  currentStep?: number
+  journeyLabel?: string
+}
+
+export function firstRunGuide(options: FirstRunOptions): TemplateResult {
+  const current = Math.max(0, Math.min(options.currentStep ?? 0, Math.max(0, options.steps.length - 1)))
+  return html`<section class="k-first-run agents-state-empty" aria-label=${options.title}>
+    <div class="k-first-run__lead">
+      <span class="k-first-run__icon" aria-hidden="true">${icon(options.icon)}</span>
+      <div class="k-first-run__copy">
+        <h3>${options.title}</h3>
+        <p>${options.description}</p>
+      </div>
+      <div class="k-first-run__actions">
+        <button class="k-btn k-btn--primary" type="button" @click=${options.primary}>
+          ${options.primaryLabel} ${icon('chevron-right')}
+        </button>
+        ${options.secondaryLabel && options.secondary
+          ? html`<button class="k-btn k-btn--ghost" type="button" @click=${options.secondary}>${options.secondaryLabel}</button>`
+          : nothing}
+      </div>
+    </div>
+    ${options.steps.length
+      ? html`<ol class="k-first-run__journey" aria-label=${options.journeyLabel || 'Getting started'}>
+          ${options.steps.map((step, index) => html`<li
+            class="k-first-run__step ${index < current ? 'is-complete' : index === current ? 'is-current' : ''}"
+            aria-current=${index === current ? 'step' : nothing}
+          >
+            <span class="k-first-run__marker" aria-hidden="true">
+              ${index < current ? icon('check') : index === current ? icon('circle') : index + 1}
+            </span>
+            <span class="k-first-run__step-copy">
+              <span class="k-first-run__step-status">
+                ${index < current ? 'Completed step' : index === current ? 'Current step' : 'Upcoming step'}:
+              </span>
+              <strong>${step.label}</strong><small>${step.description}</small>
+            </span>
+          </li>`)}
+        </ol>`
+      : nothing}
+  </section>`
+}
+
+export interface CreateGuidanceValue {
+  label: string
+  value: string
+  technical?: boolean
+}
+
+export interface CreateGuidanceOptions {
+  icon: IconName
+  title: string
+  description: string
+  prerequisites?: readonly string[]
+  values?: readonly CreateGuidanceValue[]
+  valuesHeading?: string
+  nextSteps?: readonly string[]
+}
+
+export function createGuidance(options: CreateGuidanceOptions): TemplateResult {
+  const prerequisites = options.prerequisites || []
+  const values = options.values || []
+  const nextSteps = options.nextSteps || []
+  return html`<aside class="k-create-guidance" aria-label=${options.title}>
+    <div class="k-create-guidance__heading">${icon(options.icon)}<h3>${options.title}</h3></div>
+    <p class="k-create-guidance__description">${options.description}</p>
+    ${prerequisites.length
+      ? html`<section class="k-create-guidance__section"><h4>Prerequisites</h4><ul>${prerequisites.map((item) => html`<li>${item}</li>`)}</ul></section>`
+      : nothing}
+    ${values.length
+      ? html`<section class="k-create-guidance__section">
+          <h4>${options.valuesHeading || 'What Faros will create'}</h4>
+          <dl class="k-create-guidance__values">
+            ${values.map((item) => html`<dt>${item.label}</dt><dd>${item.technical ? html`<code>${item.value}</code>` : item.value}</dd>`)}
+          </dl>
+        </section>`
+      : nothing}
+    ${nextSteps.length
+      ? html`<section class="k-create-guidance__section"><h4>Next steps</h4><ol>${nextSteps.map((item) => html`<li>${item}</li>`)}</ol></section>`
+      : nothing}
+  </aside>`
+}

--- a/providers/agents/portal/src/ui/states.ts
+++ b/providers/agents/portal/src/ui/states.ts
@@ -11,6 +11,9 @@ export interface SliceViewOptions<T> {
   // emptyIcon/emptyText render when the load succeeded and returned nothing.
   emptyIcon: IconName
   emptyText: string
+  // A guided empty state can replace the compact fallback after an
+  // authoritative empty snapshot. It is never rendered before the load settles.
+  empty?: () => TemplateResult
   // retry re-runs the loader from the error state.
   retry: () => void
   // content renders the non-empty case.
@@ -19,11 +22,12 @@ export interface SliceViewOptions<T> {
 
 export function sliceView<T>(o: SliceViewOptions<T>): TemplateResult {
   const s = o.slice
+  const empty = (): TemplateResult => o.empty?.() ?? emptyState(o.emptyIcon, o.emptyText)
   // Once a slice has produced an authoritative snapshot, a later background
   // failure must not replace it with a full-page error. Keep populated *and*
   // empty snapshots stable and add a compact stale-data notice instead.
   if (s.error && s.hasSnapshot) {
-    const content = s.data.length ? o.content(s.data) : emptyState(o.emptyIcon, o.emptyText)
+    const content = s.data.length ? o.content(s.data) : empty()
     return html`${staleState(s.error, o.retry)}${content}`
   }
   if (s.error) return errorState(s.error, o.retry)
@@ -31,7 +35,7 @@ export function sliceView<T>(o: SliceViewOptions<T>): TemplateResult {
   // store normally marks loading synchronously, but treating all pre-load
   // states as pending also protects the first render and context rotations.
   if (!s.loaded) return loadingState()
-  if (!s.data.length) return emptyState(o.emptyIcon, o.emptyText)
+  if (!s.data.length) return empty()
   return o.content(s.data)
 }
 

--- a/providers/agents/portal/src/views/agent-create.ts
+++ b/providers/agents/portal/src/views/agent-create.ts
@@ -8,9 +8,11 @@ import { html, nothing, type TemplateResult } from 'lit'
 import { state } from 'lit/decorators.js'
 import { StoreElement } from '../ui/base'
 import { icon } from '../ui/icon'
+import { errorState, loadingState, staleState } from '../ui/states'
 import { mutate } from '../mutate'
 import type { CreateSuccessDetail } from '../router'
-import type { AgentCreate } from '../types'
+import type { Agent, AgentCreate } from '../types'
+import { createGuidance } from '../ui/create-flow'
 
 const NAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 
@@ -27,9 +29,14 @@ export class AgentCreateWizard extends StoreElement {
   @state() private fanOut = false
   @state() private errors: Record<string, string> = {}
   @state() private busy = false
+  private focusedName = false
 
-  firstUpdated(): void {
-    this.querySelector<HTMLInputElement>('input[name=name]')?.focus()
+  protected updated(): void {
+    if (this.focusedName) return
+    const input = this.querySelector<HTMLInputElement>('input[name=name]')
+    if (!input) return
+    input.focus()
+    this.focusedName = true
   }
 
   private async submit(e: Event): Promise<void> {
@@ -53,13 +60,17 @@ export class AgentCreateWizard extends StoreElement {
     if (this.fanOut) fams.push('spawn')
     if (fams.length > 1) body.interactiveFamilies = fams
     this.busy = true
-    const res = await mutate(this.store, {
-      run: () => this.api.createAgent(body),
-      success: `Agent “${name}” created.`,
-      failure: 'Create failed',
-      reload: ['agents'],
-    })
-    this.busy = false
+    let res: Agent | undefined
+    try {
+      res = await mutate(this.store, {
+        run: () => this.api.createAgent(body),
+        success: `Agent “${name}” created.`,
+        failure: 'Create failed',
+        reload: ['agents'],
+      })
+    } finally {
+      this.busy = false
+    }
     if (!res) return
     this.dispatchEvent(
       new CustomEvent<CreateSuccessDetail>('agents-create-success', {
@@ -75,44 +86,80 @@ export class AgentCreateWizard extends StoreElement {
   }
 
   render(): TemplateResult {
-    const creds = this.store.credentials.data
+    const agents = this.store.agents
+    const credentials = this.store.credentials
+    const retryAgents = () => void this.store.load('agents')
+    const retryCredentials = () => void this.store.load('credentials')
+    let prerequisiteState: TemplateResult | null = null
+    if (agents.error && !agents.hasSnapshot) {
+      prerequisiteState = errorState(`Could not load existing agents. ${agents.error}`, retryAgents)
+    } else if (credentials.error && !credentials.hasSnapshot) {
+      prerequisiteState = errorState(`Could not load model credentials. ${credentials.error}`, retryCredentials)
+    } else if (!agents.hasSnapshot || !credentials.hasSnapshot) {
+      prerequisiteState = loadingState('Loading existing agents and model credentials…')
+    }
+
+    if (prerequisiteState) {
+      return html`<div class="agents-create-page k-create-page">
+        <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancel()}>${icon('arrow-left')} Agents</button>
+        <header class="k-create-header"><h1 class="k-create-title">Create agent</h1><p class="k-create-description">Choose the model, instructions, and optional channel this agent starts with.</p></header>
+        ${prerequisiteState}
+      </div>`
+    }
+
+    const creds = credentials.data
     const channels = this.store.channelConnections()
+    const staleNotices = html`
+      ${agents.error ? staleState(agents.error, retryAgents) : nothing}
+      ${credentials.error ? staleState(credentials.error, retryCredentials) : nothing}
+    `
     const form = html`<form
-      class="agents-create-form k-create-surface"
+      class="agents-create-form agents-guided-form k-create-surface k-create-surface--guided"
       aria-label="Create agent"
+      aria-busy=${this.busy ? 'true' : 'false'}
       @submit=${(e: Event) => void this.submit(e)}
     >
-        <div class="k-create-body">
-        <label>
+        <div class="k-create-body k-create-body--guided">
+        <div class="k-create-fields">
+        <label for="agent-create-name">
           Name *
-          <input class="k-input"
+          <input id="agent-create-name" class="k-input"
             name="name"
             .value=${this.name}
             placeholder="research-bot"
             autocomplete="off"
+            required
+            ?disabled=${this.busy}
             aria-invalid=${this.errors.name ? 'true' : nothing}
+            aria-describedby=${this.errors.name ? 'agent-create-name-hint agent-create-name-error' : 'agent-create-name-hint'}
             @input=${(e: Event) => (this.name = (e.target as HTMLInputElement).value)}
           />
           ${this.errors.name
-            ? html`<span class="agents-fielderr">${this.errors.name}</span>`
-            : html`<span class="agents-hint">A short id you'll reference from schedules and triggers.</span>`}
+            ? html`<span id="agent-create-name-error" class="agents-fielderr" role="alert">${this.errors.name}</span>`
+            : nothing}
+          <span id="agent-create-name-hint" class="agents-hint">A short id you'll reference from schedules and triggers.</span>
         </label>
 
-        <label>
+        <label for="agent-create-model">
           Model credential *
-          <select class="k-input"
+          <select id="agent-create-model" class="k-input"
+            name="modelCredential"
             .value=${this.modelCredential}
+            required
+            ?disabled=${this.busy}
             aria-invalid=${this.errors.modelCredential ? 'true' : nothing}
+            aria-describedby=${this.errors.modelCredential ? 'agent-create-model-hint agent-create-model-error' : 'agent-create-model-hint'}
             @change=${(e: Event) => (this.modelCredential = (e.target as HTMLSelectElement).value)}
           >
             <option value="">— pick a model —</option>
             ${creds.map((c) => html`<option value=${c.name} ?selected=${c.name === this.modelCredential}>${c.name}${c.model ? ` (${c.model})` : ''}</option>`)}
           </select>
-          ${this.errors.modelCredential ? html`<span class="agents-fielderr">${this.errors.modelCredential}</span>` : nothing}
+          ${this.errors.modelCredential ? html`<span id="agent-create-model-error" class="agents-fielderr" role="alert">${this.errors.modelCredential}</span>` : nothing}
+          <span id="agent-create-model-hint" class="agents-hint">The credential and model endpoint used for every turn.</span>
           ${creds.length === 0
             ? html`<span class="agents-hint"
                 >No model credentials yet —
-                <button type="button" class="k-btn k-btn--ghost agents-linkbtn" @click=${() => this.navigate({ kind: 'menu', menu: 'models' })}>
+                <button type="button" class="k-btn k-btn--ghost agents-linkbtn" ?disabled=${this.busy} @click=${() => this.navigate({ kind: 'create', resource: 'model' })}>
                   add one under Models
                 </button>
                 first.</span
@@ -127,13 +174,14 @@ export class AgentCreateWizard extends StoreElement {
             rows="3"
             placeholder="You are a concise assistant that…"
             .value=${this.systemPrompt}
+            ?disabled=${this.busy}
             @input=${(e: Event) => (this.systemPrompt = (e.target as HTMLTextAreaElement).value)}
           ></textarea>
         </label>
 
         <label>
           Primary channel <span class="agents-hint">optional — where this agent messages you</span>
-          <select class="k-input" @change=${(e: Event) => (this.channel = (e.target as HTMLSelectElement).value)}>
+          <select class="k-input" ?disabled=${this.busy} @change=${(e: Event) => (this.channel = (e.target as HTMLSelectElement).value)}>
             <option value="">— none —</option>
             ${channels.map((c) => html`<option value=${c.metadata.name} ?selected=${c.metadata.name === this.channel}>${c.spec.displayName || c.metadata.name} (${c.spec.type})</option>`)}
           </select>
@@ -142,28 +190,51 @@ export class AgentCreateWizard extends StoreElement {
         <fieldset class="agents-cap-fs">
           <legend>Can do <span class="agents-hint">— changeable later</span></legend>
           <label class="agents-cap">
-            <input type="checkbox" .checked=${this.web} @change=${(e: Event) => (this.web = (e.target as HTMLInputElement).checked)} />
+            <input type="checkbox" .checked=${this.web} ?disabled=${this.busy} @change=${(e: Event) => (this.web = (e.target as HTMLInputElement).checked)} />
             <span><strong>Read the web</strong> <span class="muted">— fetch pages; search needs a websearch tool</span></span>
           </label>
           <label class="agents-cap">
             <input
               type="checkbox"
               .checked=${this.fanOut}
+              ?disabled=${this.busy}
               @change=${(e: Event) => (this.fanOut = (e.target as HTMLInputElement).checked)}
             />
             <span><strong>Research fan-out</strong> <span class="muted">— work independent parts in parallel</span></span>
           </label>
         </fieldset>
         </div>
+        ${createGuidance({
+          icon: 'bot',
+          title: 'Prepare a usable agent',
+          description: 'Choose the identity Faros will create and the model it can use immediately.',
+          prerequisites: [
+            creds.length ? 'A model credential is available in this workspace.' : 'Add a model credential before creating the agent.',
+            'Optional channel connections can be added now or attached later from Config.',
+          ],
+          values: [
+            { label: 'Agent name', value: this.name.trim() || 'Not entered yet', technical: true },
+            { label: 'Model', value: this.modelCredential || 'Not selected', technical: true },
+            { label: 'Primary channel', value: this.channel || 'None', technical: true },
+            { label: 'Capabilities', value: [this.web ? 'web' : '', this.fanOut ? 'fan-out' : ''].filter(Boolean).join(', ') || 'Core only' },
+          ],
+          nextSteps: [
+            'Faros creates the agent and opens its Config workspace.',
+            'Start a conversation to verify the model and instructions.',
+            'Attach toolsets, schedules, and triggers when the core behavior is ready.',
+          ],
+        })}
+        </div>
 
         <div class="k-create-actions">
-          <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancel()}>Cancel</button>
-          <button class="k-btn k-btn--primary" type="submit">${icon('check')} Create agent</button>
+          <button type="button" class="k-btn k-btn--ghost secondary" ?disabled=${this.busy} @click=${() => this.cancel()}>Cancel</button>
+          <button class="k-btn k-btn--primary" type="submit" ?disabled=${this.busy || creds.length === 0}>${icon('check')} ${this.busy ? 'Creating…' : 'Create agent'}</button>
         </div>
       </form>`
     return html`<div class="agents-create-page k-create-page">
-      <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancel()}>${icon('arrow-left')} Agents</button>
+      <button type="button" class="k-btn k-btn--ghost k-back-action" ?disabled=${this.busy} @click=${() => this.cancel()}>${icon('arrow-left')} Agents</button>
       <header class="k-create-header"><h1 class="k-create-title">Create agent</h1><p class="k-create-description">Choose the model, instructions, and optional channel this agent starts with.</p></header>
+      ${staleNotices}
       ${form}
     </div>`
   }

--- a/providers/agents/portal/src/views/agents-list.ts
+++ b/providers/agents/portal/src/views/agents-list.ts
@@ -3,15 +3,16 @@
 // wizard, which — unlike the old bare name field — collects the model
 // credential the agent needs to be usable on arrival.
 
-import { html, type TemplateResult } from 'lit'
+import { html, nothing, type TemplateResult } from 'lit'
 import { repeat } from 'lit/directives/repeat.js'
 import { StoreElement } from '../ui/base'
 import { icon } from '../ui/icon'
-import { sliceView } from '../ui/states'
+import { errorState, loadingState, sliceView, staleState } from '../ui/states'
 import { confirmModal } from '../portalkit/modal'
 import { mutate } from '../mutate'
 import type { Agent } from '../types'
 import { hashFor } from '../router'
+import { firstRunGuide } from '../ui/create-flow'
 
 export class AgentsList extends StoreElement {
   private async del(name: string): Promise<void> {
@@ -33,16 +34,50 @@ export class AgentsList extends StoreElement {
   }
 
   render(): TemplateResult {
+    const agents = this.store.agents
+    const credentials = this.store.credentials
+    const showFirstRun = agents.loaded && agents.data.length === 0 && (!agents.error || agents.hasSnapshot)
+    const renderFirstRun = (): TemplateResult => {
+      const retryCredentials = () => void this.store.load('credentials')
+      if (credentials.error && !credentials.hasSnapshot) {
+        return errorState(`Could not load model credentials. ${credentials.error}`, retryCredentials)
+      }
+      if (!credentials.loaded) return loadingState('Loading model credentials…')
+
+      const needsModel = credentials.data.length === 0
+      const guide = firstRunGuide({
+        icon: 'bot',
+        title: needsModel ? 'Connect a model before creating your first agent' : 'Create your first agent',
+        description: needsModel
+          ? 'Agents need a model credential to reason. Add one first, then return here to choose instructions, tools, and a channel.'
+          : 'Give an agent a model and standing instructions, then start a conversation or automate its work.',
+        primaryLabel: needsModel ? 'Add model credential' : 'Create agent',
+        primary: () => this.navigate({ kind: 'create', resource: needsModel ? 'model' : 'agent' }),
+        steps: [
+          { label: 'Model', description: 'Credential and model endpoint' },
+          { label: 'Agent', description: 'Identity, instructions, and capabilities' },
+          { label: 'Conversation', description: 'Chat directly or add automation' },
+        ],
+        currentStep: needsModel ? 0 : 1,
+        journeyLabel: 'Agent setup path',
+      })
+      return credentials.error
+        ? html`${staleState(credentials.error, retryCredentials)}${guide}`
+        : guide
+    }
     return html`
       <div class="agents-menu">
         <div class="agents-panel-head">
           <h3>Agents</h3>
-          <button class="k-btn k-btn--primary" @click=${() => this.navigate({ kind: 'create', resource: 'agent' })}>${icon('plus')} New agent</button>
+          ${showFirstRun
+            ? nothing
+            : html`<button class="k-btn k-btn--primary" @click=${() => this.navigate({ kind: 'create', resource: 'agent' })}>${icon('plus')} New agent</button>`}
         </div>
         ${sliceView<Agent>({
-          slice: this.store.agents,
+          slice: agents,
           emptyIcon: 'bot',
           emptyText: 'No agents yet — create one to get started.',
+          empty: renderFirstRun,
           retry: () => void this.store.load('agents'),
           content: (rows) => html`<div class="agents-grid">
             ${repeat(

--- a/providers/agents/portal/src/views/assisted-search.ts
+++ b/providers/agents/portal/src/views/assisted-search.ts
@@ -220,7 +220,7 @@ export class AssistedSearch extends StoreElement {
     const agents = this.store.agents.data
     const selected = this.selectedAgent()
     const form = html`<form
-        class="agents-conn-form k-create-surface"
+        class="agents-conn-form agents-guided-form k-create-surface"
         aria-label="Assisted search setup"
         @submit=${(e: Event) => void this.submit(e)}
       >

--- a/providers/agents/portal/src/views/connections.ts
+++ b/providers/agents/portal/src/views/connections.ts
@@ -11,6 +11,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js'
 import { StoreElement } from '../ui/base'
 import { icon } from '../ui/icon'
 import { sliceView } from '../ui/states'
+import { createGuidance, firstRunGuide } from '../ui/create-flow'
 import { toast } from '../ui/toast'
 import { confirmModal } from '../portalkit/modal'
 import { mutate } from '../mutate'
@@ -79,18 +80,35 @@ export class Connections extends StoreElement {
   @state() private connType: string | null = null
   @state() private connMode = ''
   @state() private editing: string | null = null
+  @state() private createBusy = false
+  @state() private createValues: Record<string, string> = {}
+
+  protected willUpdate(changed?: Map<PropertyKey, unknown>): void {
+    super.willUpdate()
+    if (changed?.has('createType') && changed.get('createType') !== undefined) {
+      this.createValues = {}
+      this.connMode = ''
+    }
+  }
 
   private async create(def: ConnTypeDef, form: HTMLFormElement): Promise<void> {
+    if (this.createBusy) return
     const v: Record<string, string> = {}
     form.querySelectorAll<HTMLInputElement>('input[name]').forEach((el) => (v[el.name] = el.value.trim()))
     const mode = this.connMode || def.modes?.[0].id || ''
     const body = def.build(v, mode)
-    const res = await mutate(this.store, {
-      run: () => this.api.createConnection(body),
-      success: 'Connection created.',
-      failure: 'Create failed',
-      reload: ['connections'],
-    })
+    this.createBusy = true
+    let res: Connection | undefined
+    try {
+      res = await mutate(this.store, {
+        run: () => this.api.createConnection(body),
+        success: 'Connection created.',
+        failure: 'Create failed',
+        reload: ['connections'],
+      })
+    } finally {
+      this.createBusy = false
+    }
     if (res && this.routeOwned) {
       this.dispatchEvent(
         new CustomEvent<CreateSuccessDetail>('agents-create-success', {
@@ -167,12 +185,14 @@ export class Connections extends StoreElement {
 
   render(): TemplateResult {
     if (this.createRoute) return this.createRouteSurface()
+    const connections = this.store.connections
+    const showFirstRun = connections.loaded && connections.data.length === 0 && (!connections.error || connections.hasSnapshot)
     return html`
       <div class="agents-menu">
         <div class="agents-panel k-card agents-route-panel">
           <div class="agents-panel-head">
             <h3>Connections</h3>
-            ${this.routeOwned
+            ${this.routeOwned && !showFirstRun
               ? html`<button class="k-btn k-btn--primary" @click=${() => this.navigate({ kind: 'create', resource: 'connection' })}>${icon('plus')} New connection</button>`
               : nothing}
           </div>
@@ -182,9 +202,23 @@ export class Connections extends StoreElement {
             <strong>Connection</strong>. Stored as Secrets in your workspace.
           </p>
           ${sliceView<Connection>({
-            slice: this.store.connections,
+            slice: connections,
             emptyIcon: 'plug',
             emptyText: 'No connections yet — add one below.',
+            empty: () => firstRunGuide({
+              icon: 'plug',
+              title: 'Connect tools and channels',
+              description: 'Add reusable access to an external system once, then grant it to agents directly or through a toolset.',
+              primaryLabel: 'Create connection',
+              primary: () => this.navigate({ kind: 'create', resource: 'connection' }),
+              steps: [
+                { label: 'Connection', description: 'Tool, channel, or external credential' },
+                { label: 'Toolset', description: 'Optional reusable capability bundle' },
+                { label: 'Agent', description: 'Grant access from agent Config' },
+              ],
+              currentStep: 0,
+              journeyLabel: 'Connection setup path',
+            }),
             retry: () => void this.store.load('connections'),
             content: (rows) => this.table(rows),
           })}
@@ -202,7 +236,7 @@ export class Connections extends StoreElement {
   private createRouteSurface(): TemplateResult {
     if (!this.createType) {
       return html`<div class="agents-menu agents-create-page k-create-page">
-        <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
+        <button type="button" class="k-btn k-btn--ghost k-back-action" ?disabled=${this.createBusy} @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
         <header class="k-create-header"><h1 class="k-create-title">Create connection</h1><p class="k-create-description">Choose the tool, channel, or external service you want agents to use.</p></header>
         <div class="k-create-surface k-create-surface--wide">
           <div class="k-create-body">${this.picker(false)}</div>
@@ -217,12 +251,12 @@ export class Connections extends StoreElement {
     const def = CONN_DEFS.find((d) => d.id === this.createType)
     if (!def) {
       return html`<div class="agents-create-page k-create-page">
-        <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
+        <button type="button" class="k-btn k-btn--ghost k-back-action" ?disabled=${this.createBusy} @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
         <header class="k-create-header"><h1 class="k-create-title">Connection type unavailable</h1><p class="k-create-description">That connection type is not available in this version of the Agents provider.</p></header>
       </div>`
     }
     return html`<div class="agents-menu agents-create-page k-create-page">
-      <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
+      <button type="button" class="k-btn k-btn--ghost k-back-action" ?disabled=${this.createBusy} @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
       <header class="k-create-header"><h1 class="k-create-title">Connect ${def.label}</h1><p class="k-create-description">${def.desc}</p></header>
       ${this.createForm(def)}
     </div>`
@@ -368,6 +402,9 @@ export class Connections extends StoreElement {
         placeholder=${f.placeholder || ''}
         ?required=${f.required}
         autocomplete="off"
+        .value=${this.createValues[f.key] || ''}
+        ?disabled=${this.createBusy}
+        @input=${(e: Event) => (this.createValues = { ...this.createValues, [f.key]: (e.target as HTMLInputElement).value })}
       />
       ${f.hint ? html`<span class="agents-hint">${f.hint}</span>` : nothing}
     </label>`
@@ -387,17 +424,20 @@ export class Connections extends StoreElement {
     const platformApp = isOAuthMode && this.store.oauthApps.has(def.id)
     if (platformApp) fields = fields.filter((f) => f.key !== 'clientID' && f.key !== 'clientSecret')
     return html`<form
-      class=${this.routeOwned ? 'agents-conn-form k-create-surface' : 'agents-conn-form k-card'}
+      class=${this.routeOwned ? 'agents-conn-form agents-guided-form k-create-surface k-create-surface--guided' : 'agents-conn-form k-card'}
+      aria-busy=${this.createBusy ? 'true' : 'false'}
       @submit=${(e: Event) => {
         e.preventDefault()
         void this.create(def, e.target as HTMLFormElement)
       }}
     >
-      <div class=${this.routeOwned ? 'k-create-body' : ''}>
+      <div class=${this.routeOwned ? 'k-create-body k-create-body--guided' : ''}>
+      <div class=${this.routeOwned ? 'k-create-fields' : ''}>
       <div class="agents-conn-formhead">
         <button
           type="button"
           class="k-btn k-btn--ghost agents-back"
+          ?disabled=${this.createBusy}
           @click=${() => (this.routeOwned ? this.navigate({ kind: 'create', resource: 'connection' }) : (this.connType = null))}
         >${icon('arrow-left')} connection types</button>
         ${this.routeOwned ? nothing : html`<h4>${icon(def.glyph)} ${def.label}</h4>`}
@@ -413,13 +453,17 @@ export class Connections extends StoreElement {
         : nothing}
       <label>
         Name *
-        <input class="k-input" name="name" required pattern="[a-z0-9-]+" placeholder=${`my-${def.id}`} autocomplete="off" />
+        <input class="k-input" name="name" required pattern="[a-z0-9-]+" placeholder=${`my-${def.id}`} autocomplete="off"
+          .value=${this.createValues.name || ''}
+          ?disabled=${this.createBusy}
+          @input=${(e: Event) => (this.createValues = { ...this.createValues, name: (e.target as HTMLInputElement).value })}
+        />
         <span class="agents-hint">A short id you'll reference from agents.</span>
       </label>
       ${def.modes
         ? html`<div class="agents-modeseg" role="group" aria-label="Authentication mode">
             ${def.modes.map(
-              (m) => html`<button type="button" class="k-btn k-btn--ghost agents-modebtn ${m.id === mode ? 'sel' : ''}" @click=${() => (this.connMode = m.id)}>
+              (m) => html`<button type="button" class="k-btn k-btn--ghost agents-modebtn ${m.id === mode ? 'sel' : ''}" ?disabled=${this.createBusy} aria-pressed=${m.id === mode ? 'true' : 'false'} @click=${() => (this.connMode = m.id)}>
                 ${m.label}
               </button>`,
             )}
@@ -436,14 +480,37 @@ export class Connections extends StoreElement {
         ? html`<details class="agents-adv"><summary>Advanced</summary>${advanced.map((f) => this.field(f))}</details>`
         : nothing}
       </div>
+      ${this.routeOwned ? createGuidance({
+        icon: def.glyph,
+        title: `Connect ${def.label}`,
+        description: 'Prepare the external identity once; agents receive access only when you grant this connection later.',
+        prerequisites: [
+          def.setup?.length ? 'Review the provider setup steps shown in the form.' : `Have the ${def.label} endpoint or credential ready.`,
+          `Required fields: ${['Name', ...fields.filter((field) => field.required).map((field) => field.label)].join(', ')}.`,
+        ],
+        values: [
+          { label: 'Connection', value: this.createValues.name?.trim() || 'Not entered yet', technical: true },
+          { label: 'Type', value: def.label },
+          { label: 'Mode', value: activeMode?.label || 'Default' },
+          { label: 'Required details', value: `${fields.filter((field) => field.required && this.createValues[field.key]?.trim()).length} of ${fields.filter((field) => field.required).length} entered` },
+        ],
+        nextSteps: [
+          'Faros stores secret values in this workspace and does not show them after creation.',
+          'Test or authorize the connection from the Connections page when the type supports it.',
+          'Grant the connection to an agent directly or add it to a shared toolset.',
+        ],
+      }) : nothing}
+      </div>
       <div class=${this.routeOwned ? 'k-create-actions' : ''}>
-        ${this.routeOwned ? html`<button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancelCreate()}>Cancel</button>` : nothing}
-        <button class="k-btn k-btn--primary" type="submit">Create connection</button>
+        ${this.routeOwned ? html`<button type="button" class="k-btn k-btn--ghost secondary" ?disabled=${this.createBusy} @click=${() => this.cancelCreate()}>Cancel</button>` : nothing}
+        <button class="k-btn k-btn--primary" type="submit" ?disabled=${this.createBusy}>${this.createBusy ? 'Creating…' : 'Create connection'}</button>
       </div>
     </form>`
   }
 
   private cancelCreate(): void {
+    if (this.createBusy) return
+    this.createValues = {}
     if (this.routeOwned) {
       this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
       return

--- a/providers/agents/portal/src/views/models.ts
+++ b/providers/agents/portal/src/views/models.ts
@@ -14,7 +14,8 @@ import { property, state } from 'lit/decorators.js'
 import { repeat } from 'lit/directives/repeat.js'
 import { StoreElement } from '../ui/base'
 import { icon } from '../ui/icon'
-import { errorState } from '../ui/states'
+import { errorState, sliceView } from '../ui/states'
+import { createGuidance, firstRunGuide } from '../ui/create-flow'
 import { toast } from '../ui/toast'
 import { confirmModal } from '../portalkit/modal'
 import { mutate } from '../mutate'
@@ -42,6 +43,14 @@ export class Models extends StoreElement {
   @state() private discFilter = new Map<string, string>()
   @state() private editName: string | null = null
   @state() private creating = false
+  @state() private createBusy = false
+  @state() private createDraft = {
+    name: '',
+    preset: PROVIDER_PRESETS[0].id,
+    baseURL: PROVIDER_PRESETS[0].baseURL,
+    model: '',
+    apiKey: '',
+  }
 
   private started = false
 
@@ -115,10 +124,11 @@ export class Models extends StoreElement {
   render(): TemplateResult {
     if (this.createRoute) return this.createSurface()
     const creds = this.store.credentials
+    const showFirstRun = creds.loaded && creds.data.length === 0 && (!creds.error || creds.hasSnapshot)
     return html`<div class="agents-panel k-card agents-route-panel">
       <div class="agents-panel-head">
         <h3>Models</h3>
-        ${this.creating
+        ${this.creating || showFirstRun
           ? nothing
           : html`<button
               class="k-btn k-btn--primary"
@@ -131,17 +141,33 @@ export class Models extends StoreElement {
       </p>
       ${this.dashboard()}
       <h3 class="agents-section-h">Credentials</h3>
-      ${creds.error
-        ? errorState(creds.error, () => void this.store.load('credentials'))
-        : creds.data.length === 0
-          ? html`<p class="agents-hint">${icon('cpu')} No models yet${this.creating ? '.' : ' — add one below.'}</p>`
-          : html`<div class="agents-model-grid">
+      ${sliceView<Credential>({
+        slice: creds,
+        emptyIcon: 'cpu',
+        emptyText: 'No model credentials yet.',
+        empty: () => firstRunGuide({
+          icon: 'cpu',
+          title: 'Connect your first model',
+          description: 'Store one workspace credential and model endpoint so agents can reason immediately after creation.',
+          primaryLabel: 'Add model credential',
+          primary: () => (this.routeOwned ? this.navigate({ kind: 'create', resource: 'model' }) : (this.creating = true)),
+          steps: [
+            { label: 'Credential', description: 'Provider endpoint, model, and secret' },
+            { label: 'Agent', description: 'Assign the model to an agent' },
+            { label: 'Run', description: 'Verify behavior in a conversation' },
+          ],
+          currentStep: 0,
+          journeyLabel: 'Model setup path',
+        }),
+        retry: () => void this.store.load('credentials'),
+        content: (rows) => html`<div class="agents-model-grid">
               ${repeat(
-                creds.data,
+                rows,
                 (c) => c.name,
                 (c) => this.card(c),
               )}
-            </div>`}
+            </div>`,
+      })}
       ${this.creating ? this.createForm() : nothing}
       <datalist id="agents-catalog-models">
         ${this.catalog.map((m) => html`<option value=${m.id}>${m.label || m.id}</option>`)}
@@ -151,7 +177,7 @@ export class Models extends StoreElement {
 
   private createSurface(): TemplateResult {
     return html`<div class="agents-menu agents-create-page k-create-page">
-      <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancelCreate()}>${icon('arrow-left')} Models</button>
+      <button type="button" class="k-btn k-btn--ghost k-back-action" ?disabled=${this.createBusy} @click=${() => this.cancelCreate()}>${icon('arrow-left')} Models</button>
       <header class="k-create-header"><h1 class="k-create-title">Add model credential</h1><p class="k-create-description">Configure a workspace model endpoint and credential for your agents.</p></header>
       ${this.createForm()}
       <datalist id="agents-catalog-models">
@@ -415,75 +441,130 @@ export class Models extends StoreElement {
     </form>`
   }
 
+  private updateCreateDraft(key: keyof Models['createDraft'], value: string): void {
+    this.createDraft = { ...this.createDraft, [key]: value }
+  }
+
+  private async createCredential(e: Event): Promise<void> {
+    e.preventDefault()
+    if (this.createBusy) return
+    const f = e.currentTarget as HTMLFormElement
+    const g = (n: string): string => (f.querySelector<HTMLInputElement>(`[name=${n}]`)?.value || '').trim()
+    const body = {
+      name: g('name'),
+      provider: 'openai-compatible',
+      baseURL: g('baseURL'),
+      model: g('model'),
+      apiKey: g('apiKey'),
+    }
+    this.createBusy = true
+    try {
+      const res = await mutate(this.store, {
+        run: () => this.api.saveCredential(body),
+        success: 'Credential saved.',
+        failure: 'Save failed',
+        reload: ['credentials'],
+      })
+      if (!res) return
+      this.createDraft = {
+        name: '',
+        preset: PROVIDER_PRESETS[0].id,
+        baseURL: PROVIDER_PRESETS[0].baseURL,
+        model: '',
+        apiKey: '',
+      }
+      if (this.routeOwned) {
+        this.dispatchEvent(
+          new CustomEvent<CreateSuccessDetail>('agents-create-success', {
+            detail: { resource: 'model', name: body.name, item: res },
+            bubbles: true,
+            composed: true,
+          }),
+        )
+        return
+      }
+      this.creating = false
+    } finally {
+      this.createBusy = false
+    }
+  }
+
   private createForm(): TemplateResult {
+    const draft = this.createDraft
     return html`<form
-      class=${this.createRoute ? 'agents-cred-form agents-model-create k-create-surface' : 'agents-cred-form agents-model-create'}
-      @submit=${(e: Event) => {
-        e.preventDefault()
-        const f = e.target as HTMLFormElement
-        const g = (n: string): string => (f.querySelector<HTMLInputElement>(`[name=${n}]`)?.value || '').trim()
-        const body = {
-          name: g('name'),
-          provider: 'openai-compatible',
-          baseURL: g('baseURL'),
-          model: g('model'),
-          apiKey: g('apiKey'),
-        }
-        void mutate(this.store, {
-          run: () => this.api.saveCredential(body),
-          success: 'Credential saved.',
-          failure: 'Save failed',
-          reload: ['credentials'],
-        }).then((res) => {
-          if (!res) return
-          if (this.routeOwned) {
-            this.dispatchEvent(
-              new CustomEvent<CreateSuccessDetail>('agents-create-success', {
-                detail: { resource: 'model', name: body.name, item: res },
-                bubbles: true,
-                composed: true,
-              }),
-            )
-            return
-          }
-          this.creating = false
-        })
-      }}
+      class=${this.createRoute ? 'agents-cred-form agents-model-create agents-guided-form k-create-surface k-create-surface--guided' : 'agents-cred-form agents-model-create'}
+      aria-busy=${this.createBusy ? 'true' : 'false'}
+      @submit=${(e: Event) => void this.createCredential(e)}
     >
-      <div class=${this.createRoute ? 'k-create-body' : ''}>
+      <div class=${this.createRoute ? 'k-create-body k-create-body--guided' : ''}>
+      <div class=${this.createRoute ? 'k-create-fields' : ''}>
       ${this.createRoute ? nothing : html`<h4>New model credential</h4>`}
       <div class="agents-grid2">
-        <label>Name<input class="k-input" name="name" required pattern="[a-z0-9-]+" placeholder="my-openai" /></label>
+        <label>Name<input class="k-input" name="name" required pattern="[a-z0-9-]+" placeholder="my-openai" .value=${draft.name} ?disabled=${this.createBusy} @input=${(e: Event) => this.updateCreateDraft('name', (e.target as HTMLInputElement).value)} /></label>
         <label>
           Provider
           <select class="k-input"
             name="preset"
+            ?disabled=${this.createBusy}
             @change=${(e: Event) => {
               const p = PROVIDER_PRESETS.find((x) => x.id === (e.target as HTMLSelectElement).value)
               if (!p) return
               const form = (e.target as HTMLElement).closest('form')!
               const baseURL = form.querySelector<HTMLInputElement>('input[name=baseURL]')!
               const model = form.querySelector<HTMLInputElement>('input[name=model]')!
-              if (p.id !== 'custom') baseURL.value = p.baseURL
+              if (p.id !== 'custom') {
+                baseURL.value = p.baseURL
+                this.updateCreateDraft('baseURL', p.baseURL)
+              }
               model.placeholder = p.modelHint
+              this.updateCreateDraft('preset', p.id)
             }}
           >
             ${PROVIDER_PRESETS.map((p) => html`<option value=${p.id}>${p.label}</option>`)}
           </select>
         </label>
-        <label>Base URL<input class="k-input mono" name="baseURL"  .value=${PROVIDER_PRESETS[0].baseURL} placeholder="https://api.openai.com/v1" /></label>
-        <label>Model<input class="k-input mono" name="model"  placeholder="gpt-4o" required list="agents-catalog-models" /></label>
+        <label>Base URL<input class="k-input mono" name="baseURL" .value=${draft.baseURL} placeholder="https://api.openai.com/v1" ?disabled=${this.createBusy} @input=${(e: Event) => this.updateCreateDraft('baseURL', (e.target as HTMLInputElement).value)} /></label>
+        <label>Model<input class="k-input mono" name="model" .value=${draft.model} placeholder="gpt-4o" required list="agents-catalog-models" ?disabled=${this.createBusy} @input=${(e: Event) => this.updateCreateDraft('model', (e.target as HTMLInputElement).value)} /></label>
       </div>
-      <label>API key<input class="k-input" name="apiKey" type="password" autocomplete="off" placeholder="sk-…" required /></label>
+      <label>API key<input class="k-input" name="apiKey" type="password" autocomplete="off" placeholder="sk-…" required ?disabled=${this.createBusy} @input=${(e: Event) => this.updateCreateDraft('apiKey', (e.target as HTMLInputElement).value)} /></label>
+      </div>
+      ${this.createRoute ? createGuidance({
+        icon: 'cpu',
+        title: 'Connect a model endpoint',
+        description: 'Name the credential Faros will store, then identify the exact model agents should request.',
+        prerequisites: [
+          'An OpenAI-compatible provider endpoint and model identifier.',
+          'An API key with permission to invoke that model.',
+        ],
+        values: [
+          { label: 'Credential', value: draft.name.trim() || 'Not entered yet', technical: true },
+          { label: 'Base URL', value: draft.baseURL.trim() || 'Provider default', technical: true },
+          { label: 'Model', value: draft.model.trim() || 'Not entered yet', technical: true },
+          { label: 'API key', value: draft.apiKey ? 'Provided (stored as a Secret)' : 'Not entered yet' },
+        ],
+        nextSteps: [
+          'Faros stores the API key as a workspace Secret and never shows it again.',
+          'Assign the credential when creating or configuring an agent.',
+          'Use Test on the Models page to verify endpoint access and served models.',
+        ],
+      }) : nothing}
       </div>
       <div class=${this.createRoute ? 'k-create-actions' : 'agents-form-actions'}>
-        <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancelCreate()}>Cancel</button>
-        <button class="k-btn k-btn--primary" type="submit">Add credential</button>
+        <button type="button" class="k-btn k-btn--ghost secondary" ?disabled=${this.createBusy} @click=${() => this.cancelCreate()}>Cancel</button>
+        <button class="k-btn k-btn--primary" type="submit" ?disabled=${this.createBusy}>${this.createBusy ? 'Adding…' : 'Add credential'}</button>
       </div>
     </form>`
   }
 
   private cancelCreate(): void {
+    if (this.createBusy) return
+    this.createDraft = {
+      name: '',
+      preset: PROVIDER_PRESETS[0].id,
+      baseURL: PROVIDER_PRESETS[0].baseURL,
+      model: '',
+      apiKey: '',
+    }
     if (this.createRoute) {
       this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
       return

--- a/providers/agents/portal/src/views/toolsets.ts
+++ b/providers/agents/portal/src/views/toolsets.ts
@@ -7,7 +7,8 @@ import { property, state } from 'lit/decorators.js'
 import { repeat } from 'lit/directives/repeat.js'
 import { StoreElement } from '../ui/base'
 import { icon } from '../ui/icon'
-import { errorState } from '../ui/states'
+import { errorState, loadingState, sliceView, staleState } from '../ui/states'
+import { createGuidance, firstRunGuide } from '../ui/create-flow'
 import { confirmModal } from '../portalkit/modal'
 import { mutate } from '../mutate'
 import type { CreateSuccessDetail } from '../router'
@@ -21,6 +22,7 @@ export class Toolsets extends StoreElement {
   @state() private draftName = ''
   @state() private draftDisplay = ''
   @state() private draftConns: string[] = []
+  @state() private createBusy = false
 
   private openCreate(): void {
     if (this.routeOwned) {
@@ -42,6 +44,7 @@ export class Toolsets extends StoreElement {
 
   private async save(e: Event): Promise<void> {
     e.preventDefault()
+    if (this.createBusy) return
     const form = e.currentTarget as HTMLFormElement
     // Read the create id from the form as well as the draft state. This keeps
     // the route surface correct for native form submission and for callers
@@ -51,19 +54,25 @@ export class Toolsets extends StoreElement {
     const families = this.store.familiesFor(connections)
     const displayName = this.draftDisplay.trim()
     const editing = this.editing
-    const res = editing
-      ? await mutate(this.store, {
-          run: () => this.api.patchToolset(editing, { displayName, families, connections }),
-          success: 'Toolset updated.',
-          failure: 'Update failed',
-          reload: ['toolsets'],
-        })
-      : await mutate(this.store, {
-          run: () => this.api.createToolset({ name, displayName, families, connections }),
-          success: 'Toolset created.',
-          failure: 'Create failed',
-          reload: ['toolsets'],
-        })
+    this.createBusy = true
+    let res: Toolset | undefined
+    try {
+      res = editing
+        ? await mutate(this.store, {
+            run: () => this.api.patchToolset(editing, { displayName, families, connections }),
+            success: 'Toolset updated.',
+            failure: 'Update failed',
+            reload: ['toolsets'],
+          })
+        : await mutate(this.store, {
+            run: () => this.api.createToolset({ name, displayName, families, connections }),
+            success: 'Toolset created.',
+            failure: 'Create failed',
+            reload: ['toolsets'],
+          })
+    } finally {
+      this.createBusy = false
+    }
     if (res && this.routeOwned && !editing) {
       this.dispatchEvent(
         new CustomEvent<CreateSuccessDetail>('agents-create-success', {
@@ -103,24 +112,69 @@ export class Toolsets extends StoreElement {
   render(): TemplateResult {
     if (this.createRoute) return this.createSurface()
     const slice = this.store.toolsets
+    const connections = this.store.connections
+    const showFirstRun = slice.hasSnapshot && slice.data.length === 0
+    const renderFirstRun = (): TemplateResult => {
+      const retryConnections = () => void this.store.load('connections')
+      const connectionSnapshot = connections.hasSnapshot
+      const hasToolConnections = connectionSnapshot && this.store.toolConnections().length > 0
+      const guide = firstRunGuide({
+        icon: 'package',
+        title: hasToolConnections ? 'Bundle tools for reuse' : 'Create your first toolset',
+        description: hasToolConnections
+          ? 'Group available tool connections so the same capability bundle can be attached to multiple agents.'
+          : connectionSnapshot
+            ? 'Start with core and edge capabilities now. External tool connections are optional and can be added whenever the bundle needs them.'
+            : 'Start with core and edge capabilities now. Available external tool connections will appear after they finish loading.',
+        primaryLabel: 'Create toolset',
+        primary: () => this.navigate({ kind: 'create', resource: 'toolset' }),
+        secondaryLabel: connectionSnapshot && !hasToolConnections ? 'Create connection' : undefined,
+        secondary: connectionSnapshot && !hasToolConnections
+          ? () => this.navigate({ kind: 'create', resource: 'connection' })
+          : undefined,
+        steps: hasToolConnections
+          ? [
+              { label: 'Connection', description: 'Callable external tools are available' },
+              { label: 'Toolset', description: 'Bundle the tools for reuse' },
+              { label: 'Agent', description: 'Attach the bundle from Config' },
+            ]
+          : [
+              { label: 'Toolset', description: 'Begin with core and edge capabilities' },
+              { label: 'Agent', description: 'Attach the bundle from Config' },
+              { label: 'Expand', description: 'Add external connections when needed' },
+            ],
+        currentStep: hasToolConnections ? 1 : 0,
+        journeyLabel: 'Toolset setup path',
+      })
+
+      if (!connectionSnapshot) {
+        const notice = connections.error
+          ? errorState(`Could not load optional tool connections. ${connections.error}`, retryConnections)
+          : loadingState('Loading optional tool connections…')
+        return html`${notice}${guide}`
+      }
+      return connections.error ? html`${staleState(connections.error, retryConnections)}${guide}` : guide
+    }
     return html`<div class="agents-panel k-card agents-route-panel">
       <div class="agents-panel-head">
         <h3>${icon('package')} Toolsets</h3>
-        ${this.editing === null ? html`<button class="k-btn k-btn--ghost secondary" @click=${() => this.openCreate()}>${icon('plus')} New toolset</button>` : nothing}
+        ${this.editing === null && !showFirstRun ? html`<button class="k-btn k-btn--ghost secondary" @click=${() => this.openCreate()}>${icon('plus')} New toolset</button>` : nothing}
       </div>
       <p class="muted">Shared bundles of Tools. Define once, link from any agent's Config pane.</p>
-      ${slice.error
-        ? errorState(slice.error, () => void this.store.load('toolsets'))
-        : slice.data.length === 0
-          ? html`<p class="agents-hint">${icon('package')} No toolsets yet.</p>`
-          : html`<div class="agents-tablewrap k-table">
+      ${sliceView<Toolset>({
+        slice,
+        emptyIcon: 'package',
+        emptyText: 'No toolsets yet.',
+        empty: renderFirstRun,
+        retry: () => void this.store.load('toolsets'),
+        content: (rows) => html`<div class="agents-tablewrap k-table">
               <table class="agents-table">
                 <thead>
                   <tr><th>Name</th><th>Tools</th><th>Used by</th><th class="agents-th-actions">Actions</th></tr>
                 </thead>
                 <tbody>
                   ${repeat(
-                    slice.data,
+                    rows,
                     (t) => t.metadata.name,
                     (t) => {
                       const conns = t.spec.connections || []
@@ -150,14 +204,15 @@ export class Toolsets extends StoreElement {
                   )}
                 </tbody>
               </table>
-            </div>`}
+            </div>`,
+      })}
       ${this.editing !== null ? this.form() : nothing}
     </div>`
   }
 
   private createSurface(): TemplateResult {
     return html`<div class="agents-menu agents-create-page k-create-page">
-      <button type="button" class="k-btn k-btn--ghost k-back-action" @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
+      <button type="button" class="k-btn k-btn--ghost k-back-action" ?disabled=${this.createBusy} @click=${() => this.cancelCreate()}>${icon('arrow-left')} Connections</button>
       <header class="k-create-header"><h1 class="k-create-title">Create toolset</h1><p class="k-create-description">Bundle reusable tools once, then attach the toolset to any agent.</p></header>
       ${this.form()}
     </div>`
@@ -166,8 +221,9 @@ export class Toolsets extends StoreElement {
   private form(): TemplateResult {
     const toolConns = this.store.toolConnections()
     const isEdit = !!this.editing
-    return html`<form class=${this.createRoute ? 'agents-toolset-form k-create-surface' : 'agents-toolset-form k-card'} @submit=${(e: Event) => void this.save(e)}>
-      <div class=${this.createRoute ? 'k-create-body' : ''}>
+    return html`<form class=${this.createRoute ? 'agents-toolset-form agents-guided-form k-create-surface k-create-surface--guided' : 'agents-toolset-form k-card'} aria-busy=${this.createBusy ? 'true' : 'false'} @submit=${(e: Event) => void this.save(e)}>
+      <div class=${this.createRoute ? 'k-create-body k-create-body--guided' : ''}>
+      <div class=${this.createRoute ? 'k-create-fields' : ''}>
       ${this.createRoute ? nothing : html`<h4>${isEdit ? html`Edit toolset <code>${this.editing}</code>` : 'New toolset'}</h4>`}
       ${isEdit
         ? html`<label>Display name<input class="k-input" .value=${this.draftDisplay} @input=${(e: Event) => (this.draftDisplay = (e.target as HTMLInputElement).value)} /></label>`
@@ -179,12 +235,14 @@ export class Toolsets extends StoreElement {
                 pattern="[a-z0-9-]+"
                 placeholder="dev-tools"
                 .value=${this.draftName}
+                ?disabled=${this.createBusy}
                 @input=${(e: Event) => (this.draftName = (e.target as HTMLInputElement).value)}
             /></label>
             <label
               >Display name<input class="k-input"
                 placeholder="optional"
                 .value=${this.draftDisplay}
+                ?disabled=${this.createBusy}
                 @input=${(e: Event) => (this.draftDisplay = (e.target as HTMLInputElement).value)}
             /></label>
           </div>`}
@@ -197,6 +255,7 @@ export class Toolsets extends StoreElement {
                   <input
                     type="checkbox"
                     .checked=${this.draftConns.includes(c.metadata.name)}
+                    ?disabled=${this.createBusy}
                     @change=${(e: Event) => {
                       const on = (e.target as HTMLInputElement).checked
                       this.draftConns = on
@@ -212,14 +271,36 @@ export class Toolsets extends StoreElement {
         <span class="agents-hint">Tool families are derived from these connections — never picked by hand.</span>
       </fieldset>
       </div>
+      ${this.createRoute ? createGuidance({
+        icon: 'package',
+        title: 'Build a reusable capability bundle',
+        description: 'Choose existing tool connections; Faros derives the required tool families from those selections.',
+        prerequisites: [
+          toolConns.length ? 'At least one tool connection is available in this workspace.' : 'Create a tool connection first if this bundle should expose external tools.',
+          'Cluster edge tools remain available independently and do not need a connection here.',
+        ],
+        values: [
+          { label: 'Toolset', value: this.draftName.trim() || 'Not entered yet', technical: true },
+          { label: 'Display name', value: this.draftDisplay.trim() || 'Same as name' },
+          { label: 'Connections', value: this.draftConns.length ? this.draftConns.join(', ') : 'None selected', technical: true },
+          { label: 'Families', value: this.store.familiesFor(this.draftConns).join(', '), technical: true },
+        ],
+        nextSteps: [
+          'Faros creates the bundle without changing any existing agents.',
+          'Attach the toolset to interactive or background work from agent Config.',
+          'Connection authorization is still checked when an agent invokes a tool.',
+        ],
+      }) : nothing}
+      </div>
       <div class=${this.createRoute ? 'k-create-actions' : 'agents-form-actions'}>
-        <button type="button" class="k-btn k-btn--ghost secondary" @click=${() => this.cancelCreate()}>Cancel</button>
-        <button class="k-btn k-btn--primary" type="submit">${isEdit ? 'Save' : 'Create toolset'}</button>
+        <button type="button" class="k-btn k-btn--ghost secondary" ?disabled=${this.createBusy} @click=${() => this.cancelCreate()}>Cancel</button>
+        <button class="k-btn k-btn--primary" type="submit" ?disabled=${this.createBusy}>${this.createBusy ? 'Creating…' : isEdit ? 'Save' : 'Create toolset'}</button>
       </div>
     </form>`
   }
 
   private cancelCreate(): void {
+    if (this.createBusy) return
     if (this.createRoute) {
       this.dispatchEvent(new CustomEvent('agents-cancel', { bubbles: true, composed: true }))
       return

--- a/providers/app-studio/portal/src/portalkit/CreateGuidance.vue
+++ b/providers/app-studio/portal/src/portalkit/CreateGuidance.vue
@@ -1,0 +1,72 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { Info } from 'lucide-vue-next'
+import { useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface CreateGuidanceValue {
+  label: string
+  value: string
+  technical?: boolean
+}
+
+withDefaults(defineProps<{
+  title: string
+  description: string
+  prerequisites?: string[]
+  values?: CreateGuidanceValue[]
+  nextSteps?: string[]
+  valuesHeading?: string
+}>(), {
+  prerequisites: () => [],
+  values: () => [],
+  nextSteps: () => [],
+  valuesHeading: 'What Faros will create',
+})
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-create-guidance-${id}-title`
+const prerequisiteID = `k-create-guidance-${id}-prerequisites`
+const valuesID = `k-create-guidance-${id}-values`
+const nextStepsID = `k-create-guidance-${id}-next-steps`
+</script>
+
+<template>
+  <aside class="k-create-guidance" :aria-labelledby="titleID">
+    <div class="k-create-guidance__heading">
+      <Info :size="16" :stroke-width="1.75" aria-hidden="true" />
+      <h3 :id="titleID">{{ title }}</h3>
+    </div>
+    <p class="k-create-guidance__description">{{ description }}</p>
+
+    <section v-if="prerequisites.length" class="k-create-guidance__section" :aria-labelledby="prerequisiteID">
+      <h4 :id="prerequisiteID">Prerequisites</h4>
+      <ul>
+        <li v-for="prerequisite in prerequisites" :key="prerequisite">{{ prerequisite }}</li>
+      </ul>
+    </section>
+
+    <section v-if="values.length" class="k-create-guidance__section" :aria-labelledby="valuesID">
+      <h4 :id="valuesID">{{ valuesHeading }}</h4>
+      <dl class="k-create-guidance__values">
+        <template v-for="item in values" :key="item.label">
+          <dt>{{ item.label }}</dt>
+          <dd><code v-if="item.technical">{{ item.value }}</code><span v-else>{{ item.value }}</span></dd>
+        </template>
+      </dl>
+    </section>
+
+    <section v-if="nextSteps.length" class="k-create-guidance__section" :aria-labelledby="nextStepsID">
+      <h4 :id="nextStepsID">Next steps</h4>
+      <ol>
+        <li v-for="step in nextSteps" :key="step">{{ step }}</li>
+      </ol>
+    </section>
+  </aside>
+</template>

--- a/providers/app-studio/portal/src/portalkit/FirstRunGuide.vue
+++ b/providers/app-studio/portal/src/portalkit/FirstRunGuide.vue
@@ -1,0 +1,85 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { ArrowRight, Check, CircleDot } from 'lucide-vue-next'
+import { computed, useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface FirstRunStep {
+  label: string
+  description: string
+}
+
+const props = withDefaults(defineProps<{
+  title: string
+  description: string
+  primaryLabel: string
+  secondaryLabel?: string
+  steps: readonly FirstRunStep[]
+  currentStep?: number
+  journeyLabel?: string
+}>(), {
+  secondaryLabel: '',
+  currentStep: 0,
+  journeyLabel: 'Getting started',
+})
+
+const emit = defineEmits<{
+  (event: 'primary'): void
+  (event: 'secondary'): void
+}>()
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-first-run-${id}-title`
+const boundedCurrentStep = computed(() => Math.max(0, Math.min(props.currentStep, props.steps.length - 1)))
+</script>
+
+<template>
+  <section class="k-first-run" :aria-labelledby="titleID">
+    <div class="k-first-run__lead">
+      <span class="k-first-run__icon" aria-hidden="true"><slot name="icon" /></span>
+      <div class="k-first-run__copy">
+        <h3 :id="titleID">{{ title }}</h3>
+        <p>{{ description }}</p>
+      </div>
+      <div class="k-first-run__actions">
+        <button class="k-btn k-btn--primary" type="button" @click="emit('primary')">
+          {{ primaryLabel }} <ArrowRight :stroke-width="1.75" aria-hidden="true" />
+        </button>
+        <button v-if="secondaryLabel" class="k-btn k-btn--ghost" type="button" @click="emit('secondary')">
+          {{ secondaryLabel }}
+        </button>
+      </div>
+    </div>
+
+    <ol v-if="steps.length" class="k-first-run__journey" :aria-label="journeyLabel">
+      <li
+        v-for="(step, index) in steps"
+        :key="`${index}-${step.label}`"
+        :class="['k-first-run__step', {
+          'is-complete': index < boundedCurrentStep,
+          'is-current': index === boundedCurrentStep,
+        }]"
+        :aria-current="index === boundedCurrentStep ? 'step' : undefined"
+      >
+        <span class="k-first-run__marker" aria-hidden="true">
+          <Check v-if="index < boundedCurrentStep" :stroke-width="2" />
+          <CircleDot v-else-if="index === boundedCurrentStep" :stroke-width="1.75" />
+          <span v-else>{{ index + 1 }}</span>
+        </span>
+        <span class="k-first-run__step-copy">
+          <span class="k-first-run__step-status">
+            {{ index < boundedCurrentStep ? 'Completed step' : index === boundedCurrentStep ? 'Current step' : 'Upcoming step' }}:
+          </span>
+          <strong>{{ step.label }}</strong>
+          <small>{{ step.description }}</small>
+        </span>
+      </li>
+    </ol>
+  </section>
+</template>

--- a/providers/app-studio/portal/src/portalkit/faros-ui.css
+++ b/providers/app-studio/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/providers/app-studio/portal/src/portalkit/styles.ts
+++ b/providers/app-studio/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 3
+export const FAROS_UI_VERSION = 4
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/code/portal/src/App.vue
+++ b/providers/code/portal/src/App.vue
@@ -15,6 +15,14 @@ import { resolveConfirm } from './portalkit/confirm'
 import { createResourceDeletions } from './refresh'
 import Tabs from './portalkit/Tabs.vue'
 import { contextGenerationKey } from './context'
+import {
+  clearCodeReturnIntent,
+  codeJourneyStorage,
+  codeJourneyTenantKey,
+  readCodeReturnIntent,
+  writeCodeReturnIntent,
+  type CodeReturnPath,
+} from './journey'
 import { codeNavigationDetail, parseCodeSubPath, type CodeRoute } from './routes'
 
 // Sub-path routing (the shell pushes the trailing /providers/code/<sub> segment):
@@ -33,7 +41,22 @@ const contextGeneration = ref(0)
 provide(contextGenerationKey, contextGeneration)
 const contextInitialized = computed(() => props.ctx !== null)
 const deletions = createResourceDeletions()
+const journeyStorage = codeJourneyStorage()
+const prerequisiteReturnPath = ref<CodeReturnPath | null>(null)
+const prerequisiteExpectedPath = ref<string | null>(null)
+const prerequisiteTenantKey = ref<string | null>(null)
+let observedJourneyAuthorityKey: string | null = null
 let deletionAuthority = ''
+
+function journeyTenantKey(): string | null {
+  if (!props.ctx?.tenant) return null
+  const caller = props.ctx.user?.sub ?? props.ctx.user?.email ?? null
+  return codeJourneyTenantKey(props.ctx.tenant, caller)
+}
+
+function activeJourneyPath(): string {
+  return (props.ctx?.subPath ?? '').replace(/^\/+|\/+$/g, '')
+}
 
 // Feed identity into the API client and remount the active route whenever its
 // authority changes. This clears actionable old-workspace state immediately and
@@ -56,6 +79,40 @@ watch(
   },
   { immediate: true, flush: 'sync' },
 )
+watch(
+  () => [props.ctx?.tenant, props.ctx?.subPath, props.ctx?.user?.sub, props.ctx?.user?.email] as const,
+  () => {
+    const tenantKey = journeyTenantKey()
+    const activePath = activeJourneyPath()
+    if (observedJourneyAuthorityKey && observedJourneyAuthorityKey !== tenantKey) {
+      clearCodeReturnIntent(journeyStorage, observedJourneyAuthorityKey)
+    }
+    observedJourneyAuthorityKey = tenantKey
+    const storedReturnPath = tenantKey
+      ? readCodeReturnIntent(journeyStorage, tenantKey, activePath)
+      : null
+    if (storedReturnPath) {
+      prerequisiteReturnPath.value = storedReturnPath
+      prerequisiteExpectedPath.value = null
+      prerequisiteTenantKey.value = tenantKey
+      return
+    }
+
+    // Storage is reload continuity, not live-transition authority. Preserve an
+    // intent seeded by the prerequisite CTA when storage is blocked or full,
+    // but only for the exact tenant and route that CTA selected.
+    if (prerequisiteReturnPath.value
+      && prerequisiteExpectedPath.value === activePath
+      && prerequisiteTenantKey.value === tenantKey) {
+      prerequisiteExpectedPath.value = null
+      return
+    }
+    prerequisiteReturnPath.value = null
+    prerequisiteExpectedPath.value = null
+    prerequisiteTenantKey.value = null
+  },
+  { immediate: true },
+)
 
 const hasTenant = computed(() => !!props.ctx?.tenant)
 
@@ -70,10 +127,48 @@ const tabs = [
 // and pushes the shell's vue-router. detail.path is the trailing segment the
 // shell appends to /providers/code/.
 const rootRef = ref<HTMLElement | null>(null)
-function navigate(path: string, options: { replace?: boolean } = {}) {
+function dispatchNavigation(path: string, options: { replace?: boolean } = {}) {
   const el = rootRef.value
   if (!el) return
   el.dispatchEvent(new CustomEvent('faros-navigate', { detail: codeNavigationDetail(path, options), bubbles: true }))
+}
+
+function clearCurrentJourneyIntent(): void {
+  const tenantKey = journeyTenantKey()
+  if (tenantKey) clearCodeReturnIntent(journeyStorage, tenantKey)
+}
+
+function navigate(path: string, options: { replace?: boolean } = {}) {
+  prerequisiteReturnPath.value = null
+  prerequisiteExpectedPath.value = null
+  prerequisiteTenantKey.value = null
+  clearCurrentJourneyIntent()
+  dispatchNavigation(path, options)
+}
+
+function startRepositoryConnection(): void {
+  const expectedPath = 'create/connection/token'
+  const tenantKey = journeyTenantKey()
+  prerequisiteReturnPath.value = 'create/repository'
+  prerequisiteExpectedPath.value = expectedPath
+  prerequisiteTenantKey.value = tenantKey
+  if (tenantKey) writeCodeReturnIntent(journeyStorage, tenantKey, 'create/repository', expectedPath)
+  dispatchNavigation(expectedPath)
+}
+
+function completeConnectionPrerequisite(success: boolean, connectionName?: string): void {
+  const returnPath = prerequisiteReturnPath.value
+  prerequisiteReturnPath.value = null
+  prerequisiteExpectedPath.value = null
+  prerequisiteTenantKey.value = null
+  clearCurrentJourneyIntent()
+  if (returnPath) {
+    dispatchNavigation(success ? returnPath : 'repositories', { replace: true })
+    return
+  }
+  dispatchNavigation(success && connectionName
+    ? `connections/${encodeURIComponent(connectionName)}`
+    : 'connections', { replace: true })
 }
 </script>
 
@@ -108,8 +203,8 @@ function navigate(path: string, options: { replace?: boolean } = {}) {
           :key="`${contextGeneration}:create-connection:${route.create.method}`"
           :method="route.create.method"
           :deletions="deletions"
-          @cancel="navigate('connections', { replace: true })"
-          @created="(n: string) => navigate('connections/' + encodeURIComponent(n), { replace: true })"
+          @cancel="completeConnectionPrerequisite(false)"
+          @created="(n: string) => completeConnectionPrerequisite(true, n)"
         />
         <RepositoryCreateView
           v-if="route.create?.resource === 'repository'"
@@ -117,6 +212,7 @@ function navigate(path: string, options: { replace?: boolean } = {}) {
           :deletions="deletions"
           @cancel="navigate('repositories', { replace: true })"
           @created="(n: string) => navigate('repositories/' + encodeURIComponent(n), { replace: true })"
+          @create-connection="startRepositoryConnection"
         />
         <ConnectionDetailView v-if="route.page === 'connections' && route.connection" :key="`${contextGeneration}:connection:${route.connection}`" :name="route.connection" :deletions="deletions" @back="navigate('connections')" />
         <RepoDetailView v-if="route.repo" :key="`${contextGeneration}:repository:${route.repo}`" :name="route.repo" :deletions="deletions" @back="navigate('repositories')" />
@@ -141,6 +237,7 @@ function navigate(path: string, options: { replace?: boolean } = {}) {
             :deletions="deletions"
             @open="(n: string) => navigate('repositories/' + encodeURIComponent(n))"
             @create="navigate('create/repository')"
+            @create-connection="startRepositoryConnection"
           />
         </KeepAlive>
       </template>

--- a/providers/code/portal/src/app-context.behavior.test.ts
+++ b/providers/code/portal/src/app-context.behavior.test.ts
@@ -23,9 +23,23 @@ vi.mock('./portalkit/ConfirmDialog.vue', () => ({
     },
   }),
 }))
-vi.mock('./views/ConnectionCreateView.vue', () => ({ default: { setup: () => () => null } }))
+vi.mock('./views/ConnectionCreateView.vue', () => ({
+  default: defineComponent({
+    emits: ['created'],
+    setup(_props, { emit }) {
+      return () => h('button', { id: 'complete-connection', onClick: () => emit('created', 'github-created') })
+    },
+  }),
+}))
 vi.mock('./views/ConnectionDetailView.vue', () => ({ default: { setup: () => () => null } }))
-vi.mock('./views/RepositoriesView.vue', () => ({ default: { setup: () => () => null } }))
+vi.mock('./views/RepositoriesView.vue', () => ({
+  default: defineComponent({
+    emits: ['create-connection'],
+    setup(_props, { emit }) {
+      return () => h('button', { id: 'start-repository-connection', onClick: () => emit('create-connection') })
+    },
+  }),
+}))
 vi.mock('./views/RepositoryCreateView.vue', () => ({ default: { setup: () => () => null } }))
 vi.mock('./views/RepoDetailView.vue', () => ({ default: { setup: () => () => null } }))
 vi.mock('./views/PackagesView.vue', () => ({ default: { setup: () => () => null } }))
@@ -73,10 +87,22 @@ interface TreeNode {
   parent: TreeNode | null
   props: Record<string, unknown>
   text?: string
+  dispatchEvent(event: Event): boolean
 }
 
+const navigationEvents: CustomEvent[] = []
+
 function node(type: string): TreeNode {
-  return { type, children: [], parent: null, props: {} }
+  return {
+    type,
+    children: [],
+    parent: null,
+    props: {},
+    dispatchEvent(event) {
+      if (event instanceof CustomEvent && event.type === 'faros-navigate') navigationEvents.push(event)
+      return true
+    },
+  }
 }
 
 const rendererOptions: RendererOptions<TreeNode, TreeNode> = {
@@ -117,6 +143,16 @@ const rendererOptions: RendererOptions<TreeNode, TreeNode> = {
 
 const renderer = createRenderer(rendererOptions)
 
+function allNodes(root: TreeNode): TreeNode[] {
+  return [root, ...root.children.flatMap(allNodes)]
+}
+
+function click(root: TreeNode, id: string): void {
+  const target = allNodes(root).find(item => item.props.id === id)
+  if (!target || typeof target.props.onClick !== 'function') throw new Error(`button ${id} was not rendered`)
+  target.props.onClick()
+}
+
 describe('Code App context authority generation', () => {
   it('increments synchronously for every shell authority field before child unmount', async () => {
     captured.generation = undefined
@@ -150,5 +186,107 @@ describe('Code App context authority generation', () => {
 
     await nextTick()
     app.unmount()
+  })
+
+  it('continues repository setup from in-memory intent when session storage is unavailable', async () => {
+    navigationEvents.length = 0
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+    Reflect.deleteProperty(globalThis, 'window')
+    try {
+      const context = reactive<FarosContext>({
+        basePath: '/ui/providers/code',
+        token: 'token',
+        tenant: 'root:tenant-a',
+        user: { sub: 'user-a' },
+        subPath: 'repositories',
+      })
+      const root = node('root')
+      const app = renderer.createApp(App, { ctx: context })
+      app.provide(ssrContextKey, { modules: new Set<string>() })
+      app.mount(root)
+      click(root, 'start-repository-connection')
+      expect(navigationEvents.at(-1)?.detail).toEqual({ path: 'create/connection/token' })
+
+      context.subPath = 'create/connection/token'
+      await nextTick()
+      click(root, 'complete-connection')
+      expect(navigationEvents.at(-1)?.detail).toEqual({ path: 'create/repository', replace: true })
+      app.unmount()
+    } finally {
+      if (windowDescriptor) Object.defineProperty(globalThis, 'window', windowDescriptor)
+      else Reflect.deleteProperty(globalThis, 'window')
+    }
+  })
+
+  it('revokes an in-memory repository continuation when the caller changes', async () => {
+    navigationEvents.length = 0
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+    Reflect.deleteProperty(globalThis, 'window')
+    try {
+      const context = reactive<FarosContext>({
+        basePath: '/ui/providers/code',
+        token: 'token-a',
+        tenant: 'root:tenant-a',
+        user: { sub: 'user-a' },
+        subPath: 'repositories',
+      })
+      const root = node('root')
+      const app = renderer.createApp(App, { ctx: context })
+      app.provide(ssrContextKey, { modules: new Set<string>() })
+      app.mount(root)
+      click(root, 'start-repository-connection')
+
+      context.subPath = 'create/connection/token'
+      await nextTick()
+      context.user = { sub: 'user-b' }
+      context.token = 'token-b'
+      await nextTick()
+      click(root, 'complete-connection')
+      expect(navigationEvents.at(-1)?.detail).toEqual({ path: 'connections/github-created', replace: true })
+      app.unmount()
+    } finally {
+      if (windowDescriptor) Object.defineProperty(globalThis, 'window', windowDescriptor)
+      else Reflect.deleteProperty(globalThis, 'window')
+    }
+  })
+
+  it('removes a persisted continuation when the caller changes before prerequisite navigation settles', async () => {
+    navigationEvents.length = 0
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+    const values = new Map<string, string>()
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        sessionStorage: {
+          getItem: (key: string) => values.get(key) ?? null,
+          setItem: (key: string, value: string) => { values.set(key, value) },
+          removeItem: (key: string) => { values.delete(key) },
+        },
+      },
+    })
+    try {
+      const context = reactive<FarosContext>({
+        basePath: '/ui/providers/code',
+        token: 'token-a',
+        tenant: 'root:tenant-a',
+        user: { sub: 'user-a' },
+        subPath: 'repositories',
+      })
+      const root = node('root')
+      const app = renderer.createApp(App, { ctx: context })
+      app.provide(ssrContextKey, { modules: new Set<string>() })
+      app.mount(root)
+      click(root, 'start-repository-connection')
+      expect(values.size).toBe(1)
+
+      context.user = { sub: 'user-b' }
+      context.token = 'token-b'
+      await nextTick()
+      expect(values.size).toBe(0)
+      app.unmount()
+    } finally {
+      if (windowDescriptor) Object.defineProperty(globalThis, 'window', windowDescriptor)
+      else Reflect.deleteProperty(globalThis, 'window')
+    }
   })
 })

--- a/providers/code/portal/src/create-flow.regression.test.mjs
+++ b/providers/code/portal/src/create-flow.regression.test.mjs
@@ -4,6 +4,7 @@ import { expect, it } from 'vitest'
 const app = fs.readFileSync(new URL('./App.vue', import.meta.url), 'utf8')
 const connectionCollection = fs.readFileSync(new URL('./views/ConnectionsView.vue', import.meta.url), 'utf8')
 const connectionCreate = fs.readFileSync(new URL('./views/ConnectionCreateView.vue', import.meta.url), 'utf8')
+const repositoryCollection = fs.readFileSync(new URL('./views/RepositoriesView.vue', import.meta.url), 'utf8')
 const repositoryCreate = fs.readFileSync(new URL('./views/RepositoryCreateView.vue', import.meta.url), 'utf8')
 
 it('Code collections stay cached across routed create and detail surfaces', () => {
@@ -67,4 +68,44 @@ it('primary create forms expose native constraints, field errors, focus recovery
   }
   expect(connectionCreate).toContain('autocomplete="new-password"')
   expect(repositoryCreate).toContain('code-repository-connection-error')
+})
+
+it('authoritative empty collections use the shared first-run journey', () => {
+  for (const source of [connectionCollection, repositoryCollection]) {
+    expect(source).toMatch(/import FirstRunGuide from '\.\.\/portalkit\/FirstRunGuide\.vue'/)
+    expect(source).toMatch(/const showFirstRun = computed\(\(\) => loaded\.value/)
+    expect(source).toMatch(/<FirstRunGuide[\s\S]*v-if="showFirstRun"/)
+    expect(source).toMatch(/<ResourceTable[\s\S]*v-else/)
+    expect(source).toContain('CODE_JOURNEY_STEPS')
+    expect(source).toContain('journey-label="Code setup path"')
+  }
+  expect(connectionCollection).toMatch(/oauthLoaded\.value[\s\S]*!error\.value[\s\S]*connections\.value\.length === 0/)
+  expect(connectionCollection).not.toMatch(/showFirstRun = computed\([^\n]*oauthError/)
+  expect(repositoryCollection).toMatch(/repositoryCollectionIsAuthoritativelyEmpty/)
+  expect(repositoryCollection).toMatch(/&& repositoryCollectionEmpty\.value/)
+})
+
+it('repository first-run state exposes its connection prerequisite action', () => {
+  expect(repositoryCollection).toMatch(/function handleFirstRun\(action: CodeJourneyAction\)/)
+  expect(repositoryCollection).toMatch(/action === 'create-connection'\) emit\('create-connection'\)/)
+  expect(app).toMatch(/@create-connection="startRepositoryConnection"/)
+  expect(app).toMatch(/prerequisiteReturnPath\.value = 'create\/repository'[\s\S]*writeCodeReturnIntent/)
+  expect(app).toMatch(/prerequisiteExpectedPath\.value === activePath[\s\S]*prerequisiteTenantKey\.value === tenantKey/)
+  expect(app).toMatch(/writeCodeReturnIntent\(journeyStorage, tenantKey, 'create\/repository', expectedPath\)/)
+  expect(app).toMatch(/dispatchNavigation\(success \? returnPath : 'repositories', \{ replace: true \}\)/)
+  expect(repositoryCreate).toMatch(/Add an active connection first[\s\S]*Create connection/)
+  expect(repositoryCreate).toMatch(/:disabled="submitting \|\| !connectionChoices\.length"/)
+})
+
+it('connection and repository forms use the shared live guidance rail', () => {
+  for (const source of [connectionCreate, repositoryCreate]) {
+    expect(source).toMatch(/import CreateGuidance from '\.\.\/portalkit\/CreateGuidance\.vue'/)
+    expect(source).toContain('k-create-surface--guided')
+    expect(source).toContain('k-create-body--guided')
+    expect(source).toContain('k-create-fields')
+    expect(source).toMatch(/<CreateGuidance[\s\S]*:values="guidanceValues"[\s\S]*:next-steps="guidanceNextSteps"/)
+  }
+  expect(connectionCreate).toMatch(/label: 'Credential'[\s\S]*stored as a Secret/)
+  expect(repositoryCreate).toMatch(/label: 'GitHub repository'/)
+  expect(repositoryCreate).toMatch(/label: 'Initial content'/)
 })

--- a/providers/code/portal/src/journey.test.ts
+++ b/providers/code/portal/src/journey.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CODE_JOURNEY_STEPS,
+  clearCodeReturnIntent,
+  codeFirstRunModel,
+  codeJourneyStorage,
+  codeJourneyTenantKey,
+  readCodeReturnIntent,
+  writeCodeReturnIntent,
+  type CodeJourneyStorage,
+} from './journey'
+
+describe('Code first-run journey', () => {
+  it('starts connection setup with the available authentication method', () => {
+    expect(codeFirstRunModel('connection', false, false).primary).toEqual({
+      label: 'Add token manually',
+      action: 'create-connection',
+    })
+    expect(codeFirstRunModel('connection', false, true).primary.label).toBe('Connect with GitHub')
+    expect(codeFirstRunModel('connection', false, true).secondary?.label).toBe('Add token manually')
+  })
+
+  it('keeps repository onboarding on the connection prerequisite until one exists', () => {
+    const blocked = codeFirstRunModel('repository', false)
+    expect(blocked.currentStep).toBe(0)
+    expect(blocked.primary.action).toBe('create-connection')
+
+    const ready = codeFirstRunModel('repository', true)
+    expect(ready.currentStep).toBe(1)
+    expect(ready.primary.action).toBe('create-repository')
+    expect(CODE_JOURNEY_STEPS.map(step => step.label)).toEqual(['Connection', 'Repository', 'Manage'])
+  })
+
+  it('restores only a validated, tenant-scoped repository return intent', () => {
+    const values = new Map<string, string>()
+    const storage: CodeJourneyStorage = {
+      getItem: key => values.get(key) ?? null,
+      setItem: (key, value) => { values.set(key, value) },
+      removeItem: key => { values.delete(key) },
+    }
+    const tenantA = codeJourneyTenantKey('root:tenant-a', 'user-a')
+    const tenantAUserB = codeJourneyTenantKey('root:tenant-a', 'user-b')
+    const tenantB = codeJourneyTenantKey('root:tenant-b', 'user-a')
+
+    writeCodeReturnIntent(storage, tenantA, 'create/repository', 'create/connection/token')
+    expect(readCodeReturnIntent(storage, tenantAUserB, 'create/connection/token')).toBeNull()
+    expect(readCodeReturnIntent(storage, tenantB, 'create/connection/token')).toBeNull()
+    expect(readCodeReturnIntent(storage, tenantA, 'create/connection/token')).toBe('create/repository')
+
+    writeCodeReturnIntent(storage, tenantA, 'create/repository', 'create/connection/token')
+    expect(readCodeReturnIntent(storage, tenantA, 'connections')).toBeNull()
+    expect(readCodeReturnIntent(storage, tenantA, 'create/connection/token')).toBeNull()
+
+    values.set('faros:code:return-intent', JSON.stringify({
+      [tenantA]: { returnPath: 'https://example.invalid', expectedPath: 'create/connection/token' },
+    }))
+    expect(readCodeReturnIntent(storage, tenantA, 'create/connection/token')).toBeNull()
+
+    writeCodeReturnIntent(storage, tenantA, 'create/repository', 'create/connection/token')
+    clearCodeReturnIntent(storage, tenantA)
+    expect(readCodeReturnIntent(storage, tenantA, 'create/connection/token')).toBeNull()
+  })
+
+  it('degrades to in-memory routing when browser storage throws', () => {
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        get sessionStorage() {
+          throw new Error('storage denied')
+        },
+      },
+    })
+    try {
+      expect(codeJourneyStorage()).toBeNull()
+    } finally {
+      if (windowDescriptor) Object.defineProperty(globalThis, 'window', windowDescriptor)
+      else Reflect.deleteProperty(globalThis, 'window')
+    }
+  })
+})

--- a/providers/code/portal/src/journey.ts
+++ b/providers/code/portal/src/journey.ts
@@ -1,0 +1,173 @@
+export type CodeJourneyAction = 'create-connection' | 'create-repository'
+export type CodeJourneyKind = 'connection' | 'repository'
+export type CodeReturnPath = 'create/repository'
+
+const CODE_RETURN_INTENT_KEY = 'faros:code:return-intent'
+
+export interface CodeJourneyStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+interface StoredCodeReturnIntent {
+  returnPath?: unknown
+  expectedPath?: unknown
+}
+
+type StoredCodeReturnIntents = Record<string, StoredCodeReturnIntent>
+
+export interface CodeJourneyStep {
+  label: string
+  description: string
+}
+
+export interface CodeFirstRunModel {
+  title: string
+  description: string
+  currentStep: 0 | 1
+  primary: { label: string; action: CodeJourneyAction }
+  secondary?: { label: string; action: CodeJourneyAction }
+}
+
+export const CODE_JOURNEY_STEPS: readonly CodeJourneyStep[] = [
+  { label: 'Connection', description: 'Git identity and credential' },
+  { label: 'Repository', description: 'Remote repository and access' },
+  { label: 'Manage', description: 'Deploy keys and collaborators' },
+]
+
+export function codeJourneyTenantKey(tenant?: string | null, caller?: string | null): string {
+  return JSON.stringify([tenant || '', caller || ''])
+}
+
+export function codeJourneyStorage(): CodeJourneyStorage | null {
+  try {
+    if (typeof window === 'undefined') return null
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isCodeReturnPath(value: unknown): value is CodeReturnPath {
+  return value === 'create/repository'
+}
+
+function readStoredIntents(storage: CodeJourneyStorage): StoredCodeReturnIntents | null {
+  let raw: string | null
+  try {
+    raw = storage.getItem(CODE_RETURN_INTENT_KEY)
+  } catch {
+    return null
+  }
+  if (!raw) return {}
+
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!isRecord(parsed)) return null
+    const intents: StoredCodeReturnIntents = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      if (key === '__proto__' || !isRecord(value)) continue
+      intents[key] = { returnPath: value.returnPath, expectedPath: value.expectedPath }
+    }
+    return intents
+  } catch {
+    return null
+  }
+}
+
+function persistStoredIntents(storage: CodeJourneyStorage, intents: StoredCodeReturnIntents): void {
+  try {
+    if (!Object.keys(intents).length) storage.removeItem(CODE_RETURN_INTENT_KEY)
+    else storage.setItem(CODE_RETURN_INTENT_KEY, JSON.stringify(intents))
+  } catch {
+    // Return routing is a convenience; unavailable storage must not block setup.
+  }
+}
+
+export function writeCodeReturnIntent(
+  storage: CodeJourneyStorage | null,
+  tenantKey: string,
+  returnPath: CodeReturnPath,
+  expectedPath: string,
+): void {
+  if (!storage) return
+  const intents = readStoredIntents(storage)
+  if (intents === null) return
+  intents[tenantKey] = { returnPath, expectedPath }
+  persistStoredIntents(storage, intents)
+}
+
+/** Consume a tenant-scoped intent only on its exact expected prerequisite route. */
+export function readCodeReturnIntent(
+  storage: CodeJourneyStorage | null,
+  tenantKey: string,
+  activePath: string,
+): CodeReturnPath | null {
+  if (!storage) return null
+  const intents = readStoredIntents(storage)
+  if (intents === null) {
+    try { storage.removeItem(CODE_RETURN_INTENT_KEY) } catch { /* storage may be unavailable */ }
+    return null
+  }
+  const intent = intents[tenantKey]
+  if (!intent) return null
+  const result = intent.expectedPath === activePath && isCodeReturnPath(intent.returnPath)
+    ? intent.returnPath
+    : null
+  delete intents[tenantKey]
+  persistStoredIntents(storage, intents)
+  return result
+}
+
+export function clearCodeReturnIntent(storage: CodeJourneyStorage | null, tenantKey?: string | null): void {
+  if (!storage) return
+  if (!tenantKey) {
+    try { storage.removeItem(CODE_RETURN_INTENT_KEY) } catch { /* storage may be unavailable */ }
+    return
+  }
+  const intents = readStoredIntents(storage)
+  if (intents === null) return
+  delete intents[tenantKey]
+  persistStoredIntents(storage, intents)
+}
+
+export function codeFirstRunModel(
+  kind: CodeJourneyKind,
+  hasConnections: boolean,
+  oauthEnabled = false,
+): CodeFirstRunModel {
+  if (kind === 'connection') {
+    return {
+      title: 'Connect a GitHub account',
+      description: 'Connect once so Faros can create and manage repositories for this workspace.',
+      currentStep: 0,
+      primary: oauthEnabled
+        ? { label: 'Connect with GitHub', action: 'create-connection' }
+        : { label: 'Add token manually', action: 'create-connection' },
+      ...(oauthEnabled
+        ? { secondary: { label: 'Add token manually', action: 'create-connection' as const } }
+        : {}),
+    }
+  }
+
+  if (!hasConnections) {
+    return {
+      title: 'Connect a GitHub account first',
+      description: 'Repositories belong to a connection. Add one, then return here to create the repository.',
+      currentStep: 0,
+      primary: { label: 'Create connection', action: 'create-connection' },
+    }
+  }
+
+  return {
+    title: 'Create your first repository',
+    description: 'Choose a connected GitHub owner, repository name, visibility, and initial content.',
+    currentStep: 1,
+    primary: { label: 'Create repository', action: 'create-repository' },
+  }
+}

--- a/providers/code/portal/src/oauth-config.behavior.test.ts
+++ b/providers/code/portal/src/oauth-config.behavior.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createRenderer, nextTick, ref, ssrContextKey, type RendererOptions } from '@vue/runtime-core'
+import { createRenderer, defineComponent, h, KeepAlive, nextTick, ref, ssrContextKey, type Component, type RendererOptions } from '@vue/runtime-core'
 import * as VueRuntime from 'vue'
 import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc'
 import type { VNode } from 'vue'
@@ -41,9 +41,22 @@ vi.mock('./portalkit/StatusBadge.vue', async () => {
   const { h } = await import('vue')
   return { default: { setup: () => () => h('span', 'status') } }
 })
+vi.mock('./portalkit/FirstRunGuide.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      props: { title: String, primaryLabel: String },
+      setup: props => () => h('section', { class: 'k-first-run' }, [
+        h('h3', props.title),
+        h('button', props.primaryLabel),
+      ]),
+    }),
+  }
+})
 vi.mock('lucide-vue-next', async () => {
   const { h } = await import('vue')
-  return { ArrowLeft: { setup: () => () => h('span', { 'aria-hidden': 'true' }) } }
+  const icon = { setup: () => () => h('span', { 'aria-hidden': 'true' }) }
+  return { ArrowLeft: icon, ArrowRight: icon, Check: icon, CircleDot: icon, Link2: icon }
 })
 
 import ConnectionsView from './views/ConnectionsView.vue'
@@ -207,7 +220,7 @@ async function settle(): Promise<void> {
   }
 }
 
-function mount(component: typeof ConnectionsView | typeof ConnectionCreateView | typeof RepositoryCreateView, props: Record<string, unknown>) {
+function mount(component: Component, props: Record<string, unknown>) {
   const root = createTreeElement('root')
   const app = renderer.createApp(component, props)
   app.provide(ssrContextKey, { modules: new Set<string>() })
@@ -266,7 +279,11 @@ describe('OAuth configuration error states', () => {
   it('shows a retry action on the connections collection when configuration fails', async () => {
     const configRequest = deferred<{ enabled: boolean }>()
     mocks.api.oauthConfig.mockReturnValue(configRequest.promise)
-    const { app, root } = mount(ConnectionsView, { deletions: createResourceDeletions() })
+    const deletions = createResourceDeletions()
+    const host = defineComponent({
+      setup: () => () => h(KeepAlive, null, { default: () => h(ConnectionsView, { deletions }) }),
+    })
+    const { app, root } = mount(host, {})
     await settle()
 
     configRequest.reject(new Error('oauth backend unavailable'))
@@ -274,6 +291,9 @@ describe('OAuth configuration error states', () => {
 
     expect(textContent(root)).toContain('GitHub sign-in configuration could not be loaded: oauth backend unavailable')
     expect(textContent(root)).toContain('Retry GitHub sign-in')
+    expect(textContent(root)).toContain('Connect a GitHub account')
+    expect(textContent(root)).toContain('Add token manually')
+    expect(findNode(root, node => String(node.props.class || '').split(' ').includes('k-first-run'))).toBeDefined()
     expect(findNode(root, node => node.props.role === 'alert')).toBeDefined()
     app.unmount()
   })

--- a/providers/code/portal/src/portalkit/CreateGuidance.vue
+++ b/providers/code/portal/src/portalkit/CreateGuidance.vue
@@ -1,0 +1,72 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { Info } from 'lucide-vue-next'
+import { useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface CreateGuidanceValue {
+  label: string
+  value: string
+  technical?: boolean
+}
+
+withDefaults(defineProps<{
+  title: string
+  description: string
+  prerequisites?: string[]
+  values?: CreateGuidanceValue[]
+  nextSteps?: string[]
+  valuesHeading?: string
+}>(), {
+  prerequisites: () => [],
+  values: () => [],
+  nextSteps: () => [],
+  valuesHeading: 'What Faros will create',
+})
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-create-guidance-${id}-title`
+const prerequisiteID = `k-create-guidance-${id}-prerequisites`
+const valuesID = `k-create-guidance-${id}-values`
+const nextStepsID = `k-create-guidance-${id}-next-steps`
+</script>
+
+<template>
+  <aside class="k-create-guidance" :aria-labelledby="titleID">
+    <div class="k-create-guidance__heading">
+      <Info :size="16" :stroke-width="1.75" aria-hidden="true" />
+      <h3 :id="titleID">{{ title }}</h3>
+    </div>
+    <p class="k-create-guidance__description">{{ description }}</p>
+
+    <section v-if="prerequisites.length" class="k-create-guidance__section" :aria-labelledby="prerequisiteID">
+      <h4 :id="prerequisiteID">Prerequisites</h4>
+      <ul>
+        <li v-for="prerequisite in prerequisites" :key="prerequisite">{{ prerequisite }}</li>
+      </ul>
+    </section>
+
+    <section v-if="values.length" class="k-create-guidance__section" :aria-labelledby="valuesID">
+      <h4 :id="valuesID">{{ valuesHeading }}</h4>
+      <dl class="k-create-guidance__values">
+        <template v-for="item in values" :key="item.label">
+          <dt>{{ item.label }}</dt>
+          <dd><code v-if="item.technical">{{ item.value }}</code><span v-else>{{ item.value }}</span></dd>
+        </template>
+      </dl>
+    </section>
+
+    <section v-if="nextSteps.length" class="k-create-guidance__section" :aria-labelledby="nextStepsID">
+      <h4 :id="nextStepsID">Next steps</h4>
+      <ol>
+        <li v-for="step in nextSteps" :key="step">{{ step }}</li>
+      </ol>
+    </section>
+  </aside>
+</template>

--- a/providers/code/portal/src/portalkit/FirstRunGuide.vue
+++ b/providers/code/portal/src/portalkit/FirstRunGuide.vue
@@ -1,0 +1,85 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { ArrowRight, Check, CircleDot } from 'lucide-vue-next'
+import { computed, useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface FirstRunStep {
+  label: string
+  description: string
+}
+
+const props = withDefaults(defineProps<{
+  title: string
+  description: string
+  primaryLabel: string
+  secondaryLabel?: string
+  steps: readonly FirstRunStep[]
+  currentStep?: number
+  journeyLabel?: string
+}>(), {
+  secondaryLabel: '',
+  currentStep: 0,
+  journeyLabel: 'Getting started',
+})
+
+const emit = defineEmits<{
+  (event: 'primary'): void
+  (event: 'secondary'): void
+}>()
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-first-run-${id}-title`
+const boundedCurrentStep = computed(() => Math.max(0, Math.min(props.currentStep, props.steps.length - 1)))
+</script>
+
+<template>
+  <section class="k-first-run" :aria-labelledby="titleID">
+    <div class="k-first-run__lead">
+      <span class="k-first-run__icon" aria-hidden="true"><slot name="icon" /></span>
+      <div class="k-first-run__copy">
+        <h3 :id="titleID">{{ title }}</h3>
+        <p>{{ description }}</p>
+      </div>
+      <div class="k-first-run__actions">
+        <button class="k-btn k-btn--primary" type="button" @click="emit('primary')">
+          {{ primaryLabel }} <ArrowRight :stroke-width="1.75" aria-hidden="true" />
+        </button>
+        <button v-if="secondaryLabel" class="k-btn k-btn--ghost" type="button" @click="emit('secondary')">
+          {{ secondaryLabel }}
+        </button>
+      </div>
+    </div>
+
+    <ol v-if="steps.length" class="k-first-run__journey" :aria-label="journeyLabel">
+      <li
+        v-for="(step, index) in steps"
+        :key="`${index}-${step.label}`"
+        :class="['k-first-run__step', {
+          'is-complete': index < boundedCurrentStep,
+          'is-current': index === boundedCurrentStep,
+        }]"
+        :aria-current="index === boundedCurrentStep ? 'step' : undefined"
+      >
+        <span class="k-first-run__marker" aria-hidden="true">
+          <Check v-if="index < boundedCurrentStep" :stroke-width="2" />
+          <CircleDot v-else-if="index === boundedCurrentStep" :stroke-width="1.75" />
+          <span v-else>{{ index + 1 }}</span>
+        </span>
+        <span class="k-first-run__step-copy">
+          <span class="k-first-run__step-status">
+            {{ index < boundedCurrentStep ? 'Completed step' : index === boundedCurrentStep ? 'Current step' : 'Upcoming step' }}:
+          </span>
+          <strong>{{ step.label }}</strong>
+          <small>{{ step.description }}</small>
+        </span>
+      </li>
+    </ol>
+  </section>
+</template>

--- a/providers/code/portal/src/portalkit/faros-ui.css
+++ b/providers/code/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/providers/code/portal/src/portalkit/styles.ts
+++ b/providers/code/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 3
+export const FAROS_UI_VERSION = 4
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/code/portal/src/repositoriesPagination.test.ts
+++ b/providers/code/portal/src/repositoriesPagination.test.ts
@@ -3,6 +3,7 @@ import {
   EMPTY_REPOSITORY_FILTERS,
   applyRepositoryPaginationChange,
   hasActiveRepositoryFilters,
+  repositoryCollectionIsAuthoritativelyEmpty,
   repositoryFilters,
   repositoryPageInfo,
   repositoryStatus,
@@ -28,6 +29,24 @@ describe('repository table pagination state', () => {
     expect(repositoryPageInfo()).toEqual({ hasNext: false, nextCursor: null })
     expect(repositoryPageInfo('opaque-next')).toEqual({ hasNext: true, nextCursor: 'opaque-next' })
     expect(repositoryPageInfo('')).toEqual({ hasNext: false, nextCursor: null })
+  })
+
+  it('shows first-run only for a complete empty collection, never an empty later cursor page', () => {
+    expect(repositoryCollectionIsAuthoritativelyEmpty({
+      mode: 'server', page: 1, cursor: null, pageInfo: repositoryPageInfo(), rowCount: 0,
+    })).toBe(true)
+    expect(repositoryCollectionIsAuthoritativelyEmpty({
+      mode: 'server', page: 2, cursor: 'opaque-page-2', pageInfo: repositoryPageInfo(), rowCount: 0,
+    })).toBe(false)
+    expect(repositoryCollectionIsAuthoritativelyEmpty({
+      mode: 'server', page: 1, cursor: null, pageInfo: repositoryPageInfo('opaque-next'), rowCount: 0,
+    })).toBe(false)
+    expect(repositoryCollectionIsAuthoritativelyEmpty({
+      mode: 'client', page: 4, cursor: null, pageInfo: null, rowCount: 0,
+    })).toBe(true)
+    expect(repositoryCollectionIsAuthoritativelyEmpty({
+      mode: 'client', page: 1, cursor: null, pageInfo: null, rowCount: 1,
+    })).toBe(false)
   })
 
   it('preserves server page navigation instead of treating it as a clear', () => {

--- a/providers/code/portal/src/repositoriesPagination.ts
+++ b/providers/code/portal/src/repositoriesPagination.ts
@@ -1,5 +1,5 @@
 import type { Connection, Repository } from './types'
-import type { ResourceTableChange, TableFilterDefinition, TableFilterOption, TablePageInfo } from './portalkit/table'
+import { isCompleteFirstCursorPage, type ResourceTableChange, type TableFilterDefinition, type TableFilterOption, type TablePageInfo } from './portalkit/table'
 
 /** The default page shown while the repository table has no active filters. */
 export const REPOSITORY_PAGE_SIZE = 10
@@ -141,6 +141,24 @@ export interface RepositoryPageInfo extends TablePageInfo {
 export function repositoryPageInfo(nextCursor?: string): RepositoryPageInfo {
   const cursor = nextCursor || null
   return { hasNext: cursor !== null, nextCursor: cursor }
+}
+
+export interface RepositoryEmptyAuthority {
+  mode: RepositoryPaginationMode
+  page: number
+  cursor: string | null
+  pageInfo: RepositoryPageInfo | null
+  rowCount: number
+}
+
+/**
+ * An empty client-mode source is a complete collection. In server mode, only
+ * an empty terminal first page proves the collection itself is empty; a later
+ * cursor page may be empty while earlier pages still contain repositories.
+ */
+export function repositoryCollectionIsAuthoritativelyEmpty(input: RepositoryEmptyAuthority): boolean {
+  if (input.rowCount !== 0) return false
+  return input.mode === 'client' || isCompleteFirstCursorPage(input)
 }
 
 /**

--- a/providers/code/portal/src/views/ConnectionCreateView.vue
+++ b/providers/code/portal/src/views/ConnectionCreateView.vue
@@ -6,6 +6,7 @@ import { contextGenerationKey } from '../context'
 import type { Connection, ErrorResponse } from '../types'
 import type { ConnectionCreateMethod } from '../routes'
 import type { ResourceDeletions } from '../refresh'
+import CreateGuidance from '../portalkit/CreateGuidance.vue'
 
 const props = defineProps<{
   method: ConnectionCreateMethod
@@ -58,6 +59,45 @@ const pageTitle = computed(() => isGitHub.value ? 'Connect with GitHub' : 'Add a
 const pageMeta = computed(() => isGitHub.value
   ? 'Authorize GitHub, then choose the account or organization where repositories should be created.'
   : 'Store a GitHub personal access token in this workspace and validate the connection.')
+const guidanceTitle = computed(() => isGitHub.value ? 'Authorize and connect GitHub' : 'Name and connect GitHub')
+const guidanceDescription = computed(() => isGitHub.value
+  ? 'Authorize Faros in GitHub, then review the workspace-local connection before creating it.'
+  : 'Choose the Faros connection name and GitHub owner, then provide a personal access token.')
+const guidancePrerequisites = computed(() => isGitHub.value
+  ? [
+      'A GitHub session with access to the account or organization that will own repositories.',
+      'Permission to authorize the configured Faros GitHub OAuth app.',
+    ]
+  : [
+      'A GitHub account or organization name that will own repositories.',
+      'A personal access token with permission to create and manage repositories for that owner.',
+      'For GitHub Enterprise Server, the API base URL for the instance.',
+    ])
+const guidanceValues = computed(() => [
+  { label: 'Faros name', value: name.value.trim() || 'Not entered yet', technical: true },
+  { label: 'GitHub owner', value: owner.value.trim() || 'Not entered yet', technical: true },
+  { label: 'Authentication', value: isGitHub.value ? 'GitHub OAuth' : 'Personal access token' },
+  {
+    label: 'Git host',
+    value: isGitHub.value ? 'Configured by OAuth' : baseURL.value.trim() || 'github.com',
+    technical: !isGitHub.value,
+  },
+  {
+    label: 'Credential',
+    value: oauthAuthorized.value
+      ? 'Authorized (stored as a Secret)'
+      : token.value
+        ? 'Provided (stored as a Secret)'
+        : isGitHub.value && oauthBusy.value
+          ? 'Waiting for GitHub authorization'
+          : 'Not provided yet',
+  },
+])
+const guidanceNextSteps = [
+  'Faros stores the credential as a Secret in this workspace; it is not shown after submission.',
+  'The connection controller validates the credential and reports the GitHub login and readiness.',
+  'Use the connection when creating repositories; manage deploy keys and collaborators from each repository.',
+]
 
 function isDeleting(connection: Pick<Connection, 'name' | 'uid' | 'deletionTimestamp'>): boolean {
   return !!connection.deletionTimestamp || props.deletions.has('connection', connection.name, connection.uid)
@@ -323,16 +363,25 @@ onMounted(() => window.addEventListener('message', onMessage))
       <button class="k-btn k-btn--ghost" type="button" @click="loadConnections">Retry connections</button>
     </div>
 
-    <div v-if="isGitHub && !oauthAuthorized" class="k-create-surface">
-      <div class="k-create-body">
-      <p class="muted">A separate GitHub window will open. After authorization, review the connection details before creating it.</p>
-      <span v-if="oauthLoaded && !oauthEnabled && !oauthConfigError" class="muted">GitHub OAuth is not configured. Use the token connection flow instead.</span>
-      <span v-else-if="!oauthLoaded" class="muted" role="status" aria-live="polite">Checking GitHub sign-in…</span>
-      <div v-if="oauthConfigError" class="error read-error" role="alert" aria-live="assertive">
-        <span>GitHub sign-in configuration could not be loaded: {{ oauthConfigError }}</span>
-        <button class="k-btn k-btn--ghost" type="button" @click="loadOAuthConfig">Retry GitHub sign-in</button>
-      </div>
-      <p v-if="formError" class="error" role="alert">{{ formError }}</p>
+    <div v-if="isGitHub && !oauthAuthorized" class="k-create-surface k-create-surface--guided">
+      <div class="k-create-body k-create-body--guided">
+        <div class="k-create-fields">
+          <p class="muted">A separate GitHub window will open. After authorization, review the connection details before creating it.</p>
+          <span v-if="oauthLoaded && !oauthEnabled && !oauthConfigError" class="muted">GitHub OAuth is not configured. Use the token connection flow instead.</span>
+          <span v-else-if="!oauthLoaded" class="muted" role="status" aria-live="polite">Checking GitHub sign-in…</span>
+          <div v-if="oauthConfigError" class="error read-error" role="alert" aria-live="assertive">
+            <span>GitHub sign-in configuration could not be loaded: {{ oauthConfigError }}</span>
+            <button class="k-btn k-btn--ghost" type="button" @click="loadOAuthConfig">Retry GitHub sign-in</button>
+          </div>
+          <p v-if="formError" class="error" role="alert">{{ formError }}</p>
+        </div>
+        <CreateGuidance
+          :title="guidanceTitle"
+          :description="guidanceDescription"
+          :prerequisites="guidancePrerequisites"
+          :values="guidanceValues"
+          :next-steps="guidanceNextSteps"
+        />
       </div>
       <div class="k-create-actions">
         <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="cancel">Cancel</button>
@@ -342,19 +391,28 @@ onMounted(() => window.addEventListener('message', onMessage))
       </div>
     </div>
 
-    <form v-if="method === 'token' || oauthAuthorized" class="k-create-surface" :aria-busy="submitting" novalidate @submit.prevent="submit">
-      <div class="k-create-body">
-        <p v-if="oauthAuthorized" class="muted">
-          Authorized via GitHub<span v-if="owner"> as <code>{{ owner }}</code></span>. Pick the org/account to create repositories under, then confirm.
-        </p>
-        <label class="field" for="code-connection-name"><span class="field-label">Name</span><input id="code-connection-name" ref="nameInput" v-model="name" class="k-input" placeholder="my-github" autocomplete="off" required aria-required="true" :aria-invalid="fieldErrors.name ? 'true' : undefined" :aria-describedby="fieldErrors.name ? 'code-connection-name-error' : undefined" @input="clearFieldError('name')" /><span v-if="fieldErrors.name" id="code-connection-name-error" class="error" role="alert">{{ fieldErrors.name }}</span></label>
-        <label class="field" for="code-connection-owner"><span class="field-label">Owner (org or user)</span><input id="code-connection-owner" ref="ownerInput" v-model="owner" class="k-input" placeholder="acme" autocomplete="off" required aria-required="true" :aria-invalid="fieldErrors.owner ? 'true' : undefined" :aria-describedby="fieldErrors.owner ? 'code-connection-owner-error' : undefined" @input="clearFieldError('owner')" /><span v-if="fieldErrors.owner" id="code-connection-owner-error" class="error" role="alert">{{ fieldErrors.owner }}</span></label>
-        <label v-if="!oauthAuthorized" class="field" for="code-connection-token"><span class="field-label">Personal access token</span><input id="code-connection-token" ref="tokenInput" v-model="token" class="k-input" type="password" placeholder="ghp_…" autocomplete="new-password" required aria-required="true" :aria-invalid="fieldErrors.token ? 'true' : undefined" :aria-describedby="fieldErrors.token ? 'code-connection-token-error' : undefined" @input="clearFieldError('token')" /><span v-if="fieldErrors.token" id="code-connection-token-error" class="error" role="alert">{{ fieldErrors.token }}</span></label>
-        <label v-else class="field"><span class="field-label">Credential</span><input class="k-input" value="GitHub OAuth — authorized" disabled /></label>
-        <label v-if="!oauthAuthorized" class="field"><span class="field-label">Base URL (GHES, optional)</span><input v-model="baseURL" class="k-input" placeholder="https://github.example.com/api/v3" autocomplete="url" /></label>
-        <p class="muted">The token is stored as a Secret in your workspace; the provider validates it and shows the login below.</p>
-        <span v-if="formError" class="error" role="alert">{{ formError }}</span>
-        <span v-if="submitting" class="sr-only" role="status" aria-live="polite">Creating connection…</span>
+    <form v-if="method === 'token' || oauthAuthorized" class="k-create-surface k-create-surface--guided" :aria-busy="submitting" novalidate @submit.prevent="submit">
+      <div class="k-create-body k-create-body--guided">
+        <div class="k-create-fields">
+          <p v-if="oauthAuthorized" class="muted">
+            Authorized via GitHub<span v-if="owner"> as <code>{{ owner }}</code></span>. Pick the org/account to create repositories under, then confirm.
+          </p>
+          <label class="field" for="code-connection-name"><span class="field-label">Name</span><input id="code-connection-name" ref="nameInput" v-model="name" class="k-input" placeholder="my-github" autocomplete="off" required aria-required="true" :aria-invalid="fieldErrors.name ? 'true' : undefined" :aria-describedby="fieldErrors.name ? 'code-connection-name-error' : undefined" @input="clearFieldError('name')" /><span v-if="fieldErrors.name" id="code-connection-name-error" class="error" role="alert">{{ fieldErrors.name }}</span></label>
+          <label class="field" for="code-connection-owner"><span class="field-label">Owner (org or user)</span><input id="code-connection-owner" ref="ownerInput" v-model="owner" class="k-input" placeholder="acme" autocomplete="off" required aria-required="true" :aria-invalid="fieldErrors.owner ? 'true' : undefined" :aria-describedby="fieldErrors.owner ? 'code-connection-owner-error' : undefined" @input="clearFieldError('owner')" /><span v-if="fieldErrors.owner" id="code-connection-owner-error" class="error" role="alert">{{ fieldErrors.owner }}</span></label>
+          <label v-if="!oauthAuthorized" class="field" for="code-connection-token"><span class="field-label">Personal access token</span><input id="code-connection-token" ref="tokenInput" v-model="token" class="k-input" type="password" placeholder="ghp_…" autocomplete="new-password" required aria-required="true" :aria-invalid="fieldErrors.token ? 'true' : undefined" :aria-describedby="fieldErrors.token ? 'code-connection-token-error' : undefined" @input="clearFieldError('token')" /><span v-if="fieldErrors.token" id="code-connection-token-error" class="error" role="alert">{{ fieldErrors.token }}</span></label>
+          <label v-else class="field"><span class="field-label">Credential</span><input class="k-input" value="GitHub OAuth — authorized" disabled /></label>
+          <label v-if="!oauthAuthorized" class="field"><span class="field-label">Base URL (GHES, optional)</span><input v-model="baseURL" class="k-input" placeholder="https://github.example.com/api/v3" autocomplete="url" /></label>
+          <p class="muted">The token is stored as a Secret in your workspace; the provider validates it and shows the login below.</p>
+          <span v-if="formError" class="error" role="alert">{{ formError }}</span>
+          <span v-if="submitting" class="sr-only" role="status" aria-live="polite">Creating connection…</span>
+        </div>
+        <CreateGuidance
+          :title="guidanceTitle"
+          :description="guidanceDescription"
+          :prerequisites="guidancePrerequisites"
+          :values="guidanceValues"
+          :next-steps="guidanceNextSteps"
+        />
       </div>
       <div class="k-create-actions">
         <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="cancel">Cancel</button>

--- a/providers/code/portal/src/views/ConnectionsView.vue
+++ b/providers/code/portal/src/views/ConnectionsView.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
+import { Link2 } from 'lucide-vue-next'
 import { computed, onActivated, onMounted, onUnmounted, ref } from 'vue'
 import { api } from '../api'
+import { CODE_JOURNEY_STEPS, codeFirstRunModel } from '../journey'
 import type { Connection, ErrorResponse } from '../types'
+import FirstRunGuide from '../portalkit/FirstRunGuide.vue'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
 import StatusBadge from '../portalkit/StatusBadge.vue'
@@ -52,6 +55,8 @@ function isDeleting(connection: Pick<Connection, 'name' | 'uid' | 'deletionTimes
 const oauthEnabled = ref(false)
 const oauthLoaded = ref(false)
 const oauthError = ref<string | null>(null)
+const showFirstRun = computed(() => loaded.value && oauthLoaded.value && !error.value && connections.value.length === 0)
+const firstRun = computed(() => codeFirstRunModel('connection', false, oauthEnabled.value))
 let mounted = false
 let refresh!: LatestRefreshController
 const refreshMode = ref<ResourceRefreshMode>('foreground')
@@ -97,6 +102,10 @@ function load(mode: ResourceRefreshMode = 'foreground') {
 function openConnection(row: Record<string, unknown>) {
   const resourceName = String(row.name)
   if (!row.deleting && !operations.isLocked(operationKey('connection', resourceName))) emit('open', resourceName)
+}
+
+function startFirstRun(primary: boolean): void {
+  emit('create', oauthEnabled.value && primary ? 'github' : 'token')
 }
 
 async function remove(row: Record<string, unknown>) {
@@ -168,7 +177,7 @@ onUnmounted(() => {
         <h2 class="page-title">Connections</h2>
         <p class="page-meta">A connection binds your workspace to a git account. Repositories are created under it.</p>
       </div>
-      <div class="code-form-actions">
+      <div v-if="!showFirstRun" class="code-form-actions">
         <button v-if="oauthEnabled" class="k-btn k-btn--primary" :disabled="!loaded" @click="emit('create', 'github')">
           Connect with GitHub
         </button>
@@ -187,7 +196,23 @@ onUnmounted(() => {
     </p>
 
     <p v-if="mutationError" class="error mutation-error" role="alert" aria-live="assertive">{{ mutationError }}</p>
+    <FirstRunGuide
+      v-if="showFirstRun"
+      :title="firstRun.title"
+      :description="firstRun.description"
+      :primary-label="firstRun.primary.label"
+      :secondary-label="firstRun.secondary?.label"
+      :steps="CODE_JOURNEY_STEPS"
+      :current-step="firstRun.currentStep"
+      journey-label="Code setup path"
+      @primary="startFirstRun(true)"
+      @secondary="startFirstRun(false)"
+    >
+      <template #icon><Link2 :stroke-width="1.5" /></template>
+    </FirstRunGuide>
+
     <ResourceTable
+      v-else
       :columns="columns"
       :rows="rows"
       aria-label="Git connections"

--- a/providers/code/portal/src/views/RepositoriesView.vue
+++ b/providers/code/portal/src/views/RepositoriesView.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { computed, onActivated, onMounted, onUnmounted, ref } from 'vue'
-import { ExternalLink } from 'lucide-vue-next'
+import { ExternalLink, GitBranch, Link2 } from 'lucide-vue-next'
 import { api } from '../api'
+import { CODE_JOURNEY_STEPS, codeFirstRunModel, type CodeJourneyAction } from '../journey'
 import type { Connection, ErrorResponse, Repository } from '../types'
+import FirstRunGuide from '../portalkit/FirstRunGuide.vue'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
 import StatusBadge from '../portalkit/StatusBadge.vue'
@@ -27,6 +29,7 @@ import {
   applyRepositoryPaginationChange,
   REPOSITORY_PAGE_SIZE,
   repositoryFilters,
+  repositoryCollectionIsAuthoritativelyEmpty,
   repositoryPageInfo as toRepositoryPageInfo,
   repositoryStatus,
   type RepositoryFilterValues,
@@ -38,6 +41,7 @@ const props = defineProps<{ deletions: ResourceDeletions }>()
 const emit = defineEmits<{
   (e: 'open', name: string): void
   (e: 'create'): void
+  (e: 'create-connection'): void
 }>()
 const deletionScope = 'repository'
 
@@ -72,9 +76,30 @@ const rows = computed<Array<Record<string, unknown>>>(() => repos.value
     const deleting = isDeleting(repository)
     return { ...repository, deleting, url: repository.htmlURL || '', status: deleting ? 'Deleting' : repositoryStatus(repository), actions: '' }
   }))
+const availableConnections = computed(() => connections.value.filter(connection => (
+  !connection.deletionTimestamp && !props.deletions.has('connection', connection.name, connection.uid)
+)))
+const repositoryCollectionEmpty = computed(() => repositoryCollectionIsAuthoritativelyEmpty({
+  mode: repositoryMode.value,
+  page: repositoryPage.value,
+  cursor: repositoryCursor.value,
+  pageInfo: repositoryPageInfo.value,
+  rowCount: repos.value.length,
+}))
+const showFirstRun = computed(() => loaded.value
+  && connectionsLoaded.value
+  && !error.value
+  && !connectionsError.value
+  && repositoryCollectionEmpty.value)
+const firstRun = computed(() => codeFirstRunModel('repository', availableConnections.value.length > 0))
 
 function isDeleting(repository: Pick<Repository, 'name' | 'uid' | 'deletionTimestamp'>): boolean {
   return !!repository.deletionTimestamp || props.deletions.has(deletionScope, repository.name, repository.uid)
+}
+
+function handleFirstRun(action: CodeJourneyAction): void {
+  if (action === 'create-connection') emit('create-connection')
+  else emit('create')
 }
 const repositoryFilterDefinitions = computed(() => repositoryFilters(connections.value))
 
@@ -387,7 +412,7 @@ onUnmounted(() => {
         <h2 class="page-title">Repositories</h2>
         <p class="page-meta">Repositories the provider manages on the git host. Click one to manage deploy keys and collaborators.</p>
       </div>
-      <button class="k-btn k-btn--primary" :disabled="!loaded" @click="emit('create')">
+      <button v-if="!showFirstRun" class="k-btn k-btn--primary" :disabled="!loaded || !connectionsLoaded" @click="emit('create')">
         New repository
       </button>
     </header>
@@ -399,7 +424,24 @@ onUnmounted(() => {
     </div>
     <span v-else-if="connectionsLoading && connectionsLoaded" class="sr-only" role="status" aria-live="polite">Updating connections…</span>
     <p v-if="mutationError" class="error mutation-error" role="alert" aria-live="assertive">{{ mutationError }}</p>
+    <FirstRunGuide
+      v-if="showFirstRun"
+      :title="firstRun.title"
+      :description="firstRun.description"
+      :primary-label="firstRun.primary.label"
+      :steps="CODE_JOURNEY_STEPS"
+      :current-step="firstRun.currentStep"
+      journey-label="Code setup path"
+      @primary="handleFirstRun(firstRun.primary.action)"
+    >
+      <template #icon>
+        <Link2 v-if="firstRun.currentStep === 0" :stroke-width="1.5" />
+        <GitBranch v-else :stroke-width="1.5" />
+      </template>
+    </FirstRunGuide>
+
     <ResourceTable
+      v-else
       :columns="columns"
       :rows="rows"
       aria-label="Repositories"

--- a/providers/code/portal/src/views/RepositoryCreateView.vue
+++ b/providers/code/portal/src/views/RepositoryCreateView.vue
@@ -7,11 +7,13 @@ import type { Connection, ErrorResponse, Repository } from '../types'
 import type { ResourceDeletions } from '../refresh'
 import { createFullListReadCoordinator } from '../hybridPagination'
 import { createOperationLocks, operationKey } from '../refresh'
+import CreateGuidance from '../portalkit/CreateGuidance.vue'
 
 const props = defineProps<{ deletions: ResourceDeletions }>()
 const emit = defineEmits<{
   (e: 'cancel'): void
   (e: 'created', name: string): void
+  (e: 'create-connection'): void
 }>()
 
 const repositories = ref<Repository[]>([])
@@ -47,6 +49,25 @@ let mutationGeneration = 0
 const connectionChoices = computed(() => connections.value.filter(connection => (
   !connection.deletionTimestamp && !props.deletions.has('connection', connection.name, connection.uid)
 )))
+const guidanceValues = computed(() => {
+  const objectName = name.value.trim() ? normalizeResourceName(name.value) : ''
+  return [
+    { label: 'Faros object', value: objectName || 'Not entered yet', technical: true },
+    { label: 'GitHub repository', value: repo.value.trim() || objectName || 'Not entered yet', technical: true },
+    { label: 'Connection', value: connectionRef.value || 'Not selected yet', technical: true },
+    { label: 'Visibility', value: visibility.value, technical: true },
+    { label: 'Initial content', value: autoInit.value ? 'README' : 'Empty repository' },
+  ]
+})
+const guidancePrerequisites = [
+  'An active GitHub connection in this workspace that is not being deleted.',
+  'Permission for that connection to create repositories for its configured owner.',
+]
+const guidanceNextSteps = [
+  'Faros creates the repository through the selected connection and records its remote URL.',
+  'The repository controller reports readiness independently after GitHub accepts the request.',
+  'Add deploy keys and collaborators from the repository detail page after creation.',
+]
 
 function errMessage(e: unknown): string {
   const err = e as ErrorResponse
@@ -246,7 +267,7 @@ onUnmounted(() => {
     </button>
     <header class="k-create-header">
       <h2 class="k-create-title">Create repository</h2>
-      <p class="k-create-description">Create a repository through one of your ready GitHub connections. Deploy keys and collaborators stay managed on the repository detail page.</p>
+      <p class="k-create-description">Create a repository through one of your active GitHub connections. Deploy keys and collaborators stay managed on the repository detail page.</p>
     </header>
 
     <div v-if="(repositoryLoading && !repositoryLoaded) || (connectionsLoading && !connectionsLoaded)" class="panel k-card" role="status" aria-live="polite">
@@ -260,35 +281,47 @@ onUnmounted(() => {
       <span>{{ connectionsLoaded ? 'Showing cached connection choices. ' : '' }}{{ connectionsError }}</span>
       <button class="k-btn k-btn--ghost" type="button" @click="loadConnections">Retry connections</button>
     </div>
-    <p v-if="connectionsLoaded && !connectionChoices.length" class="empty">Add a ready connection first, then create repositories under it.</p>
+    <div v-if="connectionsLoaded && !connectionChoices.length" class="panel k-card">
+      <p class="empty">Add an active connection first, then create repositories under it.</p>
+      <button class="k-btn k-btn--ghost" type="button" @click="emit('create-connection')">Create connection</button>
+    </div>
 
-    <form class="k-create-surface" :aria-busy="submitting" novalidate @submit.prevent="submit">
-      <div class="k-create-body">
-        <label class="field" for="code-repository-connection">
-          <span class="field-label">Connection</span>
-          <select id="code-repository-connection" ref="connectionInput" v-model="connectionRef" class="k-input" :disabled="connectionsLoading && !connectionsLoaded" required aria-required="true" :aria-invalid="fieldErrors.connection ? 'true' : undefined" :aria-describedby="fieldErrors.connection ? 'code-repository-connection-error' : undefined" @change="clearFieldError('connection')">
-            <option v-for="connection in connectionChoices" :key="connection.name" :value="connection.name">{{ connection.name }} ({{ connection.owner }})</option>
-          </select>
-          <span v-if="fieldErrors.connection" id="code-repository-connection-error" class="error" role="alert">{{ fieldErrors.connection }}</span>
-        </label>
-        <label class="field" for="code-repository-name"><span class="field-label">Object name</span><input id="code-repository-name" ref="nameInput" v-model="name" class="k-input" placeholder="my-service" autocomplete="off" required aria-required="true" :aria-invalid="fieldErrors.name ? 'true' : undefined" :aria-describedby="fieldErrors.name ? 'code-repository-name-error' : undefined" @input="clearFieldError('name')" /><span v-if="fieldErrors.name" id="code-repository-name-error" class="error" role="alert">{{ fieldErrors.name }}</span></label>
-        <label class="field"><span class="field-label">Repo name (defaults to object name)</span><input v-model="repo" class="k-input" placeholder="my-service" autocomplete="off" /></label>
-        <label class="field">
-          <span class="field-label">Visibility</span>
-          <select v-model="visibility" class="k-input">
-            <option value="private">private</option>
-            <option value="public">public</option>
-            <option value="internal">internal</option>
-          </select>
-        </label>
-        <label class="field"><span class="field-label">Description</span><input v-model="description" class="k-input" autocomplete="off" /></label>
-        <label class="field field-check"><input v-model="autoInit" type="checkbox" /> Initialize with a README</label>
-        <span v-if="formError" class="error" role="alert">{{ formError }}</span>
-        <span v-if="submitting" class="sr-only" role="status" aria-live="polite">Creating repository…</span>
+    <form class="k-create-surface k-create-surface--guided" :aria-busy="submitting" novalidate @submit.prevent="submit">
+      <div class="k-create-body k-create-body--guided">
+        <div class="k-create-fields">
+          <label class="field" for="code-repository-connection">
+            <span class="field-label">Connection</span>
+            <select id="code-repository-connection" ref="connectionInput" v-model="connectionRef" class="k-input" :disabled="connectionsLoading && !connectionsLoaded" required aria-required="true" :aria-invalid="fieldErrors.connection ? 'true' : undefined" :aria-describedby="fieldErrors.connection ? 'code-repository-connection-error' : undefined" @change="clearFieldError('connection')">
+              <option v-for="connection in connectionChoices" :key="connection.name" :value="connection.name">{{ connection.name }} ({{ connection.owner }})</option>
+            </select>
+            <span v-if="fieldErrors.connection" id="code-repository-connection-error" class="error" role="alert">{{ fieldErrors.connection }}</span>
+          </label>
+          <label class="field" for="code-repository-name"><span class="field-label">Object name</span><input id="code-repository-name" ref="nameInput" v-model="name" class="k-input" placeholder="my-service" autocomplete="off" required aria-required="true" :aria-invalid="fieldErrors.name ? 'true' : undefined" :aria-describedby="fieldErrors.name ? 'code-repository-name-error' : undefined" @input="clearFieldError('name')" /><span v-if="fieldErrors.name" id="code-repository-name-error" class="error" role="alert">{{ fieldErrors.name }}</span></label>
+          <label class="field"><span class="field-label">Repo name (defaults to object name)</span><input v-model="repo" class="k-input" placeholder="my-service" autocomplete="off" /></label>
+          <label class="field">
+            <span class="field-label">Visibility</span>
+            <select v-model="visibility" class="k-input">
+              <option value="private">private</option>
+              <option value="public">public</option>
+              <option value="internal">internal</option>
+            </select>
+          </label>
+          <label class="field"><span class="field-label">Description</span><input v-model="description" class="k-input" autocomplete="off" /></label>
+          <label class="field field-check"><input v-model="autoInit" type="checkbox" /> Initialize with a README</label>
+          <span v-if="formError" class="error" role="alert">{{ formError }}</span>
+          <span v-if="submitting" class="sr-only" role="status" aria-live="polite">Creating repository…</span>
+        </div>
+        <CreateGuidance
+          title="Define the GitHub repository"
+          description="Choose the workspace identity and remote repository settings Faros will manage."
+          :prerequisites="guidancePrerequisites"
+          :values="guidanceValues"
+          :next-steps="guidanceNextSteps"
+        />
       </div>
       <div class="k-create-actions">
         <button class="k-btn k-btn--ghost" type="button" :disabled="submitting" @click="cancel">Cancel</button>
-        <button class="k-btn k-btn--primary" type="submit" :disabled="submitting">{{ submitting ? 'Creating…' : 'Create repository' }}</button>
+        <button class="k-btn k-btn--primary" type="submit" :disabled="submitting || !connectionChoices.length">{{ submitting ? 'Creating…' : 'Create repository' }}</button>
       </div>
     </form>
   </section>

--- a/providers/databricks/portal/src/components/DatabricksEmptyState.vue
+++ b/providers/databricks/portal/src/components/DatabricksEmptyState.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ArrowRight, Check, CircleDot, Link2, Table2, Warehouse } from 'lucide-vue-next'
+import { Link2, Table2, Warehouse } from 'lucide-vue-next'
 import { computed } from 'vue'
+import FirstRunGuide from '../portalkit/FirstRunGuide.vue'
 import {
   DATABRICKS_JOURNEY_STEPS,
   firstRunModel,
@@ -19,48 +20,21 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{ (event: 'action', action: DatabricksJourneyAction): void }>()
 const model = computed(() => firstRunModel(props.kind, props.hasConnections, props.hasWarehouses))
-const titleID = computed(() => `databricks-${props.kind}-first-run-title`)
 const icons = [Link2, Warehouse, Table2] as const
 </script>
 
 <template>
-  <section class="databricks-first-run" :aria-labelledby="titleID">
-    <div class="databricks-first-run__lead">
-      <component :is="icons[model.currentStep]" class="databricks-first-run__icon" :stroke-width="1.5" aria-hidden="true" />
-      <div class="databricks-first-run__copy">
-        <h3 :id="titleID">{{ model.title }}</h3>
-        <p>{{ model.description }}</p>
-      </div>
-      <div class="databricks-first-run__actions">
-        <button class="k-btn k-btn--primary" type="button" @click="emit('action', model.primary.action)">
-          {{ model.primary.label }} <ArrowRight :stroke-width="1.75" aria-hidden="true" />
-        </button>
-        <button v-if="model.secondary" class="k-btn k-btn--ghost" type="button" @click="emit('action', model.secondary.action)">
-          {{ model.secondary.label }}
-        </button>
-      </div>
-    </div>
-
-    <ol class="databricks-journey" aria-label="Databricks setup path">
-      <li
-        v-for="(step, index) in DATABRICKS_JOURNEY_STEPS"
-        :key="step.label"
-        :class="['databricks-journey__step', {
-          'databricks-journey__step--complete': index < model.currentStep,
-          'databricks-journey__step--current': index === model.currentStep,
-        }]"
-        :aria-current="index === model.currentStep ? 'step' : undefined"
-      >
-        <span class="databricks-journey__marker" aria-hidden="true">
-          <Check v-if="index < model.currentStep" :stroke-width="2" />
-          <CircleDot v-else-if="index === model.currentStep" :stroke-width="1.75" />
-          <span v-else>{{ index + 1 }}</span>
-        </span>
-        <span class="databricks-journey__copy">
-          <strong>{{ step.label }}</strong>
-          <small>{{ step.description }}</small>
-        </span>
-      </li>
-    </ol>
-  </section>
+  <FirstRunGuide
+    :title="model.title"
+    :description="model.description"
+    :primary-label="model.primary.label"
+    :secondary-label="model.secondary?.label"
+    :steps="DATABRICKS_JOURNEY_STEPS"
+    :current-step="model.currentStep"
+    journey-label="Databricks setup path"
+    @primary="emit('action', model.primary.action)"
+    @secondary="model.secondary && emit('action', model.secondary.action)"
+  >
+    <template #icon><component :is="icons[model.currentStep]" :stroke-width="1.5" /></template>
+  </FirstRunGuide>
 </template>

--- a/providers/databricks/portal/src/components/ManualCreateGuidance.vue
+++ b/providers/databricks/portal/src/components/ManualCreateGuidance.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { Info } from 'lucide-vue-next'
-import { computed, useId } from 'vue'
+import { computed } from 'vue'
+import CreateGuidance, { type CreateGuidanceValue } from '../portalkit/CreateGuidance.vue'
 
 type ManualCreateKind = 'connection' | 'warehouse' | 'table'
 
@@ -14,12 +14,6 @@ interface ManualCreateValues {
   catalog?: string
   schema?: string
   table?: string
-}
-
-interface LiveValue {
-  label: string
-  value: string
-  technical?: boolean
 }
 
 interface GuidanceCopy {
@@ -84,12 +78,6 @@ const guidanceCopy: Record<ManualCreateKind, GuidanceCopy> = {
   },
 }
 
-const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
-const titleID = `manual-create-guidance-${id}-title`
-const prerequisiteID = `manual-create-guidance-${id}-prerequisites`
-const nextStepsID = `manual-create-guidance-${id}-next-steps`
-const valuesID = `manual-create-guidance-${id}-values`
-
 const copy = computed<GuidanceCopy>(() => {
   if (props.kind !== 'table' || !props.editing) return guidanceCopy[props.kind]
   return {
@@ -109,7 +97,7 @@ function present(value: string | undefined, fallback = 'Not entered yet'): strin
   return normalized || fallback
 }
 
-const liveValues = computed<LiveValue[]>(() => {
+const liveValues = computed<CreateGuidanceValue[]>(() => {
   const values = props.values
   if (props.kind === 'connection') {
     return [
@@ -146,38 +134,12 @@ const outputHeading = computed(() => props.editing ? 'What Faros will save' : 'W
 </script>
 
 <template>
-  <aside class="manual-create-guidance" :aria-labelledby="titleID">
-    <div class="manual-create-guidance__heading">
-      <Info :size="16" :stroke-width="1.75" aria-hidden="true" />
-      <h3 :id="titleID">{{ copy.heading }}</h3>
-    </div>
-    <p class="manual-create-guidance__description">{{ copy.description }}</p>
-
-    <section class="manual-create-guidance__section" :aria-labelledby="prerequisiteID">
-      <h4 :id="prerequisiteID">Prerequisites</h4>
-      <ul>
-        <li v-for="prerequisite in copy.prerequisites" :key="prerequisite">{{ prerequisite }}</li>
-      </ul>
-    </section>
-
-    <section class="manual-create-guidance__section" :aria-labelledby="valuesID">
-      <h4 :id="valuesID">{{ outputHeading }}</h4>
-      <dl class="manual-create-guidance__values">
-        <template v-for="item in liveValues" :key="item.label">
-          <dt>{{ item.label }}</dt>
-          <dd :class="{ 'manual-create-guidance__value--technical': item.technical }">
-            <code v-if="item.technical">{{ item.value }}</code>
-            <span v-else>{{ item.value }}</span>
-          </dd>
-        </template>
-      </dl>
-    </section>
-
-    <section class="manual-create-guidance__section" :aria-labelledby="nextStepsID">
-      <h4 :id="nextStepsID">Next steps</h4>
-      <ol>
-        <li v-for="step in copy.nextSteps" :key="step">{{ step }}</li>
-      </ol>
-    </section>
-  </aside>
+  <CreateGuidance
+    :title="copy.heading"
+    :description="copy.description"
+    :prerequisites="copy.prerequisites"
+    :values="liveValues"
+    :values-heading="outputHeading"
+    :next-steps="copy.nextSteps"
+  />
 </template>

--- a/providers/databricks/portal/src/databricksPolish.source.test.mjs
+++ b/providers/databricks/portal/src/databricksPolish.source.test.mjs
@@ -36,12 +36,12 @@ test('prerequisite recovery actions share the compact callout pattern', async ()
   assert.match(styles, /@media \(max-width: 620px\) \{[\s\S]*?\.prerequisite \{[\s\S]*?flex-wrap:\s*wrap;/)
 })
 
-test('all three collections use one first-run journey without changing page width', async () => {
-  const [connections, warehouses, tables, styles] = await Promise.all([
+test('all three collections use the shared first-run journey without changing page width', async () => {
+  const [connections, warehouses, tables, sharedStyles] = await Promise.all([
     read('./views/ConnectionsView.vue'),
     read('./views/WarehousesView.vue'),
     read('./views/TablesView.vue'),
-    read('./style.css'),
+    read('./portalkit/faros-ui.css'),
   ])
   for (const source of [connections, warehouses, tables]) {
     assert.match(source, /<DatabricksEmptyState/)
@@ -51,12 +51,11 @@ test('all three collections use one first-run journey without changing page widt
     assert.match(source, /page--first-run/)
     assert.match(source, /loaded && !showFirstRun/)
   }
-  const firstRun = styles.match(/faros-provider-databricks \.databricks-first-run\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+  const firstRun = sharedStyles.match(/\.k-first-run\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
   assert.match(firstRun, /justify-content:\s*flex-start/)
   assert.match(firstRun, /min-height:\s*0/)
   assert.doesNotMatch(firstRun, /max-width|width:\s*min/)
-  assert.doesNotMatch(styles, /min-height:\s*calc\(100vh\s*-\s*150px\)|margin-block:\s*auto/)
-  assert.match(styles, /@media \(max-width: 620px\)[\s\S]*\.page-head \{ flex-wrap: wrap; \}/)
+  assert.doesNotMatch(sharedStyles, /min-height:\s*calc\(100vh\s*-\s*150px\)|margin-block:\s*auto/)
 })
 
 test('table actions and onboarding remain prerequisite-aware at wide widths', async () => {
@@ -66,8 +65,9 @@ test('table actions and onboarding remain prerequisite-aware at wide widths', as
   ])
 
   assert.match(tables, /<button v-if="loaded && !showFirstRun" class="k-btn k-btn--ghost icon-text"/)
-  assert.match(styles, /\.databricks-journey \{[\s\S]*grid-template-columns: repeat\(3, minmax\(0, 20rem\)\)[\s\S]*max-inline-size: 60rem/)
-  assert.match(styles, /@media \(max-width: 620px\)[\s\S]*\.databricks-journey \{ gap: 12px; grid-template-columns: minmax\(0, 1fr\); \}/)
+  const sharedStyles = await read('./portalkit/faros-ui.css')
+  assert.match(sharedStyles, /\.k-first-run__journey \{[\s\S]*repeat\(auto-fit/)
+  assert.match(sharedStyles, /@media \(max-width: 620px\)[\s\S]*\.k-first-run__journey \{ gap: 12px; grid-template-columns: minmax\(0, 1fr\); \}/)
 })
 
 test('collection first-run surfaces stay latched during refresh', async () => {
@@ -135,7 +135,7 @@ test('import dialog close and disclosure focus use canonical action treatments',
   assert.match(coarseIconAction, /\.k-icon-action\s*\{[\s\S]*flex-basis:\s*44px[\s\S]*height:\s*44px[\s\S]*width:\s*44px/)
   assert.match(styles, /\.field-disclosure summary:focus-visible\s*\{[\s\S]*outline:\s*2px solid var\(--color-accent/)
   assert.doesNotMatch(styles.match(/\.field-disclosure summary:focus-visible\s*\{([\s\S]*?)\n\}/)?.[1] ?? '', /accent-glow|box-shadow/)
-  const firstRun = styles.match(/faros-provider-databricks \.databricks-first-run\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+  const firstRun = sharedStyles.match(/\.k-first-run\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
   assert.match(firstRun, /background:\s*var\(--color-surface-raised/)
   assert.doesNotMatch(firstRun, /linear-gradient|color-mix/)
 })
@@ -172,23 +172,26 @@ test('credential help is concise with progressive disclosure', async () => {
   assert.match(connection, /Faros stores the token as a Secret in this workspace/)
 })
 
-test('manual create routes share an honest responsive guidance rail', async () => {
-  const [guidance, connection, warehouse, table, styles] = await Promise.all([
+test('manual create routes share an honest responsive PortalKit guidance rail', async () => {
+  const [guidance, sharedGuidance, connection, warehouse, table, styles, sharedStyles] = await Promise.all([
     read('./components/ManualCreateGuidance.vue'),
+    read('./portalkit/CreateGuidance.vue'),
     read('./views/CreateConnectionView.vue'),
     read('./views/CreateWarehouseView.vue'),
     read('./views/CreateTableView.vue'),
     read('./style.css'),
+    read('./portalkit/faros-ui.css'),
   ])
 
-  assert.match(guidance, /<aside class="manual-create-guidance" :aria-labelledby="titleID">/)
-  assert.match(guidance, /<section class="manual-create-guidance__section" :aria-labelledby="prerequisiteID">/)
-  assert.match(guidance, /<section class="manual-create-guidance__section" :aria-labelledby="nextStepsID">/)
+  assert.match(guidance, /<CreateGuidance/)
+  assert.match(sharedGuidance, /<aside class="k-create-guidance" :aria-labelledby="titleID">/)
+  assert.match(sharedGuidance, /<section v-if="prerequisites\.length" class="k-create-guidance__section"/)
+  assert.match(sharedGuidance, /<section v-if="nextSteps\.length" class="k-create-guidance__section"/)
   assert.match(guidance, /What Faros will register/)
   assert.match(guidance, /HTTPS Databricks workspace root URL/)
   assert.match(guidance, /personal access token/)
   assert.match(guidance, /stored as a Secret/)
-  assert.match(guidance, /Next steps/)
+  assert.match(sharedGuidance, /Next steps/)
   assert.match(guidance, /16-character hexadecimal warehouse ID/)
   assert.match(guidance, /not the numeric \?o= workspace ID/)
   assert.match(guidance, /Can use permission/)
@@ -208,22 +211,22 @@ test('manual create routes share an honest responsive guidance rail', async () =
   for (const [source, kind] of [[connection, 'connection'], [warehouse, 'warehouse'], [table, 'table']]) {
     assert.match(source, /import ManualCreateGuidance from '\.\.\/components\/ManualCreateGuidance\.vue'/)
     assert.match(source, new RegExp(`<ManualCreateGuidance[\\s\\S]*kind="${kind}"`))
-    assert.match(source, new RegExp(`class="k-create-surface k-create-surface--wide manual-create-form manual-create-form--${kind}"`))
-    assert.match(source, /class="k-create-body manual-create-body--guided"/)
-    assert.match(source, new RegExp(`manual-create-form-fields manual-create-form-fields--${kind}`))
-    assert.ok(source.indexOf('manual-create-form-fields') < source.indexOf('<ManualCreateGuidance'), `${kind} fields precede guidance in the DOM`)
+    assert.match(source, new RegExp(`class="k-create-surface k-create-surface--guided manual-create-form manual-create-form--${kind}"`))
+    assert.match(source, /class="k-create-body k-create-body--guided manual-create-body-guided"/)
+    assert.match(source, new RegExp(`k-create-fields manual-create-form-fields--${kind}`))
+    assert.ok(source.indexOf('k-create-fields') < source.indexOf('<ManualCreateGuidance'), `${kind} fields precede guidance in the DOM`)
   }
   assert.match(table, /:editing="editing"/)
 
-  assert.match(styles, /\.manual-create-form\s*\{[\s\S]*max-width: none[\s\S]*width: 100%/)
-  assert.match(styles, /\.manual-create-body--guided\s*\{[\s\S]*display: grid[\s\S]*grid-template-columns: minmax\(0, 2fr\) minmax\(17\.5rem, 0\.8fr\)/)
-  assert.match(styles, /\.manual-create-form-fields\s*\{[\s\S]*grid-column: 1[\s\S]*grid-row: 1/)
-  assert.match(styles, /\.manual-create-guidance\s*\{[\s\S]*border-inline-start: 1px solid var\(--color-border-subtle/)
-  assert.match(styles, /@container manual-create-form \(min-width: 1400px\)[\s\S]*\.manual-create-fields-grid--connection,[\s\S]*\.manual-create-fields-grid--warehouse[\s\S]*repeat\(2, minmax\(0, 1fr\)/)
-  assert.match(styles, /@container manual-create-form \(min-width: 1600px\)[\s\S]*\.manual-create-form-fields--table \.form-grid[\s\S]*repeat\(3, minmax\(0, 1fr\)/)
-  assert.match(styles, /@container manual-create-form \(max-width: 960px\)[\s\S]*\.manual-create-body--guided\s*\{[\s\S]*grid-template-columns: minmax\(0, 1fr\)/)
-  assert.match(styles, /@container manual-create-form \(max-width: 960px\)[\s\S]*\.manual-create-form-fields[\s\S]*grid-row: 1[\s\S]*\.manual-create-guidance[\s\S]*grid-row: 2/)
-  assert.match(styles, /@container manual-create-form \(max-width: 960px\)[\s\S]*\.manual-create-fields-grid--connection,[\s\S]*\.manual-create-fields-grid--warehouse,[\s\S]*\.manual-create-form-fields--table \.form-grid[\s\S]*grid-template-columns: minmax\(0, 1fr\)/)
+  assert.match(sharedStyles, /\.k-create-surface--guided\s*\{[\s\S]*container-name: k-create-surface/)
+  assert.match(sharedStyles, /\.k-create-body--guided\s*\{[\s\S]*display: grid[\s\S]*grid-template-columns: minmax\(0, 2fr\) minmax\(17\.5rem, 0\.8fr\)/)
+  assert.match(sharedStyles, /\.k-create-fields\s*\{[\s\S]*grid-column: 1[\s\S]*grid-row: 1/)
+  assert.match(sharedStyles, /\.k-create-guidance\s*\{[\s\S]*border-inline-start: 1px solid var\(--color-border-subtle/)
+  assert.match(styles, /@container k-create-surface \(min-width: 1400px\)[\s\S]*\.manual-create-fields-grid--connection,[\s\S]*\.manual-create-fields-grid--warehouse[\s\S]*repeat\(2, minmax\(0, 1fr\)/)
+  assert.match(styles, /@container k-create-surface \(min-width: 1600px\)[\s\S]*\.manual-create-form-fields--table \.form-grid[\s\S]*repeat\(3, minmax\(0, 1fr\)/)
+  assert.match(sharedStyles, /@container k-create-surface \(max-width: 960px\)[\s\S]*\.k-create-body--guided[\s\S]*grid-template-columns: minmax\(0, 1fr\)/)
+  assert.match(sharedStyles, /@container k-create-surface \(max-width: 960px\)[\s\S]*\.k-create-fields[\s\S]*grid-row: 1[\s\S]*\.k-create-guidance[\s\S]*grid-row: 2/)
+  assert.match(styles, /@container k-create-surface \(max-width: 960px\)[\s\S]*\.manual-create-fields-grid--connection,[\s\S]*\.manual-create-fields-grid--warehouse,[\s\S]*\.manual-create-form-fields--table \.form-grid[\s\S]*grid-template-columns: minmax\(0, 1fr\)/)
 })
 
 test('wide provider surfaces stay readable at 4K and in detail/import views', async () => {
@@ -239,13 +242,14 @@ test('wide provider surfaces stay readable at 4K and in detail/import views', as
     read('./views/TablesView.vue'),
   ])
 
-  assert.match(styles, /\.manual-create-form\s*\{[\s\S]*container-name: manual-create-form[\s\S]*container-type: inline-size/)
-  assert.match(styles, /\.manual-create-guidance\s*\{[\s\S]*max-inline-size: 75ch/)
-  assert.match(styles, /@container manual-create-form \(min-width: 1800px\)[\s\S]*\.manual-create-body--guided[\s\S]*minmax\(17\.5rem, min\(32rem, 40%\)\)/)
-  assert.match(styles, /@container manual-create-form \(min-width: 1800px\)[\s\S]*\.manual-create-fields-grid--connection[\s\S]*repeat\(3, minmax\(0, 1fr\)/)
-  assert.match(styles, /@container manual-create-form \(min-width: 3000px\)[\s\S]*\.manual-create-form-fields--table \.form-grid[\s\S]*repeat\(4, minmax\(0, 1fr\)/)
+  const sharedStyles = await read('./portalkit/faros-ui.css')
+  assert.match(sharedStyles, /\.k-create-surface--guided\s*\{[\s\S]*container-name: k-create-surface[\s\S]*container-type: inline-size/)
+  assert.match(sharedStyles, /\.k-create-guidance\s*\{[\s\S]*max-inline-size: 75ch/)
+  assert.match(styles, /@container k-create-surface \(min-width: 1800px\)[\s\S]*\.manual-create-body-guided[\s\S]*minmax\(17\.5rem, min\(32rem, 40%\)\)/)
+  assert.match(styles, /@container k-create-surface \(min-width: 1800px\)[\s\S]*\.manual-create-fields-grid--connection[\s\S]*repeat\(3, minmax\(0, 1fr\)/)
+  assert.match(styles, /@container k-create-surface \(min-width: 3000px\)[\s\S]*\.manual-create-form-fields--table \.form-grid[\s\S]*repeat\(4, minmax\(0, 1fr\)/)
   assert.match(styles, /@media \(max-width: 620px\)[\s\S]*\.manual-create-form input:not\(\[type='hidden'\]\)[\s\S]*min-height: 44px/)
-  assert.match(styles, /@media \(max-width: 620px\)[\s\S]*\.manual-create-form > \.manual-create-body--guided \+ div\s*\{[\s\S]*position: static[\s\S]*z-index: auto/)
+  assert.match(styles, /@media \(max-width: 620px\)[\s\S]*\.manual-create-form > \.manual-create-body-guided \+ div\s*\{[\s\S]*position: static[\s\S]*z-index: auto/)
   assert.match(warehouseCreate, /manual-create-support-note/)
   assert.match(warehouseCreate, /Can use and startable access before it reports Ready/)
   assert.match(wizard, /:class="\['import-body', `import-body--\$\{step\}`\]"/)

--- a/providers/databricks/portal/src/portalkit/CreateGuidance.vue
+++ b/providers/databricks/portal/src/portalkit/CreateGuidance.vue
@@ -1,0 +1,72 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { Info } from 'lucide-vue-next'
+import { useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface CreateGuidanceValue {
+  label: string
+  value: string
+  technical?: boolean
+}
+
+withDefaults(defineProps<{
+  title: string
+  description: string
+  prerequisites?: string[]
+  values?: CreateGuidanceValue[]
+  nextSteps?: string[]
+  valuesHeading?: string
+}>(), {
+  prerequisites: () => [],
+  values: () => [],
+  nextSteps: () => [],
+  valuesHeading: 'What Faros will create',
+})
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-create-guidance-${id}-title`
+const prerequisiteID = `k-create-guidance-${id}-prerequisites`
+const valuesID = `k-create-guidance-${id}-values`
+const nextStepsID = `k-create-guidance-${id}-next-steps`
+</script>
+
+<template>
+  <aside class="k-create-guidance" :aria-labelledby="titleID">
+    <div class="k-create-guidance__heading">
+      <Info :size="16" :stroke-width="1.75" aria-hidden="true" />
+      <h3 :id="titleID">{{ title }}</h3>
+    </div>
+    <p class="k-create-guidance__description">{{ description }}</p>
+
+    <section v-if="prerequisites.length" class="k-create-guidance__section" :aria-labelledby="prerequisiteID">
+      <h4 :id="prerequisiteID">Prerequisites</h4>
+      <ul>
+        <li v-for="prerequisite in prerequisites" :key="prerequisite">{{ prerequisite }}</li>
+      </ul>
+    </section>
+
+    <section v-if="values.length" class="k-create-guidance__section" :aria-labelledby="valuesID">
+      <h4 :id="valuesID">{{ valuesHeading }}</h4>
+      <dl class="k-create-guidance__values">
+        <template v-for="item in values" :key="item.label">
+          <dt>{{ item.label }}</dt>
+          <dd><code v-if="item.technical">{{ item.value }}</code><span v-else>{{ item.value }}</span></dd>
+        </template>
+      </dl>
+    </section>
+
+    <section v-if="nextSteps.length" class="k-create-guidance__section" :aria-labelledby="nextStepsID">
+      <h4 :id="nextStepsID">Next steps</h4>
+      <ol>
+        <li v-for="step in nextSteps" :key="step">{{ step }}</li>
+      </ol>
+    </section>
+  </aside>
+</template>

--- a/providers/databricks/portal/src/portalkit/FirstRunGuide.vue
+++ b/providers/databricks/portal/src/portalkit/FirstRunGuide.vue
@@ -1,0 +1,85 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { ArrowRight, Check, CircleDot } from 'lucide-vue-next'
+import { computed, useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface FirstRunStep {
+  label: string
+  description: string
+}
+
+const props = withDefaults(defineProps<{
+  title: string
+  description: string
+  primaryLabel: string
+  secondaryLabel?: string
+  steps: readonly FirstRunStep[]
+  currentStep?: number
+  journeyLabel?: string
+}>(), {
+  secondaryLabel: '',
+  currentStep: 0,
+  journeyLabel: 'Getting started',
+})
+
+const emit = defineEmits<{
+  (event: 'primary'): void
+  (event: 'secondary'): void
+}>()
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-first-run-${id}-title`
+const boundedCurrentStep = computed(() => Math.max(0, Math.min(props.currentStep, props.steps.length - 1)))
+</script>
+
+<template>
+  <section class="k-first-run" :aria-labelledby="titleID">
+    <div class="k-first-run__lead">
+      <span class="k-first-run__icon" aria-hidden="true"><slot name="icon" /></span>
+      <div class="k-first-run__copy">
+        <h3 :id="titleID">{{ title }}</h3>
+        <p>{{ description }}</p>
+      </div>
+      <div class="k-first-run__actions">
+        <button class="k-btn k-btn--primary" type="button" @click="emit('primary')">
+          {{ primaryLabel }} <ArrowRight :stroke-width="1.75" aria-hidden="true" />
+        </button>
+        <button v-if="secondaryLabel" class="k-btn k-btn--ghost" type="button" @click="emit('secondary')">
+          {{ secondaryLabel }}
+        </button>
+      </div>
+    </div>
+
+    <ol v-if="steps.length" class="k-first-run__journey" :aria-label="journeyLabel">
+      <li
+        v-for="(step, index) in steps"
+        :key="`${index}-${step.label}`"
+        :class="['k-first-run__step', {
+          'is-complete': index < boundedCurrentStep,
+          'is-current': index === boundedCurrentStep,
+        }]"
+        :aria-current="index === boundedCurrentStep ? 'step' : undefined"
+      >
+        <span class="k-first-run__marker" aria-hidden="true">
+          <Check v-if="index < boundedCurrentStep" :stroke-width="2" />
+          <CircleDot v-else-if="index === boundedCurrentStep" :stroke-width="1.75" />
+          <span v-else>{{ index + 1 }}</span>
+        </span>
+        <span class="k-first-run__step-copy">
+          <span class="k-first-run__step-status">
+            {{ index < boundedCurrentStep ? 'Completed step' : index === boundedCurrentStep ? 'Current step' : 'Upcoming step' }}:
+          </span>
+          <strong>{{ step.label }}</strong>
+          <small>{{ step.description }}</small>
+        </span>
+      </li>
+    </ol>
+  </section>
+</template>

--- a/providers/databricks/portal/src/portalkit/faros-ui.css
+++ b/providers/databricks/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/providers/databricks/portal/src/portalkit/styles.ts
+++ b/providers/databricks/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 3
+export const FAROS_UI_VERSION = 4
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/databricks/portal/src/resourceTable.ssr.test.mjs
+++ b/providers/databricks/portal/src/resourceTable.ssr.test.mjs
@@ -3958,8 +3958,10 @@ async function loadNavigationApp() {
     ['ConfirmDialog', '/src/portalkit/ConfirmDialog.vue'],
     ['CreateConnectionView', '/src/views/CreateConnectionView.vue'],
     ['ManualCreateGuidance', '/src/components/ManualCreateGuidance.vue'],
+    ['CreateGuidance', '/src/portalkit/CreateGuidance.vue'],
     ['TablesView', '/src/views/TablesView.vue'],
     ['DatabricksEmptyState', '/src/components/DatabricksEmptyState.vue'],
+    ['FirstRunGuide', '/src/portalkit/FirstRunGuide.vue'],
   ]) {
     try {
       components[name] = await loadMountedSFC(path)
@@ -3970,6 +3972,8 @@ async function loadNavigationApp() {
   }
   App.components = { ...(App.components ?? {}), ...components }
   components.ResourceImportWizard.components = { ...(components.ResourceImportWizard.components ?? {}), FormSelect: components.FormSelect }
+  components.ManualCreateGuidance.components = { ...(components.ManualCreateGuidance.components ?? {}), CreateGuidance: components.CreateGuidance }
+  components.DatabricksEmptyState.components = { ...(components.DatabricksEmptyState.components ?? {}), FirstRunGuide: components.FirstRunGuide }
   components.TablesView.components = { ...(components.TablesView.components ?? {}), DatabricksEmptyState: components.DatabricksEmptyState }
   return App
 }

--- a/providers/databricks/portal/src/style.css
+++ b/providers/databricks/portal/src/style.css
@@ -179,34 +179,6 @@ faros-provider-databricks .databricks-resource-table {
   min-width: 0;
 }
 
-/* Manual create routes use one fluid surface. The body grid keeps the form
- * controls dominant while reserving a quiet rail for prerequisites and the
- * live registration summary. */
-faros-provider-databricks .manual-create-form {
-  container-name: manual-create-form;
-  container-type: inline-size;
-  inline-size: 100%;
-  max-width: none;
-  min-width: 0;
-  width: 100%;
-}
-
-faros-provider-databricks .manual-create-body--guided {
-  align-items: start;
-  display: grid;
-  gap: 24px;
-  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
-}
-
-faros-provider-databricks .manual-create-form-fields {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  grid-column: 1;
-  grid-row: 1;
-  min-width: 0;
-}
-
 faros-provider-databricks .manual-create-fields-grid {
   display: grid;
   gap: 12px;
@@ -220,107 +192,6 @@ faros-provider-databricks .manual-create-security-note {
 faros-provider-databricks .manual-create-support-note {
   line-height: 1.5;
   margin: 0;
-}
-
-faros-provider-databricks .manual-create-guidance {
-  border-inline-start: 1px solid var(--color-border-subtle);
-  color: var(--color-text-secondary);
-  grid-column: 2;
-  grid-row: 1;
-  max-inline-size: 75ch;
-  min-width: 0;
-  overflow-wrap: anywhere;
-  padding: 2px 0 4px;
-  padding-inline-start: 18px;
-}
-
-faros-provider-databricks .manual-create-guidance__heading {
-  align-items: center;
-  color: var(--color-text-primary);
-  display: flex;
-  gap: 8px;
-}
-
-faros-provider-databricks .manual-create-guidance__heading svg {
-  color: var(--color-text-muted);
-  flex: none;
-}
-
-faros-provider-databricks .manual-create-guidance__heading h3 {
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1.35;
-  margin: 0;
-}
-
-faros-provider-databricks .manual-create-guidance__description {
-  font-size: 12px;
-  line-height: 1.5;
-  margin: 7px 0 0;
-}
-
-faros-provider-databricks .manual-create-guidance__section {
-  border-top: 1px solid var(--color-border-subtle);
-  margin-top: 18px;
-  padding-top: 13px;
-}
-
-faros-provider-databricks .manual-create-guidance__section h4 {
-  color: var(--color-text-muted);
-  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.08em;
-  line-height: 1.4;
-  margin: 0;
-  text-transform: uppercase;
-}
-
-faros-provider-databricks .manual-create-guidance__section ul,
-faros-provider-databricks .manual-create-guidance__section ol {
-  display: grid;
-  gap: 8px;
-  margin: 10px 0 0;
-  padding-inline-start: 18px;
-}
-
-faros-provider-databricks .manual-create-guidance__section li {
-  font-size: 11px;
-  line-height: 1.5;
-  padding-inline-start: 2px;
-}
-
-faros-provider-databricks .manual-create-guidance__section li::marker {
-  color: var(--color-text-muted);
-  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
-  font-size: 10px;
-}
-
-faros-provider-databricks .manual-create-guidance__values {
-  display: grid;
-  gap: 8px 12px;
-  grid-template-columns: minmax(0, 7rem) minmax(0, 1fr);
-  margin: 10px 0 0;
-}
-
-faros-provider-databricks .manual-create-guidance__values dt {
-  color: var(--color-text-muted);
-  font-size: 11px;
-  line-height: 1.45;
-}
-
-faros-provider-databricks .manual-create-guidance__values dd {
-  color: var(--color-text-primary);
-  font-size: 11px;
-  line-height: 1.45;
-  margin: 0;
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-faros-provider-databricks .manual-create-guidance__values code {
-  color: inherit;
-  font-size: inherit;
 }
 
 faros-provider-databricks .databricks-create-head {
@@ -583,132 +454,6 @@ faros-provider-databricks .empty {
   color: var(--color-text-secondary, #8a8ca6);
   font-size: 12px;
   margin: 0;
-}
-
-/* First-use guidance stays within AppLayout's canonical content column. Keep
- * the surface compact and top-aligned so large monitors do not turn a short
- * onboarding message into a vertically centered billboard. */
-faros-provider-databricks .databricks-first-run {
-  background: var(--color-surface-raised, #111320);
-  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
-  border-radius: 6px;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  min-height: 0;
-  overflow: hidden;
-  padding: 24px clamp(24px, 3vw, 40px);
-}
-
-faros-provider-databricks .databricks-first-run__lead {
-  align-items: start;
-  display: grid;
-  gap: 18px;
-  grid-template-columns: auto minmax(0, 1fr);
-}
-
-faros-provider-databricks .databricks-first-run__icon {
-  color: var(--color-accent, #8b6bff);
-  height: 24px;
-  margin-top: 2px;
-  width: 24px;
-}
-
-faros-provider-databricks .databricks-first-run__copy h3 {
-  font-size: 18px;
-  font-weight: 600;
-  margin: 0 0 7px;
-}
-
-faros-provider-databricks .databricks-first-run__copy p {
-  color: var(--color-text-secondary, #8a8ca6);
-  font-size: 13px;
-  line-height: 1.55;
-  margin: 0;
-  max-width: 62ch;
-}
-
-faros-provider-databricks .databricks-first-run__actions {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  grid-column: 2;
-}
-
-faros-provider-databricks .databricks-first-run__actions svg {
-  height: 14px;
-  width: 14px;
-}
-
-faros-provider-databricks .databricks-journey {
-  display: grid;
-  gap: 0;
-  grid-template-columns: repeat(3, minmax(0, 20rem));
-  list-style: none;
-  margin: 28px 0 0;
-  max-inline-size: 60rem;
-  padding: 0;
-}
-
-faros-provider-databricks .databricks-journey__step {
-  align-items: flex-start;
-  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
-  color: var(--color-text-secondary, #8a8ca6);
-  display: grid;
-  gap: 9px;
-  grid-template-columns: auto minmax(0, 1fr);
-  padding: 15px 16px 0 0;
-}
-
-faros-provider-databricks .databricks-journey__step--complete,
-faros-provider-databricks .databricks-journey__step--current {
-  border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default));
-}
-
-faros-provider-databricks .databricks-journey__marker {
-  align-items: center;
-  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
-  border-radius: 3px;
-  display: inline-flex;
-  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
-  font-size: 10px;
-  height: 20px;
-  justify-content: center;
-  width: 20px;
-}
-
-faros-provider-databricks .databricks-journey__marker svg {
-  height: 12px;
-  width: 12px;
-}
-
-faros-provider-databricks .databricks-journey__step--complete .databricks-journey__marker {
-  color: var(--color-success, #2fd6a0);
-}
-
-faros-provider-databricks .databricks-journey__step--current .databricks-journey__marker {
-  background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14));
-  border-color: var(--color-accent, #8b6bff);
-  color: var(--color-accent, #8b6bff);
-}
-
-faros-provider-databricks .databricks-journey__copy {
-  display: grid;
-  gap: 3px;
-  min-width: 0;
-}
-
-faros-provider-databricks .databricks-journey__copy strong {
-  color: var(--color-text-primary, #e9e9f2);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-faros-provider-databricks .databricks-journey__copy small {
-  color: var(--color-text-secondary, #8a8ca6);
-  font-size: 11px;
-  line-height: 1.45;
 }
 
 faros-provider-databricks .import-backdrop {
@@ -1057,7 +802,7 @@ faros-provider-databricks .import-primary > :is(.import-actions, footer) :where(
 
 @keyframes provider-spin { to { transform: rotate(360deg); } }
 
-@container manual-create-form (min-width: 1400px) {
+@container k-create-surface (min-width: 1400px) {
   /* Short forms use the available left track without stretching each field
    * into a single long control. The security note occupies the fourth cell
    * beside the token guidance. */
@@ -1067,16 +812,16 @@ faros-provider-databricks .import-primary > :is(.import-actions, footer) :where(
   }
 }
 
-@container manual-create-form (min-width: 1600px) {
+@container k-create-surface (min-width: 1600px) {
   /* Three locator fields remain readable on true ultrawide surfaces. */
   faros-provider-databricks .manual-create-form-fields--table .form-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
-@container manual-create-form (min-width: 1800px) {
+@container k-create-surface (min-width: 1800px) {
   /* The rail grows to a quiet, bounded column while the form owns the rest. */
-  faros-provider-databricks .manual-create-body--guided {
+  faros-provider-databricks .manual-create-body-guided {
     grid-template-columns: minmax(0, 2fr) minmax(17.5rem, min(32rem, 40%));
   }
 
@@ -1088,7 +833,7 @@ faros-provider-databricks .import-primary > :is(.import-actions, footer) :where(
   }
 }
 
-@container manual-create-form (min-width: 3000px) {
+@container k-create-surface (min-width: 3000px) {
   /* At 4K, keep each control below a comfortable reading width. */
   faros-provider-databricks .manual-create-fields-grid--connection,
   faros-provider-databricks .manual-create-fields-grid--warehouse,
@@ -1097,27 +842,7 @@ faros-provider-databricks .import-primary > :is(.import-actions, footer) :where(
   }
 }
 
-@container manual-create-form (max-width: 960px) {
-  /* Let users reach the controls before the full guidance rail when the form
-   * container stacks. The explicit rows also override wide-screen rules when
-   * a narrow create surface sits inside a wide viewport. */
-  faros-provider-databricks .manual-create-body--guided {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  faros-provider-databricks .manual-create-form-fields {
-    grid-column: 1;
-    grid-row: 1;
-  }
-
-  faros-provider-databricks .manual-create-guidance {
-    border-block-end: 1px solid var(--color-border-subtle);
-    border-inline-start: 0;
-    grid-column: 1;
-    grid-row: 2;
-    padding: 0 0 18px;
-  }
-
+@container k-create-surface (max-width: 960px) {
   faros-provider-databricks .manual-create-fields-grid--connection,
   faros-provider-databricks .manual-create-fields-grid--warehouse,
   faros-provider-databricks .manual-create-form-fields--table .form-grid {
@@ -1131,10 +856,6 @@ faros-provider-databricks .import-primary > :is(.import-actions, footer) :where(
   faros-provider-databricks .page-head { flex-wrap: wrap; }
   faros-provider-databricks .page-head > :first-child { flex: 1 1 100%; min-width: 0; }
   faros-provider-databricks .page-head > .actions { flex: 1 1 100%; justify-content: flex-start; }
-  faros-provider-databricks .databricks-first-run__lead { grid-template-columns: minmax(0, 1fr); }
-  faros-provider-databricks .databricks-first-run__actions { grid-column: 1; }
-  faros-provider-databricks .databricks-journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
-  faros-provider-databricks .databricks-journey__step { border-left: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0 0 0 14px; }
   faros-provider-databricks .import-backdrop {
     align-items: stretch;
     padding: 10px calc(10px + var(--app-inset-right, 0px)) calc(10px + var(--app-inset-bottom, 0px)) calc(10px + var(--app-inset-left, 0px));
@@ -1147,10 +868,10 @@ faros-provider-databricks .import-primary > :is(.import-actions, footer) :where(
   faros-provider-databricks .result-row { grid-template-columns: minmax(0, 1fr); }
   faros-provider-databricks .manual-create-form input:not([type='hidden']),
   faros-provider-databricks .manual-create-form [data-form-select-trigger],
-  faros-provider-databricks .manual-create-form > .manual-create-body--guided + div :is(button, a) {
+  faros-provider-databricks .manual-create-form > .manual-create-body-guided + div :is(button, a) {
     min-height: 44px;
   }
-  faros-provider-databricks .manual-create-form > .manual-create-body--guided + div {
+  faros-provider-databricks .manual-create-form > .manual-create-body-guided + div {
     position: static;
     z-index: auto;
   }

--- a/providers/databricks/portal/src/views/CreateConnectionView.vue
+++ b/providers/databricks/portal/src/views/CreateConnectionView.vue
@@ -162,9 +162,9 @@ onBeforeUnmount(() => {
       <p class="k-create-description">Connect a Databricks workspace for warehouse and table imports.</p>
     </header>
 
-    <form class="k-create-surface k-create-surface--wide manual-create-form manual-create-form--connection" @submit.prevent="submit">
-      <div class="k-create-body manual-create-body--guided">
-        <div class="manual-create-form-fields manual-create-form-fields--connection">
+    <form class="k-create-surface k-create-surface--guided manual-create-form manual-create-form--connection" @submit.prevent="submit">
+      <div class="k-create-body k-create-body--guided manual-create-body-guided">
+        <div class="k-create-fields manual-create-form-fields--connection">
           <p v-if="loading" class="muted" role="status"><LoaderCircle class="spin" :size="14" aria-hidden="true" /> Loading existing connections…</p>
           <p v-if="loadError" class="error" role="alert" aria-live="assertive">
             <span>Could not load existing connections: {{ loadError }}</span>

--- a/providers/databricks/portal/src/views/CreateTableView.vue
+++ b/providers/databricks/portal/src/views/CreateTableView.vue
@@ -261,9 +261,9 @@ watch(() => form.connectionRef, connectionRef => {
       <p class="k-create-description">{{ editing ? 'Update the metadata-only Databricks table handle used by App Studio and MCP.' : 'Register a metadata-only Databricks table handle for App Studio and MCP.' }}</p>
     </header>
 
-    <form class="k-create-surface k-create-surface--wide manual-create-form manual-create-form--table" @submit.prevent="submit">
-      <div class="k-create-body manual-create-body--guided">
-        <div class="manual-create-form-fields manual-create-form-fields--table">
+    <form class="k-create-surface k-create-surface--guided manual-create-form manual-create-form--table" @submit.prevent="submit">
+      <div class="k-create-body k-create-body--guided manual-create-body-guided">
+        <div class="k-create-fields manual-create-form-fields--table">
           <div class="databricks-resource-panel-head">
             <span class="databricks-resource-panel-title">{{ editing ? 'Table configuration' : 'Table details' }}</span>
             <button v-if="!editing" class="k-btn k-btn--ghost databricks-inline-action" type="button" :disabled="loading || submitting" @click="fillDemo" title="Prefill samples.nyctaxi.trips — Databricks demo data available in every workspace">Fill with demo data</button>

--- a/providers/databricks/portal/src/views/CreateWarehouseView.vue
+++ b/providers/databricks/portal/src/views/CreateWarehouseView.vue
@@ -181,9 +181,9 @@ onBeforeUnmount(() => {
       <p class="k-create-description">Register a Databricks SQL warehouse for table imports.</p>
     </header>
 
-    <form class="k-create-surface k-create-surface--wide manual-create-form manual-create-form--warehouse" @submit.prevent="submit">
-      <div class="k-create-body manual-create-body--guided">
-        <div class="manual-create-form-fields manual-create-form-fields--warehouse">
+    <form class="k-create-surface k-create-surface--guided manual-create-form manual-create-form--warehouse" @submit.prevent="submit">
+      <div class="k-create-body k-create-body--guided manual-create-body-guided">
+        <div class="k-create-fields manual-create-form-fields--warehouse">
           <p v-if="loading" class="muted" role="status"><LoaderCircle class="spin" :size="14" aria-hidden="true" /> Loading connections…</p>
           <p v-if="loadError" class="error" role="alert" aria-live="assertive">
             <span>Could not load warehouse prerequisites: {{ loadError }}</span>

--- a/providers/edges/portal/src/App.vue
+++ b/providers/edges/portal/src/App.vue
@@ -21,12 +21,16 @@ import {
 } from './refresh'
 import type { Edge, EdgeType, FarosContext, ErrorResponse } from './types'
 import {
+  edgeConnectPath,
+  edgeConnectionCancelPath,
+  edgeConnectionSuccessPath,
   edgeDetailPath,
   navigationDetail,
   parseSubPath,
   serviceCreatePath,
   serviceDetailPath,
   workloadDeployPath,
+  type EdgeConnectOptions,
   type EdgeRoute,
 } from './routes'
 
@@ -64,14 +68,31 @@ function onServiceNavigate(name: string | null, options?: { replace?: boolean })
   navigate(name === null ? 'services' : serviceDetailPath(name), options?.replace === true)
 }
 
-// The first empty read redirects to the same connect route users can open from
-// the collection. firstLoadDone prevents a cancel/back cycle from reopening it.
+// The collection owns its first-run surface once the first authoritative read
+// settles. Consequential connection work remains on the explicit connect route.
 const firstLoadDone = ref(false)
 const workloadResult = ref<string | null>(null)
 
 function onEdgeCreated(name: string, type: EdgeType): void {
-  navigate(edgeDetailPath(type, name), true)
+  navigate(edgeConnectionSuccessPath(route.value.connect?.successPath, type, name), true)
 }
+function connectEdgeFrom(successPath: string, options: EdgeConnectOptions = {}): void {
+  // Replace the route-owned form with its prerequisite. Returning from the
+  // wizard then restores one form entry instead of leaving a duplicate form in
+  // browser history that Back would reopen after the user exits the flow.
+  navigate(edgeConnectPath(successPath, options), true)
+}
+function cancelEdgeConnection(): void {
+  navigate(edgeConnectionCancelPath(route.value.connect?.cancelPath), true)
+}
+const edgeConnectionCancelLabel = computed(() => {
+  const cancelPath = route.value.connect?.cancelPath
+  if (cancelPath === 'services') return 'Back to services'
+  if (cancelPath === 'workloads') return 'Back to workloads'
+  if (cancelPath?.startsWith('create/service')) return 'Back to service setup'
+  if (cancelPath?.startsWith('deploy/workload')) return 'Back to workload setup'
+  return 'Back to edges'
+})
 function onServiceCreated(name: string): void {
   navigate(serviceDetailPath(name), true)
 }
@@ -119,13 +140,7 @@ const edgeRefresh = createLatestRefreshController(async (requestID, mode) => {
     if (!edgeRefresh.isCurrent(requestID)) return
     edges.value = nextEdges
     error.value = null
-    // Redirect to the route-owned wizard the first time we confirm the
-    // workspace has no edges. The flag remains set after cancellation.
-    if (!firstLoadDone.value) {
-      firstLoadDone.value = true
-      const collectionRoute = route.value.page === 'edges' && !route.value.edge && !route.value.connect
-      if (edges.value.length === 0 && collectionRoute) navigate('connect/edge', true)
-    }
+    firstLoadDone.value = true
   } catch (e) {
     if (!edgeRefresh.isCurrent(requestID)) return
     error.value = (e as ErrorResponse)?.message ?? 'Failed to load edges'
@@ -211,6 +226,7 @@ onUnmounted(() => {
       :initial-edge-name="route.create.edgeName"
       @cancel="navigate('services', true)"
       @created="onServiceCreated"
+      @connect-edge="connectEdgeFrom(serviceCreatePath(route.create.edgeType, route.create.edgeName))"
     />
     <WorkloadCreate
       v-if="route.deploy?.resource === 'workload'"
@@ -219,11 +235,14 @@ onUnmounted(() => {
       :app-type="route.deploy.app"
       @cancel="navigate('workloads', true)"
       @completed="onWorkloadCompleted"
+      @connect-edge="connectEdgeFrom(workloadDeployPath(route.deploy.mode, route.deploy.app), { requiredType: 'kubernetes' })"
     />
     <Wizard
       v-if="route.connect?.resource === 'edge'"
       :cluster="props.ctx?.tenant ?? null"
-      @cancel="navigate('', true)"
+      :required-type="route.connect.requiredType"
+      :cancel-label="edgeConnectionCancelLabel"
+      @cancel="cancelEdgeConnection"
       @created="onEdgeCreated"
     />
     <Detail
@@ -253,6 +272,7 @@ onUnmounted(() => {
         :key="`services:${contextGeneration}`"
         @navigate="onServiceNavigate"
         @create="navigate('create/service')"
+        @connect-edge="connectEdgeFrom('create/service', { cancelPath: 'services' })"
       />
     </KeepAlive>
     <KeepAlive>
@@ -261,6 +281,7 @@ onUnmounted(() => {
         :key="`workloads:${contextGeneration}`"
         :result="workloadResult"
         @create="navigate('deploy/workload/manual')"
+        @connect-edge="connectEdgeFrom('deploy/workload/manual', { cancelPath: 'workloads', requiredType: 'kubernetes' })"
         @deploy="(app) => navigate(workloadDeployPath('marketplace', app.type))"
         @dismiss-result="onWorkloadDismissResult"
       />
@@ -279,7 +300,7 @@ onUnmounted(() => {
         @refresh="refresh"
         @open="openDetail"
         @delete="onDelete"
-        @connect="navigate('connect/edge')"
+        @connect="navigate(edgeConnectPath())"
       />
     </KeepAlive>
     <ConfirmDialog />

--- a/providers/edges/portal/src/EdgeCollection.vue
+++ b/providers/edges/portal/src/EdgeCollection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, onActivated } from 'vue'
+import { computed, onActivated, ref } from 'vue'
 import { Boxes, Plus, RefreshCw, Server } from 'lucide-vue-next'
+import FirstRunGuide from './portalkit/FirstRunGuide.vue'
 import ResourceTable from './portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from './portalkit/ResourceTableDeleteButton.vue'
 import StatusBadge from './portalkit/StatusBadge.vue'
@@ -42,6 +43,15 @@ const edgeRows = computed(() => props.edges.map(edge => ({
   lastHeartbeat: relativeTime(edge.lastHeartbeatTime),
   actions: '',
 })))
+const tableQuery = ref('')
+const tableFilters = ref<Record<string, string>>({ typeLabel: '', status: '' })
+const hasActiveTableFilters = computed(() => !!tableQuery.value.trim() || Object.values(tableFilters.value).some(Boolean))
+const showFirstRun = computed(() => props.loaded && !props.error && props.edges.length === 0 && !hasActiveTableFilters.value)
+const edgeJourney = [
+  { label: 'Configure edge', description: 'Choose its workspace name, type, and scheduling labels.' },
+  { label: 'Install agent', description: 'Run the generated Helm or CLI command with a one-time join token.' },
+  { label: 'Connected', description: 'The agent opens its outbound tunnel and reports its version.' },
+]
 
 function edgeRowAriaLabel(row: Record<string, unknown>): string {
   return `Open ${row.type === 'server' ? 'server' : 'Kubernetes'} edge ${String(row.name)}`
@@ -71,7 +81,7 @@ onActivated(() => emit('activated'))
         <h1>Edges</h1>
         <p>Kubernetes clusters and Linux/SSH servers connected to this workspace.</p>
       </div>
-      <div class="header-actions">
+      <div v-if="!showFirstRun" class="header-actions">
         <button class="k-btn k-btn--ghost" :disabled="props.foregroundLoading" @click="emit('refresh')">
           <RefreshCw :size="14" :class="{ spin: props.foregroundLoading }" /> {{ props.foregroundLoading ? 'Refreshing…' : 'Refresh' }}
         </button>
@@ -81,7 +91,20 @@ onActivated(() => emit('activated'))
       </div>
     </header>
 
+    <FirstRunGuide
+      v-if="showFirstRun"
+      title="Connect your first edge"
+      description="Connect a Kubernetes cluster or Linux server. The Faros agent dials out, so the target needs no inbound firewall rule, VPN, or public IP."
+      primary-label="Connect edge"
+      :steps="edgeJourney"
+      journey-label="Edge connection path"
+      @primary="emit('connect')"
+    >
+      <template #icon><Server aria-hidden="true" /></template>
+    </FirstRunGuide>
+
     <ResourceTable
+      v-else
       :columns="edgeColumns"
       :rows="edgeRows"
       aria-label="Edges"
@@ -93,6 +116,8 @@ onActivated(() => emit('activated'))
       :error="props.error"
       retryable
       searchable
+      v-model:query="tableQuery"
+      v-model:filter-values="tableFilters"
       search-placeholder="Search edges…"
       :filters="[{ key: 'typeLabel', label: 'Type' }, { key: 'status', label: 'Status', allLabel: 'Any status' }]"
       paginated

--- a/providers/edges/portal/src/ServiceCreate.vue
+++ b/providers/edges/portal/src/ServiceCreate.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { ArrowLeft, Globe2, Loader2, Plus } from 'lucide-vue-next'
+import { ArrowLeft, Globe2, Loader2, Plus, Server } from 'lucide-vue-next'
 import { createKubeEdgeService, fetchServiceCatalog, listEdges } from './api'
 import type { CatalogEntry } from './api'
 import type { Edge, EdgeServiceDraft, EdgeType, ErrorResponse } from './types'
+import CreateGuidance, { type CreateGuidanceValue } from './portalkit/CreateGuidance.vue'
+import FirstRunGuide from './portalkit/FirstRunGuide.vue'
 
 const props = withDefaults(defineProps<{
   initialEdgeType?: EdgeType | null
@@ -15,6 +17,7 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   cancel: []
   created: [name: string]
+  connectEdge: []
 }>()
 
 const catalog = ref<CatalogEntry[]>([])
@@ -135,6 +138,39 @@ function applyHostUrl(): void {
 }
 
 const normalizedHost = computed(() => normalizeHost(draft.value.host))
+const serviceTypeLabel = computed(() => selectedCatalogEntry.value?.displayName || draft.value.serviceType || 'Not selected')
+const endpointSummary = computed(() => {
+  if (targetMode.value === 'host') {
+    return `${draft.value.scheme || 'http'}://${normalizedHost.value || 'agent-loopback'}:${Number(draft.value.port) || 8123}`
+  }
+  const namespace = draft.value.targetNamespace.trim() || 'default'
+  return `${namespace}/${draft.value.targetName.trim() || 'not-selected'}:${Number(draft.value.port) || 8123}`
+})
+const credentialSummary = computed(() => {
+  const selected = selectedCatalogEntry.value
+  if (!selected || selected.auth === 'none' || !selected.credential.fields?.length) return 'Not required'
+  return selected.credential.optional ? 'Optional after creation' : 'Required after creation'
+})
+const serviceGuidanceValues = computed<CreateGuidanceValue[]>(() => [
+  { label: 'Service name', value: draft.value.name.trim() || 'Not entered yet', technical: true },
+  { label: 'Edge', value: selectedEdge.value?.name || 'Not selected', technical: true },
+  { label: 'Service type', value: serviceTypeLabel.value },
+  { label: 'Endpoint', value: endpointSummary.value, technical: true },
+  { label: 'Credentials', value: credentialSummary.value },
+  { label: 'MCP tools', value: selectedCatalogEntry.value?.tools?.length ? `${selectedCatalogEntry.value.tools.length} declared` : 'None declared' },
+])
+const servicePrerequisites = [
+  'An edge that can reach this service.',
+  'For a host target, a hostname or IP reachable from the agent; blank uses agent loopback when the type allows it.',
+  'For a Kubernetes target, the Service namespace and name on the selected cluster.',
+  'The protocol and port exposed by the target.',
+]
+const serviceNextSteps = [
+  'Faros creates a cluster-scoped Service bound to the selected edge.',
+  'The controller probes the endpoint and reports status separately.',
+  'If authentication is required, add the credential on the Service detail page; Faros stores it in a workspace Secret.',
+  'Provider-declared tools become available through the Edges MCP endpoint when the Service is ready.',
+]
 const canCreate = computed(() => {
   if (!draft.value.name.trim() || !selectedEdge.value) return false
   if (hostRequired.value) return targetMode.value === 'host' && !!normalizedHost.value
@@ -208,14 +244,31 @@ onMounted(async () => {
       <Loader2 :size="14" class="spin" /> Loading service types and edges…
     </div>
 
-    <form v-else class="k-create-surface k-create-surface--wide" @submit.prevent="onCreate">
-      <div class="k-create-body">
-      <div class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
+    <FirstRunGuide
+      v-else-if="!error && edges.length === 0"
+      title="Connect an edge first"
+      description="A Service must run beside an edge before Faros can expose its endpoint and tools."
+      primary-label="Connect edge"
+      :steps="[
+        { label: 'Edge', description: 'Connect the cluster or server that can reach the service.' },
+        { label: 'Service endpoint', description: 'Choose its type, address, protocol, and port.' },
+        { label: 'Credentials and Ready', description: 'Add credentials when required and let the controller verify it.' },
+      ]"
+      journey-label="Service setup path"
+      @primary="emit('connectEdge')"
+    >
+      <template #icon><Server aria-hidden="true" /></template>
+    </FirstRunGuide>
+
+    <form v-else class="k-create-surface k-create-surface--wide k-create-surface--guided" @submit.prevent="onCreate">
+      <div class="k-create-body k-create-body--guided">
+      <div class="k-create-fields">
+      <div class="service-create-grid service-create-grid--two">
+        <label class="fld">
           <span class="lbl">Name</span>
           <input v-model="draft.name" class="k-input" placeholder="home-assistant" />
         </label>
-        <label class="fld" style="flex: 1;">
+        <label class="fld">
           <span class="lbl">Edge</span>
           <select v-model="selectedEdgeKey" class="k-input" @change="onEdgeChange">
             <option value="" disabled>Select an edge</option>
@@ -226,8 +279,8 @@ onMounted(async () => {
         </label>
       </div>
 
-      <div class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
+      <div class="service-create-grid service-create-grid--three">
+        <label class="fld">
           <span class="lbl">Type</span>
           <select v-model="draft.serviceType" class="k-input" @change="onTypeChange">
             <optgroup v-for="group in catalogGroups" :key="group.category" :label="group.category">
@@ -235,14 +288,14 @@ onMounted(async () => {
             </optgroup>
           </select>
         </label>
-        <label class="fld" style="flex: 0 0 120px;">
+        <label class="fld">
           <span class="lbl">Scheme</span>
           <select v-model="draft.scheme" class="k-input" :disabled="schemeLocked" :title="schemeLocked ? 'Fixed by the service type' : ''">
             <option value="http">http</option>
             <option value="https">https</option>
           </select>
         </label>
-        <label class="fld" style="flex: 0 0 120px;">
+        <label class="fld">
           <span class="lbl">Port</span>
           <input v-model="draft.port" type="number" min="1" max="65535" class="k-input" />
         </label>
@@ -250,29 +303,29 @@ onMounted(async () => {
 
       <label class="fld">
         <span class="lbl">Target</span>
-        <div class="row" style="gap: 16px;">
-          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+        <div class="service-create-target-modes">
+          <label>
             <input v-model="targetMode" type="radio" value="host" /> <Globe2 :size="13" aria-hidden="true" /> Host / IP
           </label>
-          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;" :style="{ opacity: selectedEdgeIsServer || hostRequired ? 0.5 : 1 }">
+          <label :class="{ 'is-disabled': selectedEdgeIsServer || hostRequired }">
             <input v-model="targetMode" type="radio" value="kube" :disabled="selectedEdgeIsServer || hostRequired" /> Kubernetes Service
           </label>
         </div>
       </label>
 
-      <div v-if="targetMode === 'host'" class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
+      <div v-if="targetMode === 'host'" class="service-create-grid">
+        <label class="fld">
           <span class="lbl">Host {{ catalogFor(draft.serviceType)?.hostRequired ? '(required)' : '(blank = agent loopback)' }}</span>
           <input v-model="draft.host" class="k-input" @blur="applyHostUrl" placeholder="192.168.1.1, myui.example.com, or paste https://myui.example.com" />
           <span v-if="catalogFor(draft.serviceType)?.hostHelp" class="muted" style="font-size: 12px; margin-top: 4px;">{{ catalogFor(draft.serviceType)?.hostHelp }}</span>
         </label>
       </div>
-      <div v-else class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
+      <div v-else class="service-create-grid service-create-grid--two">
+        <label class="fld">
           <span class="lbl">Target namespace</span>
           <input v-model="draft.targetNamespace" class="k-input" placeholder="home" />
         </label>
-        <label class="fld" style="flex: 1;">
+        <label class="fld">
           <span class="lbl">Target service name</span>
           <input v-model="draft.targetName" class="k-input" placeholder="home-assistant" />
         </label>
@@ -283,6 +336,14 @@ onMounted(async () => {
         <textarea v-model="draft.instructions" class="k-input" rows="3" placeholder="Gates are cover.gate_main. Living room light is light.living_room." />
       </label>
 
+      </div>
+      <CreateGuidance
+        title="Describe the service endpoint"
+        description="Choose where the service runs and how Edges reaches it. Credentials are added after creation only when the selected type requires them."
+        :prerequisites="servicePrerequisites"
+        :values="serviceGuidanceValues"
+        :next-steps="serviceNextSteps"
+      />
       </div>
       <div class="k-create-actions">
         <button type="button" class="k-btn k-btn--ghost" :disabled="busy" @click="cancel">Cancel</button>

--- a/providers/edges/portal/src/Services.vue
+++ b/providers/edges/portal/src/Services.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, onActivated, watch } from 'vue'
-import { RefreshCw, Plus, Check } from 'lucide-vue-next'
+import { RefreshCw, Plus, Check, Plug, Server } from 'lucide-vue-next'
 import {
   listServices, listServicesPage, deleteEdgeService, listEdges,
   fetchServiceCatalog,
@@ -13,6 +13,7 @@ import ResourceTableDeleteButton from './portalkit/ResourceTableDeleteButton.vue
 import ResourceTableEditButton from './portalkit/ResourceTableEditButton.vue'
 import StatusBadge from './portalkit/StatusBadge.vue'
 import ServiceEdit from './ServiceEdit.vue'
+import FirstRunGuide from './portalkit/FirstRunGuide.vue'
 import { isCompleteFirstCursorPage, type ResourceTableChange, type TableFilterDefinition, type TablePageInfo } from './portalkit/table'
 import { createFullListReadCoordinator, createInFlightReadCoordinator, hasActiveTableFilters, sameTableRequest, tablePageInfo as makeTablePageInfo, type PaginationMode, type TableRequestState } from './pagination'
 import {
@@ -27,6 +28,7 @@ const props = defineProps<{ selectedName?: string | null }>()
 const emit = defineEmits<{
   navigate: [name: string | null, options?: { replace?: boolean }]
   create: []
+  connectEdge: []
 }>()
 
 // Service type catalog — fetched from the backend (svccatalog.All()) so the form
@@ -75,6 +77,22 @@ const serviceRows = computed<Array<Record<string, unknown>>>(() => services.valu
   credentials: service.hasCredentials ? 'Configured' : 'Missing',
   actions: '',
 })))
+const showFirstRun = computed(() => loaded.value && !error.value && services.value.length === 0 && isCompleteFirstCursorPage({
+  page: tablePage.value,
+  cursor: tableCursor.value,
+  pageInfo: tablePageInfo.value,
+}) && !hasActiveTableFilters(tableQuery.value, filterValues.value))
+const hasEdges = computed(() => edges.value.length > 0)
+const serviceJourney = [
+  { label: 'Edge', description: 'Connect the cluster or server that can reach the service.' },
+  { label: 'Service endpoint', description: 'Choose its type, address, protocol, and port.' },
+  { label: 'Credentials and Ready', description: 'Add credentials when required and let the controller verify it.' },
+]
+
+function handleFirstRunPrimary(): void {
+  if (hasEdges.value) emit('create')
+  else emit('connectEdge')
+}
 
 const SERVICE_STATUS_OPTIONS = [
   { value: 'Pending', label: 'Pending' },
@@ -429,7 +447,7 @@ function serviceRowAriaLabel(row: Record<string, unknown>): string {
         <h1>Services</h1>
         <p>Services running next to your edges (e.g. Home Assistant). Attach a token to make one Ready, and give it AI guidance — its tools appear in the MCP endpoint.</p>
       </div>
-      <div class="header-actions">
+      <div v-if="!showFirstRun" class="header-actions">
         <button class="k-btn k-btn--ghost" :disabled="foregroundLoading" @click="refresh">
           <RefreshCw :size="14" :class="{ spin: foregroundLoading }" /> {{ foregroundLoading ? 'Refreshing…' : 'Refresh' }}
         </button>
@@ -443,7 +461,23 @@ function serviceRowAriaLabel(row: Record<string, unknown>): string {
       </div>
     </header>
 
+    <FirstRunGuide
+      v-if="showFirstRun"
+      :title="hasEdges ? 'Expose your first service' : 'Connect an edge first'"
+      :description="hasEdges
+        ? 'Declare an app reachable from an edge, then add credentials when its service type requires them.'
+        : 'A Service must run beside an edge before Faros can expose its endpoint and tools.'"
+      :primary-label="hasEdges ? 'Create service' : 'Connect edge'"
+      :steps="serviceJourney"
+      :current-step="hasEdges ? 1 : 0"
+      journey-label="Service setup path"
+      @primary="handleFirstRunPrimary"
+    >
+      <template #icon><component :is="hasEdges ? Plug : Server" aria-hidden="true" /></template>
+    </FirstRunGuide>
+
     <ResourceTable
+      v-else
       :columns="serviceColumns"
       :rows="serviceRows"
       aria-label="Services"

--- a/providers/edges/portal/src/Wizard.vue
+++ b/providers/edges/portal/src/Wizard.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
-import { ref, computed, onUnmounted } from 'vue'
+import { ref, computed, nextTick, onUnmounted, watch } from 'vue'
 import { ArrowLeft, Boxes, Server, ArrowRight, Copy, Check, Loader2, CircleDot, PartyPopper } from 'lucide-vue-next'
 import { createEdge, probeEdge } from './api'
+import CreateGuidance, { type CreateGuidanceValue } from './portalkit/CreateGuidance.vue'
 import type { EdgeType, ErrorResponse } from './types'
 
-const props = defineProps<{ cluster: string | null }>()
+const props = withDefaults(defineProps<{
+  cluster: string | null
+  requiredType?: EdgeType
+  cancelLabel?: string
+}>(), {
+  cancelLabel: 'Back to edges',
+})
 const emit = defineEmits<{
   cancel: []
   created: [name: string, type: EdgeType]
@@ -13,7 +20,7 @@ const emit = defineEmits<{
 type Step = 1 | 2 | 3
 const step = ref<Step>(1)
 const name = ref('')
-const edgeType = ref<EdgeType>('kubernetes')
+const edgeType = ref<EdgeType>(props.requiredType ?? 'kubernetes')
 const labels = ref('')
 const saving = ref(false)
 const error = ref<string | null>(null)
@@ -22,6 +29,8 @@ const joinToken = ref<string | null>(null)
 const tokenError = ref<string | null>(null)
 const copied = ref<string | null>(null)
 const copyFeedback = ref('')
+const failedCopyField = ref<string | null>(null)
+const revealedCommand = ref<string | null>(null)
 const agentVersion = ref<string | null>(null)
 const elapsed = ref(0)
 
@@ -35,7 +44,35 @@ onUnmounted(() => {
 })
 
 const trimmed = computed(() => name.value.trim())
-const canContinue = computed(() => trimmed.value.length > 0 && !saving.value)
+const edgeTypeLocked = computed(() => props.requiredType !== undefined)
+const canContinue = computed(() => trimmed.value.length > 0 && !saving.value && (!props.requiredType || edgeType.value === props.requiredType))
+const stepLabels = ['Configure', 'Install agent', 'Connected'] as const
+async function focusCurrentStepHeading(): Promise<void> {
+  await nextTick()
+  document.getElementById('edge-wizard-step-heading')?.focus()
+}
+watch(step, (current) => {
+  if (current === 1) return
+  void focusCurrentStepHeading()
+})
+watch(() => props.requiredType, (requiredType) => {
+  if (requiredType) edgeType.value = requiredType
+}, { immediate: true })
+const edgeGuidanceValues = computed<CreateGuidanceValue[]>(() => [
+  { label: 'Edge name', value: trimmed.value || 'Not entered yet', technical: true },
+  { label: 'Resource type', value: edgeType.value === 'kubernetes' ? 'KubernetesCluster' : 'LinuxServer', technical: true },
+  { label: 'Scheduling labels', value: labels.value.trim() || 'None', technical: true },
+])
+const edgePrerequisites = [
+  'Access to the target cluster with Helm, or to the Linux host with the Faros CLI.',
+  'A unique Kubernetes-compatible name in this workspace.',
+  'Optional key=value labels if Workloads will target this edge.',
+]
+const edgeNextSteps = [
+  'Faros creates a KubernetesCluster or LinuxServer resource and mints a one-time join token.',
+  'Run the generated command on the target; the token is masked here and copied only when requested.',
+  'The agent exchanges the token for an edge-scoped credential and opens its outbound tunnel.',
+]
 
 const hubURL = computed(() => {
   const origin = window.location.origin
@@ -66,19 +103,39 @@ function copyControlLabel(field: string, label: string): string {
 
 async function copy(build: (t: string) => string, field: string, label: string) {
   if (!joinToken.value) return
+  if (copyTimer) {
+    clearTimeout(copyTimer)
+    copyTimer = null
+  }
+  copied.value = null
+  failedCopyField.value = null
+  revealedCommand.value = null
   try {
     await navigator.clipboard.writeText(build(joinToken.value))
     copied.value = field
+    failedCopyField.value = null
+    revealedCommand.value = null
     copyFeedback.value = `${label} copied to clipboard.`
-    if (copyTimer) clearTimeout(copyTimer)
     copyTimer = setTimeout(() => {
       copied.value = null
       copyFeedback.value = ''
       copyTimer = null
     }, 2000)
   } catch {
-    copyFeedback.value = `Could not copy the ${label.toLowerCase()}. Select the command and copy it manually.`
+    failedCopyField.value = field
+    copyFeedback.value = `Could not copy the ${label.toLowerCase()}. Reveal it to copy manually.`
   }
+}
+
+function revealForManualCopy(field: string): void {
+  if (!joinToken.value || failedCopyField.value !== field) return
+  revealedCommand.value = field
+  copyFeedback.value = 'Command revealed. The join token is sensitive; hide it after copying.'
+}
+
+function hideRevealedCommand(): void {
+  revealedCommand.value = null
+  copyFeedback.value = 'Command hidden.'
 }
 
 function parseLabels(): Record<string, string> {
@@ -94,6 +151,11 @@ function parseLabels(): Record<string, string> {
 
 async function handleCreate() {
   if (!trimmed.value) { error.value = 'Name is required'; return }
+  if (props.requiredType && edgeType.value !== props.requiredType) {
+    error.value = `This flow requires a ${props.requiredType === 'kubernetes' ? 'KubernetesCluster' : 'LinuxServer'} edge.`
+    edgeType.value = props.requiredType
+    return
+  }
   saving.value = true
   error.value = null
   try {
@@ -140,54 +202,68 @@ function fmt(s: number) {
 <template>
   <div class="wiz">
     <div class="wiz-hero">
-      <h1>Connect your first edge</h1>
+      <h1>Connect an edge</h1>
       <p>A Kubernetes cluster or Linux/SSH server you want to manage from this workspace.</p>
     </div>
 
-    <div class="wiz-steps">
-      <span v-for="(l, i) in ['Configure', 'Install agent', 'Connected']" :key="l"
-            class="wiz-step" :class="{ done: step > i + 1, active: step === i + 1 }">
+    <ol class="wiz-steps" aria-label="Edge connection progress">
+      <li v-for="(l, i) in stepLabels" :key="l"
+          class="wiz-step" :class="{ done: step > i + 1, active: step === i + 1 }"
+          :aria-current="step === i + 1 ? 'step' : undefined">
         <CircleDot :size="12" /> {{ l }}
-      </span>
-    </div>
+      </li>
+    </ol>
+    <span class="wiz-sr-only" role="status" aria-live="polite">Step {{ step }} of 3: {{ stepLabels[step - 1] }}</span>
 
     <div v-if="error" class="banner error">{{ error }}</div>
 
     <!-- Step 1 -->
-    <div v-if="step === 1" class="wiz-card k-card">
-      <label for="edge-name" class="lbl">Edge name</label>
-      <input id="edge-name" v-model="name" class="k-input" placeholder="e.g. prod-us-east-1" @keyup.enter="canContinue && handleCreate()" />
+    <div v-if="step === 1" class="wiz-card k-card k-create-surface--guided">
+      <div class="k-create-body--guided">
+        <div class="k-create-fields">
+          <label for="edge-name" class="lbl">Edge name</label>
+          <input id="edge-name" v-model="name" class="k-input" placeholder="e.g. prod-us-east-1" @keyup.enter="canContinue && handleCreate()" />
 
-      <fieldset class="types">
-        <legend class="lbl">Type</legend>
-        <label class="type" :class="{ sel: edgeType === 'kubernetes' }" for="edge-type-kubernetes">
-          <input id="edge-type-kubernetes" v-model="edgeType" class="type-radio" name="edge-type" type="radio" value="kubernetes" />
-          <Boxes :size="15" aria-hidden="true" /> <span><b>Kubernetes</b><small>Existing K8s cluster</small></span>
-        </label>
-        <label class="type" :class="{ sel: edgeType === 'server' }" for="edge-type-server">
-          <input id="edge-type-server" v-model="edgeType" class="type-radio" name="edge-type" type="radio" value="server" />
-          <Server :size="15" aria-hidden="true" /> <span><b>Server</b><small>Bare-metal or VM (SSH)</small></span>
-        </label>
-      </fieldset>
+          <fieldset class="types">
+            <legend class="lbl">Type</legend>
+            <label class="type" :class="{ sel: edgeType === 'kubernetes' }" for="edge-type-kubernetes">
+              <input id="edge-type-kubernetes" v-model="edgeType" class="type-radio" name="edge-type" type="radio" value="kubernetes" :disabled="edgeTypeLocked && props.requiredType !== 'kubernetes'" />
+              <Boxes :size="15" aria-hidden="true" /> <span><b>Kubernetes</b><small>Existing K8s cluster</small></span>
+            </label>
+            <label class="type" :class="{ sel: edgeType === 'server' }" for="edge-type-server">
+              <input id="edge-type-server" v-model="edgeType" class="type-radio" name="edge-type" type="radio" value="server" :disabled="edgeTypeLocked && props.requiredType !== 'server'" />
+              <Server :size="15" aria-hidden="true" /> <span><b>Server</b><small>Bare-metal or VM (SSH)</small></span>
+            </label>
+          </fieldset>
+          <p v-if="edgeTypeLocked" class="muted">This edge type is required to continue the originating {{ props.requiredType === 'kubernetes' ? 'workload' : 'resource' }} flow.</p>
 
-      <label for="edge-labels" class="lbl">Labels <span class="muted">(optional)</span></label>
-      <input id="edge-labels" v-model="labels" class="k-input" placeholder="env=prod, region=us-east" />
+          <label for="edge-labels" class="lbl">Labels <span class="muted">(optional)</span></label>
+          <input id="edge-labels" v-model="labels" class="k-input" placeholder="env=prod, region=us-east" />
 
-      <div class="wiz-actions">
-        <button type="button" class="k-btn k-btn--ghost" @click="emit('cancel')">
-          <ArrowLeft :size="14" aria-hidden="true" /> Back to edges
-        </button>
-        <button type="button" class="k-btn k-btn--primary" :disabled="!canContinue" @click="handleCreate">
-          <Loader2 v-if="saving" :size="14" class="spin" />
-          {{ saving ? 'Creating…' : 'Create & continue' }}
-          <ArrowRight v-if="!saving" :size="14" />
-        </button>
+          <div class="wiz-actions">
+            <button type="button" class="k-btn k-btn--ghost" :disabled="saving" @click="emit('cancel')">
+              <ArrowLeft :size="14" aria-hidden="true" /> {{ props.cancelLabel }}
+            </button>
+            <button type="button" class="k-btn k-btn--primary" :disabled="!canContinue" @click="handleCreate">
+              <Loader2 v-if="saving" :size="14" class="spin" />
+              {{ saving ? 'Creating…' : 'Create & continue' }}
+              <ArrowRight v-if="!saving" :size="14" />
+            </button>
+          </div>
+        </div>
+        <CreateGuidance
+          title="Configure the edge"
+          description="Choose how Faros will identify and manage this target. After creation, install the agent from the generated command."
+          :prerequisites="edgePrerequisites"
+          :values="edgeGuidanceValues"
+          :next-steps="edgeNextSteps"
+        />
       </div>
     </div>
 
     <!-- Step 2 -->
     <div v-else-if="step === 2" class="wiz-card k-card">
-      <h3>Install the agent on your {{ edgeType === 'kubernetes' ? 'cluster' : 'server' }}</h3>
+      <h3 id="edge-wizard-step-heading" tabindex="-1">Install the agent on your {{ edgeType === 'kubernetes' ? 'cluster' : 'server' }}</h3>
       <p class="muted">Run one of the commands below from the target. This updates automatically when
         <b>{{ trimmed }}</b> connects.</p>
 
@@ -208,7 +284,7 @@ function fmt(s: number) {
               <component :is="copied === 'helm' ? Check : Copy" :size="12" :stroke-width="1.75" aria-hidden="true" />
             </button>
           </div>
-          <pre>{{ helmText }}</pre>
+          <pre>{{ revealedCommand === 'helm' && joinToken ? helmSnippet(joinToken) : helmText }}</pre>
         </div>
         <div class="snippet">
           <div class="snippet-head"><span>CLI — faros agent join</span>
@@ -223,26 +299,42 @@ function fmt(s: number) {
               <component :is="copied === 'cli' ? Check : Copy" :size="12" :stroke-width="1.75" aria-hidden="true" />
             </button>
           </div>
-          <pre>{{ cliText }}</pre>
+          <pre>{{ revealedCommand === 'cli' && joinToken ? cliSnippet(joinToken) : cliText }}</pre>
         </div>
       </template>
+
+      <div v-if="failedCopyField" class="banner warn" role="alert">
+        Clipboard access is unavailable. Revealing the command will display its sensitive one-time join token.
+        <button
+          v-if="revealedCommand !== failedCopyField"
+          type="button"
+          class="k-btn k-btn--ghost compact-control"
+          @click="revealForManualCopy(failedCopyField)"
+        >Reveal command for manual copy</button>
+        <button
+          v-else
+          type="button"
+          class="k-btn k-btn--ghost compact-control"
+          @click="hideRevealedCommand"
+        >Hide join token</button>
+      </div>
 
       <span class="wiz-sr-only" role="status" aria-live="polite">{{ copyFeedback }}</span>
 
       <div class="waiting"><Loader2 :size="14" class="spin" /> Waiting for <b>{{ trimmed }}</b> to connect… <span class="muted">({{ fmt(elapsed) }})</span></div>
       <div class="wiz-actions">
-        <button type="button" class="k-btn k-btn--ghost" @click="emit('cancel')">Back to edges</button>
-        <button type="button" class="k-btn k-btn--ghost" @click="emit('created', trimmed, edgeType)">Skip — view edge details</button>
+        <button type="button" class="k-btn k-btn--ghost" @click="emit('cancel')">{{ props.cancelLabel }}</button>
+        <button type="button" class="k-btn k-btn--ghost" @click="emit('created', trimmed, edgeType)">Skip waiting — continue</button>
       </div>
     </div>
 
     <!-- Step 3 -->
     <div v-else class="wiz-card k-card center">
       <PartyPopper :size="30" />
-      <h3><b>{{ trimmed }}</b> is online</h3>
+      <h3 id="edge-wizard-step-heading" tabindex="-1"><b>{{ trimmed }}</b> is online</h3>
       <p class="muted">Agent {{ agentVersion || '—' }} · connected after {{ fmt(elapsed) }}</p>
       <div class="wiz-actions">
-        <button type="button" class="k-btn k-btn--primary" @click="emit('created', trimmed, edgeType)">View edge details <ArrowRight :size="14" /></button>
+        <button type="button" class="k-btn k-btn--primary" @click="emit('created', trimmed, edgeType)">Continue <ArrowRight :size="14" /></button>
       </div>
     </div>
   </div>

--- a/providers/edges/portal/src/WorkloadCreate.vue
+++ b/providers/edges/portal/src/WorkloadCreate.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { ArrowLeft, Loader2, Rocket } from 'lucide-vue-next'
+import { ArrowLeft, Loader2, Rocket, Server } from 'lucide-vue-next'
 import { createWorkload, deployMarketplaceApp, listEdges, type WorkloadDraft } from './api'
 import { MARKETPLACE, type MarketplaceApp } from './marketplace'
 import type { Edge, ErrorResponse } from './types'
+import CreateGuidance, { type CreateGuidanceValue } from './portalkit/CreateGuidance.vue'
+import FirstRunGuide from './portalkit/FirstRunGuide.vue'
 
 const props = defineProps<{
   mode: 'manual' | 'marketplace'
@@ -12,12 +14,14 @@ const props = defineProps<{
 const emit = defineEmits<{
   cancel: []
   completed: [message: string]
+  connectEdge: []
 }>()
 
 const edges = ref<Edge[]>([])
 const loading = ref(true)
 const busy = ref(false)
 const error = ref<string | null>(null)
+const edgeLoadError = ref<string | null>(null)
 const draft = ref({
   name: '',
   image: 'nginx:latest',
@@ -60,22 +64,85 @@ const credentialHint: Record<string, string> = {
   optional: 'no token needed',
 }
 
-function parseSelector(value: string): Record<string, string> {
-  const selector: Record<string, string> = {}
-  for (const pair of value.split(',')) {
-    const [key, val] = pair.split('=').map((part) => part.trim())
-    if (key && val) selector[key] = val
-  }
-  return selector
+type SelectorResult = {
+  value: Record<string, string>
+  error: string | null
 }
 
+function parseSelector(value: string): SelectorResult {
+  const selector: Record<string, string> = {}
+  if (!value.trim()) return { value: selector, error: null }
+
+  for (const rawPair of value.split(',')) {
+    const parts = rawPair.split('=')
+    if (parts.length !== 2) {
+      return { value: selector, error: 'Use key=value pairs separated by commas.' }
+    }
+    const [key, val] = parts.map((part) => part.trim())
+    if (!key || !val) {
+      return { value: selector, error: 'Selector keys and values cannot be empty.' }
+    }
+    if (Object.hasOwn(selector, key)) {
+      return { value: selector, error: `Selector key "${key}" is listed more than once.` }
+    }
+    selector[key] = val
+  }
+  return { value: selector, error: null }
+}
+
+const selectorResult = computed(() => parseSelector(draft.value.selector))
+const selectorError = computed(() => selectorResult.value.error)
 const canSubmit = computed(() => {
-  if (!active || loading.value || busy.value) return false
+  if (!active || loading.value || busy.value || edgeLoadError.value || kubernetesEdges.value.length === 0) return false
   if (props.mode === 'marketplace') {
     return !!app.value && !!deployName.value.trim() && kubernetesEdges.value.some((edge) => edge.name === deployEdge.value)
   }
-  return !!draft.value.name.trim() && !!draft.value.image.trim()
+  return !!draft.value.name.trim() && !!draft.value.image.trim() && !selectorError.value
 })
+const manualSelector = computed(() => selectorError.value ? {} : selectorResult.value.value)
+const matchingEdges = computed(() => kubernetesEdges.value.filter(edge => {
+  return Object.entries(manualSelector.value).every(([key, value]) => edge.labels?.[key] === value)
+}))
+const placementCount = computed(() => draft.value.strategy === 'Singleton'
+  ? Math.min(1, matchingEdges.value.length)
+  : matchingEdges.value.length)
+const placementSummary = computed(() => selectorError.value
+  ? 'Fix the selector to preview placements'
+  : `${placementCount.value} current match${placementCount.value === 1 ? '' : 'es'}`)
+const workloadGuidanceValues = computed<CreateGuidanceValue[]>(() => app.value ? [
+  { label: 'Workload name', value: deployName.value.trim() || 'Not entered yet', technical: true },
+  { label: 'Kubernetes edge', value: deployEdge.value || 'Not selected', technical: true },
+  { label: 'Chart', value: `${app.value.chart.chart}@${app.value.chart.version}`, technical: true },
+  { label: 'Service port', value: String(app.value.port), technical: true },
+  { label: 'Credentials', value: credentialHint[app.value.credential] || 'Review after creation' },
+] : [
+  { label: 'Workload name', value: draft.value.name.trim() || 'Not entered yet', technical: true },
+  { label: 'Namespace', value: 'default', technical: true },
+  { label: 'Image', value: draft.value.image.trim() || 'Not entered yet', technical: true },
+  { label: 'Replicas', value: String(Number(draft.value.replicas) || 1), technical: true },
+  { label: 'Strategy', value: draft.value.strategy },
+  { label: 'Edge selector', value: draft.value.selector.trim() || 'All Kubernetes edges', technical: true },
+  { label: 'Placements', value: placementSummary.value },
+])
+const workloadPrerequisites = computed(() => app.value ? [
+  'A KubernetesCluster edge available for this singleton deployment.',
+  'The pinned marketplace chart and version shown here.',
+  'Any service credential listed below, added after deployment when required.',
+] : [
+  'At least one KubernetesCluster edge.',
+  'A container image the target clusters can pull.',
+  'Matching labels on target edges. Spread uses every match; Singleton uses one.',
+])
+const workloadNextSteps = computed(() => app.value ? [
+  'Faros creates a singleton Helm Workload pinned to the selected edge.',
+  'Faros also declares an Edges Service for the chart endpoint.',
+  'The edge agent applies the chart and reports workload readiness.',
+  'Add the Service credential after deployment when the app requires one.',
+] : [
+  'Faros creates the Workload in the default namespace.',
+  'The scheduler creates Placements for matching Kubernetes edges.',
+  'Edge agents apply the derived Deployments and Workload status aggregates their readiness.',
+])
 
 async function submit(): Promise<void> {
   if (!active || !canSubmit.value) return
@@ -124,7 +191,7 @@ async function submit(): Promise<void> {
       image: draft.value.image.trim(),
       replicas: Number(draft.value.replicas) || 1,
       strategy: draft.value.strategy,
-      selector: parseSelector(draft.value.selector),
+      selector: manualSelector.value,
     }
     await createWorkload(workload)
     if (!isCurrent(generation)) return
@@ -137,8 +204,10 @@ async function submit(): Promise<void> {
   }
 }
 
-onMounted(async () => {
+async function loadEdges(): Promise<void> {
   const generation = lifecycleGeneration
+  loading.value = true
+  edgeLoadError.value = null
   const result = await listEdges().then((value) => ({ value }), (reason) => ({ reason }))
   if (!isCurrent(generation)) return
   if ('value' in result) {
@@ -148,9 +217,13 @@ onMounted(async () => {
     }
     deployEdge.value = (props.mode === 'marketplace' ? kubernetesEdges.value : edges.value)[0]?.name ?? ''
   } else {
-    error.value = (result.reason as ErrorResponse)?.message ?? 'Failed to load edges'
+    edgeLoadError.value = (result.reason as ErrorResponse)?.message ?? 'Failed to load edges'
   }
   loading.value = false
+}
+
+onMounted(async () => {
+  await loadEdges()
 })
 
 onUnmounted(() => {
@@ -175,8 +248,43 @@ onUnmounted(() => {
       <Loader2 :size="14" class="spin" /> Loading edges…
     </div>
 
-    <form v-else-if="app && props.mode === 'marketplace'" class="k-create-surface k-create-surface--wide" @submit.prevent="submit">
+    <div v-else-if="edgeLoadError" class="k-create-surface">
       <div class="k-create-body">
+        <div class="banner error" role="alert">{{ edgeLoadError }}</div>
+        <p class="muted">Faros could not verify that a KubernetesCluster edge is available, so workload creation is paused.</p>
+      </div>
+      <div class="k-create-actions">
+        <button type="button" class="k-btn k-btn--ghost" :disabled="busy" @click="cancel">Back to workloads</button>
+        <button type="button" class="k-btn k-btn--primary" :disabled="busy" @click="loadEdges">Retry</button>
+      </div>
+    </div>
+
+    <div v-else-if="props.mode === 'marketplace' && !app" class="k-create-surface">
+      <div class="k-create-body">
+      <p class="banner error" role="alert">That marketplace app is not available.</p>
+      </div>
+      <div class="k-create-actions"><button class="k-btn k-btn--ghost" :disabled="busy" @click="cancel">Back to workloads</button></div>
+    </div>
+
+    <FirstRunGuide
+      v-else-if="!error && kubernetesEdges.length === 0"
+      title="Connect a Kubernetes edge first"
+      description="Workloads are scheduled only onto KubernetesCluster edges."
+      primary-label="Connect edge"
+      :steps="[
+        { label: 'Kubernetes edge', description: 'Connect the cluster that will run the workload.' },
+        { label: 'Workload and placement', description: 'Choose an image or chart and the edges it should target.' },
+        { label: 'Placements running', description: 'Agents apply the workload and report readiness per edge.' },
+      ]"
+      journey-label="Workload deployment path"
+      @primary="emit('connectEdge')"
+    >
+      <template #icon><Server aria-hidden="true" /></template>
+    </FirstRunGuide>
+
+    <form v-else-if="app && props.mode === 'marketplace'" class="k-create-surface k-create-surface--wide k-create-surface--guided" @submit.prevent="submit">
+      <div class="k-create-body k-create-body--guided">
+      <div class="k-create-fields">
       <label class="fld">
         <span class="lbl">Workload name</span>
         <input v-model="deployName" class="k-input" :placeholder="app.type" />
@@ -188,8 +296,15 @@ onUnmounted(() => {
           <option v-for="edge in kubernetesEdges" :key="edge.name" :value="edge.name">{{ edge.name }} (KubernetesCluster)</option>
         </select>
       </label>
-      <p v-if="kubernetesEdges.length === 0" class="banner warn" role="status">Connect a KubernetesCluster edge before deploying a marketplace app.</p>
       <p class="muted">Deploys <span class="mono">{{ app.chart.chart }}@{{ app.chart.version }}</span> onto <b>{{ deployEdge || '—' }}</b> and wires an Edges Service on port {{ app.port }}. Auth: {{ credentialHint[app.credential] }}.</p>
+      </div>
+      <CreateGuidance
+        title="Deploy this marketplace app"
+        description="Review the pinned chart, target edge, and follow-up Service before starting the deployment."
+        :prerequisites="workloadPrerequisites"
+        :values="workloadGuidanceValues"
+        :next-steps="workloadNextSteps"
+      />
       </div>
       <div class="k-create-actions">
         <button type="button" class="k-btn k-btn--ghost" :disabled="busy" @click="cancel">Cancel</button>
@@ -201,15 +316,9 @@ onUnmounted(() => {
       </div>
     </form>
 
-    <div v-else-if="props.mode === 'marketplace'" class="k-create-surface">
-      <div class="k-create-body">
-      <p class="banner error" role="alert">That marketplace app is not available.</p>
-      </div>
-      <div class="k-create-actions"><button class="k-btn k-btn--ghost" :disabled="busy" @click="cancel">Back to workloads</button></div>
-    </div>
-
-    <form v-else class="k-create-surface k-create-surface--wide" @submit.prevent="submit">
-      <div class="k-create-body">
+    <form v-else class="k-create-surface k-create-surface--wide k-create-surface--guided" @submit.prevent="submit">
+      <div class="k-create-body k-create-body--guided">
+      <div class="k-create-fields">
       <label class="fld">
         <span class="lbl">Name</span>
         <input v-model="draft.name" class="k-input" placeholder="nginx-demo" />
@@ -218,12 +327,12 @@ onUnmounted(() => {
         <span class="lbl">Image</span>
         <input v-model="draft.image" class="k-input" placeholder="nginx:latest" />
       </label>
-      <div class="row" style="gap: 12px; align-items: flex-start;">
-        <label class="fld" style="flex: 1;">
+      <div class="workload-create-grid">
+        <label class="fld">
           <span class="lbl">Replicas</span>
           <input v-model="draft.replicas" type="number" min="1" class="k-input" />
         </label>
-        <label class="fld" style="flex: 1;">
+        <label class="fld">
           <span class="lbl">Strategy</span>
           <select v-model="draft.strategy" class="k-input">
             <option value="Spread">Spread (all matching edges)</option>
@@ -233,8 +342,23 @@ onUnmounted(() => {
       </div>
       <label class="fld">
         <span class="lbl">Edge selector (key=value, comma-separated)</span>
-        <input v-model="draft.selector" class="k-input" placeholder="env=dev" />
+        <input
+          v-model="draft.selector"
+          class="k-input"
+          placeholder="env=dev"
+          :aria-invalid="selectorError ? 'true' : undefined"
+          :aria-describedby="selectorError ? 'workload-selector-error' : undefined"
+        />
+        <span v-if="selectorError" id="workload-selector-error" class="field-error" role="alert">{{ selectorError }}</span>
       </label>
+      </div>
+      <CreateGuidance
+        title="Define the workload and placement"
+        description="Choose the image and match labels to the Kubernetes edges that should run it."
+        :prerequisites="workloadPrerequisites"
+        :values="workloadGuidanceValues"
+        :next-steps="workloadNextSteps"
+      />
       </div>
       <div class="k-create-actions">
         <button type="button" class="k-btn k-btn--ghost" :disabled="busy" @click="cancel">Cancel</button>

--- a/providers/edges/portal/src/Workloads.vue
+++ b/providers/edges/portal/src/Workloads.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, onUnmounted, onActivated } from 'vue'
-import { RefreshCw, Plus, ChevronRight, ChevronDown, Store, Rocket } from 'lucide-vue-next'
+import { computed, ref, onMounted, onUnmounted, onActivated, watch } from 'vue'
+import { RefreshCw, Plus, ChevronRight, ChevronDown, Store, Rocket, Boxes, Server } from 'lucide-vue-next'
 import { listWorkloads, listWorkloadsPage, deleteWorkload, listEdges } from './api'
 import type { Workload, Edge, ErrorResponse } from './types'
 import { confirmDialog } from './portalkit/confirm'
 import ResourceTable from './portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from './portalkit/ResourceTableDeleteButton.vue'
 import StatusBadge from './portalkit/StatusBadge.vue'
+import FirstRunGuide from './portalkit/FirstRunGuide.vue'
 import { MARKETPLACE_CATEGORIES, type MarketplaceApp } from './marketplace'
 import { isCompleteFirstCursorPage, type ResourceTableChange, type TableFilterDefinition, type TablePageInfo } from './portalkit/table'
 import { createFullListReadCoordinator, createInFlightReadCoordinator, hasActiveTableFilters, sameTableRequest, tablePageInfo as makeTablePageInfo, type PaginationMode, type TableRequestState } from './pagination'
@@ -23,6 +24,7 @@ const emit = defineEmits<{
   create: []
   deploy: [app: MarketplaceApp]
   dismissResult: []
+  connectEdge: []
 }>()
 
 const workloads = ref<Workload[]>([])
@@ -51,6 +53,28 @@ const workloadRows = computed<Array<Record<string, unknown>>>(() => workloads.va
   ready: `${workload.readyReplicas ?? 0}/${workload.replicas ?? 1}`,
   actions: '',
 })))
+const kubernetesEdges = computed(() => edges.value.filter(edge => edge.type === 'kubernetes'))
+const hasKubernetesEdges = computed(() => kubernetesEdges.value.length > 0)
+const firstRunDismissed = ref(false)
+const showFirstRun = computed(() => !firstRunDismissed.value && loaded.value && !error.value && workloads.value.length === 0 && isCompleteFirstCursorPage({
+  page: tablePage.value,
+  cursor: tableCursor.value,
+  pageInfo: tablePageInfo.value,
+}) && !hasActiveTableFilters(tableQuery.value, filterValues.value))
+const workloadJourney = [
+  { label: 'Kubernetes edge', description: 'Connect the cluster that will run the workload.' },
+  { label: 'Workload and placement', description: 'Choose an image or chart and the edges it should target.' },
+  { label: 'Placements running', description: 'Agents apply the workload and report readiness per edge.' },
+]
+
+function handleFirstRunPrimary(): void {
+  if (hasKubernetesEdges.value) emit('create')
+  else emit('connectEdge')
+}
+
+watch(hasKubernetesEdges, (available) => {
+  if (!available) firstRunDismissed.value = false
+})
 
 const WORKLOAD_STRATEGY_OPTIONS = [
   { value: 'Spread', label: 'Spread' },
@@ -358,7 +382,7 @@ function workloadRowAriaLabel(row: Record<string, unknown>): string {
         <h1>Workloads</h1>
         <p>Deploy a workload across matching Kubernetes edges. Each edge's agent runs it locally.</p>
       </div>
-      <div class="header-actions">
+      <div v-if="!showFirstRun" class="header-actions">
         <button class="k-btn k-btn--ghost" :disabled="foregroundLoading" @click="refresh">
           <RefreshCw :size="14" :class="{ spin: foregroundLoading }" /> {{ foregroundLoading ? 'Refreshing…' : 'Refresh' }}
         </button>
@@ -377,8 +401,25 @@ function workloadRowAriaLabel(row: Record<string, unknown>): string {
       <button type="button" class="k-btn k-btn--ghost compact-control" @click="emit('dismissResult')">Dismiss</button>
     </div>
 
+    <FirstRunGuide
+      v-if="showFirstRun"
+      :title="hasKubernetesEdges ? 'Deploy your first workload' : 'Connect a Kubernetes edge first'"
+      :description="hasKubernetesEdges
+        ? 'Deploy a container manually or start from a pinned marketplace chart.'
+        : 'Workloads are scheduled only onto KubernetesCluster edges.'"
+      :primary-label="hasKubernetesEdges ? 'Create workload' : 'Connect edge'"
+      :secondary-label="hasKubernetesEdges ? 'Browse marketplace' : ''"
+      :steps="workloadJourney"
+      :current-step="hasKubernetesEdges ? 1 : 0"
+      journey-label="Workload deployment path"
+      @primary="handleFirstRunPrimary"
+      @secondary="firstRunDismissed = true"
+    >
+      <template #icon><component :is="hasKubernetesEdges ? Boxes : Server" aria-hidden="true" /></template>
+    </FirstRunGuide>
+
     <!-- Marketplace -->
-    <div class="market k-card">
+    <div v-else class="market k-card">
       <button
         type="button"
         class="market-head"
@@ -392,7 +433,7 @@ function workloadRowAriaLabel(row: Record<string, unknown>): string {
         <span class="muted">one-click self-hosted apps, deployed as Helm workloads onto an edge</span>
       </button>
       <div v-if="showMarket" id="edges-marketplace-body" class="market-body">
-        <div v-if="edges.length === 0" class="muted pad">
+        <div v-if="!hasKubernetesEdges" class="muted pad">
           Connect a KubernetesCluster edge first — marketplace apps deploy onto one.
         </div>
         <div v-for="grp in MARKETPLACE_CATEGORIES" :key="grp.category" class="market-cat">
@@ -405,7 +446,7 @@ function workloadRowAriaLabel(row: Record<string, unknown>): string {
               </div>
               <p class="market-desc">{{ app.description }}</p>
               <div class="market-meta muted mono">{{ app.chart.chart }}@{{ app.chart.version }} · :{{ app.port }}</div>
-              <button class="k-btn k-btn--primary compact-control" :disabled="edges.length === 0" @click="emit('deploy', app)">
+              <button class="k-btn k-btn--primary compact-control" :disabled="!hasKubernetesEdges" @click="emit('deploy', app)">
                 <Rocket :size="13" /> Deploy
               </button>
             </div>
@@ -415,6 +456,7 @@ function workloadRowAriaLabel(row: Record<string, unknown>): string {
     </div>
 
     <ResourceTable
+      v-if="!showFirstRun"
       :columns="workloadColumns"
       :rows="workloadRows"
       aria-label="Workloads"

--- a/providers/edges/portal/src/create-guidance.regression.test.mjs
+++ b/providers/edges/portal/src/create-guidance.regression.test.mjs
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readSource = file => readFileSync(resolve(process.cwd(), 'src', file), 'utf8')
+
+describe('Edges create guidance', () => {
+  it('uses shared first-run journeys for every user-created resource surface', () => {
+    const edgeCollection = readSource('EdgeCollection.vue')
+    const services = readSource('Services.vue')
+    const workloads = readSource('Workloads.vue')
+
+    for (const source of [edgeCollection, services, workloads]) {
+      expect(source).toMatch(/import FirstRunGuide from '\.\/portalkit\/FirstRunGuide\.vue'/)
+      expect(source).toMatch(/<FirstRunGuide/)
+      expect(source).toMatch(/journey-label=/)
+    }
+    expect(services).toMatch(/hasEdges \? 'Create service' : 'Connect edge'/)
+    expect(services).toMatch(/if \(hasEdges\.value\) emit\('create'\)[\s\S]*else emit\('connectEdge'\)/)
+    expect(services).toMatch(/services\.value\.length === 0 && isCompleteFirstCursorPage\(/)
+    expect(services).toMatch(/<ResourceTable\s+v-else/)
+    expect(workloads).toMatch(/hasKubernetesEdges \? 'Create workload' : 'Connect edge'/)
+    expect(workloads).toMatch(/secondary-label="hasKubernetesEdges \? 'Browse marketplace' : ''"/)
+    expect(workloads).toMatch(/workloads\.value\.length === 0 && isCompleteFirstCursorPage\(/)
+    expect(workloads).toMatch(/<ResourceTable\s+v-if="!showFirstRun"/)
+  })
+
+  it('adds live shared guidance rails without changing create mutations', () => {
+    const wizard = readSource('Wizard.vue')
+    const service = readSource('ServiceCreate.vue')
+    const workload = readSource('WorkloadCreate.vue')
+
+    for (const source of [wizard, service, workload]) {
+      expect(source).toMatch(/import CreateGuidance/)
+      expect(source).toMatch(/<CreateGuidance/)
+      expect(source).toMatch(/k-create-body--guided/)
+      expect(source).toMatch(/k-create-fields/)
+    }
+    expect(wizard).toMatch(/Edge name[\s\S]*Resource type[\s\S]*Scheduling labels/)
+    expect(service).toMatch(/Service name[\s\S]*Endpoint[\s\S]*Credentials[\s\S]*MCP tools/)
+    expect(workload).toMatch(/Namespace[\s\S]*Edge selector[\s\S]*Placements/)
+    expect(service).toMatch(/await createKubeEdgeService\(\{/)
+    expect(workload).toMatch(/await createWorkload\(workload\)/)
+  })
+
+  it('makes edge connection progress semantic while retaining masked token display', () => {
+    const wizard = readSource('Wizard.vue')
+    expect(wizard).toMatch(/<ol class="wiz-steps" aria-label="Edge connection progress">/)
+    expect(wizard).toMatch(/:aria-current="step === i \+ 1 \? 'step' : undefined"/)
+    expect(wizard).toMatch(/role="status" aria-live="polite">Step \{\{ step \}\} of 3/)
+    expect(wizard).toMatch(/const masked = '••••••••••••••••'/)
+    expect(wizard).toMatch(/navigator\.clipboard\.writeText\(build\(joinToken\.value\)\)/)
+  })
+})

--- a/providers/edges/portal/src/edge-collection.regression.test.mjs
+++ b/providers/edges/portal/src/edge-collection.regression.test.mjs
@@ -21,4 +21,23 @@ describe('Edges collection route-state regression', () => {
   it('replaces the detail route on Back so browser Back does not reopen it', () => {
     expect(app).toMatch(/<Detail[\s\S]*@back="navigate\('', true\)"/)
   })
+
+  it('replaces prerequisite entry so returning does not duplicate the create route in history', () => {
+    expect(app).toMatch(/function connectEdgeFrom\(successPath: string, options: EdgeConnectOptions = \{\}\): void \{[\s\S]*navigate\(edgeConnectPath\(successPath, options\), true\)/)
+    expect(app).toMatch(/@connect-edge="connectEdgeFrom\(workloadDeployPath\(route\.deploy\.mode, route\.deploy\.app\), \{ requiredType: 'kubernetes' \}\)"/)
+    expect(app).toMatch(/@connect-edge="connectEdgeFrom\('create\/service', \{ cancelPath: 'services' \}\)"/)
+    expect(app).toMatch(/@connect-edge="connectEdgeFrom\('deploy\/workload\/manual', \{ cancelPath: 'workloads', requiredType: 'kubernetes' \}\)"/)
+    expect(app).toMatch(/:required-type="route\.connect\.requiredType"/)
+  })
+
+  it('keeps an authoritative empty collection on an instructive first-run surface', () => {
+    expect(app).not.toMatch(/edges\.value\.length === 0[\s\S]*navigate\('connect\/edge'/)
+    expect(collection).toMatch(/import FirstRunGuide from '\.\/portalkit\/FirstRunGuide\.vue'/)
+    expect(collection).toMatch(/const hasActiveTableFilters = computed\(/)
+    expect(collection).toMatch(/const showFirstRun = computed\(\(\) => props\.loaded && !props\.error && props\.edges\.length === 0 && !hasActiveTableFilters\.value\)/)
+    expect(collection).toMatch(/v-model:query="tableQuery"/)
+    expect(collection).toMatch(/v-model:filter-values="tableFilters"/)
+    expect(collection).toMatch(/<FirstRunGuide[\s\S]*title="Connect your first edge"[\s\S]*primary-label="Connect edge"/)
+    expect(collection).toMatch(/<ResourceTable\s+v-else/)
+  })
 })

--- a/providers/edges/portal/src/portalkit/CreateGuidance.vue
+++ b/providers/edges/portal/src/portalkit/CreateGuidance.vue
@@ -1,0 +1,72 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { Info } from 'lucide-vue-next'
+import { useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface CreateGuidanceValue {
+  label: string
+  value: string
+  technical?: boolean
+}
+
+withDefaults(defineProps<{
+  title: string
+  description: string
+  prerequisites?: string[]
+  values?: CreateGuidanceValue[]
+  nextSteps?: string[]
+  valuesHeading?: string
+}>(), {
+  prerequisites: () => [],
+  values: () => [],
+  nextSteps: () => [],
+  valuesHeading: 'What Faros will create',
+})
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-create-guidance-${id}-title`
+const prerequisiteID = `k-create-guidance-${id}-prerequisites`
+const valuesID = `k-create-guidance-${id}-values`
+const nextStepsID = `k-create-guidance-${id}-next-steps`
+</script>
+
+<template>
+  <aside class="k-create-guidance" :aria-labelledby="titleID">
+    <div class="k-create-guidance__heading">
+      <Info :size="16" :stroke-width="1.75" aria-hidden="true" />
+      <h3 :id="titleID">{{ title }}</h3>
+    </div>
+    <p class="k-create-guidance__description">{{ description }}</p>
+
+    <section v-if="prerequisites.length" class="k-create-guidance__section" :aria-labelledby="prerequisiteID">
+      <h4 :id="prerequisiteID">Prerequisites</h4>
+      <ul>
+        <li v-for="prerequisite in prerequisites" :key="prerequisite">{{ prerequisite }}</li>
+      </ul>
+    </section>
+
+    <section v-if="values.length" class="k-create-guidance__section" :aria-labelledby="valuesID">
+      <h4 :id="valuesID">{{ valuesHeading }}</h4>
+      <dl class="k-create-guidance__values">
+        <template v-for="item in values" :key="item.label">
+          <dt>{{ item.label }}</dt>
+          <dd><code v-if="item.technical">{{ item.value }}</code><span v-else>{{ item.value }}</span></dd>
+        </template>
+      </dl>
+    </section>
+
+    <section v-if="nextSteps.length" class="k-create-guidance__section" :aria-labelledby="nextStepsID">
+      <h4 :id="nextStepsID">Next steps</h4>
+      <ol>
+        <li v-for="step in nextSteps" :key="step">{{ step }}</li>
+      </ol>
+    </section>
+  </aside>
+</template>

--- a/providers/edges/portal/src/portalkit/FirstRunGuide.vue
+++ b/providers/edges/portal/src/portalkit/FirstRunGuide.vue
@@ -1,0 +1,85 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { ArrowRight, Check, CircleDot } from 'lucide-vue-next'
+import { computed, useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface FirstRunStep {
+  label: string
+  description: string
+}
+
+const props = withDefaults(defineProps<{
+  title: string
+  description: string
+  primaryLabel: string
+  secondaryLabel?: string
+  steps: readonly FirstRunStep[]
+  currentStep?: number
+  journeyLabel?: string
+}>(), {
+  secondaryLabel: '',
+  currentStep: 0,
+  journeyLabel: 'Getting started',
+})
+
+const emit = defineEmits<{
+  (event: 'primary'): void
+  (event: 'secondary'): void
+}>()
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-first-run-${id}-title`
+const boundedCurrentStep = computed(() => Math.max(0, Math.min(props.currentStep, props.steps.length - 1)))
+</script>
+
+<template>
+  <section class="k-first-run" :aria-labelledby="titleID">
+    <div class="k-first-run__lead">
+      <span class="k-first-run__icon" aria-hidden="true"><slot name="icon" /></span>
+      <div class="k-first-run__copy">
+        <h3 :id="titleID">{{ title }}</h3>
+        <p>{{ description }}</p>
+      </div>
+      <div class="k-first-run__actions">
+        <button class="k-btn k-btn--primary" type="button" @click="emit('primary')">
+          {{ primaryLabel }} <ArrowRight :stroke-width="1.75" aria-hidden="true" />
+        </button>
+        <button v-if="secondaryLabel" class="k-btn k-btn--ghost" type="button" @click="emit('secondary')">
+          {{ secondaryLabel }}
+        </button>
+      </div>
+    </div>
+
+    <ol v-if="steps.length" class="k-first-run__journey" :aria-label="journeyLabel">
+      <li
+        v-for="(step, index) in steps"
+        :key="`${index}-${step.label}`"
+        :class="['k-first-run__step', {
+          'is-complete': index < boundedCurrentStep,
+          'is-current': index === boundedCurrentStep,
+        }]"
+        :aria-current="index === boundedCurrentStep ? 'step' : undefined"
+      >
+        <span class="k-first-run__marker" aria-hidden="true">
+          <Check v-if="index < boundedCurrentStep" :stroke-width="2" />
+          <CircleDot v-else-if="index === boundedCurrentStep" :stroke-width="1.75" />
+          <span v-else>{{ index + 1 }}</span>
+        </span>
+        <span class="k-first-run__step-copy">
+          <span class="k-first-run__step-status">
+            {{ index < boundedCurrentStep ? 'Completed step' : index === boundedCurrentStep ? 'Current step' : 'Upcoming step' }}:
+          </span>
+          <strong>{{ step.label }}</strong>
+          <small>{{ step.description }}</small>
+        </span>
+      </li>
+    </ol>
+  </section>
+</template>

--- a/providers/edges/portal/src/portalkit/faros-ui.css
+++ b/providers/edges/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/providers/edges/portal/src/portalkit/styles.ts
+++ b/providers/edges/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 3
+export const FAROS_UI_VERSION = 4
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/edges/portal/src/routes.test.ts
+++ b/providers/edges/portal/src/routes.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  edgeConnectPath,
+  edgeConnectionCancelPath,
+  edgeConnectionSuccessPath,
   edgeDetailPath,
   navigationDetail,
   parseSubPath,
@@ -50,5 +53,76 @@ describe('Edges provider routes', () => {
     expect(serviceCreatePath()).toBe('create/service')
     expect(workloadDeployPath('manual')).toBe('deploy/workload/manual')
     expect(workloadDeployPath('marketplace', 'grafana')).toBe('deploy/workload/marketplace/grafana')
+  })
+
+  it.each([
+    ['service collection', serviceCreatePath(), { cancelPath: 'services' }, 'services'],
+    ['manual workload collection', workloadDeployPath('manual'), { cancelPath: 'workloads', requiredType: 'kubernetes' }, 'workloads'],
+    ['marketplace workload form', workloadDeployPath('marketplace', 'grafana'), { requiredType: 'kubernetes' }, workloadDeployPath('marketplace', 'grafana')],
+  ] as const)('preserves distinct %s success and cancel destinations without duplicate history', (_label, origin, options, cancelPath) => {
+    const connectPath = edgeConnectPath(origin, options)
+    expect(parseSubPath(connectPath)).toEqual({
+      page: 'edges',
+      connect: {
+        resource: 'edge',
+        successPath: origin,
+        cancelPath,
+        ...('requiredType' in options ? { requiredType: options.requiredType } : {}),
+      },
+    })
+    // Entry and exit both replace the current action route. Restoring the form
+    // therefore leaves one form entry, not a duplicate that Back can reopen.
+    expect(navigationDetail(connectPath, true)).toEqual({ path: connectPath, replace: true })
+    expect(navigationDetail(edgeConnectionCancelPath(cancelPath), true)).toEqual({ path: cancelPath, replace: true })
+    expect(navigationDetail(edgeConnectionSuccessPath(origin, 'kubernetes', 'new-edge'), true)).toEqual({ path: origin, replace: true })
+  })
+
+  it('infers the Kubernetes requirement from a workload return route that omitted its type', () => {
+    const origin = workloadDeployPath('manual')
+    expect(parseSubPath(edgeConnectPath(origin, { cancelPath: 'workloads' }))).toEqual({
+      page: 'edges',
+      connect: { resource: 'edge', successPath: origin, cancelPath: 'workloads', requiredType: 'kubernetes' },
+    })
+    const legacy = `connect/edge/return/${encodeURIComponent(origin)}`
+    expect(parseSubPath(legacy)).toEqual({
+      page: 'edges',
+      connect: { resource: 'edge', successPath: origin, cancelPath: origin, requiredType: 'kubernetes' },
+    })
+  })
+
+  it('rejects a server requirement for a workload return route', () => {
+    const invalid = `connect/edge/server/return/${encodeURIComponent(workloadDeployPath('manual'))}`
+    expect(parseSubPath(invalid)).toEqual({ page: 'edges', connect: { resource: 'edge' } })
+  })
+
+  it('rejects a prerequisite cancel destination outside its originating journey', () => {
+    const invalid = `connect/edge/success/${encodeURIComponent(serviceCreatePath())}/cancel/${encodeURIComponent('../../settings')}`
+    expect(parseSubPath(invalid)).toEqual({ page: 'edges', connect: { resource: 'edge' } })
+  })
+
+  it('canonicalizes accepted shell-prefixed prerequisite destinations before navigation', () => {
+    const success = `providers/edges/${serviceCreatePath()}`
+    const cancel = 'providers/edges/services'
+    const path = `connect/edge/success/${encodeURIComponent(success)}/cancel/${encodeURIComponent(cancel)}`
+    expect(parseSubPath(path)).toEqual({
+      page: 'edges',
+      connect: { resource: 'edge', successPath: 'create/service', cancelPath: 'services' },
+    })
+  })
+
+  it.each([
+    'create/service/kubernetes/../../../../../settings',
+    'create/service/kubernetes/..\\..\\..\\..\\..\\settings',
+    'create/service/kubernetes/%252E%252E%252F%252E%252E%252Fsettings',
+    'create/service/kubernetes/%2e%2e/%zz/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/settings',
+  ])('rejects dot-segment prerequisite callbacks before shell navigation: %s', (success) => {
+    const path = `connect/edge/success/${encodeURIComponent(success)}/cancel/${encodeURIComponent('services')}`
+    expect(parseSubPath(path)).toEqual({ page: 'edges', connect: { resource: 'edge' } })
+  })
+
+  it('falls back to the new edge detail when no create journey is active', () => {
+    expect(edgeConnectPath()).toBe('connect/edge')
+    expect(edgeConnectionCancelPath()).toBe('')
+    expect(edgeConnectionSuccessPath(undefined, 'server', 'edge/a')).toBe('edges/server/edge%2Fa')
   })
 })

--- a/providers/edges/portal/src/routes.ts
+++ b/providers/edges/portal/src/routes.ts
@@ -16,7 +16,7 @@ export interface EdgeRoute {
   page: EdgeCollectionPage
   edge?: { type: EdgeType; name: string }
   service?: string
-  connect?: { resource: 'edge' }
+  connect?: { resource: 'edge'; successPath?: string; cancelPath?: string; requiredType?: EdgeType }
   create?: ServiceCreateRoute
   deploy?: WorkloadDeployRoute
 }
@@ -45,6 +45,27 @@ function normalizeSubPath(subPath: string | null | undefined): string {
   return normalized
 }
 
+function hasEncodedDotSegment(path: string): boolean {
+  let candidate = path
+  for (let depth = 0; depth < 5; depth += 1) {
+    if (candidate.includes('\\')) return true
+    if (candidate.split('/').some(segment => segment === '.' || segment === '..')) return true
+    let decoded: string
+    try {
+      decoded = decodeURIComponent(candidate)
+    } catch {
+      // A malformed escape makes the callback ambiguous to downstream URL
+      // parsers. Fail closed instead of letting it hide encoded dot segments.
+      return true
+    }
+    if (decoded === candidate) return false
+    candidate = decoded
+  }
+  // Excessive nested encoding is not produced by provider navigation helpers;
+  // reject it instead of passing an ambiguous callback to the shell router.
+  return true
+}
+
 /** Parse the provider-relative path after `/providers/edges/`. */
 export function parseSubPath(subPath: string | null | undefined): EdgeRoute {
   const normalized = normalizeSubPath(subPath)
@@ -54,7 +75,53 @@ export function parseSubPath(subPath: string | null | undefined): EdgeRoute {
   if (normalized === 'services') return { page: 'services' }
   if (normalized === 'workloads') return { page: 'workloads' }
 
-  if (parts[0] === 'connect' && parts[1] === 'edge' && parts.length === 2) {
+  if (parts[0] === 'connect' && parts[1] === 'edge') {
+    if (parts.length === 2) return { page: 'edges', connect: { resource: 'edge' } }
+    const hasRequiredType = parts[2] === 'kubernetes' || parts[2] === 'server'
+    const actionIndex = hasRequiredType ? 3 : 2
+    const requestedType = hasRequiredType ? parts[2] as EdgeType : undefined
+    let successPath: string | undefined
+    let cancelPath: string | undefined
+    // Keep legacy `return` links refresh-safe. New links persist separate
+    // success and cancel destinations so prerequisite onboarding can resume a
+    // form on success without sending Cancel back into that form.
+    if (parts[actionIndex] === 'return' && parts.length === actionIndex + 2 && parts[actionIndex + 1] !== '') {
+      successPath = decodeSegment(parts[actionIndex + 1])
+      cancelPath = successPath
+    } else if (
+      parts[actionIndex] === 'success' && parts[actionIndex + 1] !== '' &&
+      parts[actionIndex + 2] === 'cancel' && parts[actionIndex + 3] !== '' &&
+      parts.length === actionIndex + 4
+    ) {
+      successPath = decodeSegment(parts[actionIndex + 1])
+      cancelPath = decodeSegment(parts[actionIndex + 3])
+    }
+    if (successPath && cancelPath) {
+      if (hasEncodedDotSegment(successPath) || hasEncodedDotSegment(cancelPath)) {
+        return { page: 'edges', connect: { resource: 'edge' } }
+      }
+      const successRoute = parseSubPath(successPath)
+      const normalizedSuccessPath = normalizeSubPath(successPath)
+      const normalizedCancelPath = normalizeSubPath(cancelPath)
+      const validCancelPath = normalizedCancelPath === normalizedSuccessPath ||
+        (successRoute.create?.resource === 'service' && normalizedCancelPath === 'services') ||
+        (successRoute.deploy?.resource === 'workload' && normalizedCancelPath === 'workloads')
+      if (validCancelPath && (successRoute.create?.resource === 'service' || successRoute.deploy?.resource === 'workload')) {
+        if (successRoute.deploy?.resource === 'workload' && requestedType && requestedType !== 'kubernetes') {
+          return { page: 'edges', connect: { resource: 'edge' } }
+        }
+        const requiredType = successRoute.deploy?.resource === 'workload' ? 'kubernetes' : requestedType
+        return {
+          page: 'edges',
+          connect: {
+            resource: 'edge',
+            successPath: normalizedSuccessPath,
+            cancelPath: normalizedCancelPath,
+            ...(requiredType ? { requiredType } : {}),
+          },
+        }
+      }
+    }
     return { page: 'edges', connect: { resource: 'edge' } }
   }
 
@@ -117,6 +184,26 @@ export function navigationDetail(path: string, replace = false): EdgeNavigationD
 
 export function edgeDetailPath(type: EdgeType, name: string): string {
   return `edges/${type}/${encodeURIComponent(name)}`
+}
+
+export interface EdgeConnectOptions {
+  requiredType?: EdgeType
+  cancelPath?: string
+}
+
+export function edgeConnectPath(successPath?: string, options: EdgeConnectOptions = {}): string {
+  if (!successPath) return 'connect/edge'
+  const typeSegment = options.requiredType ? `/${options.requiredType}` : ''
+  const cancelPath = options.cancelPath ?? successPath
+  return `connect/edge${typeSegment}/success/${encodeURIComponent(successPath)}/cancel/${encodeURIComponent(cancelPath)}`
+}
+
+export function edgeConnectionCancelPath(cancelPath?: string): string {
+  return cancelPath ?? ''
+}
+
+export function edgeConnectionSuccessPath(successPath: string | undefined, type: EdgeType, name: string): string {
+  return successPath ?? edgeDetailPath(type, name)
 }
 
 export function serviceDetailPath(name: string): string {

--- a/providers/edges/portal/src/style.css
+++ b/providers/edges/portal/src/style.css
@@ -44,12 +44,26 @@ faros-provider-edges .header-actions button { flex: 0 0 auto; white-space: nowra
 @media (max-width: 720px) {
   faros-provider-edges .edges-header { align-items: stretch; flex-direction: column; }
   faros-provider-edges .header-actions { justify-content: flex-start; width: 100%; }
+  faros-provider-edges .types { grid-template-columns: minmax(0, 1fr); }
+  faros-provider-edges .wiz-actions { align-items: stretch; flex-direction: column-reverse; }
+  faros-provider-edges .service-create-grid--two,
+  faros-provider-edges .service-create-grid--three,
+  faros-provider-edges .workload-create-grid { grid-template-columns: minmax(0, 1fr); }
 }
 
 /* ── Inputs & labels ── */
 faros-provider-edges .lbl { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .15em; color: var(--color-text-muted, #5d5f78); }
 /* Labelled form field: label stacked above its control with a small gap. */
 faros-provider-edges .fld { display: flex; flex-direction: column; gap: 5px; }
+faros-provider-edges .field-error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+faros-provider-edges .service-create-grid,
+faros-provider-edges .workload-create-grid { display: grid; gap: 12px; grid-template-columns: minmax(0, 1fr); }
+faros-provider-edges .service-create-grid--two,
+faros-provider-edges .workload-create-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+faros-provider-edges .service-create-grid--three { grid-template-columns: minmax(0, 1fr) minmax(6rem, 120px) minmax(6rem, 120px); }
+faros-provider-edges .service-create-target-modes { display: flex; flex-wrap: wrap; gap: 16px; }
+faros-provider-edges .service-create-target-modes label { align-items: center; cursor: pointer; display: inline-flex; gap: 6px; }
+faros-provider-edges .service-create-target-modes label.is-disabled { opacity: .5; }
 
 /* ── Cards ── */
 faros-provider-edges .wiz-card { padding: 18px; display: flex; flex-direction: column; gap: 12px; }
@@ -60,7 +74,7 @@ faros-provider-edges .wiz-card h3 { margin: 0; font-size: 14px; font-weight: 600
 faros-provider-edges .wiz { margin: 0; }
 faros-provider-edges .wiz-hero h1 { font-size: 18px; font-weight: 600; margin: 0; color: var(--color-text-primary, #e9e9f2); }
 faros-provider-edges .wiz-hero p { margin: 4px 0 0; color: var(--color-text-secondary, #8a8ca6); font-size: 12px; }
-faros-provider-edges .wiz-steps { display: flex; gap: 14px; margin: 16px 0; }
+faros-provider-edges .wiz-steps { display: flex; flex-wrap: wrap; gap: 14px; list-style: none; margin: 16px 0; padding: 0; }
 faros-provider-edges .wiz-step { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: var(--color-text-muted, #5d5f78); }
 faros-provider-edges .wiz-step.active { color: var(--color-text-primary, #e9e9f2); }
 faros-provider-edges .wiz-step.done { color: var(--color-success, #2fd6a0); }

--- a/providers/edges/portal/src/views.behavior.test.ts
+++ b/providers/edges/portal/src/views.behavior.test.ts
@@ -22,6 +22,8 @@ const api = vi.hoisted(() => ({
   getEdge: vi.fn(),
   deleteEdge: vi.fn(),
   listEdgeServices: vi.fn(),
+  setToken: vi.fn(),
+  setTenant: vi.fn(),
 }))
 const confirm = vi.hoisted(() => ({
   confirmDialog: vi.fn(),
@@ -31,6 +33,8 @@ vi.mock('./api', () => api)
 vi.mock('./portalkit/confirm', () => confirm)
 
 import Services from './Services.vue'
+import App from './App.vue'
+import EdgeCollection from './EdgeCollection.vue'
 import ServiceEdit from './ServiceEdit.vue'
 import ServiceCreate from './ServiceCreate.vue'
 import Workloads from './Workloads.vue'
@@ -38,6 +42,7 @@ import WorkloadCreate from './WorkloadCreate.vue'
 import Wizard from './Wizard.vue'
 import Detail from './Detail.vue'
 import ActionMenu, { type ActionMenuItem } from './portalkit/ActionMenu.vue'
+import { edgeConnectPath } from './routes'
 
 type HostNode = {
   type: string
@@ -116,7 +121,7 @@ async function mount(component: Component, props: Record<string, unknown> = {}) 
   const { renderer, root } = createHostRenderer()
   const app = renderer.createApp(component, props)
   app._context.provides[Symbol.for('v-scx')] = { modules: new Set() }
-  const proxy = app.mount(root) as unknown as { $: { setupState: Record<string, any> } }
+  const proxy = app.mount(root) as unknown as { $: { setupState: Record<string, any>; props: Record<string, any> } }
   await nextTick()
   return {
     instance: proxy.$,
@@ -534,6 +539,98 @@ describe('edge list views', () => {
     }
   })
 
+  it('routes an empty Services first-run action through the missing-edge prerequisite', async () => {
+    api.listServicesPage.mockResolvedValueOnce({ items: [], continue: undefined })
+    api.listEdges.mockResolvedValueOnce([])
+    const connectEdge = vi.fn()
+    const mounted = await mount(Services, { onConnectEdge: connectEdge })
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      expect(state.showFirstRun).toBe(true)
+      expect(state.hasEdges).toBe(false)
+      state.handleFirstRunPrimary()
+      expect(connectEdge).toHaveBeenCalledOnce()
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it.each([
+    ['Services', Services, api.listServicesPage],
+    ['Workloads', Workloads, api.listWorkloadsPage],
+  ] as const)('keeps the %s table and cursor controls for an empty nonterminal first page', async (_label, component, pageMock) => {
+    pageMock.mockResolvedValueOnce({ items: [], continue: 'next-page' })
+    api.listEdges.mockResolvedValueOnce([])
+    const mounted = await mount(component)
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      expect(state.loaded).toBe(true)
+      expect(state.tablePageInfo).toEqual({ hasNext: true, nextCursor: 'next-page' })
+      expect(state.showFirstRun).toBe(false)
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('retains a controlled edge-table query when the authoritative fleet becomes empty', async () => {
+    const mounted = await mount(EdgeCollection, {
+      edges: [edge], loaded: true, loading: false, refreshMode: 'foreground', error: null, foregroundLoading: false,
+    })
+    try {
+      const state = mounted.instance.setupState
+      state.tableQuery = 'missing-edge'
+      mounted.instance.props.edges = []
+      await nextTick()
+      expect(state.hasActiveTableFilters).toBe(true)
+      expect(state.showFirstRun).toBe(false)
+
+      state.tableQuery = ''
+      await nextTick()
+      expect(state.showFirstRun).toBe(true)
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('routes an empty Workloads first-run action through the Kubernetes-edge prerequisite', async () => {
+    api.listWorkloadsPage.mockResolvedValueOnce({ items: [], continue: undefined })
+    api.listEdges.mockResolvedValueOnce([{ ...edge, type: 'server' }])
+    const connectEdge = vi.fn()
+    const mounted = await mount(Workloads, { onConnectEdge: connectEdge })
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      expect(state.showFirstRun).toBe(true)
+      expect(state.hasKubernetesEdges).toBe(false)
+      state.handleFirstRunPrimary()
+      expect(connectEdge).toHaveBeenCalledOnce()
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('restores Kubernetes prerequisite guidance when the last eligible edge disappears', async () => {
+    api.listWorkloadsPage.mockResolvedValueOnce({ items: [], continue: undefined })
+    const mounted = await mount(Workloads)
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      expect(state.hasKubernetesEdges).toBe(true)
+      state.firstRunDismissed = true
+      expect(state.showFirstRun).toBe(false)
+
+      state.edges = [{ ...edge, type: 'server' }]
+      await nextTick()
+      expect(state.hasKubernetesEdges).toBe(false)
+      expect(state.firstRunDismissed).toBe(false)
+      expect(state.showFirstRun).toBe(true)
+    } finally {
+      mounted.unmount()
+    }
+  })
+
   it('derives service filter options from the complete catalog and edge fleet', async () => {
     api.fetchServiceCatalog.mockResolvedValue([
       { type: 'generic', displayName: 'Generic HTTP', category: 'Other', auth: 'none', credential: {} },
@@ -601,6 +698,73 @@ describe('edge list views', () => {
       expect(state.deployEdge).toBe('')
       expect(state.error).toBe('The selected KubernetesCluster edge is no longer available. Choose another edge.')
       expect(state.busy).toBe(false)
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('pauses workload creation and offers retry when edge prerequisites cannot be read', async () => {
+    api.listEdges.mockRejectedValueOnce({ message: 'Edges are unavailable' })
+    const mounted = await mount(WorkloadCreate, { mode: 'manual' })
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      state.draft.name = 'nginx-demo'
+      expect(state.edgeLoadError).toBe('Edges are unavailable')
+      expect(state.loading).toBe(false)
+      expect(state.canSubmit).toBe(false)
+      await state.submit()
+      expect(api.createWorkload).not.toHaveBeenCalled()
+
+      api.listEdges.mockResolvedValueOnce([edge])
+      await state.loadEdges()
+      expect(state.edgeLoadError).toBeNull()
+      expect(state.kubernetesEdges).toEqual([edge])
+      expect(state.canSubmit).toBe(true)
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it.each([
+    ['empty value', 'env=', 'Selector keys and values cannot be empty.'],
+    ['missing separator', 'env', 'Use key=value pairs separated by commas.'],
+    ['duplicate key', 'env=dev,env=prod', 'Selector key "env" is listed more than once.'],
+    ['mixed valid and invalid entries', 'env=dev,region', 'Use key=value pairs separated by commas.'],
+  ])('rejects a manual workload selector with an %s', async (_label, selector, expectedError) => {
+    const mounted = await mount(WorkloadCreate, { mode: 'manual' })
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      state.draft.name = 'nginx-demo'
+      state.draft.selector = selector
+      await nextTick()
+      expect(state.selectorError).toBe(expectedError)
+      expect(state.canSubmit).toBe(false)
+      expect(state.workloadGuidanceValues.find((item: { label: string }) => item.label === 'Placements')?.value)
+        .toBe('Fix the selector to preview placements')
+      await state.submit()
+      expect(api.createWorkload).not.toHaveBeenCalled()
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('submits a fully validated manual workload selector unchanged', async () => {
+    api.listEdges.mockResolvedValueOnce([{ ...edge, labels: { env: 'dev', region: 'us' } }])
+    const mounted = await mount(WorkloadCreate, { mode: 'manual' })
+    try {
+      await flush()
+      const state = mounted.instance.setupState
+      state.draft.name = 'nginx-demo'
+      state.draft.selector = 'env=dev, region=us'
+      await nextTick()
+      expect(state.selectorError).toBeNull()
+      expect(state.canSubmit).toBe(true)
+      await state.submit()
+      expect(api.createWorkload).toHaveBeenCalledWith(expect.objectContaining({
+        selector: { env: 'dev', region: 'us' },
+      }))
     } finally {
       mounted.unmount()
     }
@@ -953,6 +1117,32 @@ describe('edge detail actions', () => {
 })
 
 describe('edge onboarding controls', () => {
+  it.each([
+    ['service', 'create/service', 'services'],
+    ['workload', 'deploy/workload/manual', 'workloads'],
+  ] as const)('returns a collection-launched %s prerequisite to the collection on cancel and resumes creation on success', async (_label, successPath, cancelPath) => {
+    const subPath = edgeConnectPath(successPath, {
+      cancelPath,
+      ...(successPath.startsWith('deploy/') ? { requiredType: 'kubernetes' as const } : {}),
+    })
+    const mounted = await mount(App, {
+      ctx: { tenant: 'root:faros:tenant', token: 'token', user: { sub: 'user' }, subPath },
+    })
+    try {
+      await flush()
+      const dispatchEvent = vi.fn()
+      mounted.instance.setupState.rootRef = { dispatchEvent }
+
+      mounted.instance.setupState.cancelEdgeConnection()
+      expect((dispatchEvent.mock.calls[0][0] as CustomEvent).detail).toEqual({ path: cancelPath, replace: true })
+
+      mounted.instance.setupState.onEdgeCreated('new-edge', 'kubernetes')
+      expect((dispatchEvent.mock.calls[1][0] as CustomEvent).detail).toEqual({ path: successPath, replace: true })
+    } finally {
+      mounted.unmount()
+    }
+  })
+
   it('mounts labelled native radio cards and keeps checked state in sync', async () => {
     const markup = await renderToString(createSSRApp(Wizard, { cluster: null }))
     expect(markup).toContain('for="edge-name"')
@@ -972,6 +1162,37 @@ describe('edge onboarding controls', () => {
     } finally {
       mounted.unmount()
     }
+  })
+
+  it('locks and validates the edge type required by an originating workload flow', async () => {
+    const markup = await renderToString(createSSRApp(Wizard, { cluster: null, requiredType: 'kubernetes' }))
+    expect(markup).toContain('id="edge-type-server"')
+    expect(markup).toMatch(/id="edge-type-server"[^>]*disabled/)
+
+    const mounted = await mount(Wizard, { cluster: null, requiredType: 'kubernetes' })
+    try {
+      const state = mounted.instance.setupState
+      expect(state.edgeType).toBe('kubernetes')
+      expect(state.edgeTypeLocked).toBe(true)
+      state.name = 'workload-edge'
+      state.edgeType = 'server'
+      await state.handleCreate()
+      expect(api.createEdge).not.toHaveBeenCalled()
+      expect(state.edgeType).toBe('kubernetes')
+      expect(state.error).toBe('This flow requires a KubernetesCluster edge.')
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('labels wizard cancellation for the route it will actually restore', async () => {
+    const markup = await renderToString(createSSRApp(Wizard, {
+      cluster: null,
+      requiredType: 'kubernetes',
+      cancelLabel: 'Back to workloads',
+    }))
+    expect(markup.match(/Back to workloads/g)).toHaveLength(1)
+    expect(markup).not.toContain('Back to edges')
   })
 
   it('announces copy success and retains the copied control state', async () => {
@@ -995,6 +1216,76 @@ describe('edge onboarding controls', () => {
         configurable: true,
         value: previousNavigator,
       })
+    }
+  })
+
+  it('offers an explicit masked-to-revealed fallback when clipboard access fails', async () => {
+    const previousNavigator = globalThis.navigator
+    const previousWindow = globalThis.window
+    const writeText = vi.fn().mockRejectedValue(new Error('clipboard denied'))
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { clipboard: { writeText } },
+    })
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { location: { origin: 'https://faros.test' } },
+    })
+    const mounted = await mount(Wizard, { cluster: null })
+    try {
+      const state = mounted.instance.setupState
+      state.name = 'edge-a'
+      state.joinToken = 'join-secret'
+      await state.copy(state.cliSnippet, 'cli', 'CLI command')
+      expect(state.failedCopyField).toBe('cli')
+      expect(state.revealedCommand).toBeNull()
+      expect(state.cliText).toContain('••••••••••••••••')
+      expect(state.cliText).not.toContain('join-secret')
+
+      state.revealForManualCopy('cli')
+      expect(state.revealedCommand).toBe('cli')
+      expect(state.cliSnippet(state.joinToken)).toContain('--token join-secret')
+      expect(state.copyFeedback).toContain('join token is sensitive')
+
+      await state.copy(state.helmSnippet, 'helm', 'Helm command')
+      expect(state.failedCopyField).toBe('helm')
+      expect(state.revealedCommand).toBeNull()
+      expect(state.cliText).not.toContain('join-secret')
+
+      state.revealForManualCopy('helm')
+      expect(state.revealedCommand).toBe('helm')
+      state.hideRevealedCommand()
+      expect(state.revealedCommand).toBeNull()
+    } finally {
+      mounted.unmount()
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        value: previousNavigator,
+      })
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: previousWindow,
+      })
+    }
+  })
+
+  it('moves focus to the heading after both wizard step transitions', async () => {
+    const mounted = await mount(Wizard, { cluster: null })
+    try {
+      const state = mounted.instance.setupState
+      const focus = vi.fn()
+      globalThis.document.getElementById = () => ({ focus }) as unknown as HTMLElement
+      state.name = 'edge-focus'
+      await state.handleCreate()
+      await flush()
+      expect(state.step).toBe(2)
+      expect(focus).toHaveBeenCalledOnce()
+
+      state.step = 3
+      await flush()
+      expect(focus).toHaveBeenCalledTimes(2)
+    } finally {
+      mounted.unmount()
     }
   })
 

--- a/providers/edges/portal/src/workload-create.regression.test.mjs
+++ b/providers/edges/portal/src/workload-create.regression.test.mjs
@@ -11,7 +11,8 @@ describe('Marketplace workload target regression', () => {
     expect(source).toMatch(/const selectedEdge = kubernetesEdges\.value\.find\(\(edge\) => edge\.name === deployEdge\.value\)/)
     expect(source).toMatch(/v-for="edge in kubernetesEdges"/)
     expect(source).not.toMatch(/v-for="edge in edges"/)
-    expect(source).toMatch(/Connect a KubernetesCluster edge before deploying a marketplace app\./)
+    expect(source).toMatch(/Connect a Kubernetes edge first/)
+    expect(source).toMatch(/@primary="emit\('connectEdge'\)"/)
   })
 
   it('fences route teardown and disables cancellation while deployment is in flight', () => {

--- a/providers/infrastructure/portal/src/portalkit/CreateGuidance.vue
+++ b/providers/infrastructure/portal/src/portalkit/CreateGuidance.vue
@@ -1,0 +1,72 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { Info } from 'lucide-vue-next'
+import { useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface CreateGuidanceValue {
+  label: string
+  value: string
+  technical?: boolean
+}
+
+withDefaults(defineProps<{
+  title: string
+  description: string
+  prerequisites?: string[]
+  values?: CreateGuidanceValue[]
+  nextSteps?: string[]
+  valuesHeading?: string
+}>(), {
+  prerequisites: () => [],
+  values: () => [],
+  nextSteps: () => [],
+  valuesHeading: 'What Faros will create',
+})
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-create-guidance-${id}-title`
+const prerequisiteID = `k-create-guidance-${id}-prerequisites`
+const valuesID = `k-create-guidance-${id}-values`
+const nextStepsID = `k-create-guidance-${id}-next-steps`
+</script>
+
+<template>
+  <aside class="k-create-guidance" :aria-labelledby="titleID">
+    <div class="k-create-guidance__heading">
+      <Info :size="16" :stroke-width="1.75" aria-hidden="true" />
+      <h3 :id="titleID">{{ title }}</h3>
+    </div>
+    <p class="k-create-guidance__description">{{ description }}</p>
+
+    <section v-if="prerequisites.length" class="k-create-guidance__section" :aria-labelledby="prerequisiteID">
+      <h4 :id="prerequisiteID">Prerequisites</h4>
+      <ul>
+        <li v-for="prerequisite in prerequisites" :key="prerequisite">{{ prerequisite }}</li>
+      </ul>
+    </section>
+
+    <section v-if="values.length" class="k-create-guidance__section" :aria-labelledby="valuesID">
+      <h4 :id="valuesID">{{ valuesHeading }}</h4>
+      <dl class="k-create-guidance__values">
+        <template v-for="item in values" :key="item.label">
+          <dt>{{ item.label }}</dt>
+          <dd><code v-if="item.technical">{{ item.value }}</code><span v-else>{{ item.value }}</span></dd>
+        </template>
+      </dl>
+    </section>
+
+    <section v-if="nextSteps.length" class="k-create-guidance__section" :aria-labelledby="nextStepsID">
+      <h4 :id="nextStepsID">Next steps</h4>
+      <ol>
+        <li v-for="step in nextSteps" :key="step">{{ step }}</li>
+      </ol>
+    </section>
+  </aside>
+</template>

--- a/providers/infrastructure/portal/src/portalkit/FirstRunGuide.vue
+++ b/providers/infrastructure/portal/src/portalkit/FirstRunGuide.vue
@@ -1,0 +1,85 @@
+<!--
+  CANONICAL SOURCE — provider-sdk/portalkit-vue. Do not edit vendored copies
+  under providers/*/portal/src/portalkit/; edit here and run
+  `make sync-portalkit`.
+-->
+<script setup lang="ts">
+import { ArrowRight, Check, CircleDot } from 'lucide-vue-next'
+import { computed, useId } from 'vue'
+import { ensureFarosUIStyles } from '../portalkit/styles'
+
+ensureFarosUIStyles()
+
+export interface FirstRunStep {
+  label: string
+  description: string
+}
+
+const props = withDefaults(defineProps<{
+  title: string
+  description: string
+  primaryLabel: string
+  secondaryLabel?: string
+  steps: readonly FirstRunStep[]
+  currentStep?: number
+  journeyLabel?: string
+}>(), {
+  secondaryLabel: '',
+  currentStep: 0,
+  journeyLabel: 'Getting started',
+})
+
+const emit = defineEmits<{
+  (event: 'primary'): void
+  (event: 'secondary'): void
+}>()
+
+const id = useId().replace(/[^a-zA-Z0-9_-]/g, '-')
+const titleID = `k-first-run-${id}-title`
+const boundedCurrentStep = computed(() => Math.max(0, Math.min(props.currentStep, props.steps.length - 1)))
+</script>
+
+<template>
+  <section class="k-first-run" :aria-labelledby="titleID">
+    <div class="k-first-run__lead">
+      <span class="k-first-run__icon" aria-hidden="true"><slot name="icon" /></span>
+      <div class="k-first-run__copy">
+        <h3 :id="titleID">{{ title }}</h3>
+        <p>{{ description }}</p>
+      </div>
+      <div class="k-first-run__actions">
+        <button class="k-btn k-btn--primary" type="button" @click="emit('primary')">
+          {{ primaryLabel }} <ArrowRight :stroke-width="1.75" aria-hidden="true" />
+        </button>
+        <button v-if="secondaryLabel" class="k-btn k-btn--ghost" type="button" @click="emit('secondary')">
+          {{ secondaryLabel }}
+        </button>
+      </div>
+    </div>
+
+    <ol v-if="steps.length" class="k-first-run__journey" :aria-label="journeyLabel">
+      <li
+        v-for="(step, index) in steps"
+        :key="`${index}-${step.label}`"
+        :class="['k-first-run__step', {
+          'is-complete': index < boundedCurrentStep,
+          'is-current': index === boundedCurrentStep,
+        }]"
+        :aria-current="index === boundedCurrentStep ? 'step' : undefined"
+      >
+        <span class="k-first-run__marker" aria-hidden="true">
+          <Check v-if="index < boundedCurrentStep" :stroke-width="2" />
+          <CircleDot v-else-if="index === boundedCurrentStep" :stroke-width="1.75" />
+          <span v-else>{{ index + 1 }}</span>
+        </span>
+        <span class="k-first-run__step-copy">
+          <span class="k-first-run__step-status">
+            {{ index < boundedCurrentStep ? 'Completed step' : index === boundedCurrentStep ? 'Current step' : 'Upcoming step' }}:
+          </span>
+          <strong>{{ step.label }}</strong>
+          <small>{{ step.description }}</small>
+        </span>
+      </li>
+    </ol>
+  </section>
+</template>

--- a/providers/infrastructure/portal/src/portalkit/faros-ui.css
+++ b/providers/infrastructure/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/providers/infrastructure/portal/src/portalkit/styles.ts
+++ b/providers/infrastructure/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 3
+export const FAROS_UI_VERSION = 4
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/kuery/portal/src/portalkit/faros-ui.css
+++ b/providers/kuery/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/providers/kuery/portal/src/portalkit/styles.ts
+++ b/providers/kuery/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 3
+export const FAROS_UI_VERSION = 4
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/quickstart/portal/src/portalkit/faros-ui.css
+++ b/providers/quickstart/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 3;
+  --faros-ui-version: 4;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
   --k-layer-menu: 1000;
@@ -315,6 +315,160 @@ html.light .k-create-surface {
 .k-create-actions > [role="alert"] {
   flex: 1 1 100%;
   order: -1;
+}
+
+/* Guided create forms pair the task fields with a quiet, live help rail. The
+ * provider owns copy and values; PortalKit owns layout, hierarchy, and the
+ * responsive form-first reading order. */
+.k-create-surface--guided {
+  container-name: k-create-surface;
+  container-type: inline-size;
+  max-width: none;
+}
+.k-create-body--guided {
+  align-items: start;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2fr) minmax(17.5rem, 0.8fr);
+}
+.k-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+.k-create-guidance {
+  border-inline-start: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  color: var(--color-text-secondary, #8a8ca6);
+  grid-column: 2;
+  grid-row: 1;
+  max-inline-size: 75ch;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 2px 0 4px;
+  padding-inline-start: 18px;
+}
+.k-create-guidance__heading {
+  align-items: center;
+  color: var(--color-text-primary, #e9e9f2);
+  display: flex;
+  gap: 8px;
+}
+.k-create-guidance__heading svg { color: var(--color-text-muted, #8587a1); flex: none; }
+.k-create-guidance__heading h3 { font-size: 13px; font-weight: 600; line-height: 1.35; margin: 0; }
+.k-create-guidance__description { font-size: 12px; line-height: 1.5; margin: 7px 0 0; }
+.k-create-guidance__section {
+  border-top: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  margin-top: 18px;
+  padding-top: 13px;
+}
+.k-create-guidance__section h4 {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  margin: 0;
+  text-transform: uppercase;
+}
+.k-create-guidance__section :is(ul, ol) { display: grid; gap: 8px; margin: 10px 0 0; padding-inline-start: 18px; }
+.k-create-guidance__section li { font-size: 11px; line-height: 1.5; padding-inline-start: 2px; }
+.k-create-guidance__section li::marker {
+  color: var(--color-text-muted, #8587a1);
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 10px;
+}
+.k-create-guidance__values { display: grid; gap: 8px 12px; grid-template-columns: minmax(0, 7rem) minmax(0, 1fr); margin: 10px 0 0; }
+.k-create-guidance__values dt { color: var(--color-text-muted, #8587a1); font-size: 11px; line-height: 1.45; }
+.k-create-guidance__values dd { color: var(--color-text-primary, #e9e9f2); font-size: 11px; line-height: 1.45; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.k-create-guidance__values code { color: inherit; font-size: inherit; }
+
+@container k-create-surface (max-width: 960px) {
+  .k-create-body--guided { grid-template-columns: minmax(0, 1fr); }
+  .k-create-fields { grid-column: 1; grid-row: 1; }
+  .k-create-guidance {
+    border-block-end: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+    border-inline-start: 0;
+    grid-column: 1;
+    grid-row: 2;
+    padding: 0 0 18px;
+  }
+}
+
+/* First-use onboarding explains value, offers an immediate action, and makes
+ * the shortest useful resource journey visible without a blocking tour. */
+.k-first-run {
+  background: var(--color-surface-raised, #111320);
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px clamp(24px, 3vw, 40px);
+}
+.k-first-run__lead { align-items: start; display: grid; gap: 18px; grid-template-columns: auto minmax(0, 1fr); }
+.k-first-run__icon { color: var(--color-accent, #8b6bff); display: inline-flex; margin-top: 2px; }
+.k-first-run__icon svg { height: 24px; width: 24px; }
+.k-first-run__copy h3 { color: var(--color-text-primary, #e9e9f2); font-size: 18px; font-weight: 600; margin: 0 0 7px; }
+.k-first-run__copy p { color: var(--color-text-secondary, #8a8ca6); font-size: 13px; line-height: 1.55; margin: 0; max-width: 62ch; }
+.k-first-run__actions { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; grid-column: 2; }
+.k-first-run__actions svg { height: 14px; width: 14px; }
+.k-first-run__journey {
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  list-style: none;
+  margin: 28px 0 0;
+  max-inline-size: 72rem;
+  padding: 0;
+}
+.k-first-run__step {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  color: var(--color-text-secondary, #8a8ca6);
+  display: grid;
+  gap: 9px;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 15px 16px 0 0;
+}
+.k-first-run__step:is(.is-complete, .is-current) { border-top-color: color-mix(in srgb, var(--color-accent, #8b6bff) 72%, var(--color-border-default, rgba(255, 255, 255, 0.11))); }
+.k-first-run__marker {
+  align-items: center;
+  border: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11));
+  border-radius: 3px;
+  display: inline-flex;
+  font-family: var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  font-size: 10px;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+.k-first-run__marker svg { height: 12px; width: 12px; }
+.k-first-run__step.is-complete .k-first-run__marker { color: var(--color-success, #2fd6a0); }
+.k-first-run__step.is-current .k-first-run__marker { background: var(--color-accent-subtle, rgba(139, 107, 255, 0.14)); border-color: var(--color-accent, #8b6bff); color: var(--color-accent, #8b6bff); }
+.k-first-run__step-copy { display: grid; gap: 3px; min-width: 0; }
+.k-first-run__step-status {
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+.k-first-run__step-copy strong { color: var(--color-text-primary, #e9e9f2); font-size: 12px; font-weight: 600; }
+.k-first-run__step-copy small { color: var(--color-text-secondary, #8a8ca6); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 620px) {
+  .k-first-run__lead { grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__actions { grid-column: 1; }
+  .k-first-run__journey { gap: 12px; grid-template-columns: minmax(0, 1fr); }
+  .k-first-run__step { border-inline-start: 1px solid var(--color-border-default, rgba(255, 255, 255, 0.11)); border-top: 0; padding: 0; padding-inline-start: 14px; }
 }
 
 @media (max-width: 620px) {

--- a/providers/quickstart/portal/src/portalkit/styles.ts
+++ b/providers/quickstart/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 3
+export const FAROS_UI_VERSION = 4
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())


### PR DESCRIPTION
## Summary

Standardizes the first-run and create experiences for Databricks, Code, Agents, and Edges around a shared PortalKit vocabulary, using the Databricks experience as the baseline. The shared components are synced into every Vue provider portal so future create flows can reuse the same structure without copying provider-specific markup.

## User-facing changes

### Shared create experience

- Adds a consistent first-run guide with an explanation, primary action, and visible journey steps for empty resource collections.
- Adds a consistent guided-create layout with contextual help, prerequisites, a live summary of entered values, and next steps alongside forms.
- Gives completed, current, and upcoming journey steps accessible status text in addition to visual styling.
- Makes the shared layouts responsive so guidance moves below the form on narrower screens while keeping the primary task readable.

### Databricks

- Preserves the existing instructive Connections, SQL warehouses, and Tables journey while moving its empty states and create guidance onto the shared PortalKit components.
- Keeps Databricks-specific prerequisites, live registration summaries, and next-step explanations intact as the reference experience.

### Code

- Adds guided empty states for Connections and Repositories, including both GitHub OAuth and manual-token onboarding paths.
- Keeps manual-token setup available when OAuth configuration cannot be loaded and provides a retry path for the unavailable OAuth option.
- Resumes repository creation after a prerequisite connection is created, including across a page reload when browser storage is available.
- Scopes saved create intent to the active tenant and caller, and clears it when identity changes so one user cannot inherit another user's journey.
- Prevents partially loaded or later pagination pages from being shown as a truly empty workspace.
- Adds contextual guidance to connection and repository create forms.

### Agents

- Adds first-run guides for Agents, Connections, Models, and Toolsets.
- Brings agent, connection, model, and toolset creation onto the same guided visual structure.
- Waits for authoritative agent and credential data before deciding whether credentials are missing or names are duplicates; initial-load failures are retryable, while stale data remains usable with a warning.
- Allows core-only and edge-only toolsets to be created without an external connection; connection data is treated as optional and can be retried independently.
- Improves busy and disabled states so actions do not appear available while prerequisites or submissions are still resolving.

### Edges

- Adds first-run guides for Edges, Services, and Workloads and shared contextual guidance throughout their create flows.
- Makes Kubernetes an explicit prerequisite for workloads; the prerequisite wizard preselects and locks the correct edge type.
- Returns users to the correct next step after completing a prerequisite, while Cancel returns to the collection that launched the flow. Completed prerequisite routes replace stale history entries.
- Prevents invalid selectors from showing a misleading partial placement preview.
- Masks edge join commands by default. A failed clipboard copy reveals the command only after an explicit user action and clears any previous reveal when a new command is generated.
- Restricts create-flow callbacks to canonical, explicitly allowed provider routes and rejects malformed encodings, encoded traversal segments, and backslashes.
- Uses complete first-page pagination results before deciding that Services or Workloads are empty.

## PortalKit and maintainability

- Adds reusable `FirstRunGuide` and `CreateGuidance` Vue components plus shared first-run/create CSS recipes.
- Refactors the Databricks implementation to consume those components instead of maintaining local equivalents.
- Updates PortalKit synchronization, documentation, the design book, and create-flow conformance coverage. Synced provider copies are included intentionally; they do not change App Studio, Infrastructure, Kuery, or Quickstart behavior.

## Verification

- Agents portal: 180 tests passed
- Code portal: 129 tests passed
- Edges portal: 124 tests passed
- Databricks portal: 135 tests passed
- Affected portal typechecks and production builds passed
- `make verify-portalkit`
- `make verify-ui-conformance` (354 files scanned, 0 violations)
- `git diff --check`

