### PR TITLE
Polish the Kuery provider experience

### DIFF
--- a/hack/ui-conformance-exceptions.json
+++ b/hack/ui-conformance-exceptions.json
@@ -4,7 +4,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 55,
+      "line": 57,
       "column": 69,
       "match": "#e0b34f",
       "reference": "design-book §8 Kuery graph",
@@ -13,7 +13,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 59,
+      "line": 61,
       "column": 85,
       "match": "#4f9be0",
       "reference": "design-book §8 Kuery graph",
@@ -22,7 +22,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 63,
+      "line": 65,
       "column": 81,
       "match": "#9b6de0",
       "reference": "design-book §8 Kuery graph",
@@ -31,7 +31,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 67,
+      "line": 69,
       "column": 72,
       "match": "#4fe0a8",
       "reference": "design-book §8 Kuery graph",
@@ -40,7 +40,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 71,
+      "line": 73,
       "column": 84,
       "match": "#e07a4f",
       "reference": "design-book §8 Kuery graph",
@@ -49,7 +49,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 75,
+      "line": 77,
       "column": 70,
       "match": "#e0519b",
       "reference": "design-book §8 Kuery graph",
@@ -58,7 +58,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 79,
+      "line": 81,
       "column": 72,
       "match": "#8a93a8",
       "reference": "design-book §8 Kuery graph",
@@ -67,7 +67,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 83,
+      "line": 85,
       "column": 78,
       "match": "#5fae7a",
       "reference": "design-book §8 Kuery graph",
@@ -76,7 +76,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 87,
+      "line": 89,
       "column": 77,
       "match": "#5fae7a",
       "reference": "design-book §8 Kuery graph",
