### PR TITLE
fix(agents): remove unimplemented message encryption setting

### DIFF
--- a/docs/agents-provider-architecture.md
+++ b/docs/agents-provider-architecture.md
@@ -338,8 +338,9 @@ by provider limits to keep a delegation tree from runaway spend.
 ## Storage (own, Postgres)
 
 Mirror the app-studio `store` shape (interface + `postgres.go` + `memory.go`
-dev backend + optional at-rest encryption), tables scoped by
-org/workspace/agent:
+dev backend), tables scoped by org/workspace/agent. Content is stored in
+plaintext; at-rest encryption is the database's responsibility today
+(application-level encryption is planned, see item 8 above):
 
 - `agents_messages` — chat transcript per session, cursor pagination.
 - `agents_runs` — durable runs: phase, trigger, usage/cost, and an **opaque

--- a/providers/agents/.env.example
+++ b/providers/agents/.env.example
@@ -20,8 +20,8 @@
 # Force the old non-durable in-memory store for one-off UI work.
 # AGENTS_IN_MEMORY_STORE=true
 #
-# Optional at-rest message encryption key set.
-# AGENTS_MESSAGE_ENCRYPTION_KEYS=primary:<base64-32-byte-aes-key>
+# Message and memory content is stored in plaintext in Postgres; encryption at
+# rest is the database's responsibility. Application-level encryption is planned.
 #
 # ── Background executor ──────────────────────────────────────────────────────
 # Signing key for trigger + channel inbound webhook URLs. Empty → derived from

--- a/providers/agents/api/server.go
+++ b/providers/agents/api/server.go
@@ -39,8 +39,6 @@ type Config struct {
 	DatabaseURL string
 	// InMemoryStore forces the in-memory store even when DatabaseURL is set.
 	InMemoryStore bool
-	// EncryptionKeys is the optional at-rest message encryption key set.
-	EncryptionKeys string
 	// ProviderKubeconfig is the provider service-account kubeconfig (targets
 	// the provider's kcp workspace). Enables the background executor:
 	// autonomous schedule firing + trigger webhooks via the APIExport virtual

--- a/providers/agents/deploy/chart/README.md
+++ b/providers/agents/deploy/chart/README.md
@@ -52,14 +52,11 @@ helm upgrade --install agents oci://ghcr.io/faroshq/charts/faros-agents-provider
 | `catalogEntry.backendURL` | `""` |  |
 | `providerKubeconfig` |  | Secret holding the workspace-admin kubeconfig minted by the platform admin via /bonkers (admin onboarding). Consumed by both the init container and the serve container. Key must be "kubeconfig". |
 | `providerKubeconfig.secretName` | `faros-provider-kubeconfig` |  |
-| `store` |  | Durable store. Postgres is the agents provider's only hard dependency beyond the hub; inMemoryStore is an explicit non-durable fallback for dev only. |
+| `store` |  | Durable store. Postgres is the agents provider's only hard dependency beyond the hub; inMemoryStore is an explicit non-durable fallback for dev only. Message and memory content is stored in plaintext; encryption at rest is the database's responsibility. |
 | `store.databaseURL` | `""` |  |
 | `store.databaseURLSecretRef.name` | `""` |  |
 | `store.databaseURLSecretRef.key` | `database-url` |  |
 | `store.inMemoryStore` | `false` |  |
-| `store.messageEncryptionKeysSecretRef` |  | Optional at-rest encryption for message/transcript content. |
-| `store.messageEncryptionKeysSecretRef.name` | `""` |  |
-| `store.messageEncryptionKeysSecretRef.key` | `keys` |  |
 | `hub` |  |  |
 | `hub.url` | `"http://faros-hub.faros.svc.cluster.local:8080"` |  |
 | `hub.insecure` | `false` |  |

--- a/providers/agents/deploy/chart/templates/deployment.yaml
+++ b/providers/agents/deploy/chart/templates/deployment.yaml
@@ -102,13 +102,6 @@ spec:
             - name: AGENTS_IN_MEMORY_STORE
               value: "true"
             {{- end }}
-            {{- if .Values.store.messageEncryptionKeysSecretRef.name }}
-            - name: AGENTS_MESSAGE_ENCRYPTION_KEYS
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.store.messageEncryptionKeysSecretRef.name }}
-                  key: {{ .Values.store.messageEncryptionKeysSecretRef.key }}
-            {{- end }}
             {{- if .Values.hub.insecure }}
             - name: FAROS_HUB_INSECURE
               value: "true"

--- a/providers/agents/deploy/chart/values.yaml
+++ b/providers/agents/deploy/chart/values.yaml
@@ -40,10 +40,10 @@ store:
     name: ""
     key: database-url
   inMemoryStore: false
-  # Optional at-rest encryption for message/transcript content.
-  messageEncryptionKeysSecretRef:
-    name: ""
-    key: keys
+  # Message and memory content is stored in plaintext in Postgres. Encryption
+  # at rest is the database's responsibility (use encrypted volumes or a
+  # managed Postgres with encryption enabled). Application-level encryption is
+  # planned but not implemented.
 
 hub:
   url: "http://faros-hub.faros.svc.cluster.local:8080"

