### PR TITLE
chore(security): generate a random hub token in the install scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,8 @@ hack/tools/
 certs/
 dex.db
 .kcp/
-.faros-install/
+# hack/install state (kubeconfigs, pidfiles, hub-token); e2e uses .faros-install-e2e
+.faros-install*/
 .env
 .kind-kubeconfig
 .edge-kubeconfig

--- a/docs/install-embedded-kcp.md
+++ b/docs/install-embedded-kcp.md
@@ -77,10 +77,15 @@ helm upgrade --install faros-hub deploy/charts/faros-hub \
   --set hub.hubExternalURL=https://localhost:9443 \
   --set hub.devMode=true \
   --set hub.embeddedGraphQL=true \
-  --set 'hub.staticAuthTokens={dev-token}' \
+  --set "hub.staticAuthTokens={$(cat .faros-install/hub-token)}" \
   --set 'hub.tls.selfSigned.dnsNames={faros.kcp.localhost}' \
   --wait
 ```
+
+The static token is not a fixed value: the first `hack/install` script you
+run generates a random one, saves it to `.faros-install/hub-token` and prints
+it; every later script reuses it. Export `FAROS_STATIC_TOKEN` before step 1 to
+bring your own.
 
 No `kcp.*` overrides: embedded kcp is the chart default. The pod runs two
 containers (kcp + hub); the hub waits for kcp's `admin.kubeconfig` before
@@ -101,7 +106,7 @@ curl -k --resolve faros.kcp.localhost:8443:127.0.0.1 \
   https://faros.kcp.localhost:8443/healthz              # hub via the gateway
 
 faros login --hub-url https://localhost:9443 \
-  --token dev-token --insecure-skip-tls-verify
+  --token "$(cat .faros-install/hub-token)" --insecure-skip-tls-verify
 kubectl get organizations
 ```
 

--- a/docs/install-external-kcp.md
+++ b/docs/install-external-kcp.md
@@ -38,7 +38,7 @@ All knobs are environment variables with defaults (see `hack/install/lib.sh`):
 | `KCP_DOMAIN` | `kcp.localhost` | kcp base domain (front-proxy hostname) |
 | `KCP_SHARD_2` | `theseus` | name of the second shard |
 | `KCP_GATEWAY_IP` | `10.96.2.2` | fixed ClusterIP the gateway claims |
-| `FAROS_STATIC_TOKEN` | `dev-token` | shared static bearer token |
+| `FAROS_STATIC_TOKEN` | random, saved to `.faros-install/hub-token` | shared static bearer token (generated and printed by the first script you run; set it to bring your own) |
 | `HUB_DOMAIN` | `faros.kcp.localhost` | hub hostname on the gateway |
 | `HUB_EXTERNAL_URL` | `https://localhost:9443` | URL baked into kubeconfigs |
 | `HUB_REPLICAS` | `2` | hub Deployment replicas |
@@ -237,8 +237,9 @@ This is the heart of the install. The script applies (all in namespace
 `default`; full YAML in the script):
 
 1. **`Secret kcp-static-tokens`** — a `--token-auth-file` CSV mapping
-   `dev-token` to the identity the faros hub derives from the same token
-   (`faros:static:<first 16 hex of sha256("static-token/dev-token")>`). Both
+   the static token (`$FAROS_STATIC_TOKEN`, from `.faros-install/hub-token`)
+   to the identity the faros hub derives from the same token
+   (`faros:static:<first 16 hex of sha256("static-token/<token>")>`). Both
    the shards *and* the front-proxy get this file via `spec.auth.tokenAuthFile`
    — the front-proxy authenticates first, so wiring only the shards would 401.
 2. **`RootShard root`** — etcd prefix `/shard/root`, shard base URL
@@ -307,7 +308,7 @@ helm upgrade --install faros-hub deploy/charts/faros-hub \
   --set hub.hubExternalURL=https://localhost:9443 \
   --set hub.devMode=true \
   --set hub.embeddedGraphQL=true \
-  --set 'hub.staticAuthTokens={dev-token}' \
+  --set "hub.staticAuthTokens={$(cat .faros-install/hub-token)}" \
   --set 'hub.tls.selfSigned.dnsNames={faros.kcp.localhost}' \
   --set hostAliases[0].ip=10.96.2.2 \
   --set hostAliases[0].hostnames[0]=kcp.localhost \
@@ -335,9 +336,13 @@ curl -k --resolve faros.kcp.localhost:8443:127.0.0.1 \
   https://faros.kcp.localhost:8443/healthz              # hub via the gateway
 
 faros login --hub-url https://localhost:9443 \
