### PR TITLE
fix(agent): default-deny service proxy targets and pin verified dials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,9 +218,12 @@ APIExport, schemas) and registers routing/heartbeat state.
 >
 > Reachability: a `Service` on a `LinuxServer` edge hits the agent host loopback by
 > default; `spec.host` points it at another device on the edge's LAN (e.g. a UniFi
-> console) — the agent's svc proxy (`pkg/agent/tunnel/svc.go`) currently allows any
-> host (see `isAllowedSvcHost`, `TODO(security)`). A `Service` on a
-> `KubernetesCluster` edge uses `spec.targetRef` (a cluster-DNS Service) instead.
+> console) — the agent's svc proxy (`pkg/agent/tunnel/svc.go`) dials loopback
+> always, cluster DNS in kubernetes mode, and any other host only inside the
+> agent's `--svc-allow-cidr` ranges (link-local never), with `--svc-policy`
+> `warn` (this release's default: dial + log) or `enforce` (403) deciding what a
+> denial does. A `Service` on a `KubernetesCluster` edge uses `spec.targetRef`
+> (a cluster-DNS Service) instead.
 > The portal create form (`Services.vue`) branches on the selected edge's kind.
 
 ### 5.2 Hub-side provider integration (`pkg/hub/providers/`)

--- a/docs/home-assistant-edge-control.md
+++ b/docs/home-assistant-edge-control.md
@@ -97,7 +97,22 @@ is identical; only the address the agent dials differs.
 |---|---|---|
 | Declared by | discovery (auto) | the user (`targetRef`) |
 | Agent dials | `127.0.0.1:{port}` | `{targetRef.name}.{targetRef.namespace}.svc:{port}` |
-| Agent guard | loopback only | loopback + cluster DNS |
+| Agent guard | loopback + `--svc-allow-cidr` | loopback + cluster DNS + `--svc-allow-cidr` |
+
+**`spec.host` and the agent allow list.** A Service may name another device on
+the edge's LAN via `spec.host` (a UniFi console at `192.168.1.1`, say). The agent
+only dials such a host when it falls inside a range the operator passed with
+`--svc-allow-cidr` (repeatable; also `FAROS_AGENT_SVC_ALLOW_CIDR`, comma-separated),
+e.g. `faros agent run ... --svc-allow-cidr 192.168.1.0/24`. What happens to a host
+outside that set is `--svc-policy` (`FAROS_AGENT_SVC_POLICY`): `warn` — this
+release's default — still dials it but logs and stamps `X-Faros-Svc-Policy: warn`
+on the response (the Service shows `HostAllowed=True/WarnOnly`); `enforce` answers
+403 without dialing (`HostAllowed=False/HostNotAllowed`, `phase: Unreachable`);
+`allow-any` disables the list and says so loudly at startup. The next release
+flips the default to `enforce`, so add the CIDR now. Link-local (cloud metadata),
+unspecified and multicast addresses are refused under every policy. Non-loopback
+`https` hosts have their certificate verified unless the Service sets
+`spec.tlsInsecureSkipVerify: true` (needed for UniFi's self-signed console).
 
 **Why not the apiserver's `services/proxy` subresource?** It looks like the
 obvious route for kube edges — the agent SA already holds `resources: ["*"]` on
@@ -132,14 +147,19 @@ reconciler by construction: it only ever lists and prunes objects labelled
     service named by the provider-set `X-Faros-Svc-Target` header. WebSocket
     upgrades are hijacked and piped (HA uses `/api/websocket`).
 
-    This is the **SSRF boundary**, and it is mode-aware (`isAllowedSvcHost`).
-    Server mode permits loopback only. Kubernetes mode additionally permits
-    cluster-DNS Service names (`{name}.{namespace}.svc[.cluster.local]`), which
-    only resolve inside the cluster — so node IPs, the LAN and the internet stay
-    out of reach either way. IPs are parsed rather than string-matched
-    (`127.0.0.2` is loopback, `evil.svc.example.com` is not cluster DNS), and a
-    bare `.svc` with no `{name}.{namespace}` in front is rejected. See
-    `TestIsAllowedSvcHost` for the pinned cases.
+    This is the **SSRF boundary** (`vetSvcHost` / `isAllowedSvcHost`). Loopback
+    is always permitted. Kubernetes mode additionally permits cluster-DNS Service
+    names (`{name}.{namespace}.svc[.cluster.local]`), which only resolve inside
+    the cluster. Anything else — a LAN IP, or a hostname — is permitted only when
+    the address (every resolved A/AAAA record, for names) is inside
+    `--svc-allow-cidr`; link-local, unspecified and multicast are refused
+    unconditionally. The dial is pinned to the vetted addresses so DNS rebinding
+    cannot swap the target after the check. `--svc-policy` (`enforce` | `warn` |
+    `allow-any`) decides what a denial does; see §3. IPs are parsed rather than
+    string-matched (`127.0.0.2` is loopback, `evil.svc.example.com` is not
+    cluster DNS), and a bare `.svc` with no `{name}.{namespace}` in front is
+    rejected. See `TestIsAllowedSvcHost` / `TestVetSvcHostResolved` for the
+    pinned cases.
 
 Both routes work in server mode and kubernetes mode.
 
@@ -296,9 +316,11 @@ gates at 22:00" needs the follow-up in §9.
   scoped HA user for the token. The agents provider already audit-logs every
   tool call.
 - **SSRF posture** — the `/svc` proxy is agent-side host-restricted (loopback,
-  plus cluster DNS in kubernetes mode) and Service-allowlisted provider-side. It
-  must never become "reach any host on the LAN". If you touch
-  `isAllowedSvcHost`, `TestIsAllowedSvcHost` is the contract.
+  cluster DNS in kubernetes mode, plus the operator's `--svc-allow-cidr` ranges;
+  link-local never) and Service-allowlisted provider-side. It must never become
+  "reach any host on the LAN" by default. If you touch `vetSvcHost` /
+  `isAllowedSvcHost`, `TestIsAllowedSvcHost` and `TestVetSvcHostResolved` are
+  the contract.
 - **A kube Service with no `targetRef` must never fall back to loopback** — that
   would silently proxy to the agent pod itself. The CRD's CEL rule rejects it at
   admission, and the proxy, the MCP tool registration and the validation

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -327,6 +327,19 @@ type Options struct {
 	// endpoints. Use "127.0.0.1:6060" for local-only access; bind to a
 	// non-loopback address only when port-forwarding is not an option.
 	DebugAddr string
+	// SvcAllowedCIDRs are the CIDRs (e.g. "192.168.1.0/24") the /svc proxy may
+	// dial besides loopback and, in kubernetes mode, cluster-DNS names. A
+	// Service's spec.host outside this set is refused (or warned about, per
+	// SvcPolicy). Link-local, unspecified and multicast addresses are never
+	// dialable even if listed. Flag: --svc-allow-cidr (repeatable); env:
+	// FAROS_AGENT_SVC_ALLOW_CIDR (comma-separated).
+	SvcAllowedCIDRs []string
+	// SvcPolicy is what the /svc proxy does with a target outside the allowed
+	// set: "enforce" (403, never dialed), "warn" (dialed, logged, response
+	// carries X-Faros-Svc-Policy: warn) or "allow-any" (allow list disabled,
+	// logged at startup). Defaults to "warn" in this release; the next release
+	// flips the default to "enforce". Flag: --svc-policy; env: FAROS_AGENT_SVC_POLICY.
+	SvcPolicy string
 }
 
 // NewOptions returns default agent options.
@@ -345,6 +358,9 @@ type Agent struct {
 	hubConfig        *rest.Config
 	hubTLSConfig     *tls.Config
 	downstreamConfig *rest.Config // nil in server mode
+	// svcProxy is the parsed /svc host policy (Options.SvcAllowedCIDRs +
+	// Options.SvcPolicy) handed to every tunnel connection.
+	svcProxy tunnel.SvcProxyOptions
 
 	// tunnelToken holds the bearer token used by the proxy tunnel goroutine on
 	// every (re)connect. It is seeded with the bootstrap token at startup and
@@ -413,6 +429,24 @@ func New(opts *Options) (*Agent, error) {
 	agentType, err := resolveType(rawType)
 	if err != nil {
 		return nil, err
+	}
+
+	svcCIDRs, err := tunnel.ParseSvcAllowedCIDRs(opts.SvcAllowedCIDRs)
+	if err != nil {
+		return nil, fmt.Errorf("--svc-allow-cidr: %w", err)
+	}
+	svcPolicy, err := tunnel.ParseSvcPolicy(opts.SvcPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("--svc-policy: %w", err)
+	}
+	switch svcPolicy {
+	case tunnel.SvcPolicyAllowAny:
+		klog.Warningf("--svc-policy=allow-any: the /svc proxy SSRF protection is DISABLED; " +
+			"any Service in a bound workspace can make this agent dial any host it can reach " +
+			"(link-local, unspecified and multicast targets stay blocked). Use --svc-allow-cidr instead.")
+	case tunnel.SvcPolicyWarn:
+		klog.Infof("--svc-policy=warn: /svc targets outside loopback/--svc-allow-cidr are still dialed but logged; "+
+			"the default becomes enforce in the next release (allowed CIDRs: %v)", svcCIDRs)
 	}
 
 	// Auto-discover or auto-generate an SSH private key for server-type edges
@@ -499,6 +533,7 @@ func New(opts *Options) (*Agent, error) {
 		agentType:    agentType,
 		hubConfig:    hubConfig,
 		hubTLSConfig: hubTLSConfig,
+		svcProxy:     tunnel.SvcProxyOptions{AllowedCIDRs: svcCIDRs, Policy: svcPolicy},
 	}
 
 	// In server mode there is no downstream Kubernetes cluster to connect to.
@@ -655,7 +690,7 @@ func (a *Agent) runKubernetesMode(ctx context.Context, logger klog.Logger, hubCl
 		deliverOnce.Do(func() { close(agentKubeconfigDelivered) })
 	}
 	a.setTunnelToken(a.hubConfig.BearerToken)
-	go tunnel.StartProxyTunnel(ctx, tunnelURL, a.currentTunnelToken, a.opts.EdgeName, string(a.agentType), a.downstreamConfig, a.hubTLSConfig, tunnelState, a.opts.SSHProxyPort, clusterName, onAgentToken, nil)
+	go tunnel.StartProxyTunnel(ctx, tunnelURL, a.currentTunnelToken, a.opts.EdgeName, string(a.agentType), a.downstreamConfig, a.hubTLSConfig, tunnelState, a.opts.SSHProxyPort, a.svcProxy, clusterName, onAgentToken, nil)
 
 	// Out-of-cluster join-token mode: the in-memory hubClient was built from
 	// the bootstrap join token, which is not a valid kcp credential. Wait for
@@ -857,7 +892,7 @@ func (a *Agent) runServerMode(ctx context.Context, logger klog.Logger, hubClient
 
 	// downstreamConfig is nil in server mode; the tunnel only serves /ssh.
 	a.setTunnelToken(a.hubConfig.BearerToken)
-	go tunnel.StartProxyTunnel(ctx, tunnelURL, a.currentTunnelToken, a.opts.EdgeName, string(a.agentType), nil, a.hubTLSConfig, tunnelState, a.opts.SSHProxyPort, serverClusterName, serverOnAgentToken, sshHeaders)
+	go tunnel.StartProxyTunnel(ctx, tunnelURL, a.currentTunnelToken, a.opts.EdgeName, string(a.agentType), nil, a.hubTLSConfig, tunnelState, a.opts.SSHProxyPort, a.svcProxy, serverClusterName, serverOnAgentToken, sshHeaders)
 
 	// Out-of-cluster join-token mode: wait for the SA kubeconfig before
 	// starting the edge_reporter, otherwise its patch calls would all return

--- a/pkg/agent/tunnel/server.go
+++ b/pkg/agent/tunnel/server.go
@@ -34,13 +34,13 @@ import (
 
 // newRemoteServer creates the local HTTP server that is served on the revdial.Listener.
 // It handles requests from the hub that are tunneled back to the agent.
-func newRemoteServer(downstream *rest.Config, sshPort int) (*http.Server, error) {
-	router := setupRouter(downstream, sshPort)
+func newRemoteServer(downstream *rest.Config, sshPort int, svc SvcProxyOptions) (*http.Server, error) {
+	router := setupRouter(downstream, sshPort, svc)
 	return &http.Server{Handler: router}, nil
 }
 
 // setupRouter configures the mux router for the local server.
-func setupRouter(downstream *rest.Config, sshPort int) *mux.Router {
+func setupRouter(downstream *rest.Config, sshPort int, svc SvcProxyOptions) *mux.Router {
 	router := mux.NewRouter()
 
 	// SSH handler — proxies the revdial connection to the host sshd on sshPort.
@@ -51,10 +51,14 @@ func setupRouter(downstream *rest.Config, sshPort int) *mux.Router {
 	router.HandleFunc("/api/v1/services", newServicesHandler()).Methods("GET")
 
 	// Generic HTTP service proxy. The provider computes the target (from a
-	// Service CR) and sets X-Faros-Svc-Target per request. Server mode allows
-	// loopback only; kubernetes mode (downstream != nil) also allows cluster-DNS
-	// names, since Services on a KubernetesCluster edge live behind cluster DNS.
-	router.PathPrefix("/svc/").HandlerFunc(newSvcProxyHandler(downstream != nil))
+	// Service CR) and sets X-Faros-Svc-Target per request. Loopback and the
+	// --svc-allow-cidr ranges are dialable in either mode; kubernetes mode
+	// (downstream != nil) also allows cluster-DNS names, since Services on a
+	// KubernetesCluster edge live behind cluster DNS. See newSvcProxyHandler.
+	router.PathPrefix("/svc/").HandlerFunc(newSvcProxyHandler(svcProxyConfig{
+		SvcProxyOptions: svc,
+		allowCluster:    downstream != nil,
+	}))
 
 	// K8s proxy handler — only registered when a downstream k8s config is present.
 	// In server mode (downstream == nil) k8s proxying is not available.

--- a/pkg/agent/tunnel/svc.go
+++ b/pkg/agent/tunnel/svc.go
@@ -33,8 +33,18 @@ import (
 
 // svcTargetHeader carries the provider-computed upstream target for the /svc
 // reverse proxy, e.g. "http://127.0.0.1:8123". The provider is the only writer;
-// the agent enforces that the target host is loopback (see isLoopbackHost).
+// the agent decides whether it will dial the host (see vetSvcHost).
 const svcTargetHeader = "X-Faros-Svc-Target"
+
+// svcTLSInsecureHeader is set to "true" by the provider when the Service has
+// spec.tlsInsecureSkipVerify. The agent verifies upstream TLS certificates for
+// every non-loopback target unless this header is present.
+const svcTLSInsecureHeader = "X-Faros-Svc-TLS-Insecure"
+
+// svcPolicyHeader is the response header the agent stamps when the host
+// policy had something to say: "warn" when a disallowed target was dialed
+// anyway under --svc-policy=warn, "enforce" on the 403 that refuses it.
+const svcPolicyHeader = "X-Faros-Svc-Policy"
 
 // servicesResponse is the JSON body of GET /api/v1/services.
 type servicesResponse struct {
@@ -55,16 +65,30 @@ func newServicesHandler() http.HandlerFunc {
 // /svc/ to a service named by the X-Faros-Svc-Target header.
 //
 // The provider resolves a Service CR to a target and sets the header; the agent
-// decides what it is willing to dial. In server mode that is loopback only, so
-// this can never become an arbitrary-host proxy onto the LAN. In kubernetes
-// mode (allowClusterTargets) cluster-DNS names are also permitted, because a
-// Service on a KubernetesCluster edge sits behind cluster DNS rather than on
-// the agent's loopback — and those names only resolve to in-cluster Services,
-// so node IPs and external hosts stay out of reach.
+// decides what it is willing to dial, and that decision is the SSRF boundary
+// for everything a workspace member can put in Service.spec.host:
+//
+//   - loopback is always allowed;
+//   - cluster-DNS names ({name}.{namespace}.svc[.cluster.local]) are allowed
+//     in kubernetes mode only, where they resolve inside the cluster's DNS;
+//   - other literal IPs, and the addresses other hostnames resolve to, are
+//     allowed only when inside --svc-allow-cidr;
+//   - link-local (cloud metadata), unspecified and multicast addresses are
+//     never allowed, whatever the allow list or policy says.
+//
+// Hostnames are resolved once and the dial is pinned to the vetted addresses,
+// so DNS rebinding cannot swap the target after the check. --svc-policy picks
+// what a denial does: enforce answers 403 without dialing, warn dials but logs
+// and stamps X-Faros-Svc-Policy: warn, allow-any skips the allow list.
+//
+// TLS verification is skipped only for loopback targets (host-local
+// self-signed certs are common and the hop never leaves the host) or when the
+// provider sets X-Faros-Svc-TLS-Insecure from Service.spec.tlsInsecureSkipVerify.
 //
 // WebSocket/upgrade requests are handled by hijacking and piping raw bytes
 // (Home Assistant uses /api/websocket).
-func newSvcProxyHandler(allowClusterTargets bool) http.HandlerFunc {
+func newSvcProxyHandler(cfg svcProxyConfig) http.HandlerFunc {
+	policy := cfg.policy()
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := klog.Background().WithName("svc-proxy")
 
@@ -74,15 +98,33 @@ func newSvcProxyHandler(allowClusterTargets bool) http.HandlerFunc {
 			return
 		}
 		target, err := url.Parse(targetRaw)
-		if err != nil || target.Host == "" {
+		if err != nil || target.Host == "" || target.Hostname() == "" {
 			http.Error(w, "invalid "+svcTargetHeader, http.StatusBadRequest)
 			return
 		}
-		if !isAllowedSvcHost(target.Hostname(), allowClusterTargets) {
-			logger.Info("rejecting disallowed svc target", "target", targetRaw,
-				"clusterTargetsAllowed", allowClusterTargets)
-			http.Error(w, "svc target host not permitted", http.StatusForbidden)
+
+		vetted, err := vetSvcHost(r.Context(), target.Hostname(), cfg)
+		if err != nil {
+			logger.Error(err, "failed to resolve svc target", "target", targetRaw)
+			http.Error(w, "upstream error", http.StatusBadGateway)
 			return
+		}
+		warned := false
+		if d := vetted.denied; d != nil {
+			switch {
+			case d.hard || policy == SvcPolicyEnforce:
+				logger.Info("rejecting disallowed svc target", "target", targetRaw, "reason", d.reason,
+					"policy", policy, "clusterTargetsAllowed", cfg.allowCluster)
+				writeSvcDenied(w, d.reason)
+				return
+			case policy == SvcPolicyWarn:
+				logger.Info("svc target would be denied under --svc-policy=enforce; dialing anyway (warn mode). "+
+					"Add the host to --svc-allow-cidr before the default flips to enforce.",
+					"target", targetRaw, "reason", d.reason)
+				warned = true
+			default: // allow-any
+				logger.V(2).Info("svc target outside the allow list; --svc-policy=allow-any", "target", targetRaw, "reason", d.reason)
+			}
 		}
 
 		// The remaining path after /svc is the service-local path.
@@ -91,19 +133,29 @@ func newSvcProxyHandler(allowClusterTargets bool) http.HandlerFunc {
 			svcPath = "/"
 		}
 
-		// Do not leak the control header upstream.
+		// TLS verification is skipped only on the host's own loopback, or when
+		// the Service explicitly opted out (spec.tlsInsecureSkipVerify).
+		insecure := vetted.loopback || strings.EqualFold(r.Header.Get(svcTLSInsecureHeader), "true")
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: insecure, //nolint:gosec // loopback or explicit per-Service opt-in only
+			ServerName:         target.Hostname(),
+			MinVersion:         tls.VersionTLS12,
+		}
+		dial := pinnedDialer(vetted, cfg.dialer())
+
+		// Do not leak the control headers upstream.
 		r.Header.Del(svcTargetHeader)
+		r.Header.Del(svcTLSInsecureHeader)
 
 		if isUpgradeRequest(r) {
-			handleSvcUpgrade(w, r, target, svcPath, logger)
+			handleSvcUpgrade(w, r, target, svcPath, dial, tlsConfig, logger)
 			return
 		}
 
 		proxy := &httputil.ReverseProxy{
 			Transport: &http.Transport{
-				// Host-local self-signed certs are common; the hop never leaves
-				// the host, so skipping verification is acceptable here.
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+				DialContext:     dial,
+				TLSClientConfig: tlsConfig,
 			},
 			Rewrite: func(pr *httputil.ProxyRequest) {
 				pr.Out.URL.Scheme = target.Scheme
@@ -111,21 +163,45 @@ func newSvcProxyHandler(allowClusterTargets bool) http.HandlerFunc {
 				pr.Out.URL.Path = svcPath
 				pr.Out.Host = target.Host
 				pr.Out.Header.Del(svcTargetHeader)
+				pr.Out.Header.Del(svcTLSInsecureHeader)
 			},
+		}
+		if warned {
+			proxy.ModifyResponse = func(resp *http.Response) error {
+				resp.Header.Set(svcPolicyHeader, string(SvcPolicyWarn))
+				return nil
+			}
 		}
 		proxy.ServeHTTP(w, r)
 	}
 }
 
+// writeSvcDenied answers a refused target: 403 with a small JSON body and the
+// policy header, so the provider can tell an agent refusal from a 403 the
+// service itself returned.
+func writeSvcDenied(w http.ResponseWriter, reason string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(svcPolicyHeader, string(SvcPolicyEnforce))
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":  "target host not allowed",
+		"reason": reason,
+	})
+}
+
 // handleSvcUpgrade proxies a protocol-upgrade request (WebSocket) to the
-// loopback target by hijacking the tunnel connection and piping raw bytes.
-func handleSvcUpgrade(w http.ResponseWriter, r *http.Request, target *url.URL, svcPath string, logger klog.Logger) {
-	var backendConn net.Conn
-	var err error
-	if target.Scheme == "https" {
-		backendConn, err = tls.Dial("tcp", hostWithPort(target), &tls.Config{InsecureSkipVerify: true}) //nolint:gosec
-	} else {
-		backendConn, err = net.Dial("tcp", hostWithPort(target))
+// vetted target by hijacking the tunnel connection and piping raw bytes. The
+// dial is pinned (dial), and TLS is layered on top with tlsConfig so the
+// upgrade path verifies certificates exactly like the plain-HTTP path.
+func handleSvcUpgrade(w http.ResponseWriter, r *http.Request, target *url.URL, svcPath string, dial svcDialer, tlsConfig *tls.Config, logger klog.Logger) {
+	backendConn, err := dial(r.Context(), "tcp", hostWithPort(target))
+	if err == nil && target.Scheme == "https" {
+		tc := tls.Client(backendConn, tlsConfig)
+		if err = tc.HandshakeContext(r.Context()); err != nil {
+			_ = backendConn.Close()
+		} else {
+			backendConn = tc
+		}
 	}
 	if err != nil {
 		logger.Error(err, "failed to connect to svc target", "target", target.String())
@@ -151,6 +227,7 @@ func handleSvcUpgrade(w http.ResponseWriter, r *http.Request, target *url.URL, s
 	r.URL.Path = svcPath
 	r.Host = target.Host
 	r.Header.Del(svcTargetHeader)
+	r.Header.Del(svcTLSInsecureHeader)
 
 	if err := r.Write(backendConn); err != nil {
 		logger.Error(err, "failed to forward upgrade request to svc target")
@@ -172,23 +249,6 @@ func hostWithPort(u *url.URL) string {
 		return net.JoinHostPort(u.Hostname(), "443")
 	}
 	return net.JoinHostPort(u.Hostname(), "80")
-}
-
-// isAllowedSvcHost reports whether the agent may dial host. Loopback (LinuxServer
-// edges) and cluster-DNS names (kubernetes mode) are always allowed.
-//
-// A Service's spec.host may also point at another device on the edge's LAN (e.g.
-// a UniFi console), so for now any host is permitted — this intentionally trades
-// away the anti-SSRF boundary to make LAN services work. TODO(security): tighten
-// with a per-agent allowlist / opt-in before this is a general default.
-func isAllowedSvcHost(host string, allowCluster bool) bool {
-	if isLoopbackHost(host) {
-		return true
-	}
-	if allowCluster && isClusterDNSHost(host) {
-		return true
-	}
-	return true
 }
 
 // isLoopbackHost reports whether host is a loopback address or "localhost".

--- a/pkg/agent/tunnel/svc_policy.go
+++ b/pkg/agent/tunnel/svc_policy.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+)
+
+// SvcPolicy selects what the agent does when a /svc target fails the host
+// checks (see SvcProxyOptions).
+type SvcPolicy string
+
+const (
+	// SvcPolicyEnforce refuses a disallowed target with 403 and never dials it.
+	SvcPolicyEnforce SvcPolicy = "enforce"
+	// SvcPolicyWarn dials a disallowed target anyway but logs the denial and
+	// stamps X-Faros-Svc-Policy: warn on the response, so operators can find
+	// the Services that need --svc-allow-cidr before flipping to enforce.
+	SvcPolicyWarn SvcPolicy = "warn"
+	// SvcPolicyAllowAny disables the allow list entirely (loudly logged at
+	// startup). Link-local, unspecified and multicast targets stay blocked
+	// even here — those are never overridable.
+	SvcPolicyAllowAny SvcPolicy = "allow-any"
+)
+
+// DefaultSvcPolicy is the policy used when --svc-policy is not given. This
+// release defaults to warn so existing Services that point off the loopback
+// keep working while the agent logs what enforce would block; the next
+// release flips the default to enforce.
+const DefaultSvcPolicy = SvcPolicyWarn
+
+// ParseSvcPolicy validates a --svc-policy value. Empty selects DefaultSvcPolicy.
+func ParseSvcPolicy(raw string) (SvcPolicy, error) {
+	switch p := SvcPolicy(strings.ToLower(strings.TrimSpace(raw))); p {
+	case "":
+		return DefaultSvcPolicy, nil
+	case SvcPolicyEnforce, SvcPolicyWarn, SvcPolicyAllowAny:
+		return p, nil
+	default:
+		return "", fmt.Errorf("invalid svc policy %q: must be one of enforce, warn, allow-any", raw)
+	}
+}
+
+// ParseSvcAllowedCIDRs parses --svc-allow-cidr values (each a CIDR such as
+// 192.168.1.0/24 or 10.0.0.5/32; a bare IP is treated as a /32 or /128).
+func ParseSvcAllowedCIDRs(raw []string) ([]netip.Prefix, error) {
+	var out []netip.Prefix
+	for _, s := range raw {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if !strings.Contains(s, "/") {
+			addr, err := netip.ParseAddr(s)
+			if err != nil {
+				return nil, fmt.Errorf("invalid svc allow CIDR %q: %w", s, err)
+			}
+			out = append(out, netip.PrefixFrom(addr, addr.BitLen()))
+			continue
+		}
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid svc allow CIDR %q: %w", s, err)
+		}
+		out = append(out, p.Masked())
+	}
+	return out, nil
+}
+
+// SvcProxyOptions is the operator-configured part of the /svc proxy policy,
+// set from --svc-allow-cidr / --svc-policy (or FAROS_AGENT_SVC_ALLOW_CIDR /
+// FAROS_AGENT_SVC_POLICY) and threaded from agent.Options down to the tunnel's
+// remote server.
+type SvcProxyOptions struct {
+	// AllowedCIDRs are the literal-IP ranges (and resolved-hostname ranges)
+	// the agent may dial besides loopback and, in kubernetes mode, cluster DNS.
+	AllowedCIDRs []netip.Prefix
+	// Policy decides what happens when a target is outside that set.
+	Policy SvcPolicy
+}
+
+// policy returns Policy, defaulting an unset value.
+func (o SvcProxyOptions) policy() SvcPolicy {
+	if o.Policy == "" {
+		return DefaultSvcPolicy
+	}
+	return o.Policy
+}
+
+// svcResolver looks up the addresses of a hostname; net.DefaultResolver in
+// production, injected in tests.
+type svcResolver func(ctx context.Context, host string) ([]netip.Addr, error)
+
+// svcDialer opens a TCP connection; net.Dialer in production, a counter in
+// tests.
+type svcDialer func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// svcProxyConfig is everything newSvcProxyHandler needs: the operator options,
+// the mode-derived cluster-DNS switch, and the resolver/dialer hooks.
+type svcProxyConfig struct {
+	SvcProxyOptions
+	// allowCluster permits {name}.{namespace}.svc[.cluster.local] names. Set in
+	// kubernetes mode only (see setupRouter), where such names resolve inside
+	// the cluster's DNS.
+	allowCluster bool
+	resolve      svcResolver
+	dial         svcDialer
+}
+
+func (c svcProxyConfig) resolver() svcResolver {
+	if c.resolve != nil {
+		return c.resolve
+	}
+	return func(ctx context.Context, host string) ([]netip.Addr, error) {
+		return net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+	}
+}
+
+func (c svcProxyConfig) dialer() svcDialer {
+	if c.dial != nil {
+		return c.dial
+	}
+	d := &net.Dialer{}
+	return d.DialContext
+}
+
+// svcDenial explains why a target failed the host checks. hard marks the
+// never-overridable class (link-local, unspecified, multicast): warn and
+// allow-any still refuse those.
+type svcDenial struct {
+	reason string
+	hard   bool
+}
+
+func (d *svcDenial) Error() string { return d.reason }
+
+// svcVettedTarget is the outcome of vetSvcHost: the addresses the dialer is
+// pinned to, whether every one of them is loopback (so TLS verification may be
+// skipped), and the denial, if any, for the policy to act on.
+type svcVettedTarget struct {
+	addrs    []netip.Addr
+	loopback bool
+	denied   *svcDenial
+}
+
+// isHardBlockedAddr reports the addresses no policy may open up: link-local
+// (169.254.0.0/16, fe80::/10 — cloud metadata lives here), unspecified, and
+// multicast. IPv4-mapped IPv6 forms are unmapped first so ::ffff:169.254.1.1
+// cannot slip past.
+func isHardBlockedAddr(a netip.Addr) bool {
+	a = a.Unmap()
+	return !a.IsValid() ||
+		a.IsUnspecified() ||
+		a.IsMulticast() ||
+		a.IsLinkLocalUnicast() ||
+		a.IsLinkLocalMulticast() ||
+		a.IsInterfaceLocalMulticast()
+}
+
+// allowAddr applies the policy to one address. clusterName says the address
+// came from resolving a cluster-DNS name (allowed as a class in kubernetes
+// mode; a ClusterIP is not on any operator allow list).
+func (c svcProxyConfig) allowAddr(a netip.Addr, clusterName bool) *svcDenial {
+	a = a.Unmap()
+	if isHardBlockedAddr(a) {
+		return &svcDenial{reason: fmt.Sprintf("%s is link-local, unspecified or multicast; never allowed", a), hard: true}
+	}
+	if a.IsLoopback() {
+		return nil
+	}
+	if clusterName && c.allowCluster {
+		return nil
+	}
+	for _, p := range c.AllowedCIDRs {
+		if p.Contains(a) {
+			return nil
+		}
+	}
+	return &svcDenial{reason: fmt.Sprintf("%s is not loopback and not in --svc-allow-cidr", a)}
+}
+
+// isAllowedSvcHost classifies a target host without touching DNS: loopback is
+// always allowed; cluster-DNS names only when allowCluster (kubernetes mode);
+// literal IPs only when inside allow (and never when link-local, unspecified
+// or multicast, even if a prefix in allow covers them); any other hostname is
+// not decidable here and reports false — vetSvcHost resolves it and applies
+// the same address checks to every A/AAAA record.
+func isAllowedSvcHost(host string, allowCluster bool, allow []netip.Prefix) bool {
+	cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{AllowedCIDRs: allow}, allowCluster: allowCluster}
+	if isLoopbackHost(host) {
+		return true
+	}
+	if a, err := netip.ParseAddr(host); err == nil {
+		return cfg.allowAddr(a, false) == nil
+	}
+	return allowCluster && isClusterDNSHost(host)
+}
+
+// vetSvcHost decides whether the agent may dial host and, either way, pins
+// the addresses a dial must use: literals are used as-is; hostnames are
+// resolved once here and every resolved address is checked, so a name that
+// points at an allowed address cannot be re-pointed (DNS rebinding) between
+// the check and the dial. A resolution failure is returned as a plain error;
+// a policy denial is reported in the result's denied field so warn mode can
+// still dial the very addresses that were vetted.
+func vetSvcHost(ctx context.Context, host string, cfg svcProxyConfig) (svcVettedTarget, error) {
+	if a, err := netip.ParseAddr(host); err == nil {
+		a = a.Unmap()
+		return svcVettedTarget{addrs: []netip.Addr{a}, loopback: a.IsLoopback(), denied: cfg.allowAddr(a, false)}, nil
+	}
+
+	clusterName := isClusterDNSHost(host)
+	if clusterName && !cfg.allowCluster {
+		// Do not resolve: in server mode a .svc name is just a hostname the
+		// provider should never have sent.
+		return svcVettedTarget{denied: &svcDenial{reason: "cluster-DNS names are only allowed in kubernetes mode"}}, nil
+	}
+
+	addrs, err := cfg.resolver()(ctx, host)
+	if err != nil || len(addrs) == 0 {
+		if host == "localhost" {
+			// A host without "localhost" in /etc/hosts should still reach its
+			// own loopback.
+			addrs = []netip.Addr{netip.MustParseAddr("127.0.0.1"), netip.MustParseAddr("::1")}
+		} else if err != nil {
+			return svcVettedTarget{}, fmt.Errorf("resolving %q: %w", host, err)
+		} else {
+			return svcVettedTarget{}, fmt.Errorf("resolving %q: no addresses", host)
+		}
+	}
+
+	out := svcVettedTarget{loopback: true}
+	for _, a := range addrs {
+		a = a.Unmap()
+		out.addrs = append(out.addrs, a)
+		if !a.IsLoopback() {
+			out.loopback = false
+		}
+		if d := cfg.allowAddr(a, clusterName); d != nil {
+			// Keep the harder denial: a hard block must win over "not in
+			// allow list" so warn mode cannot dial it.
+			if out.denied == nil || (d.hard && !out.denied.hard) {
+				out.denied = &svcDenial{reason: fmt.Sprintf("%s resolves to %s", host, d.reason), hard: d.hard}
+			}
+		}
+	}
+	return out, nil
+}
+
+// pinnedDialer returns a DialContext that ignores the requested host and
+// dials the vetted addresses (on the requested port) in order, returning the
+// first connection that succeeds. Both the ReverseProxy transport and the
+// WebSocket upgrade path go through it, so nothing re-resolves the name.
+func pinnedDialer(vetted svcVettedTarget, dial svcDialer) svcDialer {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		var lastErr error
+		for _, a := range vetted.addrs {
+			conn, err := dial(ctx, network, net.JoinHostPort(a.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		if lastErr == nil {
+			lastErr = fmt.Errorf("no vetted address to dial")
+		}
+		return nil, lastErr
+	}
+}

--- a/pkg/agent/tunnel/svc_test.go
+++ b/pkg/agent/tunnel/svc_test.go
@@ -16,7 +16,19 @@ limitations under the License.
 
 package tunnel
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
 
 func TestIsLoopbackHost(t *testing.T) {
 	cases := []struct {
@@ -40,29 +52,72 @@ func TestIsLoopbackHost(t *testing.T) {
 	}
 }
 
-// TestIsAllowedSvcHost pins the SSRF boundary: server mode must never dial off
-// the loopback, and kubernetes mode must widen only to cluster-DNS Service
-// names — never to node IPs, the LAN, or the internet.
-func TestIsAllowedSvcHost(t *testing.T) {
-	// isAllowedSvcHost is currently permissive: a Service's spec.host may point at
-	// any device on the edge's LAN (e.g. a UniFi console), so every host is
-	// allowed regardless of mode. Loopback + cluster-DNS remain allowed for their
-	// original reasons. TODO(security): when a per-agent allowlist lands, restore
-	// rejection of arbitrary LAN/metadata/internet hosts (see TestIsClusterDNSHost
-	// for the classification coverage that gating will rely on).
-	hosts := []string{
-		"127.0.0.1", "localhost", "::1", // loopback
-		"home-assistant.home.svc", "ha.default.svc.cluster.local", // cluster DNS
-		"10.0.0.5", "192.168.1.10", "169.254.169.254", "example.com", // LAN / metadata / internet
-		"", // empty
+func prefixes(t *testing.T, cidrs ...string) []netip.Prefix {
+	t.Helper()
+	out, err := ParseSvcAllowedCIDRs(cidrs)
+	if err != nil {
+		t.Fatalf("ParseSvcAllowedCIDRs(%v): %v", cidrs, err)
 	}
-	for _, h := range hosts {
-		if got := isAllowedSvcHost(h, false); !got {
-			t.Errorf("isAllowedSvcHost(%q, allowCluster=false) = false, want true (permissive)", h)
-		}
-		if got := isAllowedSvcHost(h, true); !got {
-			t.Errorf("isAllowedSvcHost(%q, allowCluster=true) = false, want true (permissive)", h)
-		}
+	return out
+}
+
+// TestIsAllowedSvcHost pins the SSRF boundary: loopback always, cluster DNS
+// only in kubernetes mode, literal IPs only inside the allow list, and the
+// link-local / unspecified / multicast classes never — not even when an allow
+// list covers them.
+func TestIsAllowedSvcHost(t *testing.T) {
+	lan := prefixes(t, "192.168.1.0/24")
+	wide := prefixes(t, "0.0.0.0/0", "::/0")
+
+	cases := []struct {
+		name         string
+		host         string
+		allowCluster bool
+		allow        []netip.Prefix
+		want         bool
+	}{
+		// loopback, both modes, no allow list
+		{"loopback v4 server", "127.0.0.1", false, nil, true},
+		{"loopback v4 cluster", "127.0.0.1", true, nil, true},
+		{"loopback name", "localhost", false, nil, true},
+		{"loopback v6", "::1", false, nil, true},
+		{"loopback other octet", "127.0.0.2", true, nil, true},
+
+		// LAN, metadata, internet: false in both modes without an allow list
+		{"lan server", "192.168.1.10", false, nil, false},
+		{"lan cluster", "192.168.1.10", true, nil, false},
+		{"rfc1918 cluster no allow list", "10.0.0.5", true, nil, false},
+		{"rfc1918 server", "10.0.0.5", false, nil, false},
+		{"metadata server", "169.254.169.254", false, nil, false},
+		{"metadata cluster", "169.254.169.254", true, nil, false},
+		{"internet server", "example.com", false, nil, false},
+		{"internet cluster", "example.com", true, nil, false},
+		{"empty", "", false, nil, false},
+
+		// allow list
+		{"lan in allow list", "192.168.1.1", false, lan, true},
+		{"lan outside allow list", "192.168.2.1", false, lan, false},
+		{"metadata inside allow list", "169.254.169.254", false, prefixes(t, "169.254.0.0/16"), false},
+		{"metadata inside 0/0", "169.254.169.254", true, wide, false},
+		{"v6 link-local inside allow list", "fe80::1", false, prefixes(t, "fe80::/10"), false},
+		{"unspecified inside 0/0", "0.0.0.0", false, wide, false},
+		{"multicast inside 0/0", "224.0.0.1", false, wide, false},
+		{"mapped v4 metadata inside allow list", "::ffff:169.254.169.254", false, wide, false},
+		{"mapped v4 lan inside allow list", "::ffff:192.168.1.1", false, lan, true},
+
+		// cluster DNS only in kubernetes mode
+		{"cluster dns server", "svc.ns.svc.cluster.local", false, nil, false},
+		{"cluster dns cluster", "svc.ns.svc.cluster.local", true, nil, true},
+		{"short cluster dns cluster", "home-assistant.home.svc", true, nil, true},
+		{"cluster dns lookalike", "evil.svc.example.com", true, nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAllowedSvcHost(tc.host, tc.allowCluster, tc.allow); got != tc.want {
+				t.Errorf("isAllowedSvcHost(%q, allowCluster=%v, allow=%v) = %v, want %v",
+					tc.host, tc.allowCluster, tc.allow, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -89,5 +144,332 @@ func TestIsClusterDNSHost(t *testing.T) {
 		if got := isClusterDNSHost(tc.host); got != tc.want {
 			t.Errorf("isClusterDNSHost(%q) = %v, want %v", tc.host, got, tc.want)
 		}
+	}
+}
+
+func TestParseSvcPolicy(t *testing.T) {
+	for raw, want := range map[string]SvcPolicy{"": DefaultSvcPolicy, "enforce": SvcPolicyEnforce, " Warn ": SvcPolicyWarn, "allow-any": SvcPolicyAllowAny} {
+		got, err := ParseSvcPolicy(raw)
+		if err != nil || got != want {
+			t.Errorf("ParseSvcPolicy(%q) = %q, %v; want %q", raw, got, err, want)
+		}
+	}
+	if _, err := ParseSvcPolicy("yolo"); err == nil {
+		t.Error("ParseSvcPolicy(yolo) = nil error, want error")
+	}
+}
+
+func TestParseSvcAllowedCIDRs(t *testing.T) {
+	got, err := ParseSvcAllowedCIDRs([]string{"192.168.1.0/24", " 10.0.0.5 ", "", "fd00::/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"192.168.1.0/24", "10.0.0.5/32", "fd00::/8"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i].String() != want[i] {
+			t.Errorf("[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+	for _, bad := range []string{"nope", "192.168.1.0/33", "192.168.1.0/"} {
+		if _, err := ParseSvcAllowedCIDRs([]string{bad}); err == nil {
+			t.Errorf("ParseSvcAllowedCIDRs(%q) = nil error, want error", bad)
+		}
+	}
+}
+
+// fixedResolver answers hostname lookups from a table; unknown names error.
+func fixedResolver(table map[string][]string) svcResolver {
+	return func(_ context.Context, host string) ([]netip.Addr, error) {
+		ips, ok := table[host]
+		if !ok {
+			return nil, errors.New("no such host: " + host)
+		}
+		var out []netip.Addr
+		for _, ip := range ips {
+			out = append(out, netip.MustParseAddr(ip))
+		}
+		return out, nil
+	}
+}
+
+// TestVetSvcHostResolved covers the DNS side: every resolved address is
+// checked, a hostname that resolves to a blocked address is refused (hard),
+// and the vetted addresses are what a dial gets pinned to.
+func TestVetSvcHostResolved(t *testing.T) {
+	resolver := fixedResolver(map[string][]string{
+		"metadata.evil":  {"169.254.169.254"},
+		"rebind.evil":    {"192.168.1.20", "169.254.169.254"},
+		"unifi.lan":      {"192.168.1.1"},
+		"printer.lan":    {"192.168.2.7"},
+		"localhost":      {"127.0.0.1", "::1"},
+		"ha.home.svc":    {"10.96.0.12"},
+		"ha.home.svc.":   {"10.96.0.12"},
+		"dual.lan":       {"192.168.1.5", "fd00::5"},
+		"multicast.evil": {"224.0.0.251"},
+	})
+	lan := prefixes(t, "192.168.1.0/24")
+
+	cases := []struct {
+		name         string
+		host         string
+		allowCluster bool
+		allow        []netip.Prefix
+		wantDenied   bool
+		wantHard     bool
+		wantLoopback bool
+		wantAddrs    []string
+		wantErr      bool
+	}{
+		{name: "metadata hostname is hard-blocked", host: "metadata.evil", allow: prefixes(t, "0.0.0.0/0"), wantDenied: true, wantHard: true, wantAddrs: []string{"169.254.169.254"}},
+		{name: "one bad record poisons the name", host: "rebind.evil", allow: lan, wantDenied: true, wantHard: true, wantAddrs: []string{"192.168.1.20", "169.254.169.254"}},
+		{name: "multicast hostname is hard-blocked", host: "multicast.evil", wantDenied: true, wantHard: true, wantAddrs: []string{"224.0.0.251"}},
+		{name: "hostname inside allow list", host: "unifi.lan", allow: lan, wantAddrs: []string{"192.168.1.1"}},
+		{name: "hostname outside allow list", host: "printer.lan", allow: lan, wantDenied: true, wantAddrs: []string{"192.168.2.7"}},
+		{name: "hostname with one record outside allow list", host: "dual.lan", allow: lan, wantDenied: true, wantAddrs: []string{"192.168.1.5", "fd00::5"}},
+		{name: "localhost resolves to loopback", host: "localhost", wantLoopback: true, wantAddrs: []string{"127.0.0.1", "::1"}},
+		{name: "cluster dns in kubernetes mode", host: "ha.home.svc", allowCluster: true, wantAddrs: []string{"10.96.0.12"}},
+		{name: "cluster dns in server mode is not resolved", host: "ha.home.svc", wantDenied: true},
+		{name: "literal ip is not resolved", host: "192.168.1.1", allow: lan, wantAddrs: []string{"192.168.1.1"}},
+		{name: "literal loopback", host: "127.0.0.1", wantLoopback: true, wantAddrs: []string{"127.0.0.1"}},
+		{name: "literal metadata", host: "169.254.169.254", allow: prefixes(t, "169.254.0.0/16"), wantDenied: true, wantHard: true, wantAddrs: []string{"169.254.169.254"}},
+		{name: "unresolvable", host: "nope.invalid", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{AllowedCIDRs: tc.allow}, allowCluster: tc.allowCluster, resolve: resolver}
+			got, err := vetSvcHost(context.Background(), tc.host, cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("vetSvcHost(%q) = %+v, nil; want error", tc.host, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("vetSvcHost(%q): %v", tc.host, err)
+			}
+			if (got.denied != nil) != tc.wantDenied {
+				t.Errorf("denied = %v, want %v", got.denied, tc.wantDenied)
+			}
+			if got.denied != nil && got.denied.hard != tc.wantHard {
+				t.Errorf("denied.hard = %v, want %v (%s)", got.denied.hard, tc.wantHard, got.denied.reason)
+			}
+			if got.loopback != tc.wantLoopback {
+				t.Errorf("loopback = %v, want %v", got.loopback, tc.wantLoopback)
+			}
+			var addrs []string
+			for _, a := range got.addrs {
+				addrs = append(addrs, a.String())
+			}
+			if strings.Join(addrs, ",") != strings.Join(tc.wantAddrs, ",") {
+				t.Errorf("addrs = %v, want %v", addrs, tc.wantAddrs)
+			}
+		})
+	}
+}
+
+// countingDialer wraps net.Dialer and records every address dialed. fail, if
+// set, short-circuits matching addresses with an error (still counted) so a
+// test can stand in an unreachable record without waiting for a timeout.
+type countingDialer struct {
+	n     atomic.Int32
+	addrs []string
+	fail  func(addr string) bool
+}
+
+func (c *countingDialer) dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	c.n.Add(1)
+	c.addrs = append(c.addrs, addr)
+	if c.fail != nil && c.fail(addr) {
+		return nil, errors.New("unreachable (test)")
+	}
+	var d net.Dialer
+	return d.DialContext(ctx, network, addr)
+}
+
+// svcProxyFixture stands up a loopback upstream (httptest binds 127.0.0.1)
+// and returns a helper that sends one request through newSvcProxyHandler to
+// the given target, plus the counting dialer the handler was given.
+func svcProxyFixture(t *testing.T, cfg svcProxyConfig) (upstream *httptest.Server, do func(target string) *http.Response, dialer *countingDialer) {
+	t.Helper()
+	upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, h := range []string{svcTargetHeader, svcTLSInsecureHeader} {
+			if v := r.Header.Get(h); v != "" {
+				t.Errorf("control header %s leaked upstream: %q", h, v)
+			}
+		}
+		_, _ = io.WriteString(w, "hello from "+r.URL.Path)
+	}))
+	t.Cleanup(upstream.Close)
+
+	dialer = &countingDialer{}
+	cfg.dial = dialer.dial
+	h := newSvcProxyHandler(cfg)
+
+	do = func(target string) *http.Response {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/svc/api/ping", nil)
+		req.Header.Set(svcTargetHeader, target)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec.Result()
+	}
+	return upstream, do, dialer
+}
+
+// upstreamPort returns the port an httptest upstream listens on.
+func upstreamPort(t *testing.T, upstream *httptest.Server) string {
+	t.Helper()
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func readBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	return string(body)
+}
+
+// TestSvcProxyHandlerEnforceDeniesWithoutDialing is the acceptance case: under
+// enforce, a LAN / metadata / unresolved-cluster target gets a 403 with the
+// JSON body and the agent never opens a socket.
+func TestSvcProxyHandlerEnforceDeniesWithoutDialing(t *testing.T) {
+	cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: SvcPolicyEnforce},
+		resolve: fixedResolver(map[string][]string{"metadata.evil": {"169.254.169.254"}, "printer.lan": {"192.168.2.7"}})}
+	_, do, dialer := svcProxyFixture(t, cfg)
+
+	for _, target := range []string{
+		"http://169.254.169.254/latest/meta-data/",
+		"http://192.168.1.10:8080",
+		"http://10.0.0.5:6443",
+		"http://metadata.evil:80",
+		"http://printer.lan:9100",
+		"http://ha.home.svc:8123", // cluster DNS in server mode
+	} {
+		resp := do(target)
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("%s: status = %d, want 403 (body %q)", target, resp.StatusCode, body)
+			continue
+		}
+		if got := resp.Header.Get(svcPolicyHeader); got != string(SvcPolicyEnforce) {
+			t.Errorf("%s: %s = %q, want %q", target, svcPolicyHeader, got, SvcPolicyEnforce)
+		}
+		var js struct {
+			Error  string `json:"error"`
+			Reason string `json:"reason"`
+		}
+		if err := json.Unmarshal([]byte(body), &js); err != nil {
+			t.Errorf("%s: body %q is not JSON: %v", target, body, err)
+		} else if js.Error != "target host not allowed" || js.Reason == "" {
+			t.Errorf("%s: body = %+v, want error=target host not allowed and a reason", target, js)
+		}
+	}
+	if n := dialer.n.Load(); n != 0 {
+		t.Errorf("dialed %d times (%v), want 0", n, dialer.addrs)
+	}
+}
+
+// TestSvcProxyHandlerHardBlockIgnoresPolicy: link-local stays refused under
+// warn and allow-any, even when an allow list covers it.
+func TestSvcProxyHandlerHardBlockIgnoresPolicy(t *testing.T) {
+	for _, policy := range []SvcPolicy{SvcPolicyWarn, SvcPolicyAllowAny} {
+		cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: policy, AllowedCIDRs: prefixes(t, "0.0.0.0/0")}}
+		_, do, dialer := svcProxyFixture(t, cfg)
+		resp := do("http://169.254.169.254/latest/meta-data/")
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("policy %s: status = %d, want 403", policy, resp.StatusCode)
+		}
+		if n := dialer.n.Load(); n != 0 {
+			t.Errorf("policy %s: dialed %d times, want 0", policy, n)
+		}
+	}
+}
+
+// TestSvcProxyHandlerLoopbackDials: a literal loopback target and the
+// "localhost" name (resolved through the injected resolver) both reach the
+// upstream under enforce with no allow list, with exactly one dial and no
+// policy header.
+func TestSvcProxyHandlerLoopbackDials(t *testing.T) {
+	cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: SvcPolicyEnforce},
+		resolve: fixedResolver(map[string][]string{"localhost": {"127.0.0.1"}})}
+	for _, name := range []string{"127.0.0.1", "localhost"} {
+		upstream, do, dialer := svcProxyFixture(t, cfg)
+		resp := do("http://" + net.JoinHostPort(name, upstreamPort(t, upstream)))
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusOK || !strings.Contains(body, "hello from /api/ping") {
+			t.Fatalf("%s: status = %d body = %q", name, resp.StatusCode, body)
+		}
+		if got := resp.Header.Get(svcPolicyHeader); got != "" {
+			t.Errorf("%s: unexpected %s = %q on an allowed target", name, svcPolicyHeader, got)
+		}
+		if n := dialer.n.Load(); n != 1 {
+			t.Errorf("%s: dialed %d times, want 1", name, n)
+		}
+	}
+}
+
+// TestSvcProxyHandlerWarnDialsAndStamps: a target outside the allow list is
+// still dialed under warn, pinned to the resolved records, and the response
+// carries X-Faros-Svc-Policy: warn. The fake LAN name resolves to an
+// unreachable TEST-NET address first and the loopback upstream second, which
+// also exercises the pinned dialer's fallback across records.
+func TestSvcProxyHandlerWarnDialsAndStamps(t *testing.T) {
+	cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: SvcPolicyWarn},
+		resolve: fixedResolver(map[string][]string{"printer.lan": {"192.0.2.1", "127.0.0.1"}})}
+	upstream, do, dialer := svcProxyFixture(t, cfg)
+	dialer.fail = func(addr string) bool { return strings.HasPrefix(addr, "192.0.2.1:") }
+	port := upstreamPort(t, upstream)
+
+	resp := do("http://printer.lan:" + port)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(body, "hello from /api/ping") {
+		t.Fatalf("status = %d body = %q", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get(svcPolicyHeader); got != string(SvcPolicyWarn) {
+		t.Errorf("%s = %q, want %q", svcPolicyHeader, got, SvcPolicyWarn)
+	}
+	want := []string{"192.0.2.1:" + port, "127.0.0.1:" + port}
+	if strings.Join(dialer.addrs, ",") != strings.Join(want, ",") {
+		t.Errorf("dialed %v, want pinned %v", dialer.addrs, want)
+	}
+}
+
+// TestSvcProxyHandlerAllowListDials: an allow-listed non-loopback range is
+// dialable under enforce (the upstream is loopback, so the test allow-lists
+// 127.0.0.0/8 through a resolver that answers a LAN-looking name with it).
+func TestSvcProxyHandlerAllowListDials(t *testing.T) {
+	cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: SvcPolicyEnforce, AllowedCIDRs: prefixes(t, "127.0.0.0/8")},
+		resolve: fixedResolver(map[string][]string{"unifi.lan": {"127.0.0.1"}})}
+	upstream, do, dialer := svcProxyFixture(t, cfg)
+	resp := do("http://unifi.lan:" + upstreamPort(t, upstream))
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if n := dialer.n.Load(); n != 1 {
+		t.Errorf("dialed %d times, want 1", n)
+	}
+}
+
+func TestSvcProxyHandlerBadTarget(t *testing.T) {
+	cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: SvcPolicyEnforce}}
+	_, do, dialer := svcProxyFixture(t, cfg)
+	for _, target := range []string{"", "not a url", "http://", "/relative"} {
+		resp := do(target)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("%q: status = %d, want 400", target, resp.StatusCode)
+		}
+	}
+	if n := dialer.n.Load(); n != 0 {
+		t.Errorf("dialed %d times, want 0", n)
 	}
 }

--- a/pkg/agent/tunnel/tunneler.go
+++ b/pkg/agent/tunnel/tunneler.go
@@ -64,7 +64,10 @@ import (
 // bearer token. Callers should return the SA token from the saved kubeconfig
 // after token-exchange has succeeded, otherwise the join token is rejected on
 // reconnect once the hub has cleared edge.Status.JoinToken.
-func StartProxyTunnel(ctx context.Context, hubURL string, getToken func() string, edgeName string, resourceType string, downstream *rest.Config, tlsConfig *tls.Config, stateChannel chan bool, sshPort int, cluster string, onAgentToken func(string), extraHeaders http.Header) {
+//
+// svc is the /svc proxy host policy (--svc-allow-cidr / --svc-policy); see
+// SvcProxyOptions and newSvcProxyHandler.
+func StartProxyTunnel(ctx context.Context, hubURL string, getToken func() string, edgeName string, resourceType string, downstream *rest.Config, tlsConfig *tls.Config, stateChannel chan bool, sshPort int, svc SvcProxyOptions, cluster string, onAgentToken func(string), extraHeaders http.Header) {
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting proxy tunnel", "hubURL", hubURL, "edgeName", edgeName, "resourceType", resourceType)
 
@@ -83,7 +86,7 @@ func StartProxyTunnel(ctx context.Context, hubURL string, getToken func() string
 		default:
 		}
 
-		err := startTunneler(ctx, hubURL, getToken, edgeName, resourceType, downstream, tlsConfig, stateChannel, sshPort, cluster, onAgentToken, extraHeaders)
+		err := startTunneler(ctx, hubURL, getToken, edgeName, resourceType, downstream, tlsConfig, stateChannel, sshPort, svc, cluster, onAgentToken, extraHeaders)
 		if err != nil {
 			logger.Error(err, "tunnel connection failed, reconnecting")
 		}
@@ -122,7 +125,7 @@ func sendTunnelState(c chan bool, v bool) {
 	}
 }
 
-func startTunneler(ctx context.Context, hubURL string, getToken func() string, edgeName string, resourceType string, downstream *rest.Config, tlsConfig *tls.Config, stateChannel chan bool, sshPort int, cluster string, onAgentToken func(string), extraHeaders http.Header) error {
+func startTunneler(ctx context.Context, hubURL string, getToken func() string, edgeName string, resourceType string, downstream *rest.Config, tlsConfig *tls.Config, stateChannel chan bool, sshPort int, svc SvcProxyOptions, cluster string, onAgentToken func(string), extraHeaders http.Header) error {
 	logger := klog.FromContext(ctx)
 
 	// Resolve the current bearer token for this connect attempt. After
@@ -179,7 +182,7 @@ func startTunneler(ctx context.Context, hubURL string, getToken func() string, e
 	defer ln.Close() //nolint:errcheck
 
 	// Create and serve local HTTP server
-	server, err := newRemoteServer(downstream, sshPort)
+	server, err := newRemoteServer(downstream, sshPort, svc)
 	if err != nil {
 		return fmt.Errorf("failed to create remote server: %w", err)
 	}

--- a/pkg/cli/cmd/agent.go
+++ b/pkg/cli/cmd/agent.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/faroshq/faros/pkg/agent"
+	"github.com/faroshq/faros/pkg/agent/tunnel"
 	pkgversion "github.com/faroshq/faros/pkg/version"
 )
 
@@ -75,6 +76,51 @@ func agentRunFlags(cmd *cobra.Command, opts *agent.Options) {
 	cmd.Flags().StringVar(&opts.SSHPassword, "ssh-password", "", "SSH password for password-based authentication (prefer --ssh-private-key for security)")
 	cmd.Flags().StringVar(&opts.SSHPrivateKeyPath, "ssh-private-key", "", "Path to SSH private key file for key-based authentication")
 	cmd.Flags().StringVar(&opts.DebugAddr, "debug-addr", "", "Bind address for the debug HTTP server exposing /healthz and /debug/pprof/* (e.g. \"127.0.0.1:6060\"). Empty disables the server.")
+	cmd.Flags().StringSliceVar(&opts.SvcAllowedCIDRs, "svc-allow-cidr", svcAllowCIDRDefault(),
+		"CIDR the Service proxy may dial besides loopback (and cluster DNS in kubernetes mode), e.g. 192.168.1.0/24. Repeatable. Link-local, unspecified and multicast addresses are never allowed. Env: "+svcAllowCIDREnv)
+	cmd.Flags().StringVar(&opts.SvcPolicy, "svc-policy", svcPolicyDefault(),
+		"What the Service proxy does with a target outside loopback/--svc-allow-cidr: enforce (403, never dialed), warn (dialed but logged; response carries X-Faros-Svc-Policy: warn) or allow-any (allow list disabled; logged at startup). The default flips to enforce in the next release. Env: "+svcPolicyEnv)
+}
+
+// Environment fallbacks for the Service proxy policy flags, so systemd units
+// and in-cluster Deployments can set the policy without editing args.
+const (
+	svcAllowCIDREnv = "FAROS_AGENT_SVC_ALLOW_CIDR"
+	svcPolicyEnv    = "FAROS_AGENT_SVC_POLICY"
+)
+
+// svcAllowCIDRDefault reads FAROS_AGENT_SVC_ALLOW_CIDR (comma-separated).
+func svcAllowCIDRDefault() []string {
+	var out []string
+	for _, s := range strings.Split(os.Getenv(svcAllowCIDREnv), ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// svcPolicyDefault reads FAROS_AGENT_SVC_POLICY, else tunnel.DefaultSvcPolicy.
+func svcPolicyDefault() string {
+	if v := strings.TrimSpace(os.Getenv(svcPolicyEnv)); v != "" {
+		return v
+	}
+	return string(tunnel.DefaultSvcPolicy)
+}
+
+// svcPolicyArgs renders the Service proxy flags for an installed unit or
+// Deployment. The policy is only rendered when it differs from the built-in
+// default, so installs pick up the next release's default flip without a
+// reinstall; allow CIDRs are always rendered.
+func svcPolicyArgs(cidrs []string, policy string) []string {
+	var args []string
+	for _, c := range cidrs {
+		args = append(args, "--svc-allow-cidr="+c)
+	}
+	if policy != "" && policy != string(tunnel.DefaultSvcPolicy) {
+		args = append(args, "--svc-policy="+policy)
+	}
+	return args
 }
 
 // runAgentForeground contains the shared foreground-process logic used by both
@@ -475,6 +521,9 @@ roleRef:
 		if opts.Cluster != "" {
 			deployArgs += " --cluster=" + opts.Cluster
 		}
+		for _, a := range svcPolicyArgs(opts.SvcAllowedCIDRs, opts.SvcPolicy) {
+			deployArgs += " " + a
+		}
 		deployManifest = fmt.Sprintf(`apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -539,6 +588,9 @@ stringData:
 		}
 		if opts.Cluster != "" {
 			deployArgs += " --cluster=" + opts.Cluster
+		}
+		for _, a := range svcPolicyArgs(opts.SvcAllowedCIDRs, opts.SvcPolicy) {
+			deployArgs += " " + a
 		}
 		deployManifest = fmt.Sprintf(`apiVersion: apps/v1
 kind: Deployment
@@ -692,7 +744,9 @@ ExecStart={{.BinaryPath}} agent run \
   --ssh-user {{.SSHUser}}{{end}}{{if .SSHPrivateKey}} \
   --ssh-private-key {{.SSHPrivateKey}}{{end}}{{if .Cluster}} \
   --cluster {{.Cluster}}{{end}}{{if .InsecureSkipTLS}} \
-  --hub-insecure-skip-tls-verify{{end}}
+  --hub-insecure-skip-tls-verify{{end}}{{range .SvcAllowCIDRs}} \
+  --svc-allow-cidr {{.}}{{end}}{{if .SvcPolicy}} \
+  --svc-policy {{.SvcPolicy}}{{end}}
 Restart=always
 RestartSec=10
 Environment=HOME=/root
@@ -713,6 +767,10 @@ type systemdUnitData struct {
 	SSHPrivateKey   string
 	Cluster         string
 	InsecureSkipTLS bool
+	// SvcAllowCIDRs / SvcPolicy render --svc-allow-cidr / --svc-policy. SvcPolicy
+	// is left empty when it equals the built-in default (see svcPolicyArgs).
+	SvcAllowCIDRs []string
+	SvcPolicy     string
 }
 
 func newAgentInstallCommand() *cobra.Command {
@@ -726,6 +784,8 @@ func newAgentInstallCommand() *cobra.Command {
 		cluster         string
 		insecureSkipTLS bool
 		unitName        string
+		svcAllowCIDRs   []string
+		svcPolicy       string
 	)
 
 	cmd := &cobra.Command{
@@ -782,6 +842,16 @@ Example:
 				SSHPrivateKey:   sshPrivateKey,
 				Cluster:         cluster,
 				InsecureSkipTLS: insecureSkipTLS,
+				SvcAllowCIDRs:   svcAllowCIDRs,
+			}
+			if svcPolicy != "" && svcPolicy != string(tunnel.DefaultSvcPolicy) {
+				if _, err := tunnel.ParseSvcPolicy(svcPolicy); err != nil {
+					return err
+				}
+				data.SvcPolicy = svcPolicy
+			}
+			if _, err := tunnel.ParseSvcAllowedCIDRs(svcAllowCIDRs); err != nil {
+				return err
 			}
 
 			// Render systemd unit.
@@ -831,6 +901,8 @@ Example:
 	cmd.Flags().StringVar(&cluster, "cluster", "", "kcp logical cluster path")
 	cmd.Flags().BoolVar(&insecureSkipTLS, "hub-insecure-skip-tls-verify", false, "Skip TLS verification")
 	cmd.Flags().StringVar(&unitName, "unit-name", "", "Systemd unit name (default: faros-agent-<edge-name>)")
+	cmd.Flags().StringSliceVar(&svcAllowCIDRs, "svc-allow-cidr", svcAllowCIDRDefault(), "CIDR the Service proxy may dial besides loopback, e.g. 192.168.1.0/24 (repeatable; rendered into the unit)")
+	cmd.Flags().StringVar(&svcPolicy, "svc-policy", svcPolicyDefault(), "Service proxy policy for targets outside the allowed set: enforce, warn or allow-any (rendered into the unit only when not the default)")
 
 	return cmd
 }

--- a/providers/edges/apis/v1alpha1/types_service.go
+++ b/providers/edges/apis/v1alpha1/types_service.go
@@ -168,8 +168,25 @@ type ServiceSpec struct {
 	// Host is the address the agent dials directly: the agent-host loopback, or
 	// another device on the edge's LAN (e.g. a UniFi console at 192.168.1.1).
 	// Takes precedence over targetRef and works on either edge kind.
+	//
+	// The agent decides whether it will dial the host: loopback always,
+	// cluster DNS in kubernetes mode, anything else only when inside the
+	// agent's --svc-allow-cidr ranges (see pkg/agent/tunnel/svc.go). The
+	// rule below only rejects the obvious link-local literals (cloud metadata)
+	// at admission; full validation, including resolved addresses, lives in
+	// the agent.
 	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:XValidation:rule="!self.startsWith('169.254.') && !self.lowerAscii().startsWith('fe80:') && !self.lowerAscii().startsWith('[fe80:')",message="spec.host must not be a link-local address (169.254.0.0/16, fe80::/10)"
 	Host string `json:"host,omitempty"`
+
+	// TLSInsecureSkipVerify makes the agent skip TLS certificate verification
+	// when dialing an https host that is not the agent's own loopback (the
+	// loopback is always exempt). Needed for LAN devices with self-signed
+	// certificates, such as a UniFi console. Default false: the agent verifies
+	// the upstream certificate against the host's trust store.
+	// +optional
+	TLSInsecureSkipVerify bool `json:"tlsInsecureSkipVerify,omitempty"`
 
 	// Type selects the detector and the MCP tool bundle. "generic" = proxy-only.
 	// +kubebuilder:default=generic

--- a/providers/edges/config/crds/edges.faros.sh_services.yaml
+++ b/providers/edges/config/crds/edges.faros.sh_services.yaml
@@ -122,7 +122,20 @@ spec:
                   Host is the address the agent dials directly: the agent-host loopback, or
                   another device on the edge's LAN (e.g. a UniFi console at 192.168.1.1).
                   Takes precedence over targetRef and works on either edge kind.
+
+                  The agent decides whether it will dial the host: loopback always,
+                  cluster DNS in kubernetes mode, anything else only when inside the
+                  agent's --svc-allow-cidr ranges (see pkg/agent/tunnel/svc.go). The
+                  rule below only rejects the obvious link-local literals (cloud metadata)
+                  at admission; full validation, including resolved addresses, lives in
+                  the agent.
+                maxLength: 253
                 type: string
+                x-kubernetes-validations:
+                - message: spec.host must not be a link-local address (169.254.0.0/16,
+                    fe80::/10)
+                  rule: '!self.startsWith(''169.254.'') && !self.lowerAscii().startsWith(''fe80:'')
+                    && !self.lowerAscii().startsWith(''[fe80:'')'
               instructions:
                 description: |-
                   Instructions is free-form guidance surfaced to AI clients on the MCP
@@ -165,6 +178,14 @@ spec:
                 - name
                 - namespace
                 type: object
+              tlsInsecureSkipVerify:
+                description: |-
+                  TLSInsecureSkipVerify makes the agent skip TLS certificate verification
+                  when dialing an https host that is not the agent's own loopback (the
+                  loopback is always exempt). Needed for LAN devices with self-signed
+                  certificates, such as a UniFi console. Default false: the agent verifies
+                  the upstream certificate against the host's trust store.
+                type: boolean
               type:
                 default: generic
                 description: Type selects the detector and the MCP tool bundle. "generic"

--- a/providers/edges/config/crds/edges.faros.sh_workloads.yaml
+++ b/providers/edges/config/crds/edges.faros.sh_workloads.yaml
@@ -84,8 +84,9 @@ spec:
                   repoURL:
                     description: |-
                       RepoURL is the chart repository base URL, e.g.
-                      "https://grafana.github.io/helm-charts". The provider fetches the chart
-                      archive as "<repoURL>/<chart>-<version>.tgz".
+                      "https://grafana.github.io/helm-charts". The provider resolves the
+                      archive through the repo's index.yaml (falling back to
+                      "<repoURL>/<chart>-<version>.tgz" for repos without a readable index).
                     minLength: 1
                     type: string
                   values:

--- a/providers/edges/config/kcp/apiexport-edges.faros.sh.yaml
+++ b/providers/edges/config/kcp/apiexport-edges.faros.sh.yaml
@@ -21,12 +21,12 @@ spec:
       crd: {}
   - group: edges.faros.sh
     name: services
-    schema: v260820-ca9b3456.services.edges.faros.sh
+    schema: v260904-9ab06b67.services.edges.faros.sh
     storage:
       crd: {}
   - group: edges.faros.sh
     name: workloads
-    schema: v260718-e83a64f.workloads.edges.faros.sh
+    schema: v260904-9ab06b67.workloads.edges.faros.sh
     storage:
       crd: {}
 status: {}

--- a/providers/edges/config/kcp/apiresourceschema-services.edges.faros.sh.yaml
+++ b/providers/edges/config/kcp/apiresourceschema-services.edges.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260820-ca9b3456.services.edges.faros.sh
+  name: v260904-9ab06b67.services.edges.faros.sh
 spec:
   group: edges.faros.sh
   names:
@@ -118,7 +118,20 @@ spec:
                 Host is the address the agent dials directly: the agent-host loopback, or
                 another device on the edge's LAN (e.g. a UniFi console at 192.168.1.1).
                 Takes precedence over targetRef and works on either edge kind.
+
+                The agent decides whether it will dial the host: loopback always,
+                cluster DNS in kubernetes mode, anything else only when inside the
+                agent's --svc-allow-cidr ranges (see pkg/agent/tunnel/svc.go). The
+                rule below only rejects the obvious link-local literals (cloud metadata)
+                at admission; full validation, including resolved addresses, lives in
+                the agent.
+              maxLength: 253
               type: string
+              x-kubernetes-validations:
+              - message: spec.host must not be a link-local address (169.254.0.0/16,
+                  fe80::/10)
+                rule: '!self.startsWith(''169.254.'') && !self.lowerAscii().startsWith(''fe80:'')
+                  && !self.lowerAscii().startsWith(''[fe80:'')'
             instructions:
               description: |-
                 Instructions is free-form guidance surfaced to AI clients on the MCP
@@ -161,6 +174,14 @@ spec:
               - name
               - namespace
               type: object
+            tlsInsecureSkipVerify:
+              description: |-
+                TLSInsecureSkipVerify makes the agent skip TLS certificate verification
+                when dialing an https host that is not the agent's own loopback (the
+                loopback is always exempt). Needed for LAN devices with self-signed
+                certificates, such as a UniFi console. Default false: the agent verifies
+                the upstream certificate against the host's trust store.
+              type: boolean
             type:
               default: generic
               description: Type selects the detector and the MCP tool bundle. "generic"

--- a/providers/edges/config/kcp/apiresourceschema-workloads.edges.faros.sh.yaml
+++ b/providers/edges/config/kcp/apiresourceschema-workloads.edges.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260718-e83a64f.workloads.edges.faros.sh
+  name: v260904-9ab06b67.workloads.edges.faros.sh
 spec:
   group: edges.faros.sh
   names:
@@ -80,8 +80,9 @@ spec:
                 repoURL:
                   description: |-
                     RepoURL is the chart repository base URL, e.g.
-                    "https://grafana.github.io/helm-charts". The provider fetches the chart
-                    archive as "<repoURL>/<chart>-<version>.tgz".
+                    "https://grafana.github.io/helm-charts". The provider resolves the
+                    archive through the repo's index.yaml (falling back to
+                    "<repoURL>/<chart>-<version>.tgz" for repos without a readable index).
                   minLength: 1
                   type: string
                 values:

--- a/providers/edges/contrib/manifests/unifi/faros-service.example.yaml
+++ b/providers/edges/contrib/manifests/unifi/faros-service.example.yaml
@@ -28,9 +28,10 @@ spec:
   edgeRef:
     kind: LinuxServer
     name: minis-server
-  host: 192.168.1.1        # your UniFi OS console LAN IP
+  host: 192.168.1.1        # your UniFi OS console LAN IP; the agent must run with --svc-allow-cidr 192.168.1.0/24
   type: unifi-network
   scheme: https            # UniFi OS is https (self-signed)
+  tlsInsecureSkipVerify: true  # self-signed console cert: the agent verifies non-loopback https otherwise
   port: 443
   authSecretRef:
     namespace: faros-system
@@ -49,6 +50,7 @@ spec:
   host: 192.168.1.1        # same console
   type: unifi-protect
   scheme: https
+  tlsInsecureSkipVerify: true
   port: 443
   authSecretRef:
     namespace: faros-system

--- a/providers/edges/deploy/chart/files/schemas/services.edges.faros.sh.yaml
+++ b/providers/edges/deploy/chart/files/schemas/services.edges.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260820-ca9b3456.services.edges.faros.sh
+  name: v260904-9ab06b67.services.edges.faros.sh
 spec:
   group: edges.faros.sh
   names:
@@ -118,7 +118,20 @@ spec:
                 Host is the address the agent dials directly: the agent-host loopback, or
                 another device on the edge's LAN (e.g. a UniFi console at 192.168.1.1).
                 Takes precedence over targetRef and works on either edge kind.
+
+                The agent decides whether it will dial the host: loopback always,
+                cluster DNS in kubernetes mode, anything else only when inside the
+                agent's --svc-allow-cidr ranges (see pkg/agent/tunnel/svc.go). The
+                rule below only rejects the obvious link-local literals (cloud metadata)
+                at admission; full validation, including resolved addresses, lives in
+                the agent.
+              maxLength: 253
               type: string
+              x-kubernetes-validations:
+              - message: spec.host must not be a link-local address (169.254.0.0/16,
+                  fe80::/10)
+                rule: '!self.startsWith(''169.254.'') && !self.lowerAscii().startsWith(''fe80:'')
+                  && !self.lowerAscii().startsWith(''[fe80:'')'
             instructions:
               description: |-
                 Instructions is free-form guidance surfaced to AI clients on the MCP
@@ -161,6 +174,14 @@ spec:
               - name
               - namespace
               type: object
+            tlsInsecureSkipVerify:
+              description: |-
+                TLSInsecureSkipVerify makes the agent skip TLS certificate verification
+                when dialing an https host that is not the agent's own loopback (the
+                loopback is always exempt). Needed for LAN devices with self-signed
+                certificates, such as a UniFi console. Default false: the agent verifies
+                the upstream certificate against the host's trust store.
+              type: boolean
             type:
               default: generic
               description: Type selects the detector and the MCP tool bundle. "generic"

--- a/providers/edges/deploy/chart/files/schemas/workloads.edges.faros.sh.yaml
+++ b/providers/edges/deploy/chart/files/schemas/workloads.edges.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260718-e83a64f.workloads.edges.faros.sh
+  name: v260904-9ab06b67.workloads.edges.faros.sh
 spec:
   group: edges.faros.sh
   names:
@@ -80,8 +80,9 @@ spec:
                 repoURL:
                   description: |-
                     RepoURL is the chart repository base URL, e.g.
-                    "https://grafana.github.io/helm-charts". The provider fetches the chart
-                    archive as "<repoURL>/<chart>-<version>.tgz".
+                    "https://grafana.github.io/helm-charts". The provider resolves the
+                    archive through the repo's index.yaml (falling back to
+                    "<repoURL>/<chart>-<version>.tgz" for repos without a readable index).
                   minLength: 1
                   type: string
                 values:

--- a/providers/edges/internal/events/subscriber.go
+++ b/providers/edges/internal/events/subscriber.go
@@ -106,7 +106,7 @@ func (cfg SubscriberConfig) connectOnce(ctx context.Context) bool {
 		},
 	}
 	header := http.Header{}
-	header.Set(haclient.SvcTargetHeader, cfg.Target.SvcTarget())
+	cfg.Target.SetSvcHeaders(header)
 	for k, vals := range cfg.Header {
 		for _, v := range vals {
 			header.Add(k, v)

--- a/providers/edges/internal/haclient/haclient.go
+++ b/providers/edges/internal/haclient/haclient.go
@@ -30,13 +30,39 @@ import (
 )
 
 // SvcTargetHeader mirrors the agent-side constant (pkg/agent/tunnel). The agent
-// enforces that the target host is loopback. Exported so out-of-package callers
-// that build their own tunnel requests (e.g. the events WebSocket subscriber)
-// set the same header.
+// decides whether it will dial the host: loopback always, cluster DNS in
+// kubernetes mode, anything else only inside its --svc-allow-cidr ranges (see
+// SvcPolicyHeader for how it answers). Exported so out-of-package callers that
+// build their own tunnel requests (e.g. the events WebSocket subscriber) set
+// the same header — prefer Target.SetSvcHeaders.
 const SvcTargetHeader = "X-Faros-Svc-Target"
+
+// SvcTLSInsecureHeader mirrors the agent-side constant: "true" tells the agent
+// to skip TLS verification for a non-loopback https target. Set from
+// Service.spec.tlsInsecureSkipVerify.
+const SvcTLSInsecureHeader = "X-Faros-Svc-TLS-Insecure"
+
+// SvcPolicyHeader is the response header the agent stamps when its host policy
+// acted: SvcPolicyEnforce on a 403 refusing the target (never dialed),
+// SvcPolicyWarn when a target outside the allow list was dialed anyway under
+// --svc-policy=warn. Its presence on a 403 distinguishes an agent refusal from
+// a 403 the service itself returned.
+const (
+	SvcPolicyHeader  = "X-Faros-Svc-Policy"
+	SvcPolicyEnforce = "enforce"
+	SvcPolicyWarn    = "warn"
+)
 
 // svcTargetHeader is the internal spelling used throughout this package.
 const svcTargetHeader = SvcTargetHeader
+
+// IsHostNotAllowed reports whether resp is the agent refusing to dial the
+// target (403 with X-Faros-Svc-Policy: enforce), as opposed to a 403 from
+// the service. See pkg/agent/tunnel/svc.go.
+func IsHostNotAllowed(resp *http.Response) bool {
+	return resp != nil && resp.StatusCode == http.StatusForbidden &&
+		resp.Header.Get(SvcPolicyHeader) == SvcPolicyEnforce
+}
 
 // Dialer opens a fresh connection to the edge agent over the reverse tunnel.
 // *revdial.Dialer satisfies this.
@@ -46,23 +72,38 @@ type Dialer interface {
 
 // Target identifies the service to reach, plus its bearer token. Host is the
 // agent-side address: the loopback for LinuxServer edges (the default when
-// empty), or cluster DNS ({name}.{namespace}.svc) for KubernetesCluster edges.
+// empty), cluster DNS ({name}.{namespace}.svc) for KubernetesCluster edges,
+// or a spec.host the agent's --svc-allow-cidr policy permits.
 type Target struct {
 	Scheme string // "http" | "https"
 	Host   string // defaults to 127.0.0.1
 	Port   int32
 	Token  string // bearer token injected as Authorization; may be empty
+	// TLSInsecureSkipVerify mirrors Service.spec.tlsInsecureSkipVerify: ask the
+	// agent to skip certificate verification for a non-loopback https host.
+	TLSInsecureSkipVerify bool
 }
 
 // SvcTarget returns the value for the X-Faros-Svc-Target header. The agent
-// validates the host against what its mode permits (loopback always; cluster
-// DNS in kubernetes mode).
+// validates the host against its policy (loopback always; cluster DNS in
+// kubernetes mode; --svc-allow-cidr otherwise).
 func (t Target) SvcTarget() string {
 	host := t.Host
 	if host == "" {
 		host = "127.0.0.1"
 	}
 	return fmt.Sprintf("%s://%s:%d", t.Scheme, host, t.Port)
+}
+
+// SetSvcHeaders stamps the agent control headers for this target on h: the
+// target itself and, when TLSInsecureSkipVerify, the TLS opt-out.
+func (t Target) SetSvcHeaders(h http.Header) {
+	h.Set(SvcTargetHeader, t.SvcTarget())
+	if t.TLSInsecureSkipVerify {
+		h.Set(SvcTLSInsecureHeader, "true")
+	} else {
+		h.Del(SvcTLSInsecureHeader)
+	}
 }
 
 // Do issues one request to the service behind (dialer, target), injecting the
@@ -94,7 +135,7 @@ func DoWith(ctx context.Context, dialer Dialer, target Target, method, path stri
 		conn.Close() //nolint:errcheck
 		return nil, err
 	}
-	req.Header.Set(svcTargetHeader, target.SvcTarget())
+	target.SetSvcHeaders(req.Header)
 	for k, vals := range header {
 		for _, v := range vals {
 			req.Header.Add(k, v)

--- a/providers/edges/internal/servicectrl/validation_reconciler.go
+++ b/providers/edges/internal/servicectrl/validation_reconciler.go
@@ -215,9 +215,10 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 	// kinds (qBittorrent/Pi-hole) Apply performs the login, so a failure here is
 	// the credential being rejected rather than a transport error.
 	target := haclient.Target{
-		Scheme: schemeString(es.Spec.Scheme),
-		Host:   targetHost(es),
-		Port:   es.Spec.Port,
+		Scheme:                schemeString(es.Spec.Scheme),
+		Host:                  targetHost(es),
+		Port:                  es.Spec.Port,
+		TLSInsecureSkipVerify: es.Spec.TLSInsecureSkipVerify,
 	}
 	subTarget = target // captured for the subscriber defer
 	header := http.Header{}
@@ -245,6 +246,28 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, req mcreconcile.Re
 		return r.commit(ctx, c, orig, es, validationResyncInterval)
 	}
 	defer resp.Body.Close() //nolint:errcheck
+
+	// The agent refused to dial spec.host (403 + X-Faros-Svc-Policy: enforce):
+	// not a credential problem, and nothing was probed. Surface the agent's
+	// reason so the operator knows to add the host to --svc-allow-cidr.
+	if haclient.IsHostNotAllowed(resp) {
+		es.Status.Phase = "Unreachable"
+		reason := hostNotAllowedReason(resp.Body)
+		logger.Info("agent refused the service host", "type", es.Spec.Type, "host", target.Host, "reason", reason)
+		setCondition(&es.Status.Conditions, "HostAllowed", metav1.ConditionFalse, "HostNotAllowed", reason)
+		setCondition(&es.Status.Conditions, "Ready", metav1.ConditionFalse, "HostNotAllowed",
+			"the edge agent refused to dial spec.host: "+reason)
+		setNotProbed(es, "the edge agent refused to dial spec.host, so the service was never reached")
+		return r.commit(ctx, c, orig, es, validationResyncInterval)
+	}
+	if resp.Header.Get(haclient.SvcPolicyHeader) == haclient.SvcPolicyWarn {
+		// Dialed under --svc-policy=warn: works today, refused once the agent
+		// enforces. Say so on the object rather than only in the agent log.
+		setCondition(&es.Status.Conditions, "HostAllowed", metav1.ConditionTrue, "WarnOnly",
+			"spec.host is outside the edge agent's --svc-allow-cidr; it was dialed under --svc-policy=warn and will be refused under enforce")
+	} else {
+		setCondition(&es.Status.Conditions, "HostAllowed", metav1.ConditionTrue, "Allowed", "the edge agent accepts spec.host")
+	}
 
 	mode := def.ProbeMode
 	if mode == "" {
@@ -349,6 +372,23 @@ func unifiAuthHeader(ctx context.Context, dialer haclient.Dialer, target haclien
 // bodySnippet reads up to a small cap from an upstream response body and trims
 // it to max runes for inclusion in a status condition / log — enough to surface
 // an API's "why" message without dumping a whole page.
+// hostNotAllowedReason extracts the agent's reason from its 403 body
+// ({"error":"target host not allowed","reason":"..."}), falling back to the
+// raw snippet.
+func hostNotAllowedReason(body io.Reader) string {
+	raw := bodySnippet(body, 300)
+	var js struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(raw), &js); err == nil && js.Reason != "" {
+		return js.Reason
+	}
+	if raw == "" {
+		return "target host not allowed by the edge agent's --svc-allow-cidr policy"
+	}
+	return raw
+}
+
 func bodySnippet(body io.Reader, max int) string {
 	b, _ := io.ReadAll(io.LimitReader(body, 4<<10))
 	s := strings.TrimSpace(string(b))

--- a/providers/edges/internal/tunnel/mcp_service.go
+++ b/providers/edges/internal/tunnel/mcp_service.go
@@ -232,7 +232,7 @@ func (p *Server) haDo(ctx context.Context, cluster, kcpToken string, svc *servic
 	if token == "" {
 		return nil, fmt.Errorf("no auth token configured for this service (set spec.authSecretRef)")
 	}
-	target := haclient.Target{Scheme: svc.scheme(), Host: svc.targetHost(), Port: svc.Spec.Port, Token: token}
+	target := haclient.Target{Scheme: svc.scheme(), Host: svc.targetHost(), Port: svc.Spec.Port, Token: token, TLSInsecureSkipVerify: svc.Spec.TLSInsecureSkipVerify}
 	resp, err := haclient.Do(ctx, dialer, target, method, path, body)
 	if err != nil {
 		klog.FromContext(ctx).Error(err, "home assistant request failed", "method", method, "path", path)

--- a/providers/edges/internal/tunnel/service_proxy.go
+++ b/providers/edges/internal/tunnel/service_proxy.go
@@ -44,8 +44,16 @@ import (
 const serviceResource = "services"
 
 // svcTargetHeader mirrors the agent-side constant (pkg/agent/tunnel). The agent
-// enforces that the target host is loopback.
+// decides whether it dials the host: loopback always, cluster DNS in kubernetes
+// mode, any other address only inside the agent's --svc-allow-cidr ranges
+// (link-local never). A refused target comes back as a 403 with
+// X-Faros-Svc-Policy: enforce, which this proxy passes through unchanged.
 const svcTargetHeader = "X-Faros-Svc-Target"
+
+// svcTLSInsecureHeader mirrors the agent-side constant: set to "true" from
+// spec.tlsInsecureSkipVerify so the agent skips certificate verification for
+// a non-loopback https host (e.g. a self-signed UniFi console).
+const svcTLSInsecureHeader = "X-Faros-Svc-TLS-Insecure"
 
 // serviceView is the projection of a Service CR the proxy needs. As
 // with sshEdgeView, every field must be exported and non-object fields tagged
@@ -61,13 +69,14 @@ type serviceView struct {
 			Namespace string `json:"namespace"`
 			Name      string `json:"name"`
 		} `json:"targetRef,omitempty"`
-		Host          string                  `json:"host,omitempty"`
-		Type          string                  `json:"type,omitempty"`
-		Scheme        string                  `json:"scheme,omitempty"`
-		Port          int32                   `json:"port"`
-		AuthSecretRef *corev1.SecretReference `json:"authSecretRef,omitempty"`
-		Auth          string                  `json:"auth,omitempty"`
-		Instructions  string                  `json:"instructions,omitempty"`
+		Host                  string                  `json:"host,omitempty"`
+		TLSInsecureSkipVerify bool                    `json:"tlsInsecureSkipVerify,omitempty"`
+		Type                  string                  `json:"type,omitempty"`
+		Scheme                string                  `json:"scheme,omitempty"`
+		Port                  int32                   `json:"port"`
+		AuthSecretRef         *corev1.SecretReference `json:"authSecretRef,omitempty"`
+		Auth                  string                  `json:"auth,omitempty"`
+		Instructions          string                  `json:"instructions,omitempty"`
 	} `json:"spec"`
 }
 
@@ -132,6 +141,17 @@ func (v *serviceView) targetHost() string {
 // target is the full X-Faros-Svc-Target value.
 func (v *serviceView) target() string {
 	return fmt.Sprintf("%s://%s:%d", v.scheme(), v.targetHost(), v.Spec.Port)
+}
+
+// setSvcHeaders stamps the agent control headers for this Service on h: the
+// target, and the TLS opt-out when spec.tlsInsecureSkipVerify is set.
+func (v *serviceView) setSvcHeaders(h http.Header) {
+	h.Set(svcTargetHeader, v.target())
+	if v.Spec.TLSInsecureSkipVerify {
+		h.Set(svcTLSInsecureHeader, "true")
+	} else {
+		h.Del(svcTLSInsecureHeader)
+	}
 }
 
 // parseServicePath extracts {cluster}, {name}, {subresource}, and the
@@ -235,7 +255,6 @@ func (p *Server) serviceHTTPProxy(ctx context.Context, w http.ResponseWriter, r 
 		}
 	}
 
-	target := svc.target()
 	svcPath := "/svc" + rest
 
 	deviceConn, err := dialer.Dial(ctx)
@@ -246,7 +265,7 @@ func (p *Server) serviceHTTPProxy(ctx context.Context, w http.ResponseWriter, r 
 	}
 
 	if isUpgradeRequest(r) {
-		p.serviceHandleUpgrade(ctx, w, r, deviceConn, target, svcPath, mode, token)
+		p.serviceHandleUpgrade(ctx, w, r, deviceConn, svc, svcPath, mode, token)
 		return
 	}
 
@@ -264,9 +283,11 @@ func (p *Server) serviceHTTPProxy(ctx context.Context, w http.ResponseWriter, r 
 			req.URL.Scheme = "http"
 			req.URL.Host = "edge-agent"
 			req.URL.Path = svcPath
-			req.Header.Set(svcTargetHeader, target)
+			svc.setSvcHeaders(req.Header)
 			applyServiceAuth(req.Header, mode, token)
 		},
+		// The agent's answer is relayed as-is, including a 403 with
+		// X-Faros-Svc-Policy: enforce when it refuses to dial spec.host.
 		Transport: transport,
 		// Unbuffered, as on the hub's own backend proxy: this path carries
 		// log tails and other streams (a provider backend reached over an
@@ -297,7 +318,7 @@ func applyServiceAuth(h http.Header, mode, token string) {
 
 // serviceHandleUpgrade handles WebSocket/upgrade requests to a service by
 // hijacking and piping raw bytes through the tunnel (HA uses /api/websocket).
-func (p *Server) serviceHandleUpgrade(ctx context.Context, w http.ResponseWriter, r *http.Request, deviceConn net.Conn, target, svcPath, mode, token string) {
+func (p *Server) serviceHandleUpgrade(ctx context.Context, w http.ResponseWriter, r *http.Request, deviceConn net.Conn, svc *serviceView, svcPath, mode, token string) {
 	logger := klog.FromContext(ctx)
 
 	hijacker, ok := w.(http.Hijacker)
@@ -315,7 +336,7 @@ func (p *Server) serviceHandleUpgrade(ctx context.Context, w http.ResponseWriter
 
 	r.URL.Path = svcPath
 	r.RequestURI = r.URL.RequestURI()
-	r.Header.Set(svcTargetHeader, target)
+	svc.setSvcHeaders(r.Header)
 	applyServiceAuth(r.Header, mode, token)
 
 	if err := r.Write(deviceConn); err != nil {

--- a/providers/edges/internal/tunnel/service_proxy_test.go
+++ b/providers/edges/internal/tunnel/service_proxy_test.go
@@ -85,6 +85,30 @@ func TestServiceViewTargetHTTPS(t *testing.T) {
 	}
 }
 
+// TestServiceViewSetSvcHeaders pins the agent control headers: the target is
+// always set, and the TLS opt-out only when spec.tlsInsecureSkipVerify is on
+// (and is cleared when it is off, so a caller-supplied value cannot linger).
+func TestServiceViewSetSvcHeaders(t *testing.T) {
+	v := newServiceView("LinuxServer", "minis", "", "", 443)
+	v.Spec.Host = "192.168.1.1"
+	v.Spec.Scheme = "https"
+
+	h := http.Header{svcTLSInsecureHeader: []string{"true"}}
+	v.setSvcHeaders(h)
+	if got, want := h.Get(svcTargetHeader), "https://192.168.1.1:443"; got != want {
+		t.Errorf("%s = %q, want %q", svcTargetHeader, got, want)
+	}
+	if got := h.Get(svcTLSInsecureHeader); got != "" {
+		t.Errorf("%s = %q, want unset when spec.tlsInsecureSkipVerify is false", svcTLSInsecureHeader, got)
+	}
+
+	v.Spec.TLSInsecureSkipVerify = true
+	v.setSvcHeaders(h)
+	if got := h.Get(svcTLSInsecureHeader); got != "true" {
+		t.Errorf("%s = %q, want \"true\"", svcTLSInsecureHeader, got)
+	}
+}
+
 func TestParseServicePath(t *testing.T) {
 	s := testServer("/services/providers/edges/edgeproxy")
 

--- a/providers/edges/internal/tunnel/svc_catalog.go
+++ b/providers/edges/internal/tunnel/svc_catalog.go
@@ -166,7 +166,7 @@ func (p *Server) callCatalogTool(ctx context.Context, cluster, kcpToken string, 
 
 	// Auth (headers + query) is applied by the shared catalog, which also runs
 	// the session-login round-trips for qBittorrent/Pi-hole.
-	target := haclient.Target{Scheme: svc.scheme(), Host: svc.targetHost(), Port: svc.Spec.Port}
+	target := haclient.Target{Scheme: svc.scheme(), Host: svc.targetHost(), Port: svc.Spec.Port, TLSInsecureSkipVerify: svc.Spec.TLSInsecureSkipVerify}
 	header := http.Header{}
 	if err := svccatalog.Apply(ctx, dialer, target, def, token, header, q); err != nil {
 		return toolErr(err.Error()), nil, nil


### PR DESCRIPTION
Implements item 1.1 (agent-side SSRF) of `docs/security-remediation-plan.md`.

## Problem

The agent's `/svc` reverse proxy (`pkg/agent/tunnel/svc.go`) dialed whatever host the provider put in `X-Faros-Svc-Target`: `isAllowedSvcHost` returned `true` on every path (its `allowCluster` argument was dead, `TODO(security)`), `svc_test.go` pinned that permissive behaviour, and both dial paths (the `ReverseProxy` transport and the WebSocket `tls.Dial`) ran with `InsecureSkipVerify: true`.

The provider computes that target from `Service.spec.host`, a free-form string on a cluster-scoped CRD that any workspace member (cluster-admin in their workspace) can write. Any member could therefore create a `Service` naming any host and port and have the agent dial it from inside the edge — cloud metadata (`169.254.169.254`), the kubelet, cluster Services, the LAN — with bodies and WebSocket bytes relayed both ways.

## Change

**Agent** (`pkg/agent/tunnel/svc.go`, new `svc_policy.go`):
- `vetSvcHost` / `isAllowedSvcHost(host, allowCluster, allow []netip.Prefix)` are default-deny: loopback always; cluster-DNS names only in kubernetes mode (`downstream != nil`); other literal IPs, and every address a hostname resolves to, only inside `--svc-allow-cidr`. The trailing `return true` is gone.
- Link-local (`169.254.0.0/16`, `fe80::/10`), unspecified and multicast addresses are hard-blocked before the allow list — never overridable, including when an allow-list prefix covers them and under `warn` / `allow-any`. IPv4-mapped IPv6 forms are unmapped first.
- Hostnames are resolved once (`net.DefaultResolver.LookupNetIP`), every record is checked, and both the `http.Transport.DialContext` and the upgrade path dial are pinned to the vetted addresses, so DNS rebinding cannot swap the target. `localhost` resolves to loopback and passes (with a loopback fallback if the host lacks an `/etc/hosts` entry).
- TLS is skipped only when the vetted target is loopback; otherwise verified, unless the request carries `X-Faros-Svc-TLS-Insecure: true`. The upgrade path now layers `tls.Client` over the pinned connection with the same config.
- `enforce`: 403 with `{"error":"target host not allowed","reason":"..."}` and `X-Faros-Svc-Policy: enforce`, never dialed. `warn`: dialed, logged at V(0) with target and reason, response stamped `X-Faros-Svc-Policy: warn` (HTTP only; a hijacked upgrade cannot carry the header). `allow-any`: allow list off, logged at startup as a disabled protection.
- Plumbing: `agent.Options.SvcAllowedCIDRs` / `SvcPolicy` → parsed in `agent.New` → `tunnel.SvcProxyOptions` through `StartProxyTunnel` → `startTunneler` → `newRemoteServer` → `setupRouter` → `newSvcProxyHandler(svcProxyConfig)`.

**CLI** (`pkg/cli/cmd/agent.go`): `--svc-allow-cidr` (repeatable / comma-separated) and `--svc-policy` on `agent run` / `agent join` / `agent install`, defaulting from `FAROS_AGENT_SVC_ALLOW_CIDR` / `FAROS_AGENT_SVC_POLICY`. Rendered into the systemd unit and the in-cluster Deployment args (the policy only when it differs from the built-in default, so installs follow the next release's default flip without a reinstall).

**Provider** (`providers/edges`):
- `Service.spec.tlsInsecureSkipVerify bool` (default false), sent as `X-Faros-Svc-TLS-Insecure` next to `X-Faros-Svc-Target` from `service_proxy.go`, `haclient` (`Target.SetSvcHeaders`), the MCP tool path and the events subscriber. Codegen (`make codegen-edges-provider`) committed.
- CEL rule on `spec.host` rejecting `169.254.`- and `fe80:`-prefixed literals (documented as admission-only; full validation lives in the agent).
- The agent's 403 passes through the provider `ReverseProxy` unchanged (it never turned into a 502; a comment now says so). `haclient.IsHostNotAllowed` recognises it, and the validation reconciler sets `HostAllowed=False/HostNotAllowed`, `Ready=False/HostNotAllowed`, `phase: Unreachable` with the agent's reason; a warn-mode dial sets `HostAllowed=True/WarnOnly`; otherwise `HostAllowed=True/Allowed`.
- Stale comments in `svc.go`, `service_proxy.go`, `haclient.go` and the AGENTS.md §5.1 sentence now describe the policy and flags. The UniFi example manifest sets `tlsInsecureSkipVerify: true` and notes the `--svc-allow-cidr` requirement; `docs/home-assistant-edge-control.md` gains a paragraph on the flags.

Follow-up (not in this PR): `spec.caBundle` for verifying LAN devices with private CAs instead of `tlsInsecureSkipVerify`; the e2e case from the plan's acceptance criteria.

## Compatibility

Warn-then-enforce rollout:
- **This release:** `--svc-policy` defaults to `warn`. Every existing Service keeps working; an agent that dials a target outside loopback / cluster DNS / `--svc-allow-cidr` logs `svc target would be denied under --svc-policy=enforce` with the target and reason, the response carries `X-Faros-Svc-Policy: warn`, and the Service shows `HostAllowed=True/WarnOnly`. Operators use that to add `--svc-allow-cidr 192.168.1.0/24` (or `FAROS_AGENT_SVC_ALLOW_CIDR`) to the affected agents.
- **Next release:** the default flips to `enforce`; denied targets get 403 and `HostAllowed=False/HostNotAllowed`. `--svc-policy=allow-any` remains as a loudly logged escape hatch.
- Link-local / unspecified / multicast targets are refused immediately in every mode, including `warn`.
- **TLS behaviour change now, not deferred:** non-loopback `https` targets are verified from this release. LAN devices with self-signed certificates (UniFi Network / Protect) need `spec.tlsInsecureSkipVerify: true` on their Service, or the proxy and the validation probe fail with a certificate error. The UniFi example manifest and `svccatalog` host help point at this.
- New flags: `--svc-allow-cidr` (repeatable), `--svc-policy enforce|warn|allow-any`; env `FAROS_AGENT_SVC_ALLOW_CIDR`, `FAROS_AGENT_SVC_POLICY`. `faros agent install` renders them into the unit; `faros agent join --type kubernetes` renders them into the Deployment.
- API: additive optional field `spec.tlsInsecureSkipVerify`, plus a CEL rule that only rejects link-local literals; the `services` APIResourceSchema is bumped (`v260904-9ab06b67`). `make codegen-edges-provider` also picked up a pre-existing `workloads` doc-comment drift on main; that regenerated output is included as-is.

## Tests

- `TestIsAllowedSvcHost` rewritten: LAN, metadata and internet hosts false in both modes; `192.168.1.1` with `192.168.1.0/24` true; `169.254.169.254` (and `fe80::1`, `0.0.0.0`, `224.0.0.1`, `::ffff:169.254.169.254`) inside an allow list still false; `10.0.0.5` in cluster mode with no allow list false; `localhost`, `127.0.0.1`, `::1` true; `svc.ns.svc.cluster.local` true only in cluster mode.
- `TestVetSvcHostResolved` (injected resolver): a hostname resolving to link-local or multicast is hard-denied; one bad record poisons the name; allow-listed and non-listed LAN names; `localhost`; cluster DNS in both modes; literals are not resolved; unresolvable names error.
- `httptest` handler tests with a dial counter: enforce returns 403 JSON with the policy header and zero dials for LAN / metadata / resolved-blocked / cluster-DNS-in-server-mode targets; hard-block ignores `warn` and `allow-any`; loopback literal and `localhost` dial once with no header; warn dials the pinned records in order and stamps `X-Faros-Svc-Policy: warn`; allow-listed range dials; bad targets 400 without dialing; control headers never leak upstream.
- `TestParseSvcPolicy`, `TestParseSvcAllowedCIDRs`; provider `TestServiceViewSetSvcHeaders`.
- Commands: `go build ./... && go vet ./pkg/... && go test -count=1 ./pkg/agent/... ./pkg/cli/...` (pass), `make fix-lint && make lint` (0 issues), `cd providers/edges && go build ./internal/... ./apis/... && go vet ./internal/... ./apis/... && go test -count=1 ./internal/... ./apis/...` (pass; the module root needs `portal/dist` from the portal build), `make codegen-edges-provider` (diff committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