--- a/providers/agents/main.go
+++ b/providers/agents/main.go
@@ -78,7 +78,6 @@ func runServe() {
 		HubInsecure:        os.Getenv("FAROS_HUB_INSECURE") == "true",
 		DatabaseURL:        os.Getenv("AGENTS_DATABASE_URL"),
 		InMemoryStore:      os.Getenv("AGENTS_IN_MEMORY_STORE") == "true",
-		EncryptionKeys:     os.Getenv("AGENTS_MESSAGE_ENCRYPTION_KEYS"),
 		ProviderKubeconfig: os.Getenv("FAROS_PROVIDER_KUBECONFIG"),
 		WebhookKey:         os.Getenv("AGENTS_WEBHOOK_KEY"),
 		SchedulerInterval:  parseDuration(os.Getenv("AGENTS_SCHEDULER_INTERVAL")),

--- a/providers/agents/store/postgres.go
+++ b/providers/agents/store/postgres.go
@@ -58,6 +58,9 @@ var agentsSchema = []string{
 		run_id TEXT NOT NULL DEFAULT '',
 		role TEXT NOT NULL,
 		content TEXT NOT NULL,
+		-- content_encrypted / content_key_id are reserved for a future
+		-- application-level encryption layer. Nothing sets them today; content
+		-- is plaintext and at-rest encryption is the database's responsibility.
 		content_encrypted BOOLEAN NOT NULL DEFAULT FALSE,
 		content_key_id TEXT NOT NULL DEFAULT '',
 		metadata JSONB,
@@ -108,6 +111,7 @@ var agentsSchema = []string{
 		agent_name TEXT NOT NULL,
 		title TEXT NOT NULL,
 		body TEXT NOT NULL,
+		-- Reserved and unused; see agents_messages.
 		content_encrypted BOOLEAN NOT NULL DEFAULT FALSE,
 		content_key_id TEXT NOT NULL DEFAULT '',
 		created_at TIMESTAMPTZ NOT NULL,

--- a/providers/agents/store/store.go
+++ b/providers/agents/store/store.go
@@ -49,7 +49,9 @@ func (s Scope) withAgent() error {
 	return nil
 }
 
-// Message is a persisted transcript record. Content may be encrypted at rest.
+// Message is a persisted transcript record. Content is stored in plaintext;
+// ContentEncrypted and ContentKeyID are reserved for a future application-level
+// encryption layer and are always false/empty today.
 type Message struct {
 	ID               string         `json:"id"`
 	AgentName        string         `json:"agentName,omitempty"`
@@ -152,7 +154,9 @@ type SessionSummary struct {
 	UpdatedAt    time.Time `json:"updatedAt"`
 }
 
-// Memory is a long-term note the agent writes and later recalls.
+// Memory is a long-term note the agent writes and later recalls. Body is
+// stored in plaintext; ContentEncrypted and ContentKeyID are reserved and
+// unused (see Message).
 type Memory struct {
 	ID               string    `json:"id"`
 	AgentName        string    `json:"agentName"`


### PR DESCRIPTION
Implements item 0.3 of the security remediation plan.

## Problem

The agents provider advertised at-rest encryption for message and memory content that does not exist:

- `providers/agents/main.go` read `AGENTS_MESSAGE_ENCRYPTION_KEYS` into `api.Config.EncryptionKeys`, which nothing consumed. No code path derives a key, encrypts, or decrypts.
- The chart exposed `store.messageEncryptionKeysSecretRef` and wired it into the Deployment env; the chart README (embedded into the CatalogEntry via `.Files.Get`) and `.env.example` described it as "optional at-rest encryption for message/transcript content".
- The `content_encrypted` / `content_key_id` columns on `agents_messages` and `agents_memories` are only ever written as their defaults.

An operator who configured the key was told their transcripts were encrypted while they were stored in plaintext.

## Change

- Remove the env read, the `Config.EncryptionKeys` field, the chart value, its Deployment env plumbing, and the `.env.example` entry.
- Replace the claims in the chart README, `values.yaml`, `.env.example`, and `docs/agents-provider-architecture.md` (Storage section) with an honest statement: content is plaintext in Postgres, encryption at rest is the database's responsibility, application-level encryption is planned.
- Keep the schema columns in place (dropping them adds migration risk for no benefit) and comment them as reserved and unused, in both the DDL and the `store.Message` / `store.Memory` Go types.

Encryption itself is deliberately not implemented here; that is a separate item and can reuse App Studio's `store/encryption.go`.

## Compatibility

- Chart: `store.messageEncryptionKeysSecretRef` is removed. Users who set it get a Helm strict-values warning at most; the template no longer references it. Nothing changes at runtime because the env var was never used.
- Env: `AGENTS_MESSAGE_ENCRYPTION_KEYS` is silently ignored if still set (it always was).
- Schema: unchanged. `CREATE TABLE IF NOT EXISTS` statements gain SQL comments only; existing databases are untouched.
- Stored data: unchanged; content was always plaintext.

## Tests

From `providers/agents` with `GOWORK=off` (the module is not in a `go.work` here):

- `go build ./...` and `go vet ./...` pass.
- `go test -count=1 ./...` passes (api, channels, engine, llm, store, tools).
- Store tests re-run against a disposable `postgres:17-alpine` with `AGENTS_TEST_POSTGRES_DSN` set: all `TestPostgres_*` pass and `\d agents_messages` / `\d agents_memories` show the reserved columns intact with the commented DDL applied.
- `helm lint` and `helm template providers/agents/deploy/chart` pass; the rendered CatalogEntry `valuesDoc` carries the updated README with no encryption reference.
- `gofmt -l` clean on the changed Go files. `golangci-lint` was not run: `hack/tools/` is not populated in this checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