-  --token dev-token --insecure-skip-tls-verify
+  --token "$(cat .faros-install/hub-token)" --insecure-skip-tls-verify
 kubectl get organizations
 ```
+
+The token is the random one the first install script generated and printed
+(`.faros-install/hub-token`); if you exported `FAROS_STATIC_TOKEN` yourself,
+use that value instead.
 
 ---
 

--- a/hack/install/README.md
+++ b/hack/install/README.md
@@ -18,8 +18,13 @@ versa.**
 API token required) and is intentionally not covered by e2e.
 
 Every knob is an environment variable with a sane default — see `lib.sh` for
-the full contract. State (extracted kubeconfigs, port-forward pidfiles) lands
-in `.faros-install/` at the repo root (git-ignored).
+the full contract. State (extracted kubeconfigs, port-forward pidfiles, the
+generated hub token) lands in `.faros-install/` at the repo root (git-ignored).
+
+The hub's static auth token has no fixed default: the first script you run
+generates a random one, saves it to `.faros-install/hub-token` and prints it;
+later scripts and re-runs reuse it. Set `FAROS_STATIC_TOKEN` to bring your own
+(the e2e suites do).
 
 Quick start (external kcp):
 

--- a/hack/install/lib.sh
+++ b/hack/install/lib.sh
@@ -48,14 +48,6 @@ export CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.19.2}"
 export ENVOY_GATEWAY_VERSION="${ENVOY_GATEWAY_VERSION:-v1.7.0}"
 export ETCD_IMAGE="${ETCD_IMAGE:-gcr.io/etcd-development/etcd:v3.6.4}"
 
-# --- auth --------------------------------------------------------------------
-# Static bearer token shared by the hub and kcp. The hub derives a
-# deterministic kcp identity from it (see pkg/hub/kcp/embedded.go):
-#   user = faros:static:<first 16 hex chars of sha256("static-token/"+token)>
-# The kcp token-auth CSV below MUST use the same mapping or requests
-# authenticate at kcp as the wrong user and get 403.
-export FAROS_STATIC_TOKEN="${FAROS_STATIC_TOKEN:-dev-token}"
-
 # --- faros hub ---------------------------------------------------------------
 export HUB_NAMESPACE="${HUB_NAMESPACE:-faros-system}"
 # Hostname the hub is reachable at THROUGH the Envoy gateway (TLS passthrough).
@@ -72,6 +64,49 @@ export HUB_IMAGE_TAG="${HUB_IMAGE_TAG:-}"
 export HUB_IMAGE_PULL_POLICY="${HUB_IMAGE_PULL_POLICY:-}"
 # When "true", `kind load` the hub image into the cluster before installing.
 export HUB_KIND_LOAD="${HUB_KIND_LOAD:-false}"
+
+# --- auth --------------------------------------------------------------------
+# Static bearer token shared by the hub and kcp. The hub derives a
+# deterministic kcp identity from it (see pkg/hub/kcp/embedded.go):
+#   user = faros:static:<first 16 hex chars of sha256("static-token/"+token)>
+# The kcp token-auth CSV below MUST use the same mapping or requests
+# authenticate at kcp as the wrong user and get 403.
+#
+# There is deliberately no fixed default: an install that shipped with a
+# well-known token ("dev-token") was reachable by anyone who read the docs.
+# Precedence:
+#   1. FAROS_STATIC_TOKEN set in the environment — used as-is (the e2e suites
+#      and CI pin it this way). Nothing is written to disk.
+#   2. ${FAROS_INSTALL_STATE_DIR}/hub-token exists — reused, so every script
+#      of one install (and re-runs of it) agree on the token.
+#   3. Otherwise a random token is generated, written to that file (mode 0600)
+#      and printed once. teardown.sh removes the state dir, so a fresh install
+#      gets a fresh token.
+FAROS_STATIC_TOKEN_FILE="${FAROS_INSTALL_STATE_DIR}/hub-token"
+
+random_token() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 24
+  else
+    head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n'
+  fi
+}
+
+if [[ -z "${FAROS_STATIC_TOKEN:-}" ]]; then
+  if [[ -s "${FAROS_STATIC_TOKEN_FILE}" ]]; then
+    FAROS_STATIC_TOKEN="$(<"${FAROS_STATIC_TOKEN_FILE}")"
+  else
+    FAROS_STATIC_TOKEN="$(random_token)"
+    (umask 077 && printf '%s\n' "${FAROS_STATIC_TOKEN}" > "${FAROS_STATIC_TOKEN_FILE}")
+    echo "Generated a new static auth token for this install:" >&2
+    echo "  ${FAROS_STATIC_TOKEN}" >&2
+    echo "Saved to ${FAROS_STATIC_TOKEN_FILE} (mode 0600);" >&2
+    echo "every hack/install script reuses it from there. To log in later:" >&2
+    echo "  faros login --hub-url ${HUB_EXTERNAL_URL} --token \"\$(cat ${FAROS_STATIC_TOKEN_FILE})\" --insecure-skip-tls-verify" >&2
+    echo "Set FAROS_STATIC_TOKEN in the environment to use your own token instead." >&2
+  fi
+fi
+export FAROS_STATIC_TOKEN
 
 # --- helpers -----------------------------------------------------------------
 kc() { kubectl --context "${KUBE_CONTEXT}" "$@"; }

--- a/test/e2e/suites/installembedded/install_embedded_test.go
+++ b/test/e2e/suites/installembedded/install_embedded_test.go
@@ -33,7 +33,9 @@ func TestHubHealth(t *testing.T) {
 	testenv.Test(t, cases.HubHealth())
 }
 
-// TestStaticTokenLogin mirrors the doc's `faros login --token dev-token`.
+// TestStaticTokenLogin mirrors the doc's `faros login --token <static token>`.
+// The install scripts generate a random token by default; this suite pins
+// FAROS_STATIC_TOKEN to framework.DevToken (see installScriptEnv).
 func TestStaticTokenLogin(t *testing.T) {
 	testenv.Test(t, cases.StaticTokenLogin())
 }

--- a/test/e2e/suites/installexternal/install_external_test.go
+++ b/test/e2e/suites/installexternal/install_external_test.go
@@ -35,7 +35,9 @@ func TestHubHealth(t *testing.T) {
 	testenv.Test(t, cases.HubHealth())
 }
 
-// TestStaticTokenLogin mirrors the doc's `faros login --token dev-token`.
+// TestStaticTokenLogin mirrors the doc's `faros login --token <static token>`.
+// The install scripts generate a random token by default; this suite pins
+// FAROS_STATIC_TOKEN to framework.DevToken (see installScriptEnv).
 func TestStaticTokenLogin(t *testing.T) {
 	testenv.Test(t, cases.StaticTokenLogin())
 }


### PR DESCRIPTION
Implements item 0.2 of `docs/security-remediation-plan.md`.

## Problem

`hack/install/lib.sh` defaulted `FAROS_STATIC_TOKEN` to the literal `dev-token`. That value becomes the hub's `hub.staticAuthTokens` and the kcp `--token-auth-file` entry, so any install that followed `docs/install-external-kcp.md` / `docs/install-embedded-kcp.md` verbatim accepted a bearer token that is printed in the public docs. The static-token user is an admin-grade identity.

## Change

`hack/install/lib.sh` resolves the token in this order (documented in the file):

1. `FAROS_STATIC_TOKEN` set in the environment: used as-is, nothing written to disk. Explicit override keeps working under the existing variable name.
2. `${FAROS_INSTALL_STATE_DIR}/hub-token` exists: reused, so every script of one install (and re-runs) agree on the token.
3. Otherwise `openssl rand -hex 24` (fallback: `head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n'` if openssl is absent) is written to that file with mode `0600` and printed once, together with the matching `faros login` command.