@@ -85,7 +85,88 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 361,
+      "line": 57,
+      "column": 92,
+      "match": "#715100",
+      "reference": "design-book §8 Kuery graph",
+      "reason": "RELATION_METADATA includes a light-theme semantic edge palette for the Kuery graph, not UI chrome."
+    },
+    {
+      "rule": "raw-color",
+      "path": "providers/kuery/portal/src/graph.ts",
+      "line": 61,
+      "column": 108,
+      "match": "#075b9e",
+      "reference": "design-book §8 Kuery graph",
+      "reason": "RELATION_METADATA includes a light-theme semantic edge palette for the Kuery graph, not UI chrome."
+    },
+    {
+      "rule": "raw-color",
+      "path": "providers/kuery/portal/src/graph.ts",
+      "line": 65,
+      "column": 104,
+      "match": "#5f3bb8",
+      "reference": "design-book §8 Kuery graph",
+      "reason": "RELATION_METADATA includes a light-theme semantic edge palette for the Kuery graph, not UI chrome."
+    },
+    {
+      "rule": "raw-color",
+      "path": "providers/kuery/portal/src/graph.ts",
+      "line": 69,
+      "column": 95,
+      "match": "#006b4d",
+      "reference": "design-book §8 Kuery graph",
+      "reason": "RELATION_METADATA includes a light-theme semantic edge palette for the Kuery graph, not UI chrome."
+    },
+    {
+      "rule": "raw-color",
+      "path": "providers/kuery/portal/src/graph.ts",
+      "line": 73,
+      "column": 107,
+      "match": "#923b13",
+      "reference": "design-book §8 Kuery graph",
+      "reason": "RELATION_METADATA includes a light-theme semantic edge palette for the Kuery graph, not UI chrome."
+    },
+    {
+      "rule": "raw-color",
+      "path": "providers/kuery/portal/src/graph.ts",
+      "line": 77,
+      "column": 93,
+      "match": "#96205d",
+      "reference": "design-book §8 Kuery graph",
+      "reason": "RELATION_METADATA includes a light-theme semantic edge palette for the Kuery graph, not UI chrome."
+    },
+    {
+      "rule": "raw-color",
+      "path": "providers/kuery/portal/src/graph.ts",
+      "line": 81,
+      "column": 95,
+      "match": "#4d5568",
+      "reference": "design-book §8 Kuery graph",
+      "reason": "RELATION_METADATA includes a light-theme semantic edge palette for the Kuery graph, not UI chrome."
+    },
+    {
+      "rule": "raw-color",
+      "path": "providers/kuery/portal/src/graph.ts",
+      "line": 85,
+      "column": 101,
+      "match": "#24683f",
+      "reference": "design-book §8 Kuery graph",
+      "reason": "RELATION_METADATA includes a light-theme semantic edge palette for the Kuery graph, not UI chrome."
+    },
+    {
+      "rule": "raw-color",
+      "path": "providers/kuery/portal/src/graph.ts",
+      "line": 89,
+      "column": 100,
+      "match": "#24683f",
+      "reference": "design-book §8 Kuery graph",
+      "reason": "RELATION_METADATA includes a light-theme semantic edge palette for the Kuery graph, not UI chrome."
+    },
+    {
+      "rule": "raw-color",
+      "path": "providers/kuery/portal/src/graph.ts",
+      "line": 371,
       "column": 49,
       "match": "rgba(127,127,127,0.16)",
       "reference": "design-book §8 Kuery graph",
@@ -94,7 +175,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 362,
+      "line": 372,
       "column": 47,
       "match": "rgba(127,127,127,0.45)",
       "reference": "design-book §8 Kuery graph",
@@ -103,7 +184,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 363,
+      "line": 373,
       "column": 43,
       "match": "#e9e9f2",
       "reference": "design-book §8 Kuery graph",
@@ -112,7 +193,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 364,
+      "line": 374,
       "column": 42,
       "match": "#5d5f78",
       "reference": "design-book §8 Kuery graph",
@@ -121,7 +202,7 @@
     {
       "rule": "raw-color",
       "path": "providers/kuery/portal/src/graph.ts",
-      "line": 365,
+      "line": 375,
       "column": 39,
       "match": "#8b6bff",
       "reference": "design-book §8 Kuery graph",

--- a/providers/infrastructure/portal/src/App.vue
+++ b/providers/infrastructure/portal/src/App.vue
@@ -152,6 +152,7 @@ function provisioned(name: string) {
   <div ref="rootRef" class="app">
     <Tabs
       v-if="contextInitialized && tenantPath"
+      class="infra-tabs"
       :tabs="sectionTabs"
       :active="activeSection"
       aria-label="Infrastructure sections"

--- a/providers/infrastructure/portal/src/compositionConformance.test.mjs
+++ b/providers/infrastructure/portal/src/compositionConformance.test.mjs
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 const styles = readFileSync(new URL('./style.css', import.meta.url), 'utf8')
+const app = readFileSync(new URL('./App.vue', import.meta.url), 'utf8')
 const provision = readFileSync(new URL('./views/ProvisionPage.vue', import.meta.url), 'utf8')
 const dynamicForm = readFileSync(new URL('./components/DynamicForm.vue', import.meta.url), 'utf8')
 const viewValue = readFileSync(new URL('./components/ViewValue.vue', import.meta.url), 'utf8')
@@ -9,7 +10,8 @@ const templateCard = readFileSync(new URL('./components/TemplateCard.vue', impor
 
 describe('Infrastructure composition contracts', () => {
   it('separates provider tabs from routed page content', () => {
-    expect(styles).toMatch(/\.app > \.k-tabs \{[\s\S]*margin-bottom: 16px;/)
+    expect(app).toContain('class="infra-tabs"')
+    expect(styles).toMatch(/\.infra-tabs \{[\s\S]*margin-bottom: 16px;/)
   })
 
   it('adds deliberate columns for wide template catalogs', () => {

--- a/providers/infrastructure/portal/src/compositionConformance.test.mjs
+++ b/providers/infrastructure/portal/src/compositionConformance.test.mjs
@@ -8,6 +8,10 @@ const viewValue = readFileSync(new URL('./components/ViewValue.vue', import.meta
 const templateCard = readFileSync(new URL('./components/TemplateCard.vue', import.meta.url), 'utf8')
 
 describe('Infrastructure composition contracts', () => {
+  it('separates provider tabs from routed page content', () => {
+    expect(styles).toMatch(/\.app > \.k-tabs \{[\s\S]*margin-bottom: 16px;/)
+  })
+
   it('adds deliberate columns for wide template catalogs', () => {
     expect(styles).toMatch(/@media \(min-width: 1440px\)[\s\S]*repeat\(4, minmax\(0, 1fr\)\)/)
     expect(styles).toMatch(/@media \(min-width: 1920px\)[\s\S]*repeat\(5, minmax\(0, 1fr\)\)/)

--- a/providers/infrastructure/portal/src/style.css
+++ b/providers/infrastructure/portal/src/style.css
@@ -20,6 +20,12 @@ faros-provider-infrastructure .page {
   gap: 16px;
 }
 
+/* Separate provider navigation from the routed page using the same major
+ * rhythm as the page's own content groups. */
+faros-provider-infrastructure .app > .k-tabs {
+  margin-bottom: 16px;
+}
+
 faros-provider-infrastructure .page-head {
   display: flex;
   align-items: flex-start;

--- a/providers/infrastructure/portal/src/style.css
+++ b/providers/infrastructure/portal/src/style.css
@@ -22,7 +22,7 @@ faros-provider-infrastructure .page {
 
 /* Separate provider navigation from the routed page using the same major
  * rhythm as the page's own content groups. */
-faros-provider-infrastructure .app > .k-tabs {
+faros-provider-infrastructure .infra-tabs {
   margin-bottom: 16px;
 }
 

--- a/providers/kuery/portal/.gitignore
+++ b/providers/kuery/portal/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 *.log
+playwright-report/
+test-results/

--- a/providers/kuery/portal/browser/kuery.spec.ts
+++ b/providers/kuery/portal/browser/kuery.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test, type Page } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+
+const portalRoot = fileURLToPath(new URL('..', import.meta.url))
+const asset = (name: string): string => `${portalRoot}/dist/${name}`
+
+const topology = {
+  objects: [{
+    cluster: 'org/edge-a',
+    relations: {
+      members: [
+        { id: 'ns-apps', cluster: 'org/edge-a', object: { apiVersion: 'v1', kind: 'Namespace', metadata: { name: 'apps' } } },
+        { id: 'deploy-web', cluster: 'org/edge-a', object: { apiVersion: 'apps/v1', kind: 'Deployment', metadata: { name: 'web', namespace: 'apps' } } },
+        { id: 'service-web', cluster: 'org/edge-a', object: { apiVersion: 'v1', kind: 'Service', metadata: { name: 'web', namespace: 'apps' } } },
+      ],
+    },
+  }],
+}
+
+const inventory = {
+  objects: [
+    { id: 'deploy-web', cluster: 'org/edge-a', object: { apiVersion: 'apps/v1', kind: 'Deployment', metadata: { name: 'web', namespace: 'apps', creationTimestamp: '2026-09-01T00:00:00Z' } } },
+  ],
+  count: 1,
+}
+
+async function mountKuery(page: Page, theme: 'dark' | 'light'): Promise<void> {
+  await page.route('**/*', async route => {
+    const path = new URL(route.request().url()).pathname
+    if (path.endsWith('/api/edges')) return route.fulfill({ json: { edges: ['edge-a'] } })
+    if (path.endsWith('/api/query-schema')) return route.fulfill({ json: { properties: { root: {}, objects: {}, filter: {} } } })
+    if (path.endsWith('/api/query')) {
+      const body = route.request().postDataJSON() as { root?: string; count?: boolean }
+      return route.fulfill({ json: body.root === 'clusters' ? topology : body.count ? inventory : inventory })
+    }
+    for (const name of ['cytoscape.min.js', 'codemirror.bundle.js', 'codemirror.bundle.css']) {
+      if (path.endsWith(`/${name}`)) return route.fulfill({ path: asset(name) })
+    }
+    return route.abort()
+  })
+
+  await page.setContent(`<!doctype html><html class="${theme}"><head><base href="https://kuery.test/"><style>
+    :root {
+      --color-surface: ${theme === 'dark' ? '#0a0b12' : '#f1f1f6'};
+      --color-surface-raised: ${theme === 'dark' ? '#111320' : '#ffffff'};
+      --color-surface-overlay: ${theme === 'dark' ? '#171927' : '#eaeaf2'};
+      --color-surface-hover: ${theme === 'dark' ? '#1d2030' : '#e1e1eb'};
+      --color-border-subtle: ${theme === 'dark' ? '#292b3b' : '#d5d5df'};
+      --color-border-default: ${theme === 'dark' ? '#3b3e52' : '#b8b8c6'};
+      --color-accent: ${theme === 'dark' ? '#8b6bff' : '#6b48e8'};
+      --color-accent-subtle: ${theme === 'dark' ? '#211b3d' : '#e8e0ff'};
+      --color-text-primary: ${theme === 'dark' ? '#e9e9f2' : '#171721'};
+      --color-text-secondary: ${theme === 'dark' ? '#b9bbca' : '#454553'};
+      --color-text-muted: ${theme === 'dark' ? '#8a8ca0' : '#656575'};
+      --color-text-on-accent: #ffffff;
+      --color-success: ${theme === 'dark' ? '#4fe0a8' : '#087a55'};
+      --color-warning: ${theme === 'dark' ? '#e0b34f' : '#866000'};
+      --color-danger: ${theme === 'dark' ? '#ff7188' : '#b6223b'};
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; min-height: 100%; background: var(--color-surface); color: var(--color-text-primary); font-family: sans-serif; }
+    body { padding: 32px; }
+  </style></head><body><faros-provider-kuery id="kuery"></faros-provider-kuery></body></html>`)
+  await page.addScriptTag({ path: asset('main.js') })
+  await page.locator('#kuery').evaluate((element, resolvedTheme) => {
+    ;(element as HTMLElement & { farosContext: unknown }).farosContext = {
+      basePath: '/ui/providers/kuery/', token: 'test-token', orgUUID: 'org', workspaceUUID: 'workspace', theme: resolvedTheme,
+    }
+  }, theme)
+  await expect(page.getByRole('heading', { name: 'Fleet topology', exact: true })).toBeVisible()
+  await expect(page.getByText('1 edge engaged')).toBeVisible()
+}
+
+test('4K topology and playground use the available vertical workspace', async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 3840, height: 2160 })
+  await mountKuery(page, 'dark')
+
+  const graph = page.getByRole('region', { name: 'Fleet topology visualization' })
+  await expect(graph).toBeVisible()
+  expect((await graph.boundingBox())?.height).toBeGreaterThanOrEqual(1300)
+  await page.screenshot({ path: testInfo.outputPath('kuery-4k-topology-dark.png'), fullPage: true })
+
+  await page.getByRole('button', { name: 'Playground', exact: true }).click()
+  await expect(page.locator('.CodeMirror')).toBeVisible()
+  const split = page.locator('.pg-split')
+  const editor = page.locator('.pg-editor')
+  const result = page.locator('.pg-result')
+  expect((await split.boundingBox())?.height).toBeGreaterThanOrEqual(1000)
+  expect(Math.abs((await editor.boundingBox())!.height - (await result.boundingBox())!.height)).toBeLessThanOrEqual(2)
+  expect(await page.locator('.CodeMirror').evaluate(element => getComputedStyle(element).backgroundColor)).not.toBe('rgb(255, 255, 255)')
+  await page.screenshot({ path: testInfo.outputPath('kuery-4k-dark.png'), fullPage: true })
+})
+
+test('narrow inventory filters reflow without clipping', async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await mountKuery(page, 'light')
+  await page.getByRole('button', { name: 'Inventory', exact: true }).click()
+
+  const panel = page.getByRole('region', { name: 'Fleet inventory scroll area' }).locator('xpath=ancestor::section')
+  const form = page.getByRole('form', { name: 'Filter fleet inventory' })
+  const labels = form.locator('label')
+  await expect(labels).toHaveCount(2)
+  const panelBox = await panel.boundingBox()
+  for (let index = 0; index < 2; index += 1) {
+    const box = await labels.nth(index).boundingBox()
+    expect(box!.x).toBeGreaterThanOrEqual(panelBox!.x)
+    expect(box!.x + box!.width).toBeLessThanOrEqual(panelBox!.x + panelBox!.width + 1)
+    expect(box!.width).toBeGreaterThan(280)
+  }
+  await page.screenshot({ path: testInfo.outputPath('kuery-mobile-light.png'), fullPage: true })
+  await page.getByRole('button', { name: 'Playground', exact: true }).click()
+  await expect(page.locator('.CodeMirror')).toBeVisible()
+  expect(await page.locator('.CodeMirror').evaluate(element => getComputedStyle(element).backgroundColor)).toBe('rgb(241, 241, 246)')
+})

--- a/providers/kuery/portal/element.contract.test.mjs
+++ b/providers/kuery/portal/element.contract.test.mjs
@@ -11,6 +11,7 @@ const inventory = readFileSync(new URL('./src/components/InventoryView.vue', imp
 const playground = readFileSync(new URL('./src/components/PlaygroundView.vue', import.meta.url), 'utf8')
 const impact = readFileSync(new URL('./src/components/ImpactView.vue', import.meta.url), 'utf8')
 const styles = readFileSync(new URL('./src/style.css', import.meta.url), 'utf8')
+const editor = readFileSync(new URL('./src/playground.ts', import.meta.url), 'utf8')
 
 test('the provider contract is a thin reactive light-DOM Vue mount', () => {
   assert.match(element, /createApp\(App, \{ state: this\.state \}\)/u)
@@ -39,6 +40,9 @@ test('playground exposes labeled editor and live result status', () => {
   assert.match(playground, /aria-labelledby="query-editor-label"/u)
   assert.match(playground, /role="status" aria-live="polite"/u)
   assert.match(playground, /Correct the QuerySpec and run it again/u)
+  assert.match(editor, /screenReaderLabel: 'Kuery QuerySpec editor'/u)
+  assert.match(editor, /hintOptions: \{ hint, completeSingle: false, container: host \}/u)
+  assert.match(styles, /\.pg-editor \.CodeMirror\s*\{[^}]*background: var\(--color-surface\);[^}]*color: var\(--color-text-primary\);/u)
 })
 
 test('impact drill-down preserves mounted tab state and falls back to the host route', () => {
@@ -80,6 +84,14 @@ test('playground editor and results fill the same split-row height', () => {
   assert.match(styles, /\.pg-editor\s*\{[^}]*flex:\s*1 1 360px;/u)
   assert.match(styles, /\.pg-result\s*\{[^}]*flex:\s*1 1 360px;/u)
   assert.doesNotMatch(styles, /\.pg-result\s*\{[^}]*max-height:/u)
+  assert.match(styles, /height: clamp\(360px, calc\(100vh - 380px\), 1440px\);/u)
+})
+
+test('4K geometry stays useful while mobile inventory filters reflow', () => {
+  assert.match(styles, /\.kuery-graph\s*\{[^}]*height: clamp\(440px, calc\(100vh - 380px\), 1440px\);/u)
+  assert.match(styles, /\.kuery-inventory-table\s*\{[^}]*max-width: 96rem;/u)
+  assert.match(styles, /\.kuery-inventory-filters\s*>\s*label\s*\{[^}]*flex: 1 1 200px;[^}]*min-width: 0;/u)
+  assert.match(styles, /@media \(max-width: 680px\)[\s\S]*\.kuery-inventory-filters\s*>\s*label\s*\{[^}]*flex-basis: 100%;[^}]*width: 100%;/u)
 })
 
 test('Kuery requests share one context-derived transport contract', () => {
@@ -104,4 +116,6 @@ test('dashboard tile fences post-await writes to mounted context and request', (
   assert.match(tile, /if \(!isCurrent\(\)\) return[\s\S]*this\._edges = \[\]/u)
   assert.match(tile, /if \(!isCurrent\(\)\) return[\s\S]*this\._loading = false/u)
   assert.match(tile, /this\._contextGeneration \+= 1[\s\S]*this\._poller\?\.stop\(\)/u)
+  assert.match(tile, /class="kuery-tile-live" role="status" aria-live="polite" aria-atomic="true"/u)
+  assert.match(tile, /if \(html === this\._lastHTML\) return false/u)
 })

--- a/providers/kuery/portal/package-lock.json
+++ b/providers/kuery/portal/package-lock.json
@@ -12,6 +12,7 @@
         "vue": "^3.5.13"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@types/cytoscape": "^3.21.9",
         "@vitejs/plugin-vue": "^5.2.1",
         "codemirror": "^5.65.16",
@@ -510,6 +511,21 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
       "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw=="
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.4",
@@ -1519,6 +1535,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/providers/kuery/portal/package.json
+++ b/providers/kuery/portal/package.json
@@ -10,6 +10,7 @@
     "vendor-codemirror": "node vendor-codemirror.cjs",
     "dev": "vite",
     "test": "node --test --test-concurrency=1 *.test.mjs",
+    "test:browser": "npm run build && playwright test",
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
@@ -17,6 +18,7 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@types/cytoscape": "^3.21.9",
     "@vitejs/plugin-vue": "^5.2.1",
     "codemirror": "^5.65.16",

--- a/providers/kuery/portal/playwright.config.ts
+++ b/providers/kuery/portal/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './browser',
+  fullyParallel: false,
+  reporter: 'line',
+  use: {
+    headless: true,
+  },
+})

--- a/providers/kuery/portal/src/App.vue
+++ b/providers/kuery/portal/src/App.vue
@@ -100,7 +100,7 @@ onBeforeUnmount(() => { edgesRequestID += 1; edgesController?.abort(); edgesCont
     <div v-show="!impact" class="kuery-collection-surfaces">
       <div class="kuery-topbar">
         <Tabs :tabs="tabs" :active="active" aria-label="Kuery views" @select="selectTab" />
-        <span class="k-badge" :class="edges.length ? 'k-badge--success' : 'k-badge--warning'">
+        <span class="k-badge" :class="edges.length ? 'k-badge--success' : 'k-badge--warning'" role="status" aria-live="polite" aria-atomic="true">
           {{ edgesLoading && !edgesLoaded ? 'Discovering edges' : `${edges.length} edge${edges.length === 1 ? '' : 's'} engaged` }}
         </span>
       </div>

--- a/providers/kuery/portal/src/components/ImpactView.vue
+++ b/providers/kuery/portal/src/components/ImpactView.vue
@@ -4,7 +4,7 @@ import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import type { FarosContext } from '../element'
 import type { ObjectResult, QuerySpec } from '../api'
 import {
-  buildElements, IMPACT_RELATIONS, mountGraph, RELATION_DIR, RELATION_LABELS, RELATION_METADATA,
+  buildElements, IMPACT_RELATIONS, mountGraph, relationColor, RELATION_DIR, RELATION_LABELS, RELATION_METADATA,
   themeStyle, type GraphHandle,
 } from '../graph'
 import { createKueryRequestContext, errorMessage, resourceLabel, useKueryApi } from '../kuery'
@@ -36,9 +36,13 @@ const title = computed(() => {
 })
 const subtitle = computed(() => `Declared impact on ${props.anchor.cluster?.split('/').pop() || 'this edge'}`)
 const relations = computed(() => Object.entries(result.value?.relations ?? {}).filter(([, rows]) => (rows ?? []).length > 0))
-const legendRelations = computed(() => RELATION_METADATA.filter(relation => (result.value?.relations?.[relation.name]?.length ?? 0) > 0))
+const lightTheme = computed(() => props.context?.theme === 'light' || (
+  props.context?.theme === 'system' && typeof document !== 'undefined' && document.documentElement.classList.contains('light')
+))
+const legendRelations = computed(() => RELATION_METADATA
+  .filter(relation => (result.value?.relations?.[relation.name]?.length ?? 0) > 0)
+  .map(relation => ({ ...relation, displayColor: relationColor(relation, lightTheme.value) })))
 const namespaceRelationBounded = computed(() => (result.value?.relations?.namespaced?.length ?? 0) >= 200)
-
 function spec(): QuerySpec {
   const metadata = props.anchor.object?.metadata ?? {}; const version = props.anchor.object?.apiVersion || ''; const group = version.includes('/') ? version.split('/')[0] : ''
   const filter = { name: metadata.name, ...(props.anchor.object?.kind ? { groupKind: { apiGroup: group, kind: props.anchor.object.kind } } : {}), ...(metadata.namespace ? { namespace: metadata.namespace } : {}) }
@@ -109,7 +113,7 @@ onBeforeUnmount(() => { loadGeneration += 1; controller?.abort(); destroyGraph()
           <h2 id="impact-legend-title" class="kuery-workbench-title">Relation legend</h2>
           <dl class="legend">
             <div v-for="relation in legendRelations" :key="relation.name" class="legend-item">
-              <dt><span class="legend-swatch" aria-hidden="true" :style="{ backgroundColor: relation.color }" />{{ relation.legendLabel }}</dt>
+              <dt><span class="legend-swatch" aria-hidden="true" :style="{ borderTopColor: relation.displayColor, borderTopStyle: relation.lineStyle }" />{{ relation.legendLabel }}</dt>
               <dd>{{ relation.description }}</dd>
             </div>
           </dl>
@@ -120,7 +124,7 @@ onBeforeUnmount(() => { loadGeneration += 1; controller?.abort(); destroyGraph()
         <p v-if="namespaceRelationBounded" class="kuery-warning" role="status">Namespace membership reached its 200-object relation bound. Additional members may be omitted.</p>
         <div v-if="representation === 'graph'">
           <div v-if="graphError" class="kuery-inline-error" role="alert">{{ graphError }} <button type="button" class="k-btn k-btn--ghost" @click="mount">Retry graph</button></div>
-          <div ref="graphHost" class="kuery-graph" role="region" :aria-label="`Impact graph for ${title}`" :aria-describedby="legendRelations.length ? 'impact-bounds impact-legend-title' : 'impact-bounds'" tabindex="0" />
+          <div ref="graphHost" class="kuery-graph" role="img" :aria-label="`Impact visualization for ${title}`" :aria-describedby="legendRelations.length ? 'impact-bounds impact-legend-title' : 'impact-bounds'" />
         </div>
         <div v-else-if="relations.length" class="kuery-impact-list">
           <section v-for="[relation, related] in relations" :key="relation"><h2>{{ RELATION_LABELS[relation] || relation }} <span class="k-badge">{{ RELATION_DIR[relation] === 'up' ? 'impacts this object' : RELATION_DIR[relation] === 'down' ? 'impacted by this object' : 'related' }}</span></h2><ul><li v-for="row in related" :key="row.id || resourceLabel(row)"><button type="button" class="kuery-related" @click="emit('inspect', row)">{{ resourceLabel(row) }}</button></li></ul></section>

--- a/providers/kuery/portal/src/components/InventoryView.vue
+++ b/providers/kuery/portal/src/components/InventoryView.vue
@@ -100,7 +100,7 @@ onBeforeUnmount(() => controller?.abort())
 <template>
   <section class="kuery-panel k-card" aria-labelledby="inventory-title">
     <div class="kuery-panel-head"><div><h2 id="inventory-title" class="kuery-panel-title">Fleet inventory</h2><p class="meta">Server-paginated inventory across connected edges. Name, Kind, and Namespace searches are exact and apply to the full fleet query.</p></div></div>
-    <form class="kuery-toolbar" aria-label="Filter fleet inventory" @submit.prevent="applyFacetFilters">
+    <form class="kuery-toolbar kuery-inventory-filters" aria-label="Filter fleet inventory" @submit.prevent="applyFacetFilters">
       <label>
         <span class="kuery-sr-only">Exact Kind</span>
         <input id="inventory-kind-filter" v-model="kindInput" class="k-input kuery-control" type="text" autocomplete="off" placeholder="Kind (exact, e.g. Deployment)">
@@ -112,6 +112,7 @@ onBeforeUnmount(() => controller?.abort())
       <button class="k-btn k-btn--primary" type="submit">Apply filters</button>
     </form>
     <ResourceTable
+      class="kuery-inventory-table"
       :columns="columns" :rows="rows" row-key="_key" aria-label="Fleet inventory" :loaded="loaded" :loading="loading"
       refresh-mode="background" :error="error" :stale="loaded && !!error" retryable searchable search-placeholder="Exact resource name…"
       :filters="filters" pagination-mode="server" :page="pager.page" :page-size="pager.pageSize" :page-size-options="[25, 50, 100]"

--- a/providers/kuery/portal/src/components/TopologyView.vue
+++ b/providers/kuery/portal/src/components/TopologyView.vue
@@ -30,6 +30,7 @@ const graphError = ref('')
 const expansionFailure = ref<{ id: string | null; message: string } | null>(null)
 const full = ref(false)
 const expandingAll = ref(false)
+const expansionStatus = ref('')
 const responseWarnings = ref<string[]>([])
 const relationResponseTruncated = ref(false)
 const relationLimitReached = ref(false)
@@ -41,6 +42,7 @@ let graph: GraphHandle | null = null
 let graphGeneration = 0
 let graphObjects = new Map<string, ObjectResult>()
 let graphController: AbortController | null = null
+let expandAllController: AbortController | null = null
 let expansionGeneration = 0
 const expansionRequests = new Map<string, number>()
 let fullscreenGeneration = 0
@@ -108,6 +110,8 @@ function destroyGraph(): void {
   graphGeneration += 1
   graphController?.abort()
   graphController = null
+  expandAllController?.abort()
+  expandAllController = null
   graph?.destroy()
   graph = null
   graphObjects.clear()
@@ -116,6 +120,7 @@ function destroyGraph(): void {
   relationLimitReached.value = false
   expansionBound.value = null
   expandingAll.value = false
+  expansionStatus.value = ''
 }
 
 async function mount(): Promise<void> {
@@ -163,7 +168,7 @@ function recordRelationStatus(status: QueryStatus): void {
 
 async function expand(id: string): Promise<void> {
   const handle = graph; const controller = graphController; const currentGraphGeneration = graphGeneration; const row = graphObjects.get(id)
-  if (!handle || !row) return
+  if (!handle || !row || expandingAll.value) return
   if (handle.isExpanded(id)) {
     expansionRequests.set(id, ++expansionGeneration)
     handle.collapseFrom(id)
@@ -171,7 +176,12 @@ async function expand(id: string): Promise<void> {
   }
   const requestGeneration = ++expansionGeneration
   expansionRequests.set(id, requestGeneration)
-  const isCurrent = () => graph === handle && graphGeneration === currentGraphGeneration && graphController === controller && expansionRequests.get(id) === requestGeneration
+  const isCurrent = () => graph === handle
+    && graphGeneration === currentGraphGeneration
+    && graphController === controller
+    && expansionRequests.get(id) === requestGeneration
+    && handle.hasNode(id)
+    && handle.isExpanded(id)
   expansionFailure.value = null
   handle.markExpanded(id, true)
   try {
@@ -197,35 +207,65 @@ async function expand(id: string): Promise<void> {
 async function expandAll(): Promise<void> {
   const handle = graph; const controller = graphController; const currentGraphGeneration = graphGeneration
   if (!handle || expandingAll.value) return
-  const isCurrent = () => graph === handle && graphGeneration === currentGraphGeneration && graphController === controller
+  const current = new AbortController()
+  expandAllController = current
+  const isCurrent = () => graph === handle && graphGeneration === currentGraphGeneration && graphController === controller && expandAllController === current && !current.signal.aborted
   expandingAll.value = true
+  expansionStatus.value = 'Starting bounded graph expansion…'
   let rounds = 0
+  let layoutDirty = false
   try {
     for (; rounds < 30 && isCurrent() && handle.nodeCount() < 4000; rounds += 1) {
       const ids = [...graphObjects.keys()].filter(id => handle.hasNode(id) && !handle.isExpanded(id)).slice(0, 300)
       if (!ids.length) break
-      const status = await query({ maxDepth: 5, limit: ids.length, filter: { objects: ids.map(id => ({ id })) }, objects: { id: true, cluster: true, relations: impactRelations() } }, controller?.signal)
+      const status = await query({ maxDepth: 5, limit: ids.length, filter: { objects: ids.map(id => ({ id })) }, objects: { id: true, cluster: true, relations: impactRelations() } }, current.signal)
       let added = 0
       if (!isCurrent()) break
       recordRelationStatus(status)
       for (const object of status.objects ?? []) {
+        if (handle.nodeCount() >= 4000) break
         if (!object.id) continue
-        const built = relationElements(object.id, object); added += handle.add(built.elements).length
-        for (const [key, row] of Object.entries(built.nodeIndex)) graphObjects.set(key, row)
+        const built = relationElements(object.id, object)
+        added += handle.add(built.elements, 4000).length
+        for (const [key, row] of Object.entries(built.nodeIndex)) {
+          if (handle.hasNode(key)) graphObjects.set(key, row)
+        }
       }
-      ids.forEach(id => handle.markExpanded(id, true)); handle.relayout(layoutConfig())
+      ids.forEach(id => handle.markExpanded(id, true))
+      layoutDirty ||= added > 0
+      expansionStatus.value = `Expansion round ${rounds + 1}: ${handle.nodeCount().toLocaleString()} graph nodes.`
+      if ((rounds + 1) % 3 === 0 && layoutDirty) {
+        handle.relayout(layoutConfig())
+        layoutDirty = false
+      }
       if (added === 0) break
+      await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
     }
     if (isCurrent()) {
+      if (layoutDirty) handle.relayout(layoutConfig())
       if (handle.nodeCount() >= 4000) expansionBound.value = 'nodes'
       else if (rounds >= 30) expansionBound.value = 'rounds'
+      expansionStatus.value = `Expansion complete: ${handle.nodeCount().toLocaleString()} graph nodes.`
     }
   } catch (reason) {
     if (!isCurrent()) return
     if (reason instanceof DOMException && reason.name === 'AbortError') return
     const message = errorMessage(reason, 'Retry Expand all; the graph remains usable.')
     if (message) expansionFailure.value = { id: null, message }
-  } finally { if (isCurrent()) expandingAll.value = false }
+  } finally {
+    if (expandAllController === current) {
+      expandAllController = null
+      expandingAll.value = false
+    }
+  }
+}
+function cancelExpandAll(): void {
+  if (!expandAllController) return
+  expandAllController.abort()
+  expandAllController = null
+  expandingAll.value = false
+  expansionStatus.value = `Expansion cancelled. ${graph?.nodeCount().toLocaleString() ?? 0} graph nodes remain available.`
+  graph?.relayout(layoutConfig())
 }
 function retryExpansion(): void {
   const failure = expansionFailure.value
@@ -281,6 +321,7 @@ onBeforeUnmount(() => { loadGeneration += 1; fullscreenGeneration += 1; loadCont
       <label><span id="topology-kind-label">Kind</span><FormSelect v-model="kind" :options="kindOptions" labelledby="topology-kind-label" /></label>
       <label><span id="topology-namespace-label">Namespace</span><FormSelect v-model="namespace" :options="namespaceOptions" labelledby="topology-namespace-label" /></label>
       <button type="button" class="k-btn k-btn--ghost" :disabled="!graph || expandingAll" @click="expandAll">{{ expandingAll ? 'Expanding…' : 'Expand all' }}</button>
+      <button v-if="expandingAll" type="button" class="k-btn k-btn--ghost" @click="cancelExpandAll">Cancel expansion</button>
       <button type="button" class="k-btn k-btn--ghost" :disabled="!graph" @click="resetGraph">Reset graph</button>
       <button type="button" class="k-btn k-btn--ghost" @click="toggleFullscreen">{{ full ? 'Exit full screen' : 'Full screen' }}</button>
     </div>
@@ -296,7 +337,12 @@ onBeforeUnmount(() => { loadGeneration += 1; fullscreenGeneration += 1; loadCont
           <template v-if="edgeGroup.resources.length"><h4>Cluster-scoped</h4><button v-for="row in edgeGroup.resources" :key="row.key" type="button" class="kuery-topology-resource" @click="emit('inspect', row.object)">{{ resourceLabel(row.object) }}</button></template>
         </section>
       </div>
-      <div v-else><div v-if="graphError" class="kuery-inline-error" role="alert">{{ graphError }} <button type="button" class="k-btn k-btn--ghost" @click="mount">Retry graph</button></div><div v-if="expansionFailure" class="kuery-inline-error" role="alert"><span>{{ expansionFailure.message }}</span><button type="button" class="k-btn k-btn--ghost" @click="retryExpansion">Retry expansion</button></div><div ref="graphHost" class="kuery-graph" role="region" aria-label="Fleet topology graph" aria-describedby="topology-help topology-bounds" tabindex="0" @keydown="graphKeydown" /></div>
+      <div v-else>
+        <div v-if="graphError" class="kuery-inline-error" role="alert">{{ graphError }} <button type="button" class="k-btn k-btn--ghost" @click="mount">Retry graph</button></div>
+        <div v-if="expansionFailure" class="kuery-inline-error" role="alert"><span>{{ expansionFailure.message }}</span><button type="button" class="k-btn k-btn--ghost" @click="retryExpansion">Retry expansion</button></div>
+        <p class="kuery-sr-only" role="status" aria-live="polite" aria-atomic="true">{{ expansionStatus }}</p>
+        <div ref="graphHost" class="kuery-graph" role="region" aria-label="Fleet topology visualization" aria-describedby="topology-help topology-bounds" tabindex="0" @keydown="graphKeydown" />
+      </div>
     </div>
     <p v-if="incomplete" class="kuery-warning" role="status">Kuery reported response-level truncation for this query. That status does not identify relation-level bounds; the view limits above still apply.<span v-if="responseWarnings.length"> {{ responseWarnings.join(' ') }}</span></p>
     <p v-else-if="responseWarnings.length" class="kuery-warning" role="status">Kuery reported: {{ responseWarnings.join(' ') }} Relation-level bounds are listed above separately.</p>

--- a/providers/kuery/portal/src/dashboard-tile.ts
+++ b/providers/kuery/portal/src/dashboard-tile.ts
@@ -31,6 +31,7 @@ export class KueryDashboardTile extends HTMLElement {
   private _error: string | null = null
   private _contextGeneration = 0
   private _connected = false
+  private _lastHTML = ''
 
   set farosContext(v: TileContext | null) {
     const changed = createKueryRequestContext(v).identity !== createKueryRequestContext(this._ctx).identity
@@ -50,6 +51,7 @@ export class KueryDashboardTile extends HTMLElement {
 
   connectedCallback(): void {
     this._connected = true
+    this._render()
     if (!this._poller) {
       this._poller = createTilePoller(() => this._load())
       this._poller.start()
@@ -104,11 +106,11 @@ export class KueryDashboardTile extends HTMLElement {
 
   private _render(): void {
     if (this._loading) {
-      this.innerHTML = '<div class="kuery-tile-msg">Loading edges…</div>'
+      this._commit('<div class="kuery-tile-msg" role="status" aria-live="polite" aria-atomic="true">Loading edges…</div>')
       return
     }
     if (this._error) {
-      this.innerHTML = `<div class="kuery-tile-err">Failed to load: ${escapeHTML(this._error)}</div>`
+      this._commit(`<div class="kuery-tile-err" role="alert">Failed to load: ${escapeHTML(this._error)}</div>`)
       return
     }
 
@@ -134,13 +136,22 @@ export class KueryDashboardTile extends HTMLElement {
          </div>`
       : `<p class="kuery-tile-empty">No edges to query yet — enroll one in Edges first.</p>`
 
-    this.innerHTML = `<div class="kuery-tile"><div class="kuery-tile-stats">${stats}</div>${body}</div>`
+    const liveText = `${this._edges.length} ${this._edges.length === 1 ? 'edge is' : 'edges are'} queryable.`
+    const html = `<span class="kuery-tile-live" role="status" aria-live="polite" aria-atomic="true">${liveText}</span><div class="kuery-tile"><div class="kuery-tile-stats">${stats}</div>${body}</div>`
+    if (!this._commit(html)) return
 
     for (const el of Array.from(this.querySelectorAll<HTMLButtonElement>('button[data-edge]'))) {
       // The playground is the only destination this provider has; opening it
       // for the clicked edge is the useful action.
       el.addEventListener('click', () => this._navigate(''))
     }
+  }
+
+  private _commit(html: string): boolean {
+    if (html === this._lastHTML) return false
+    this._lastHTML = html
+    this.innerHTML = html
+    return true
   }
 }
 

--- a/providers/kuery/portal/src/graph.ts
+++ b/providers/kuery/portal/src/graph.ts
@@ -46,45 +46,47 @@ export interface RelationMetadata {
   label: string
   legendLabel: string
   color: string
+  lightColor: string
+  lineStyle: 'solid' | 'dashed' | 'dotted'
   direction: RelDir
   description: string
 }
 
 export const RELATION_METADATA: readonly RelationMetadata[] = [
   {
-    name: 'owners', label: 'owners', legendLabel: 'Owners', color: '#e0b34f', direction: 'up',
+    name: 'owners', label: 'owners', legendLabel: 'Owners', color: '#e0b34f', lightColor: '#715100', lineStyle: 'solid', direction: 'up',
     description: 'Upstream - deleting the related object impacts this object.',
   },
   {
-    name: 'descendants+', label: 'descendants', legendLabel: 'Descendants', color: '#4f9be0', direction: 'down',
+    name: 'descendants+', label: 'descendants', legendLabel: 'Descendants', color: '#4f9be0', lightColor: '#075b9e', lineStyle: 'dashed', direction: 'down',
     description: 'Downstream - deleting this object impacts the related object.',
   },
   {
-    name: 'references', label: 'references', legendLabel: 'References', color: '#9b6de0', direction: 'up',
+    name: 'references', label: 'references', legendLabel: 'References', color: '#9b6de0', lightColor: '#5f3bb8', lineStyle: 'dotted', direction: 'up',
     description: 'Upstream - deleting the related object impacts this object.',
   },
   {
-    name: 'selects', label: 'selects', legendLabel: 'Selects', color: '#4fe0a8', direction: 'up',
+    name: 'selects', label: 'selects', legendLabel: 'Selects', color: '#4fe0a8', lightColor: '#006b4d', lineStyle: 'dashed', direction: 'up',
     description: 'Upstream - deleting the related object impacts this object.',
   },
   {
-    name: 'selected-by', label: 'selected-by', legendLabel: 'Selected by', color: '#e07a4f', direction: 'down',
+    name: 'selected-by', label: 'selected-by', legendLabel: 'Selected by', color: '#e07a4f', lightColor: '#923b13', lineStyle: 'dotted', direction: 'down',
     description: 'Downstream - deleting this object impacts the related object.',
   },
   {
-    name: 'linked+', label: 'linked', legendLabel: 'Linked', color: '#e0519b', direction: 'lateral',
+    name: 'linked+', label: 'linked', legendLabel: 'Linked', color: '#e0519b', lightColor: '#96205d', lineStyle: 'dashed', direction: 'lateral',
     description: 'Lateral - no deletion direction is implied.',
   },
   {
-    name: 'grouped', label: 'grouped', legendLabel: 'Grouped', color: '#8a93a8', direction: 'lateral',
+    name: 'grouped', label: 'grouped', legendLabel: 'Grouped', color: '#8a93a8', lightColor: '#4d5568', lineStyle: 'dotted', direction: 'lateral',
     description: 'Lateral - no deletion direction is implied.',
   },
   {
-    name: 'namespace', label: 'namespace', legendLabel: 'Namespace', color: '#5fae7a', direction: 'up',
+    name: 'namespace', label: 'namespace', legendLabel: 'Namespace', color: '#5fae7a', lightColor: '#24683f', lineStyle: 'solid', direction: 'up',
     description: 'Upstream - deleting the related object impacts this object.',
   },
   {
-    name: 'namespaced', label: 'contains', legendLabel: 'Contains', color: '#5fae7a', direction: 'down',
+    name: 'namespaced', label: 'contains', legendLabel: 'Contains', color: '#5fae7a', lightColor: '#24683f', lineStyle: 'dashed', direction: 'down',
     description: 'Downstream - deleting this object impacts the related object.',
   },
 ]
@@ -98,6 +100,14 @@ export const RELATION_COLORS: Record<string, string> = Object.fromEntries(
 export const RELATION_LABELS: Record<string, string> = Object.fromEntries(
   RELATION_METADATA.map(({ name, label }) => [name, label]),
 )
+
+export function relationColor(relation: RelationMetadata, light: boolean): string {
+  return light ? relation.lightColor : relation.color
+}
+
+function relationLabel(rel: string): string {
+  return RELATION_LABELS[rel] ?? rel
+}
 export const RELATION_DIR: Record<string, RelDir> = {
   ...Object.fromEntries(RELATION_METADATA.map(({ name, direction }) => [name, direction])),
   // The non-transitive spellings are accepted by the engine and remain useful
@@ -150,7 +160,7 @@ export function buildElements(anchor: ObjectResult): BuildResult {
       const edgeId = relationEdgeId(source, target, rel)
       if (relationEdges.has(edgeId)) return
       relationEdges.add(edgeId)
-      elements.push({ data: { id: edgeId, source, target, rel } })
+      elements.push({ data: { id: edgeId, source, target, rel, edgeLabel: relationLabel(rel) } })
     })
   }
   return { elements, nodeIndex }
@@ -363,6 +373,7 @@ export function themeStyle(host: Element): cytoscape.StylesheetStyle[] {
   const text = v('--color-text-primary', '#e9e9f2')
   const muted = v('--color-text-muted', '#5d5f78')
   const accent = v('--color-accent', '#8b6bff')
+  const light = typeof document !== 'undefined' && document.documentElement.classList.contains('light')
 
   const style: cytoscape.StylesheetStyle[] = [
     {
@@ -424,11 +435,26 @@ export function themeStyle(host: Element): cytoscape.StylesheetStyle[] {
         'arrow-scale': 0.8,
         'line-color': muted,
         'target-arrow-color': muted,
+        label: 'data(edgeLabel)',
+        color: text,
+        'font-size': 8,
+        'text-rotation': 'autorotate',
+        'text-background-color': surface,
+        'text-background-opacity': 0.92,
+        'text-background-padding': '2px',
       },
     },
   ]
-  for (const { name, color } of RELATION_METADATA) {
-    style.push({ selector: `edge[rel = "${name}"]`, style: { 'line-color': color, 'target-arrow-color': color } })
+  for (const relation of RELATION_METADATA) {
+    const color = relationColor(relation, light)
+    style.push({
+      selector: `edge[rel = "${relation.name}"]`,
+      style: {
+        'line-color': color,
+        'target-arrow-color': color,
+        'line-style': relation.lineStyle,
+      },
+    })
   }
   return style
 }
@@ -438,7 +464,7 @@ export interface GraphHandle {
   // add merges new nodes/edges into the live graph, skipping ids already
   // present (so an object reached from two parents becomes one node with two
   // edges — the real dependency net). Returns the elements actually added.
-  add(elements: cytoscape.ElementDefinition[]): cytoscape.ElementDefinition[]
+  add(elements: cytoscape.ElementDefinition[], nodeLimit?: number): cytoscape.ElementDefinition[]
   hasNode(id: string): boolean
   // markExpanded flags a node as already drilled so the UI can style it and
   // skip re-querying. collapseFrom removes the subtree reachable only through
@@ -506,7 +532,7 @@ export function relationElements(anchorId: string, anchor: ObjectResult): BuildR
       const edgeId = relationEdgeId(source, target, rel)
       if (relationEdges.has(edgeId)) return
       relationEdges.add(edgeId)
-      elements.push({ data: { id: edgeId, source, target, rel } })
+      elements.push({ data: { id: edgeId, source, target, rel, edgeLabel: relationLabel(rel), expandedFrom: anchorId } })
     })
   }
   return { elements, nodeIndex }
@@ -560,7 +586,6 @@ export async function mountGraph(
       minNodeSpacing: 34,
       padding: 16,
     }) as unknown as cytoscape.LayoutOptions,
-    wheelSensitivity: 0.2,
     // Allow zooming far out so a fully-expanded net still fits on screen.
     minZoom: 0.02,
     maxZoom: 3,
@@ -572,9 +597,19 @@ export async function mountGraph(
   // opt into the same graph shortcuts without making the shortcuts global.
   const focusGraph = () => container.focus()
   container.addEventListener('pointerdown', focusGraph)
+  let resizeFrame = 0
+  const resizeObserver = typeof ResizeObserver === 'undefined'
+    ? null
+    : new ResizeObserver(() => {
+        cancelAnimationFrame(resizeFrame)
+        resizeFrame = requestAnimationFrame(() => cy.resize())
+      })
+  resizeObserver?.observe(container)
 
   return {
     destroy: () => {
+      resizeObserver?.disconnect()
+      if (resizeObserver) cancelAnimationFrame(resizeFrame)
       container.removeEventListener('pointerdown', focusGraph)
       cy.destroy()
     },
@@ -584,10 +619,23 @@ export async function mountGraph(
       const n = cy.getElementById(id)
       if (n.nonempty()) n.data('expanded', expanded ? 'true' : 'false')
     },
-    add: (els) => {
+    add: (els, nodeLimit = Number.POSITIVE_INFINITY) => {
+      const acceptedNodes = new Set<string>()
+      let nodeCount = cy.nodes().length
       const fresh = els.filter((e) => {
         const id = e.data?.id as string | undefined
-        return !!id && cy.getElementById(id).empty()
+        if (!id || cy.getElementById(id).nonempty()) return false
+        const source = e.data?.source as string | undefined
+        const target = e.data?.target as string | undefined
+        if (source && target) {
+          const hasEndpoint = (nodeID: string) => cy.getElementById(nodeID).nonempty() || acceptedNodes.has(nodeID)
+          return hasEndpoint(source) && hasEndpoint(target)
+        }
+        if (acceptedNodes.has(id)) return false
+        if (nodeCount >= nodeLimit) return false
+        acceptedNodes.add(id)
+        nodeCount += 1
+        return true
       })
       if (fresh.length) cy.add(fresh)
       return fresh
@@ -595,21 +643,32 @@ export async function mountGraph(
     collapseFrom: (id) => {
       const root = cy.getElementById(id)
       if (root.empty()) return
-      // Cut this node's outgoing edges, then cascade-remove any node left with
-      // no incoming edge (its exclusive subtree). Shared nodes keep an edge
-      // from elsewhere and survive; cluster roots are never removed.
-      cy.remove(root.connectedEdges().filter((e: cytoscape.EdgeSingular) => e.source().id() === id))
-      let changed = true
-      while (changed) {
-        changed = false
-        cy.nodes().forEach((n: cytoscape.NodeSingular) => {
-          if (n.id() === id || n.data('tier') === 'cluster') return
-          if (n.incomers('edge').empty()) {
-            cy.remove(n)
-            changed = true
-          }
+      // Impact arrows encode deletion direction, not expansion ownership. Use
+      // expandedFrom to remove this node's exclusive drill-down branch while
+      // retaining nodes that are also connected by an initial or shared edge.
+      const removeExclusiveChildren = (parentID: string): void => {
+        const ownedEdges = cy.edges().filter((edge: cytoscape.EdgeSingular) => edge.data('expandedFrom') === parentID)
+        const childIDs = new Set<string>()
+        ownedEdges.forEach((edge: cytoscape.EdgeSingular) => {
+          const source = edge.source().id()
+          const target = edge.target().id()
+          childIDs.add(source === parentID ? target : source)
+        })
+        cy.remove(ownedEdges)
+        childIDs.forEach(childID => {
+          if (childID === parentID) return
+          const child = cy.getElementById(childID)
+          if (child.empty() || child.data('tier') === 'cluster') return
+          const shared = child.connectedEdges().some(edge => {
+            const owner = edge.data('expandedFrom') as string | undefined
+            return !owner || owner !== childID
+          })
+          if (shared) return
+          removeExclusiveChildren(childID)
+          cy.remove(child)
         })
       }
+      removeExclusiveChildren(id)
       root.data('expanded', 'false')
     },
     relayout: (layout) => {

--- a/providers/kuery/portal/src/playground.ts
+++ b/providers/kuery/portal/src/playground.ts
@@ -98,17 +98,6 @@ export interface EditorHandle {
 // createEditor builds a JSON CodeMirror instance with prefix autocomplete over
 // the schema vocabulary. Hint fires as you type a word and on Ctrl/Cmd-Space.
 export function createEditor(CM: CMFactory, host: HTMLElement, doc: string, words: string[]): EditorHandle {
-  const cm = CM(host, {
-    value: doc,
-    mode: { name: 'javascript', json: true },
-    lineNumbers: true,
-    autoCloseBrackets: true,
-    matchBrackets: true,
-    tabSize: 2,
-    lineWrapping: true,
-    extraKeys: { 'Ctrl-Space': 'autocomplete', 'Cmd-Space': 'autocomplete' },
-  })
-
   const hint = (editor: CMInstance) => {
     const cur = editor.getCursor()
     const line = editor.getLine(cur.line)
@@ -118,10 +107,23 @@ export function createEditor(CM: CMFactory, host: HTMLElement, doc: string, word
     const list = token ? words.filter((w) => w.toLowerCase().includes(token)) : words
     return { list, from: CM.Pos(cur.line, start), to: CM.Pos(cur.line, cur.ch) }
   }
+  const cm = CM(host, {
+    value: doc,
+    mode: { name: 'javascript', json: true },
+    lineNumbers: true,
+    autoCloseBrackets: true,
+    matchBrackets: true,
+    tabSize: 2,
+    lineWrapping: true,
+    screenReaderLabel: 'Kuery QuerySpec editor',
+    hintOptions: { hint, completeSingle: false, container: host },
+    extraKeys: { 'Ctrl-Space': 'autocomplete', 'Cmd-Space': 'autocomplete' },
+  })
+
   cm.on('inputRead', (...args: unknown[]) => {
     const change = args[1] as { text?: string[] }
     const first = change.text?.[0] ?? ''
-    if (/[A-Za-z]/.test(first)) cm.showHint({ hint, completeSingle: false })
+    if (/[A-Za-z]/.test(first)) cm.showHint({ hint, completeSingle: false, container: host })
   })
 
   return {

--- a/providers/kuery/portal/src/style.css
+++ b/providers/kuery/portal/src/style.css
@@ -35,18 +35,6 @@ faros-provider-kuery .kuery-topbar {
   flex-wrap: wrap;
 }
 
-faros-provider-kuery .kuery-grid {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 720px) {
-  faros-provider-kuery .kuery-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
 faros-provider-kuery .kuery-panel {
   padding: 14px 16px;
   color: var(--color-text-primary, inherit);
@@ -59,6 +47,11 @@ faros-provider-kuery .kuery-panel-head {
   gap: 8px;
   margin-bottom: 10px;
   flex-wrap: wrap;
+}
+
+faros-provider-kuery .kuery-panel-head > div,
+faros-provider-kuery .kuery-panel > .meta {
+  max-width: 75ch;
 }
 
 faros-provider-kuery .kuery-panel-title {
@@ -116,6 +109,20 @@ faros-provider-kuery .kuery-toolbar .kuery-control {
   width: auto;
 }
 
+faros-provider-kuery .kuery-inventory-filters {
+  max-width: 42rem;
+}
+
+faros-provider-kuery .kuery-inventory-filters > label {
+  flex: 1 1 200px;
+  min-width: 0;
+}
+
+faros-provider-kuery .kuery-inventory-filters .kuery-control {
+  width: 100%;
+  min-width: 0;
+}
+
 faros-provider-kuery .kuery-topology-controls > label,
 faros-provider-kuery .kuery-example {
   display: grid;
@@ -156,24 +163,9 @@ faros-provider-kuery .kuery-warning {
 
 /* ── inventory table ───────────────────────────────────────────────── */
 
-faros-provider-kuery table.objects {
-  width: 100%;
-}
-
-/* The shared table recipe intentionally clips its rounded shell. Inventory
-   rows are wider than a phone viewport, so this surface owns the horizontal
-   scroll instead of losing columns at the edge. */
 faros-provider-kuery .kuery-inventory-table {
-  overflow-x: auto;
-  overflow-y: hidden;
-}
-
-faros-provider-kuery .kuery-inventory-table table.objects {
-  min-width: 560px;
-}
-
-faros-provider-kuery tr.row {
-  cursor: pointer;
+  width: 100%;
+  max-width: 96rem;
 }
 
 faros-provider-kuery .name {
@@ -181,40 +173,11 @@ faros-provider-kuery .name {
   color: var(--color-text-primary, inherit);
 }
 
-faros-provider-kuery .error {
-  color: var(--color-danger);
-  font-size: 11px;
-}
-
 faros-provider-kuery .kuery-error {
   color: var(--color-danger, currentColor);
 }
 
-/* ── impact view ───────────────────────────────────────────────────── */
-
-faros-provider-kuery .rel-title {
-  font-size: 12px;
-  margin: 14px 0 4px;
-  color: var(--color-text-primary, inherit);
-}
-
-faros-provider-kuery .rel-list {
-  margin: 0;
-  padding-left: 18px;
-  font-size: 12px;
-}
-
-faros-provider-kuery .rel-list li {
-  padding: 2px 0;
-}
-
 /* ── impact graph ──────────────────────────────────────────────────── */
-
-faros-provider-kuery .head-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
 
 /* Segmented Graph / List toggle. */
 faros-provider-kuery .kuery-view-switch {
@@ -254,7 +217,7 @@ faros-provider-kuery .kuery-view-btn:hover {
 /* Cytoscape needs an explicitly sized box; it draws to a canvas inside. */
 faros-provider-kuery .kuery-graph {
   width: 100%;
-  height: 440px;
+  height: clamp(440px, calc(100vh - 380px), 1440px);
   border: 1px solid var(--color-border-subtle);
   border-radius: 6px;
   background: var(--color-surface, var(--color-surface-raised, transparent));
@@ -332,6 +295,7 @@ faros-provider-kuery .kuery-sr-only {
   faros-provider-kuery .kuery-example { width: 100%; }
   faros-provider-kuery .kuery-toolbar > button { width: 100%; justify-content: center; }
   faros-provider-kuery .kuery-graph { height: 60vh; min-height: 360px; }
+  faros-provider-kuery .kuery-inventory-filters > label { flex-basis: 100%; width: 100%; }
 }
 
 faros-provider-kuery .kuery-graph:focus-visible {
@@ -346,51 +310,6 @@ faros-provider-kuery .kuery-topology-list {
   border-radius: 6px;
   background: var(--color-surface-raised);
   padding: 12px;
-}
-
-faros-provider-kuery .kuery-topology-tree,
-faros-provider-kuery .kuery-topology-namespaces,
-faros-provider-kuery .kuery-topology-resources {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-faros-provider-kuery .kuery-topology-edge + .kuery-topology-edge {
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid var(--color-border-subtle);
-}
-
-faros-provider-kuery .kuery-topology-namespace {
-  margin: 8px 0 0 14px;
-  padding-left: 12px;
-  border-left: 1px solid var(--color-border-subtle);
-}
-
-faros-provider-kuery .kuery-topology-group-label {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: 28px;
-  color: var(--color-text-primary, inherit);
-  font-size: 12px;
-}
-
-faros-provider-kuery .kuery-topology-edge-label {
-  min-height: 32px;
-  padding: 0 4px;
-  font-weight: 600;
-}
-
-faros-provider-kuery .kuery-topology-edge-name,
-faros-provider-kuery .kuery-topology-namespace-name {
-  color: var(--color-text-secondary, inherit);
-}
-
-faros-provider-kuery .kuery-topology-resource-item {
-  margin-top: 4px;
 }
 
 faros-provider-kuery .kuery-topology-resource {
@@ -417,25 +336,6 @@ faros-provider-kuery .kuery-topology-resource:hover {
 faros-provider-kuery .kuery-topology-resource:focus-visible {
   outline: 2px solid var(--color-accent, #8b6bff);
   outline-offset: 1px;
-}
-
-faros-provider-kuery .kuery-topology-resource-kind {
-  flex: none;
-  min-width: 84px;
-  color: var(--color-text-muted, inherit);
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-faros-provider-kuery .kuery-topology-resource-name {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 12px;
 }
 
 /* Fullscreen: the panel fills the viewport and the graph grows to match. */
@@ -478,6 +378,18 @@ faros-provider-kuery .pg-split > section {
   min-width: 0;
 }
 
+@media (min-width: 821px) {
+  faros-provider-kuery .pg-split {
+    height: clamp(360px, calc(100vh - 380px), 1440px);
+  }
+
+  faros-provider-kuery .pg-editor,
+  faros-provider-kuery .pg-fallback,
+  faros-provider-kuery .pg-result {
+    min-height: 0;
+  }
+}
+
 @media (max-width: 820px) {
   faros-provider-kuery .pg-split {
     grid-template-columns: 1fr;
@@ -496,6 +408,65 @@ faros-provider-kuery .pg-editor .CodeMirror {
   height: 100%;
   min-height: 360px;
   font-size: 12px;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  caret-color: var(--color-accent);
+}
+
+faros-provider-kuery .pg-editor .CodeMirror-gutters {
+  border-right: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-overlay);
+}
+
+faros-provider-kuery .pg-editor .CodeMirror-linenumber,
+faros-provider-kuery .pg-editor .cm-comment {
+  color: var(--color-text-muted);
+}
+
+faros-provider-kuery .pg-editor .CodeMirror-cursor {
+  border-left-color: var(--color-accent);
+}
+
+faros-provider-kuery .pg-editor .CodeMirror-selected,
+faros-provider-kuery .pg-editor .CodeMirror-focused .CodeMirror-selected {
+  background: var(--color-accent-subtle);
+}
+
+faros-provider-kuery .pg-editor .cm-property,
+faros-provider-kuery .pg-editor .cm-def {
+  color: var(--color-accent);
+}
+
+faros-provider-kuery .pg-editor .cm-string {
+  color: var(--color-success);
+}
+
+faros-provider-kuery .pg-editor .cm-number,
+faros-provider-kuery .pg-editor .cm-atom {
+  color: var(--color-warning);
+}
+
+faros-provider-kuery .pg-editor .cm-error {
+  color: var(--color-danger);
+}
+
+faros-provider-kuery .pg-editor .CodeMirror-matchingbracket {
+  color: var(--color-text-primary);
+  background: var(--color-accent-subtle);
+  outline: 1px solid var(--color-accent);
+}
+
+faros-provider-kuery .pg-editor .CodeMirror-hints {
+  border: 1px solid var(--color-border-default);
+  border-radius: 4px;
+  background: var(--color-surface-overlay);
+  box-shadow: 0 12px 32px color-mix(in srgb, var(--color-surface) 70%, transparent);
+  color: var(--color-text-primary);
+}
+
+faros-provider-kuery .pg-editor .CodeMirror-hint-active {
+  background: var(--color-accent-subtle);
+  color: var(--color-accent);
 }
 
 faros-provider-kuery .pg-fallback {
@@ -539,21 +510,6 @@ faros-provider-kuery .pg-docs summary {
   color: var(--color-text-muted, #5d5f78);
 }
 
-faros-provider-kuery .rel-group {
-  margin: 0 0 14px;
-}
-
-faros-provider-kuery .rel-group-title {
-  margin: 12px 0 4px;
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--color-text-muted, #5d5f78);
-  border-bottom: 1px solid var(--color-border-subtle);
-  padding-bottom: 3px;
-}
-
 faros-provider-kuery .legend {
   display: flex;
   flex-wrap: wrap;
@@ -582,9 +538,9 @@ faros-provider-kuery .legend-item dd {
 }
 
 faros-provider-kuery .legend-swatch {
-  width: 10px;
-  height: 10px;
-  border-radius: 3px;
+  width: 18px;
+  height: 0;
+  border-top-width: 2px;
   flex: none;
 }
 
@@ -592,6 +548,10 @@ faros-provider-kuery .legend-swatch {
    Mirrors portalkit/dashboardtile.ts `tileClass`; this portal has no Tailwind
    build, so the shared vocabulary is restated. Keep the two in step. */
 faros-dashboard-tile-kuery { display: block; font-size: 13px; }
+faros-dashboard-tile-kuery .kuery-tile-live {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}
 faros-dashboard-tile-kuery .kuery-tile { display: flex; flex-direction: column; gap: 12px; }
 faros-dashboard-tile-kuery .kuery-tile-stats {
   display: flex; flex-wrap: wrap; align-items: center; gap: 4px 12px; font-size: 11px;

--- a/providers/kuery/portal/topology.contract.test.mjs
+++ b/providers/kuery/portal/topology.contract.test.mjs
@@ -135,12 +135,48 @@ test('mountGraph focuses the labeled container on pointer use and removes the li
   }
 })
 
+test('graph additions enforce a hard node limit while retaining parallel relation edges', async () => {
+  const previousWindow = globalThis.window
+  const stored = new Map([['root', { data: { id: 'root' } }]])
+  const cy = {
+    on: () => {},
+    destroy: () => {},
+    nodes: () => ({ length: [...stored.values()].filter(element => !element.data.source).length }),
+    getElementById: id => ({ nonempty: () => stored.has(id), empty: () => !stored.has(id) }),
+    add: elements => {
+      for (const element of elements) {
+        assert.ok(!stored.has(element.data.id), `duplicate ${element.data.id} must be removed before Cytoscape add`)
+        stored.set(element.data.id, element)
+      }
+    },
+  }
+
+  try {
+    globalThis.window = { cytoscape: () => cy }
+    const handle = await graphModule.mountGraph({ addEventListener: () => {}, removeEventListener: () => {} }, [], [], () => {}, '/cytoscape.min.js')
+    const added = handle.add([
+      { data: { id: 'child', label: 'child' } },
+      { data: { id: 'root>child:owners', source: 'root', target: 'child', rel: 'owners' } },
+      { data: { id: 'child', label: 'duplicate child' } },
+      { data: { id: 'root>child:references', source: 'root', target: 'child', rel: 'references' } },
+      { data: { id: 'over-limit', label: 'over limit' } },
+      { data: { id: 'root>over-limit', source: 'root', target: 'over-limit', rel: 'owners' } },
+    ], 2)
+
+    assert.deepEqual(added.map(element => element.data.id), ['child', 'root>child:owners', 'root>child:references'])
+    assert.equal(stored.has('over-limit'), false)
+    handle.destroy()
+  } finally {
+    globalThis.window = previousWindow
+  }
+})
+
 test('topology switch and resource activation are native, labeled controls', () => {
   const source = readFileSync(new URL('./src/components/TopologyView.vue', import.meta.url), 'utf8')
   assert.match(source, /role="group" aria-label="Topology representation"/u)
   assert.match(source, /:aria-pressed="representation === value"/u)
   assert.match(source, /@click="emit\('inspect', row\.object\)"/u)
-  assert.match(source, /role="region" aria-label="Fleet topology graph"[^>]*tabindex="0"/u)
+  assert.match(source, /role="region" aria-label="Fleet topology visualization"[^>]*tabindex="0"/u)
   assert.match(source, /FormSelect v-model="layout"/u)
   assert.match(source, /Reset graph/u)
 })
@@ -172,12 +208,24 @@ test('graph keyboard routing is focus-scoped and fullscreen uses the shared laye
 
 test('relation metadata is the shared source for labels, direction, and graph colors', () => {
   const metadata = graphModule.RELATION_METADATA
+  const luminance = (color) => {
+    const channels = [1, 3, 5].map(index => Number.parseInt(color.slice(index, index + 2), 16) / 255)
+      .map(value => value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4)
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+  }
+  const contrast = (foreground, background) => {
+    const [lighter, darker] = [luminance(foreground), luminance(background)].sort((a, b) => b - a)
+    return (lighter + 0.05) / (darker + 0.05)
+  }
   assert.ok(metadata.length > 0)
   assert.deepEqual(graphModule.IMPACT_RELATIONS, metadata.map(({ name }) => name))
   for (const relation of metadata) {
     assert.equal(graphModule.RELATION_COLORS[relation.name], relation.color)
     assert.equal(graphModule.RELATION_LABELS[relation.name], relation.label)
     assert.equal(graphModule.RELATION_DIR[relation.name], relation.direction)
+    assert.match(relation.lightColor, /^#[0-9a-f]{6}$/iu)
+    assert.ok(contrast(relation.lightColor, '#f1f1f6') >= 3, `${relation.name} needs 3:1 contrast on the light graph surface`)
+    assert.ok(['solid', 'dashed', 'dotted'].includes(relation.lineStyle))
     assert.ok(relation.description.length > 0)
   }
 })
@@ -201,6 +249,7 @@ test('impact graph keeps distinct declared relations between the same objects', 
 
   assert.equal(relationEdges.length, 2)
   assert.deepEqual(relationEdges.map(element => element.data.rel), ['owners', 'references'])
+  assert.ok(relationEdges.every(element => element.data.edgeLabel))
   assert.equal(new Set(relationEdges.map(element => element.data.id)).size, relationEdges.length, 'each legend relation needs its own graph edge')
 })
 
@@ -236,6 +285,27 @@ test('impact view exposes a semantic relation legend from shared metadata', () =
   assert.match(source, /<aside[^>]+aria-labelledby="impact-legend-title"/u)
   assert.match(source, /<dl class="legend">/u)
   assert.match(source, /v-for="relation in legendRelations"/u)
-  assert.match(source, /class="legend-swatch"[^>]+backgroundColor: relation\.color/u)
+  assert.match(source, /class="legend-swatch"[^>]+borderTopColor: relation\.displayColor[^>]+borderTopStyle: relation\.lineStyle/u)
   assert.doesNotMatch(source, /kuery-impact-legend kuery-panel k-card/u)
+})
+
+test('graph rendering provides theme contrast, relation labels, resize handling, and bounded expansion control', () => {
+  const graphSource = readFileSync(new URL('./src/graph.ts', import.meta.url), 'utf8')
+  const topologySource = readFileSync(new URL('./src/components/TopologyView.vue', import.meta.url), 'utf8')
+
+  assert.match(graphSource, /label: 'data\(edgeLabel\)'/u)
+  assert.match(graphSource, /'line-style': relation\.lineStyle/u)
+  assert.match(graphSource, /new ResizeObserver/u)
+  assert.match(graphSource, /resizeObserver\?\.disconnect\(\)/u)
+  assert.doesNotMatch(graphSource, /wheelSensitivity/u)
+  assert.match(topologySource, /Cancel expansion/u)
+  assert.match(topologySource, /handle\.add\(built\.elements, 4000\)/u)
+  assert.match(topologySource, /handle\.hasNode\(id\)[\s\S]*handle\.isExpanded\(id\)/u)
+  assert.match(topologySource, /if \(handle\.nodeCount\(\) >= 4000\) break/u)
+  assert.match(topologySource, /if \(handle\.hasNode\(key\)\) graphObjects\.set\(key, row\)/u)
+  assert.match(graphSource, /expandedFrom: anchorId/u)
+  assert.match(graphSource, /edge\.data\('expandedFrom'\) === parentID/u)
+  assert.match(topologySource, /await new Promise<void>\(resolve => requestAnimationFrame/u)
+  assert.match(topologySource, /\(rounds \+ 1\) % 3 === 0/u)
+  assert.match(topologySource, /aria-live="polite" aria-atomic="true"/u)
 })


### PR DESCRIPTION
## Summary

- Make Kuery topology and Playground views use the available vertical workspace on large and 4K displays while keeping narrow layouts bounded.
- Improve topology expansion with cancellation, bounded node growth, fewer relayouts, safer async response handling, and relation-aware collapse behavior.
- Clarify impact relationships with theme-aware contrast, line styles, labels, and a matching legend.
- Improve inventory filtering and table composition across wide and narrow viewports.
- Theme the QuerySpec editor and autocomplete to match Faros, and improve screen-reader labels and live-status behavior across Kuery and its dashboard tile.
- Keep the topology focused by removing the auxiliary graph-object navigation panel.
- Align Infrastructure provider routed content 16px below its tab rail.

## Verification

- Kuery portal contract tests, TypeScript typecheck, and production build
- Kuery browser checks at 3840x2160 in dark mode and 390x844 in light mode
- Kuery provider `go build ./...` and `go test -count=1 ./...`
- Infrastructure portal tests, TypeScript typecheck, and production build
- `make verify-portalkit`
- `git diff --check`

## Boundaries

- Browser coverage uses mocked Kuery APIs; live provider/backend behavior was not replayed.
- Individual topology-node expansion remains a canvas interaction after removing the auxiliary navigation panel; the List representation remains available for resource inspection.
- The new Playwright suite is local and opt-in; it is not wired into CI in this change.
- The Infrastructure change is limited to spacing below the provider tab rail.