The auth block moved below the `# --- faros hub ---` block so the message can quote `HUB_EXTERNAL_URL`; no other script changed (`06`, `07`, `08` already consume `${FAROS_STATIC_TOKEN}`). `teardown.sh` already deletes the state dir, so a fresh install gets a fresh token.

Also:
- `.gitignore`: `.faros-install/` widened to `.faros-install*/` so a token file under the e2e state dir (`.faros-install-e2e`) can never be committed either.
- `docs/install-external-kcp.md`, `docs/install-embedded-kcp.md`, `hack/install/README.md`: no longer show `dev-token`; the helm and `faros login` snippets read `.faros-install/hub-token` and a short paragraph explains where the token comes from.
- `test/e2e/suites/installexternal`, `installembedded`: comment-only update on `TestStaticTokenLogin` (it said the doc uses `dev-token`).

Not changed, per the plan: the `Tiltfile`/`Tiltfile.cluster`, `Makefile` dev targets (`STATIC_AUTH_TOKEN ?= dev-token`), `hack/scripts/dev-tenant-setup.sh`, `test/e2e/framework` and the other e2e suites all set the token explicitly and keep the literal.

## Compatibility

- **e2e install suites**: `test/e2e/framework/install.go` already passes `FAROS_STATIC_TOKEN=DevToken` in the script environment, so `make e2e-install-external` / `make e2e-install-embedded` behave exactly as before (path 1 above). They do not parse the scripts' output.
- **Existing manual installs**: the next script run on a machine without `.faros-install/hub-token` and without `FAROS_STATIC_TOKEN` exported generates a new token that will not match the `dev-token` already configured in a running hub/kcp. Either export `FAROS_STATIC_TOKEN=dev-token` (or write it to `.faros-install/hub-token`) before re-running, or re-run `06`/`07`/`08` so the cluster picks up the new token. This is the intended break.
- Scripts that only need the state dir (`port-forward.sh`, `teardown.sh`) also source `lib.sh` and will therefore generate a token if none exists; harmless, and it keeps the contract "one file, one truth".

## Tests

- `bash -n hack/install/*.sh` clean. shellcheck is not installed on this machine.
- Functional check by sourcing `lib.sh` with a temp `FAROS_INSTALL_STATE_DIR`: first source generates a 48-hex token, writes it `0600`, prints the message; second source reuses it silently; `FAROS_STATIC_TOKEN=dev-token` in env wins and does not touch or create the file; with `openssl` removed from `PATH` the urandom fallback produces a 48-hex token; `static_token_csv` still yields `<token>,faros:static:<16 hex>,...`.
- `GOWORK=off go vet ./test/e2e/suites/installexternal/ ./test/e2e/suites/installembedded/` and `gofmt -l` clean (comment-only change).
- Not run here: the install e2e suites themselves (need a kind cluster + image build); their token path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
