### PR TITLE
fix(hub): authenticate provider heartbeats with the provider service account

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,9 +232,15 @@ APIExport, schemas) and registers routing/heartbeat state.
 | registry / controller / heartbeat | In-memory routing table, catalog reconcile, `POST /api/providers/{name}/heartbeat` liveness (TTL ~90s) |
 | `pkg/hub/provider_tenant_resolver.go` | Resolves caller identity → tenant workspace path; injects `X-Faros-User` / `X-Faros-Tenant`, strips spoofed inbound copies |
 
-Heartbeat: standalone providers POST every ~30s with `FAROS_HUB_URL`,
-`FAROS_HUB_TOKEN`, `FAROS_PROVIDER_NAME`. A provider is "Ready" only when its
-endpoints are valid and (once heartbeats have started) not stale.
+Heartbeat: standalone providers POST every ~30s with `FAROS_HUB_URL` and
+`FAROS_PROVIDER_NAME`. The beat is authenticated as the provider's own
+service account: the bearer is `FAROS_HUB_TOKEN` if set, otherwise the token
+inside `FAROS_PROVIDER_KUBECONFIG` (`provider-sdk/hubclient.ResolveHubToken`),
+and the hub verifies it by TokenReview in the provider's workspace
+(`heartbeat_auth.go`). `--provider-heartbeat-auth=warn|enforce` picks whether
+a failed check is logged or rejected (default `warn` this release, `enforce`
+next). A provider is "Ready" only when its endpoints are valid and (once
+heartbeats have started) not stale.
 
 ### 5.3 Provider portal micro-frontends
 

--- a/cmd/faros-hub/main.go
+++ b/cmd/faros-hub/main.go
@@ -77,6 +77,7 @@ func main() {
 		"First-party providers to enable as CatalogEntries (comma-separated or repeat). "+
 			"Defaults to all known builtins. Dependencies are enforced — e.g. mcp requires server-edges.")
 
+	cmd.Flags().StringVar(&opts.ProviderHeartbeatAuth, "provider-heartbeat-auth", opts.ProviderHeartbeatAuth, "What to do with a provider heartbeat whose bearer token does not verify as that provider's own service account: warn (log and accept) or enforce (reject). Default warn for this release; the next release defaults to enforce.")
 	cmd.Flags().StringVar(&opts.GraphQLAddr, "graphql-addr", opts.GraphQLAddr, "Address of an external GraphQL gateway to proxy /graphql/* requests to (empty to disable)")
 	cmd.Flags().BoolVar(&opts.EmbeddedGraphQL, "embedded-graphql", opts.EmbeddedGraphQL, "Run GraphQL listener+gateway in-process (requires embedded or external kcp; overrides --graphql-addr)")
 	cmd.Flags().StringVar(&opts.GraphQLAPIExportSliceName, "graphql-apiexport-slice-name", opts.GraphQLAPIExportSliceName, "APIExportEndpointSlice name to watch for GraphQL schema generation")

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -515,6 +515,14 @@ Content-Type: application/json
   and still records the beat so providers on older charts keep reporting
   alive while they are rolled forward; `enforce` (next release's default)
   rejects them, and such a provider goes stale after the TTL.
+- A rejection body says only which class of failure it was (`heartbeat not
+  authenticated` / `forbidden` / `heartbeat verification unavailable`); the
+  reason — logical cluster, expected service account, TokenReview error —
+  goes to the hub log only, because the endpoint answers anonymous callers.
+  For the same reason `enforce` answers a beat for an unregistered provider
+  with exactly that 401 rather than a 404, so the endpoint cannot be used to
+  enumerate provider names. In `warn` mode, which accepts unauthenticated
+  beats by design, an unknown name still gets 404.
 - Provider side: the bearer is `FAROS_HUB_TOKEN` if set, otherwise the token
   in `FAROS_PROVIDER_KUBECONFIG` (`provider-sdk/hubclient.ResolveHubToken`).
   Charts need no change.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -505,8 +505,19 @@ Content-Type: application/json
 { "version": "1.2.0", "buildTime": "...", "status": "healthy" }
 ```
 
-- Authenticates the bearer token against the SA in
-  `root:faros:providers:{name}`. Rejects any other identity.
+- Authenticates the bearer token as the provider's own service account
+  (`system:serviceaccount:default:provider`) by TokenReview in the provider's
+  workspace `root:faros:providers:{name}` — the same SA and token the hub
+  minted into the provider kubeconfig. Any other identity is rejected with
+  403, a missing or unrecognised token with 401. The endpoint has no auth
+  middleware in front of it; this check is the whole of its authentication.
+  `--provider-heartbeat-auth=warn` (this release's default) logs failures
+  and still records the beat so providers on older charts keep reporting
+  alive while they are rolled forward; `enforce` (next release's default)
+  rejects them, and such a provider goes stale after the TTL.
+- Provider side: the bearer is `FAROS_HUB_TOKEN` if set, otherwise the token
+  in `FAROS_PROVIDER_KUBECONFIG` (`provider-sdk/hubclient.ResolveHubToken`).
+  Charts need no change.
 - Updates `CatalogEntry.status.lastHeartbeat` and
   `reportedVersion`.
 - TTL: 90 seconds. Catalog controller flips `Ready=false` if no heartbeat
@@ -939,8 +950,10 @@ Secret* differ.
 
 A provider's backend (if it declares one) MUST:
 
-- Heartbeat: `POST /api/providers/{name}/heartbeat` to the hub every 30s
-  (helper in the SDK).
+- Heartbeat: `POST /api/providers/{name}/heartbeat` to the hub every 30s,
+  authenticated as the provider's own service account (token from
+  `provider-sdk/hubclient.ResolveHubToken`: `FAROS_HUB_TOKEN`, else the
+  provider kubeconfig's bearer).
 - `GET /healthz` → 200 when ready (used by hub for `BackendHealthy`).
 
 A provider's controller (the kcp-talking part) MUST:
@@ -986,8 +999,13 @@ A provider's UI MUST:
   platform-owned frame sources, such as App Studio preview hosts.
 - **Internal-only services**: providers should be `ClusterIP`. Hub is the
   only public ingress. Network policies recommended.
-- **Heartbeat token**: provider SA token is short-lived (24h); rotation
-  handled by the catalog controller.
+- **Heartbeat token**: the heartbeat is authenticated as the provider's own
+  service account, verified by TokenReview in the provider's workspace. The
+  token is the provider kubeconfig's long-lived legacy SA token (a
+  `kubernetes.io/service-account-token` Secret); it stays valid until the
+  Secret or SA is deleted, and the hub caches a successful verification for
+  less than the heartbeat TTL so revocation takes effect within one liveness
+  window.
 
 ---
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -505,10 +505,19 @@ Content-Type: application/json
 { "version": "1.2.0", "buildTime": "...", "status": "healthy" }
 ```
 
+- **Platform providers only.** The endpoint addresses providers by bare name
+  with no org context, so it resolves `{name}` to the *platform* workspace
+  `root:faros:providers:{name}`. An org-owned (BYO) provider lives at
+  `root:faros:tenants:{orgUUID}:providers:{name}` and cannot beat here; that
+  is deliberate, since otherwise one org could keep a platform provider of the
+  same name looking alive. Org-owned providers never set `HeartbeatRequired`
+  and their readiness rests on endpoint validity alone
+  (`Registry.Heartbeat`). In `enforce` they receive the same generic 401 as
+  any unregistered name, so do not read that 401 as a credential problem.
 - Authenticates the bearer token as the provider's own service account
   (`system:serviceaccount:default:provider`) by TokenReview in the provider's
-  workspace `root:faros:providers:{name}` — the same SA and token the hub
-  minted into the provider kubeconfig. Any other identity is rejected with
+  platform workspace `root:faros:providers:{name}` — the same SA and token the
+  hub minted into the provider kubeconfig. Any other identity is rejected with
   403, a missing or unrecognised token with 401. The endpoint has no auth
   middleware in front of it; this check is the whole of its authentication.
   `--provider-heartbeat-auth=warn` (this release's default) logs failures
@@ -958,10 +967,13 @@ Secret* differ.
 
 A provider's backend (if it declares one) MUST:
 
-- Heartbeat: `POST /api/providers/{name}/heartbeat` to the hub every 30s,
-  authenticated as the provider's own service account (token from
-  `provider-sdk/hubclient.ResolveHubToken`: `FAROS_HUB_TOKEN`, else the
-  provider kubeconfig's bearer).
+- Heartbeat, **platform providers only**: `POST /api/providers/{name}/heartbeat`
+  to the hub every 30s, authenticated as the provider's own service account
+  (token from `provider-sdk/hubclient.ResolveHubToken`: `FAROS_HUB_TOKEN`, else
+  the provider kubeconfig's bearer). An org-owned (BYO) provider MUST NOT beat:
+  the endpoint is keyed by bare name and resolves only platform providers, so
+  the beat is rejected and would in any case never mark it Ready. Its readiness
+  comes from endpoint validity instead — see the heartbeat endpoint section.
 - `GET /healthz` → 200 when ready (used by hub for `BackendHealthy`).
 
 A provider's controller (the kcp-talking part) MUST:

--- a/pkg/hub/options.go
+++ b/pkg/hub/options.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package hub
 
-import "github.com/faroshq/faros/pkg/kcppaths"
+import (
+	"github.com/faroshq/faros/pkg/hub/providers"
+	"github.com/faroshq/faros/pkg/kcppaths"
+)
 
 // Options holds configuration for the hub server.
 type Options struct {
@@ -86,6 +89,15 @@ type Options struct {
 	// pkg/hub/kcp.builtinEntries[].Requires.
 	Providers []string
 
+	// ProviderHeartbeatAuth is what the hub does with a provider heartbeat
+	// whose bearer token does not verify as that provider's own service
+	// account: "warn" logs and records the beat, "enforce" rejects it. The
+	// default is "warn" for this release so providers installed from charts
+	// that predate the authenticated heartbeat keep reporting alive while
+	// they are rolled forward; the next release flips the default to
+	// "enforce". See providers.HeartbeatAuthMode.
+	ProviderHeartbeatAuth string
+
 	// GraphQLAddr is the address of an external GraphQL gateway to proxy /graphql/ requests to.
 	// If empty and EmbeddedGraphQL is false, the graphql proxy is disabled.
 	GraphQLAddr string
@@ -146,6 +158,8 @@ func NewOptions() *Options {
 		KCPSecurePort:       6443,
 		KCPBindAddress:      "127.0.0.1",
 		KCPBatteriesInclude: "admin,user",
+
+		ProviderHeartbeatAuth: string(providers.HeartbeatAuthWarn),
 
 		GraphQLAPIExportSliceName:      "core.faros.sh",
 		GraphQLAPIExportLogicalCluster: kcppaths.SystemControllers,

--- a/pkg/hub/providers/heartbeat.go
+++ b/pkg/hub/providers/heartbeat.go
@@ -134,7 +134,19 @@ func NewHeartbeatHandler(reg *Registry, record HeartbeatRecorder, authenticate H
 				http.Error(w, heartbeatAuthFailureBody(status), status)
 				return
 			}
-			logger.Info("heartbeat failed authentication; accepting because --provider-heartbeat-auth=warn (enforce becomes the default next release)",
+			// Warn mode exists so an operator can see which providers will
+			// break when enforce becomes the default, so a rejected identity
+			// is worth a line per beat. "Cannot verify" is not: it says
+			// nothing about this provider, repeats for every provider on
+			// every tick, and both ways it happens are already reported
+			// elsewhere — a hub with no kcp says so once at startup, and a
+			// hub whose kcp is unreachable fails the heartbeat recorder,
+			// which logs at error level.
+			warn := logger.V(0)
+			if heartbeatAuthStatus(err) == http.StatusServiceUnavailable {
+				warn = logger.V(1)
+			}
+			warn.Info("heartbeat failed authentication; accepting because --provider-heartbeat-auth=warn (enforce becomes the default next release)",
 				"provider", name, "reason", err.Error())
 		}
 		var body heartbeatRequest

--- a/pkg/hub/providers/heartbeat.go
+++ b/pkg/hub/providers/heartbeat.go
@@ -68,6 +68,11 @@ const heartbeatPersistThreshold = HeartbeatTTL / 6
 // verify). A nil authenticate means the hub cannot verify anything (no kcp)
 // and behaves like a check that always fails with ErrHeartbeatAuthUnavailable.
 //
+// A rejection says only which of those three classes it was: the reason goes to
+// the log, never to the caller. In enforce mode a beat for a name that is not
+// registered is refused with exactly the 401 a bad credential gets, so the
+// endpoint cannot be used to enumerate provider names.
+//
 // record may be nil (no kcp configured), in which case liveness stays local to
 // this process and the hub must not be scaled beyond one replica.
 func NewHeartbeatHandler(reg *Registry, record HeartbeatRecorder, authenticate HeartbeatAuthenticator, mode HeartbeatAuthMode, log logr.Logger) http.Handler {
@@ -87,10 +92,46 @@ func NewHeartbeatHandler(reg *Registry, record HeartbeatRecorder, authenticate H
 			http.NotFound(w, r)
 			return
 		}
+		// The registry lookup comes before authentication on purpose. Verifying
+		// a beat for a name the hub has never heard of costs a TokenReview round
+		// trip against kcp and, in warn mode, one log line per beat — work an
+		// unauthenticated caller can drive at will.
+		//
+		// Note that this is a different lookup from the authenticator's
+		// CatalogEntryCluster: a provider that is registered but whose
+		// CatalogEntry has not been observed yet is known here and unresolvable
+		// there. That transient startup state must stay a 503 the provider
+		// retries, so only a name absent from the registry short-circuits.
+		previous, known := reg.Get(name)
+		if !known {
+			if mode == HeartbeatAuthEnforce {
+				// Deliberately indistinguishable from a bad credential: same
+				// status, same body. This endpoint has no auth middleware in
+				// front of it, so answering 404 here — or letting the
+				// authenticator answer 503 because it cannot resolve a cluster
+				// for an unknown name — would let anyone who can reach the hub
+				// enumerate provider names by status code. The real reason is
+				// logged.
+				logger.V(1).Info("heartbeat rejected", "provider", name, "reason", "provider is not registered")
+				http.Error(w, heartbeatAuthFailureBody(http.StatusUnauthorized), http.StatusUnauthorized)
+				return
+			}
+			// Warn mode accepts unauthenticated beats by design, so a caller can
+			// tell known from unknown regardless of what this returns; there is
+			// no oracle left to close and 404 is the honest answer.
+			logger.V(1).Info("heartbeat for unknown provider", "provider", name)
+			http.Error(w, "provider not found", http.StatusNotFound)
+			return
+		}
 		if err := authenticate(r.Context(), r, name); err != nil {
 			if mode == HeartbeatAuthEnforce {
 				logger.V(1).Info("heartbeat rejected", "provider", name, "reason", err.Error())
-				http.Error(w, "heartbeat not authenticated: "+err.Error(), heartbeatAuthStatus(err))
+				// The body says only which class of failure it was. The
+				// authenticator's messages carry logical cluster IDs and the
+				// expected service account username, and this endpoint answers
+				// unauthenticated callers.
+				status := heartbeatAuthStatus(err)
+				http.Error(w, heartbeatAuthFailureBody(status), status)
 				return
 			}
 			logger.Info("heartbeat failed authentication; accepting because --provider-heartbeat-auth=warn (enforce becomes the default next release)",
@@ -105,13 +146,16 @@ func NewHeartbeatHandler(reg *Registry, record HeartbeatRecorder, authenticate H
 		}
 		now := time.Now()
 		// Apply locally first so this replica routes to the provider without
-		// waiting for the watch to loop the status write back around.
-		previous, known := reg.Get(name)
+		// waiting for the watch to loop the status write back around. The
+		// provider was in the registry above, so this only fails if it was
+		// deleted in between.
 		if !reg.Heartbeat(name, body.Version, now) {
-			http.Error(w, "provider not found: "+name, http.StatusNotFound)
+			http.Error(w, "provider not found", http.StatusNotFound)
 			return
 		}
-		if record != nil && (!known || now.Sub(previous.LastHeartbeat) >= heartbeatPersistThreshold) {
+		// previous.LastHeartbeat is zero for a provider that has never beaten,
+		// which is far enough in the past to persist.
+		if record != nil && now.Sub(previous.LastHeartbeat) >= heartbeatPersistThreshold {
 			if err := record(r.Context(), name, body.Version, now); err != nil {
 				// Fail the beat rather than silently leaving other replicas to
 				// time the provider out; the provider retries on its next tick.

--- a/pkg/hub/providers/heartbeat.go
+++ b/pkg/hub/providers/heartbeat.go
@@ -19,6 +19,7 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -54,16 +55,28 @@ type HeartbeatRecorder func(ctx context.Context, name, version string, at time.T
 const heartbeatPersistThreshold = HeartbeatTTL / 6
 
 // NewHeartbeatHandler returns an http.Handler serving
-// POST /api/providers/{name}/heartbeat. Auth is enforced by the faros auth
-// middleware mounted upstream of this handler — any bearer token faros
-// accepts will be accepted as a valid heartbeat sender in Phase 1C. Phase
-// 1D will tighten this to "must be the provider's own SA token" once SA
-// minting is in place.
+// POST /api/providers/{name}/heartbeat.
+//
+// The handler is mounted on the root router with no auth middleware in front
+// of it, so it authenticates the beat itself: authenticate must accept the
+// request as coming from provider {name}'s own service account (the one the
+// hub minted its kubeconfig for) before the beat counts. Without that check
+// anyone able to reach the hub could keep a dead provider Ready and forge its
+// reportedVersion. In HeartbeatAuthWarn mode a failed check is logged and the
+// beat is still recorded; in HeartbeatAuthEnforce it is rejected with 401
+// (no or unrecognised token), 403 (some other identity) or 503 (could not
+// verify). A nil authenticate means the hub cannot verify anything (no kcp)
+// and behaves like a check that always fails with ErrHeartbeatAuthUnavailable.
 //
 // record may be nil (no kcp configured), in which case liveness stays local to
 // this process and the hub must not be scaled beyond one replica.
-func NewHeartbeatHandler(reg *Registry, record HeartbeatRecorder, log logr.Logger) http.Handler {
+func NewHeartbeatHandler(reg *Registry, record HeartbeatRecorder, authenticate HeartbeatAuthenticator, mode HeartbeatAuthMode, log logr.Logger) http.Handler {
 	logger := log.WithName("heartbeat")
+	if authenticate == nil {
+		authenticate = func(context.Context, *http.Request, string) error {
+			return fmt.Errorf("%w: no kcp configured", ErrHeartbeatAuthUnavailable)
+		}
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -73,6 +86,15 @@ func NewHeartbeatHandler(reg *Registry, record HeartbeatRecorder, log logr.Logge
 		if !ok {
 			http.NotFound(w, r)
 			return
+		}
+		if err := authenticate(r.Context(), r, name); err != nil {
+			if mode == HeartbeatAuthEnforce {
+				logger.V(1).Info("heartbeat rejected", "provider", name, "reason", err.Error())
+				http.Error(w, "heartbeat not authenticated: "+err.Error(), heartbeatAuthStatus(err))
+				return
+			}
+			logger.Info("heartbeat failed authentication; accepting because --provider-heartbeat-auth=warn (enforce becomes the default next release)",
+				"provider", name, "reason", err.Error())
 		}
 		var body heartbeatRequest
 		if r.ContentLength > 0 {

--- a/pkg/hub/providers/heartbeat_auth.go
+++ b/pkg/hub/providers/heartbeat_auth.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	authnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/faroshq/faros/pkg/apiurl"
+)
+
+// HeartbeatAuthMode selects what the heartbeat handler does when a beat fails
+// authentication.
+type HeartbeatAuthMode string
+
+const (
+	// HeartbeatAuthWarn records the beat anyway and logs the failure with the
+	// provider name and reason. It is the default for this release so that
+	// providers deployed from charts that predate the authenticated heartbeat
+	// keep working while operators roll them forward; the next release flips
+	// the default to HeartbeatAuthEnforce.
+	HeartbeatAuthWarn HeartbeatAuthMode = "warn"
+	// HeartbeatAuthEnforce rejects unauthenticated beats. A provider that
+	// cannot prove it holds its own service-account token goes stale after
+	// HeartbeatTTL, which is the correct outcome.
+	HeartbeatAuthEnforce HeartbeatAuthMode = "enforce"
+)
+
+// ParseHeartbeatAuthMode validates a --provider-heartbeat-auth flag value.
+func ParseHeartbeatAuthMode(s string) (HeartbeatAuthMode, error) {
+	switch m := HeartbeatAuthMode(strings.ToLower(strings.TrimSpace(s))); m {
+	case HeartbeatAuthWarn, HeartbeatAuthEnforce:
+		return m, nil
+	default:
+		return "", fmt.Errorf("invalid provider heartbeat auth mode %q (want %q or %q)", s, HeartbeatAuthWarn, HeartbeatAuthEnforce)
+	}
+}
+
+// HeartbeatAuthenticator decides whether r is allowed to heartbeat on behalf
+// of providerName. A nil error accepts the beat. Errors wrap one of the
+// ErrHeartbeat* sentinels so the handler can pick the status code; anything
+// else is treated as "could not verify" (503), which the provider retries.
+type HeartbeatAuthenticator func(ctx context.Context, r *http.Request, providerName string) error
+
+var (
+	// ErrHeartbeatNoBearer means the request carried no bearer token (401).
+	ErrHeartbeatNoBearer = errors.New("heartbeat has no bearer token")
+	// ErrHeartbeatTokenRejected means the workspace did not authenticate the
+	// token at all (401).
+	ErrHeartbeatTokenRejected = errors.New("heartbeat bearer token was not authenticated")
+	// ErrHeartbeatWrongIdentity means the token authenticated as something
+	// other than the provider's own service account (403).
+	ErrHeartbeatWrongIdentity = errors.New("heartbeat bearer token is not the provider's service account")
+	// ErrHeartbeatAuthUnavailable means the hub has no way to verify the
+	// token right now: no kcp, or the provider's workspace is not known yet
+	// (503).
+	ErrHeartbeatAuthUnavailable = errors.New("heartbeat authentication unavailable")
+)
+
+// heartbeatAuthCacheTTL bounds how long a verified (token, provider) pair is
+// trusted without a fresh TokenReview. It is deliberately shorter than
+// HeartbeatTTL so a revoked token cannot outlive the liveness window it would
+// otherwise keep extending, while still collapsing a 30s beat cadence into a
+// TokenReview every other beat.
+const heartbeatAuthCacheTTL = HeartbeatTTL / 2
+
+// ProviderSAUsername is the username kcp reports for the provider's own
+// service account: the one MintProviderKubeconfigAtPath issues the provider
+// kubeconfig for. Every provider's heartbeat must authenticate as exactly it.
+const ProviderSAUsername = "system:serviceaccount:" + ProviderSANamespace + ":" + ProviderSAName
+
+// tokenReviewAuthenticator verifies heartbeat bearers with a TokenReview in
+// the provider's own workspace.
+//
+// The provider kubeconfig token is a legacy kubernetes.io/service-account-token
+// Secret token (see ensureLegacySAToken). Legacy tokens carry no audience
+// claim, and kcp validates them for the API server's implicit audience, so the
+// review is issued without a requested audience: asking for a specific one
+// (such as the workload-identity audience) would reject the very token the hub
+// minted for the provider.
+//
+// Running the review inside the provider workspace is what scopes the check:
+// kcp binds service-account tokens to the logical cluster they were issued in,
+// so a "provider" SA token from any other workspace does not authenticate here
+// at all, let alone as ProviderSAUsername.
+type tokenReviewAuthenticator struct {
+	clusters  ClusterResolver
+	newClient func(cluster string) (kubernetes.Interface, error)
+	now       func() time.Time
+	cacheTTL  time.Duration
+
+	mu    sync.Mutex
+	cache map[heartbeatAuthCacheKey]time.Time
+}
+
+// heartbeatAuthCacheKey is the sha256 of the token plus the provider it was
+// verified for, so a token verified for one provider never vouches for
+// another.
+type heartbeatAuthCacheKey struct {
+	tokenHash [sha256.Size]byte
+	provider  string
+}
+
+// NewTokenReviewHeartbeatAuthenticator returns a HeartbeatAuthenticator that
+// accepts a beat for provider N only when its bearer token authenticates, via
+// TokenReview in N's own workspace, as that workspace's provider service
+// account. Successful verifications are cached for heartbeatAuthCacheTTL.
+func NewTokenReviewHeartbeatAuthenticator(kcpConfig *rest.Config, clusters ClusterResolver) (HeartbeatAuthenticator, error) {
+	if kcpConfig == nil {
+		return nil, fmt.Errorf("kcp config is required")
+	}
+	if clusters == nil {
+		return nil, fmt.Errorf("cluster resolver is required")
+	}
+	a := &tokenReviewAuthenticator{
+		clusters: clusters,
+		newClient: func(cluster string) (kubernetes.Interface, error) {
+			cfg := rest.CopyConfig(kcpConfig)
+			cfg.Host = apiurl.KCPClusterURL(cfg.Host, cluster)
+			return kubernetes.NewForConfig(cfg)
+		},
+		now:      time.Now,
+		cacheTTL: heartbeatAuthCacheTTL,
+		cache:    map[heartbeatAuthCacheKey]time.Time{},
+	}
+	return a.Authenticate, nil
+}
+
+// Authenticate implements HeartbeatAuthenticator.
+func (a *tokenReviewAuthenticator) Authenticate(ctx context.Context, r *http.Request, providerName string) error {
+	token, ok := bearerToken(r)
+	if !ok {
+		return ErrHeartbeatNoBearer
+	}
+	key := heartbeatAuthCacheKey{tokenHash: sha256.Sum256([]byte(token)), provider: providerName}
+	now := a.now()
+	if a.cached(key, now) {
+		return nil
+	}
+
+	cluster, ok := a.clusters.CatalogEntryCluster(providerName)
+	if !ok || cluster == "" {
+		return fmt.Errorf("%w: no CatalogEntry cluster known for provider %q yet", ErrHeartbeatAuthUnavailable, providerName)
+	}
+	client, err := a.newClient(cluster)
+	if err != nil {
+		return fmt.Errorf("%w: creating client for cluster %s: %v", ErrHeartbeatAuthUnavailable, cluster, err)
+	}
+	review, err := client.AuthenticationV1().TokenReviews().Create(ctx, &authnv1.TokenReview{
+		Spec: authnv1.TokenReviewSpec{Token: token},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("%w: reviewing token in cluster %s: %v", ErrHeartbeatAuthUnavailable, cluster, err)
+	}
+	if !review.Status.Authenticated {
+		return ErrHeartbeatTokenRejected
+	}
+	if review.Status.User.Username != ProviderSAUsername {
+		return fmt.Errorf("%w: authenticated as %q, want %q", ErrHeartbeatWrongIdentity, review.Status.User.Username, ProviderSAUsername)
+	}
+
+	a.mu.Lock()
+	a.cache[key] = now.Add(a.cacheTTL)
+	a.mu.Unlock()
+	return nil
+}
+
+// cached reports whether key was verified recently enough to trust, dropping
+// expired entries as it goes so the map stays bounded by live tokens.
+func (a *tokenReviewAuthenticator) cached(key heartbeatAuthCacheKey, now time.Time) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for k, until := range a.cache {
+		if !now.Before(until) {
+			delete(a.cache, k)
+		}
+	}
+	until, ok := a.cache[key]
+	return ok && now.Before(until)
+}
+
+// bearerToken extracts the token from an Authorization: Bearer header.
+func bearerToken(r *http.Request) (string, bool) {
+	const prefix = "bearer "
+	h := r.Header.Get("Authorization")
+	if len(h) <= len(prefix) || !strings.EqualFold(h[:len(prefix)], prefix) {
+		return "", false
+	}
+	token := strings.TrimSpace(h[len(prefix):])
+	return token, token != ""
+}
+
+// heartbeatAuthStatus maps an authenticator error to the HTTP status the
+// handler returns in enforce mode.
+func heartbeatAuthStatus(err error) int {
+	switch {
+	case errors.Is(err, ErrHeartbeatNoBearer), errors.Is(err, ErrHeartbeatTokenRejected):
+		return http.StatusUnauthorized
+	case errors.Is(err, ErrHeartbeatWrongIdentity):
+		return http.StatusForbidden
+	default:
+		return http.StatusServiceUnavailable
+	}
+}

--- a/pkg/hub/providers/heartbeat_auth.go
+++ b/pkg/hub/providers/heartbeat_auth.go
@@ -215,6 +215,28 @@ func bearerToken(r *http.Request) (string, bool) {
 	return token, token != ""
 }
 
+// heartbeatAuthFailureBody is the whole body the handler returns for a beat it
+// refused in enforce mode: one short string per status class, and nothing that
+// varies with the hub's state.
+//
+// The authenticator's errors are written for the log, not for the wire — they
+// name the logical cluster the TokenReview was issued in, the service account
+// username the beat was expected to authenticate as, and whether a CatalogEntry
+// cluster is known for the provider at all. This endpoint is mounted with no
+// auth middleware in front of it, so returning any of that would hand an
+// anonymous caller a map of the deployment. The detail stays in the handler's
+// log lines, which is where an operator debugs a provider that cannot beat.
+func heartbeatAuthFailureBody(status int) string {
+	switch status {
+	case http.StatusForbidden:
+		return "forbidden"
+	case http.StatusUnauthorized:
+		return "heartbeat not authenticated"
+	default:
+		return "heartbeat verification unavailable"
+	}
+}
+
 // heartbeatAuthStatus maps an authenticator error to the HTTP status the
 // handler returns in enforce mode.
 func heartbeatAuthStatus(err error) int {

--- a/pkg/hub/providers/heartbeat_auth_test.go
+++ b/pkg/hub/providers/heartbeat_auth_test.go
@@ -1,0 +1,357 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	authnv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func heartbeatRequestWithBearer(name, token string) *http.Request {
+	req := heartbeatRequestFor(name)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req
+}
+
+// The endpoint has no auth middleware in front of it, so a beat with no bearer
+// must be turned away before it touches the registry: otherwise anyone who can
+// reach the hub keeps a dead provider Ready.
+func TestHeartbeatEnforceRejectsMissingBearerAndLeavesRegistryUntouched(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+
+	persisted := false
+	handler := NewHeartbeatHandler(reg, func(context.Context, string, string, time.Time) error {
+		persisted = true
+		return nil
+	}, func(_ context.Context, r *http.Request, _ string) error {
+		if _, ok := bearerToken(r); !ok {
+			return ErrHeartbeatNoBearer
+		}
+		return nil
+	}, HeartbeatAuthEnforce, logr.Discard())
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestFor("code"))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if persisted {
+		t.Fatal("unauthenticated beat was persisted")
+	}
+	got, _ := reg.Get("code")
+	if got.HeartbeatRequired || !got.LastHeartbeat.IsZero() {
+		t.Fatalf("registry moved on an unauthenticated beat: %+v", got)
+	}
+}
+
+func TestHeartbeatEnforceRejectsWrongIdentityWith403(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+
+	handler := NewHeartbeatHandler(reg, nil, func(context.Context, *http.Request, string) error {
+		return fmt.Errorf("%w: authenticated as %q", ErrHeartbeatWrongIdentity, "system:serviceaccount:default:someone-else")
+	}, HeartbeatAuthEnforce, logr.Discard())
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestWithBearer("code", "tok"))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if got, _ := reg.Get("code"); got.HeartbeatRequired {
+		t.Fatal("registry recorded a beat from the wrong identity")
+	}
+}
+
+// A verification outage is not an identity failure: the provider should retry,
+// not be told its token is bad.
+func TestHeartbeatEnforceReports503WhenItCannotVerify(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+
+	handler := NewHeartbeatHandler(reg, nil, func(context.Context, *http.Request, string) error {
+		return fmt.Errorf("%w: kcp down", ErrHeartbeatAuthUnavailable)
+	}, HeartbeatAuthEnforce, logr.Discard())
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestWithBearer("code", "tok"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+
+	// With no authenticator at all (no kcp) enforce mode must fail closed the
+	// same way rather than silently accepting everything.
+	handler = NewHeartbeatHandler(reg, nil, nil, HeartbeatAuthEnforce, logr.Discard())
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestWithBearer("code", "tok"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("nil authenticator: status = %d, want 503", rec.Code)
+	}
+}
+
+func TestHeartbeatEnforceRecordsTheProvidersOwnIdentity(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+
+	var seen []string
+	handler := NewHeartbeatHandler(reg, nil, func(_ context.Context, r *http.Request, name string) error {
+		token, _ := bearerToken(r)
+		seen = append(seen, name+":"+token)
+		return nil
+	}, HeartbeatAuthEnforce, logr.Discard())
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestWithBearer("code", "sa-token"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if len(seen) != 1 || seen[0] != "code:sa-token" {
+		t.Fatalf("authenticator saw %v, want the provider name and bearer from the request", seen)
+	}
+	if got, _ := reg.Get("code"); !got.HeartbeatRequired || got.LastHeartbeat.IsZero() {
+		t.Fatalf("authenticated beat not recorded: %+v", got)
+	}
+}
+
+// Warn mode is the bridge for providers on charts that predate the
+// authenticated heartbeat: the beat still counts, but the failure is logged at
+// the default verbosity with the provider name so operators can find them.
+func TestHeartbeatWarnRecordsAndLogsFailures(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+
+	var logged []string
+	log := funcr.New(func(prefix, args string) { logged = append(logged, prefix+" "+args) }, funcr.Options{})
+
+	handler := NewHeartbeatHandler(reg, nil, func(context.Context, *http.Request, string) error {
+		return ErrHeartbeatNoBearer
+	}, HeartbeatAuthWarn, log)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestFor("code"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 in warn mode", rec.Code)
+	}
+	if got, _ := reg.Get("code"); !got.HeartbeatRequired {
+		t.Fatal("warn mode dropped the beat")
+	}
+	var found bool
+	for _, line := range logged {
+		if strings.Contains(line, `"provider"="code"`) && strings.Contains(line, ErrHeartbeatNoBearer.Error()) && strings.Contains(line, "warn") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no warn-mode log line naming the provider and reason; got %q", logged)
+	}
+}
+
+func TestParseHeartbeatAuthMode(t *testing.T) {
+	for in, want := range map[string]HeartbeatAuthMode{"warn": HeartbeatAuthWarn, " Enforce ": HeartbeatAuthEnforce} {
+		got, err := ParseHeartbeatAuthMode(in)
+		if err != nil || got != want {
+			t.Fatalf("ParseHeartbeatAuthMode(%q) = %q, %v; want %q", in, got, err, want)
+		}
+	}
+	for _, in := range []string{"", "off", "audit"} {
+		if _, err := ParseHeartbeatAuthMode(in); err == nil {
+			t.Fatalf("ParseHeartbeatAuthMode(%q) accepted", in)
+		}
+	}
+}
+
+// tokenReviewFake returns a fake clientset whose TokenReview answers with the
+// given status, counting the reviews it served and recording which cluster it
+// was asked to serve.
+type tokenReviewFake struct {
+	reviews  int
+	clusters []string
+	status   authnv1.TokenReviewStatus
+}
+
+func (f *tokenReviewFake) newClient(cluster string) (kubernetes.Interface, error) {
+	f.clusters = append(f.clusters, cluster)
+	cs := fake.NewClientset()
+	cs.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		f.reviews++
+		in := action.(k8stesting.CreateAction).GetObject().(*authnv1.TokenReview)
+		if len(in.Spec.Audiences) != 0 {
+			// The provider kubeconfig token is a legacy Secret token with no
+			// audience claim; asking kcp for a specific audience would reject it.
+			return true, nil, fmt.Errorf("unexpected audiences %v requested", in.Spec.Audiences)
+		}
+		out := in.DeepCopy()
+		out.Status = f.status
+		return true, out, nil
+	})
+	return cs, nil
+}
+
+func newTestTokenReviewAuthenticator(reg *Registry, f *tokenReviewFake, now *time.Time) *tokenReviewAuthenticator {
+	return &tokenReviewAuthenticator{
+		clusters:  reg,
+		newClient: f.newClient,
+		now:       func() time.Time { return *now },
+		cacheTTL:  heartbeatAuthCacheTTL,
+		cache:     map[heartbeatAuthCacheKey]time.Time{},
+	}
+}
+
+func TestTokenReviewAuthenticatorRejectsAuthenticatedWrongUser(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true, CatalogEntryCluster: "code-cluster"})
+	f := &tokenReviewFake{status: authnv1.TokenReviewStatus{
+		Authenticated: true, User: authnv1.UserInfo{Username: "system:serviceaccount:default:not-the-provider"},
+	}}
+	now := time.Now()
+	a := newTestTokenReviewAuthenticator(reg, f, &now)
+
+	err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("code", "tok"), "code")
+	if !errors.Is(err, ErrHeartbeatWrongIdentity) {
+		t.Fatalf("err = %v, want ErrHeartbeatWrongIdentity", err)
+	}
+	if heartbeatAuthStatus(err) != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", heartbeatAuthStatus(err))
+	}
+	// A failure is never cached: the next beat is reviewed again.
+	if err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("code", "tok"), "code"); !errors.Is(err, ErrHeartbeatWrongIdentity) {
+		t.Fatalf("second err = %v, want ErrHeartbeatWrongIdentity", err)
+	}
+	if f.reviews != 2 {
+		t.Fatalf("reviews = %d, want 2 (failures are not cached)", f.reviews)
+	}
+}
+
+func TestTokenReviewAuthenticatorRejectsUnauthenticatedToken(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true, CatalogEntryCluster: "code-cluster"})
+	f := &tokenReviewFake{status: authnv1.TokenReviewStatus{Authenticated: false}}
+	now := time.Now()
+	a := newTestTokenReviewAuthenticator(reg, f, &now)
+
+	err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("code", "garbage"), "code")
+	if !errors.Is(err, ErrHeartbeatTokenRejected) || heartbeatAuthStatus(err) != http.StatusUnauthorized {
+		t.Fatalf("err = %v (status %d), want ErrHeartbeatTokenRejected/401", err, heartbeatAuthStatus(err))
+	}
+	if err := a.Authenticate(context.Background(), heartbeatRequestFor("code"), "code"); !errors.Is(err, ErrHeartbeatNoBearer) {
+		t.Fatalf("no bearer: err = %v, want ErrHeartbeatNoBearer", err)
+	}
+	if f.reviews != 1 {
+		t.Fatalf("reviews = %d, want 1 (a missing bearer never reaches kcp)", f.reviews)
+	}
+}
+
+func TestTokenReviewAuthenticatorAcceptsProviderSAAndCachesIt(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true, CatalogEntryCluster: "code-cluster"})
+	f := &tokenReviewFake{status: authnv1.TokenReviewStatus{
+		Authenticated: true, User: authnv1.UserInfo{Username: ProviderSAUsername},
+	}}
+	now := time.Now()
+	a := newTestTokenReviewAuthenticator(reg, f, &now)
+
+	for i := range 3 {
+		if err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("code", "tok"), "code"); err != nil {
+			t.Fatalf("beat %d: %v", i, err)
+		}
+	}
+	if f.reviews != 1 {
+		t.Fatalf("reviews = %d, want 1 (cache hit for the repeated token)", f.reviews)
+	}
+	if len(f.clusters) != 1 || f.clusters[0] != "code-cluster" {
+		t.Fatalf("reviewed in clusters %v, want only the provider's own", f.clusters)
+	}
+
+	// A different token for the same provider is its own review.
+	if err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("code", "other"), "code"); err != nil {
+		t.Fatal(err)
+	}
+	if f.reviews != 2 {
+		t.Fatalf("reviews = %d, want 2 (different token is not a cache hit)", f.reviews)
+	}
+
+	// The cache must lapse well before the liveness window does, so a
+	// revoked token cannot keep a provider Ready indefinitely.
+	if heartbeatAuthCacheTTL >= HeartbeatTTL {
+		t.Fatalf("cache TTL %v must be shorter than heartbeat TTL %v", heartbeatAuthCacheTTL, HeartbeatTTL)
+	}
+	now = now.Add(heartbeatAuthCacheTTL + time.Second)
+	if err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("code", "tok"), "code"); err != nil {
+		t.Fatal(err)
+	}
+	if f.reviews != 3 {
+		t.Fatalf("reviews = %d, want 3 (expired entry is re-reviewed)", f.reviews)
+	}
+}
+
+func TestTokenReviewAuthenticatorNeedsTheProviderCluster(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+	f := &tokenReviewFake{}
+	now := time.Now()
+	a := newTestTokenReviewAuthenticator(reg, f, &now)
+
+	err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("code", "tok"), "code")
+	if !errors.Is(err, ErrHeartbeatAuthUnavailable) || heartbeatAuthStatus(err) != http.StatusServiceUnavailable {
+		t.Fatalf("err = %v, want ErrHeartbeatAuthUnavailable/503", err)
+	}
+	if f.reviews != 0 {
+		t.Fatal("reviewed a token without knowing which cluster to ask")
+	}
+}
+
+func TestNewTokenReviewHeartbeatAuthenticatorRequiresInputs(t *testing.T) {
+	if _, err := NewTokenReviewHeartbeatAuthenticator(nil, NewRegistry()); err == nil {
+		t.Fatal("nil kcp config accepted")
+	}
+}
+
+func TestBearerToken(t *testing.T) {
+	for header, want := range map[string]string{
+		"Bearer abc":  "abc",
+		"bearer abc ": "abc",
+		"Basic abc":   "",
+		"Bearer":      "",
+		"Bearer  ":    "",
+		"":            "",
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		if header != "" {
+			req.Header.Set("Authorization", header)
+		}
+		got, ok := bearerToken(req)
+		if got != want || ok != (want != "") {
+			t.Errorf("bearerToken(%q) = %q, %t; want %q", header, got, ok, want)
+		}
+	}
+}

--- a/pkg/hub/providers/heartbeat_auth_test.go
+++ b/pkg/hub/providers/heartbeat_auth_test.go
@@ -176,6 +176,153 @@ func TestHeartbeatWarnRecordsAndLogsFailures(t *testing.T) {
 	}
 }
 
+// The endpoint answers anonymous callers, so a rejection must not describe the
+// deployment back to them: the authenticator's errors name logical cluster IDs
+// and the service account username a beat was expected to carry.
+func TestHeartbeatEnforceRejectionBodiesRevealNothing(t *testing.T) {
+	const (
+		cluster  = "1axwjxprfb96jgta"
+		otherSA  = "system:serviceaccount:kube-system:sneaky"
+		provider = "code"
+	)
+	cases := map[string]struct {
+		err    error
+		status int
+		body   string
+	}{
+		"no bearer": {ErrHeartbeatNoBearer, http.StatusUnauthorized, "heartbeat not authenticated"},
+		"token rejected": {
+			fmt.Errorf("%w in cluster %s", ErrHeartbeatTokenRejected, cluster),
+			http.StatusUnauthorized, "heartbeat not authenticated",
+		},
+		"wrong identity": {
+			fmt.Errorf("%w: authenticated as %q, want %q", ErrHeartbeatWrongIdentity, otherSA, ProviderSAUsername),
+			http.StatusForbidden, "forbidden",
+		},
+		"cannot verify": {
+			fmt.Errorf("%w: reviewing token in cluster %s: %v", ErrHeartbeatAuthUnavailable, cluster, errors.New("connection refused")),
+			http.StatusServiceUnavailable, "heartbeat verification unavailable",
+		},
+	}
+	for name, tc := range cases {
+		reg := NewRegistry()
+		reg.Upsert(Provider{Name: provider, EndpointsValid: true, CatalogEntryCluster: cluster})
+		handler := NewHeartbeatHandler(reg, nil, func(context.Context, *http.Request, string) error {
+			return tc.err
+		}, HeartbeatAuthEnforce, logr.Discard())
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, heartbeatRequestWithBearer(provider, "tok"))
+		if rec.Code != tc.status {
+			t.Errorf("%s: status = %d, want %d", name, rec.Code, tc.status)
+		}
+		body := strings.TrimSpace(rec.Body.String())
+		if body != tc.body {
+			t.Errorf("%s: body = %q, want %q", name, body, tc.body)
+		}
+		for _, secret := range []string{cluster, otherSA, ProviderSAUsername, ProviderSAName, ProviderSANamespace, "connection refused"} {
+			if strings.Contains(body, secret) {
+				t.Errorf("%s: body %q leaks %q", name, body, secret)
+			}
+		}
+	}
+}
+
+// Enforce mode must not answer differently for a name that exists and a name
+// that does not; otherwise the endpoint enumerates the platform's providers for
+// anyone who can reach the hub.
+func TestHeartbeatEnforceHidesUnknownProviders(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true, CatalogEntryCluster: "code-cluster"})
+	handler := NewHeartbeatHandler(reg, nil, func(context.Context, *http.Request, string) error {
+		return ErrHeartbeatTokenRejected
+	}, HeartbeatAuthEnforce, logr.Discard())
+
+	known := httptest.NewRecorder()
+	handler.ServeHTTP(known, heartbeatRequestWithBearer("code", "garbage"))
+	unknown := httptest.NewRecorder()
+	handler.ServeHTTP(unknown, heartbeatRequestWithBearer("no-such-provider", "garbage"))
+
+	if known.Code != unknown.Code {
+		t.Fatalf("status: known provider %d, unknown provider %d; they must match", known.Code, unknown.Code)
+	}
+	if known.Body.String() != unknown.Body.String() {
+		t.Fatalf("body: known provider %q, unknown provider %q; they must match", known.Body, unknown.Body)
+	}
+	if unknown.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", unknown.Code)
+	}
+	if strings.Contains(unknown.Body.String(), "not found") {
+		t.Fatalf("body %q admits the provider is unknown", unknown.Body)
+	}
+}
+
+// A registered provider whose CatalogEntry has not been observed yet is a
+// transient startup state, not an unknown name: it must keep producing the 503
+// the provider retries rather than the permanent 401 an unknown name gets.
+func TestHeartbeatEnforceStillReports503BeforeTheClusterIsKnown(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true}) // no CatalogEntryCluster yet
+	f := &tokenReviewFake{}
+	now := time.Now()
+	a := newTestTokenReviewAuthenticator(reg, f, &now)
+	handler := NewHeartbeatHandler(reg, nil, a.Authenticate, HeartbeatAuthEnforce, logr.Discard())
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestWithBearer("code", "tok"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 while the cluster is still unknown", rec.Code)
+	}
+	if body := strings.TrimSpace(rec.Body.String()); body != "heartbeat verification unavailable" || strings.Contains(body, "code") {
+		t.Fatalf("body = %q, want the generic unavailable message", body)
+	}
+
+	// Once the entry is observed the same beat authenticates and is recorded.
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true, CatalogEntryCluster: "code-cluster"})
+	f.status = authnv1.TokenReviewStatus{Authenticated: true, User: authnv1.UserInfo{Username: ProviderSAUsername}}
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, heartbeatRequestWithBearer("code", "tok"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body)
+	}
+	if got, _ := reg.Get("code"); !got.HeartbeatRequired || got.LastHeartbeat.IsZero() {
+		t.Fatalf("authenticated beat not recorded: %+v", got)
+	}
+}
+
+// The detail the response no longer carries has to stay somewhere an operator
+// can read it.
+func TestHeartbeatEnforceLogsTheDetailedReason(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+
+	var logged []string
+	log := funcr.New(func(prefix, args string) { logged = append(logged, prefix+" "+args) },
+		funcr.Options{Verbosity: 1})
+	handler := NewHeartbeatHandler(reg, nil, func(context.Context, *http.Request, string) error {
+		return fmt.Errorf("%w: authenticated as %q, want %q", ErrHeartbeatWrongIdentity, "system:serviceaccount:kube-system:sneaky", ProviderSAUsername)
+	}, HeartbeatAuthEnforce, log)
+
+	handler.ServeHTTP(httptest.NewRecorder(), heartbeatRequestWithBearer("code", "tok"))
+	handler.ServeHTTP(httptest.NewRecorder(), heartbeatRequestWithBearer("no-such-provider", "tok"))
+
+	var identity, unknown bool
+	for _, line := range logged {
+		if strings.Contains(line, `"provider"="code"`) && strings.Contains(line, "system:serviceaccount:kube-system:sneaky") && strings.Contains(line, ProviderSAUsername) {
+			identity = true
+		}
+		if strings.Contains(line, `"provider"="no-such-provider"`) && strings.Contains(line, "not registered") {
+			unknown = true
+		}
+	}
+	if !identity {
+		t.Errorf("no log line carrying the wrong-identity detail; got %q", logged)
+	}
+	if !unknown {
+		t.Errorf("no log line saying the provider is not registered; got %q", logged)
+	}
+}
+
 func TestParseHeartbeatAuthMode(t *testing.T) {
 	for in, want := range map[string]HeartbeatAuthMode{"warn": HeartbeatAuthWarn, " Enforce ": HeartbeatAuthEnforce} {
 		got, err := ParseHeartbeatAuthMode(in)

--- a/pkg/hub/providers/heartbeat_auth_test.go
+++ b/pkg/hub/providers/heartbeat_auth_test.go
@@ -323,6 +323,74 @@ func TestHeartbeatEnforceLogsTheDetailedReason(t *testing.T) {
 	}
 }
 
+// Warn mode logs a rejected identity per beat because that is the list of
+// providers an operator has to fix before enforce becomes the default. It must
+// not do the same for "cannot verify": that repeats for every provider on
+// every tick and says nothing about any of them.
+func TestHeartbeatWarnKeepsIdentityFailuresLoudAndVerificationOutagesQuiet(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		err      error
+		wantAtV0 bool
+	}{
+		{"wrong identity", ErrHeartbeatWrongIdentity, true},
+		{"token rejected", ErrHeartbeatTokenRejected, true},
+		{"no bearer", ErrHeartbeatNoBearer, true},
+		{"cannot verify", fmt.Errorf("%w: no kcp configured", ErrHeartbeatAuthUnavailable), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := NewRegistry()
+			reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+
+			var logged []string
+			// Verbosity 0: only what an operator sees by default.
+			log := funcr.New(func(prefix, args string) { logged = append(logged, prefix+" "+args) },
+				funcr.Options{Verbosity: 0})
+			handler := NewHeartbeatHandler(reg, nil, func(context.Context, *http.Request, string) error {
+				return tc.err
+			}, HeartbeatAuthWarn, log)
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, heartbeatRequestWithBearer("code", "tok"))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("warn mode must still accept the beat; got %d", rec.Code)
+			}
+
+			var sawAcceptedWarning bool
+			for _, line := range logged {
+				if strings.Contains(line, "accepting because --provider-heartbeat-auth=warn") {
+					sawAcceptedWarning = true
+				}
+			}
+			if sawAcceptedWarning != tc.wantAtV0 {
+				t.Errorf("logged at default verbosity = %v, want %v; got %q", sawAcceptedWarning, tc.wantAtV0, logged)
+			}
+		})
+	}
+}
+
+// The quiet case must still be readable when an operator turns verbosity up.
+func TestHeartbeatWarnVerificationOutageLogsAtV1(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true})
+
+	var logged []string
+	log := funcr.New(func(prefix, args string) { logged = append(logged, prefix+" "+args) },
+		funcr.Options{Verbosity: 1})
+	handler := NewHeartbeatHandler(reg, nil, func(context.Context, *http.Request, string) error {
+		return fmt.Errorf("%w: no kcp configured", ErrHeartbeatAuthUnavailable)
+	}, HeartbeatAuthWarn, log)
+
+	handler.ServeHTTP(httptest.NewRecorder(), heartbeatRequestWithBearer("code", "tok"))
+
+	for _, line := range logged {
+		if strings.Contains(line, "accepting because --provider-heartbeat-auth=warn") && strings.Contains(line, "no kcp configured") {
+			return
+		}
+	}
+	t.Errorf("no V(1) line carrying the verification-unavailable reason; got %q", logged)
+}
+
 func TestParseHeartbeatAuthMode(t *testing.T) {
 	for in, want := range map[string]HeartbeatAuthMode{"warn": HeartbeatAuthWarn, " Enforce ": HeartbeatAuthEnforce} {
 		got, err := ParseHeartbeatAuthMode(in)

--- a/pkg/hub/providers/heartbeat_test.go
+++ b/pkg/hub/providers/heartbeat_test.go
@@ -107,20 +107,46 @@ func TestHeartbeatFailsWhenPersistFails(t *testing.T) {
 }
 
 func TestHeartbeatUnknownProviderIsNotPersisted(t *testing.T) {
-	reg := NewRegistry()
-	persisted := false
-	handler := NewHeartbeatHandler(reg, func(context.Context, string, string, time.Time) error {
-		persisted = true
-		return nil
-	}, allowAllHeartbeats, HeartbeatAuthEnforce, logr.Discard())
+	// Enforce mode hides the fact that the name is unknown behind the same 401
+	// a bad credential gets (see TestHeartbeatEnforceHidesUnknownProviders);
+	// warn mode, which accepts unauthenticated beats anyway, says 404.
+	for mode, want := range map[HeartbeatAuthMode]int{
+		HeartbeatAuthEnforce: http.StatusUnauthorized,
+		HeartbeatAuthWarn:    http.StatusNotFound,
+	} {
+		reg := NewRegistry()
+		persisted := false
+		handler := NewHeartbeatHandler(reg, func(context.Context, string, string, time.Time) error {
+			persisted = true
+			return nil
+		}, allowAllHeartbeats, mode, logr.Discard())
 
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, heartbeatRequestFor("nope"))
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404", rec.Code)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, heartbeatRequestFor("nope"))
+		if rec.Code != want {
+			t.Fatalf("%s: status = %d, want %d", mode, rec.Code, want)
+		}
+		if persisted {
+			t.Fatalf("%s: persisted a heartbeat for a provider that is not registered", mode)
+		}
 	}
-	if persisted {
-		t.Fatal("persisted a heartbeat for a provider that is not registered")
+}
+
+// An unknown name must be turned away before the authenticator runs: the
+// TokenReview round trip and, in warn mode, the log line per beat are work an
+// anonymous caller would otherwise drive at will.
+func TestHeartbeatUnknownProviderIsNotAuthenticated(t *testing.T) {
+	for _, mode := range []HeartbeatAuthMode{HeartbeatAuthEnforce, HeartbeatAuthWarn} {
+		calls := 0
+		handler := NewHeartbeatHandler(NewRegistry(), nil, func(context.Context, *http.Request, string) error {
+			calls++
+			return nil
+		}, mode, logr.Discard())
+
+		handler.ServeHTTP(httptest.NewRecorder(), heartbeatRequestWithBearer("nope", "tok"))
+		if calls != 0 {
+			t.Fatalf("%s: authenticator ran %d times for an unregistered provider, want 0", mode, calls)
+		}
 	}
 }
 

--- a/pkg/hub/providers/heartbeat_test.go
+++ b/pkg/hub/providers/heartbeat_test.go
@@ -33,6 +33,10 @@ func heartbeatRequestFor(name string) *http.Request {
 	return httptest.NewRequest(http.MethodPost, PathProviderHeartbeat+"/"+name+"/heartbeat", nil)
 }
 
+// allowAllHeartbeats stands in for the TokenReview authenticator in tests that
+// exercise recording rather than authentication.
+func allowAllHeartbeats(context.Context, *http.Request, string) error { return nil }
+
 // A heartbeat reaches one replica but must become visible to all of them, which
 // is what persisting it to CatalogEntry status buys.
 func TestHeartbeatIsPersistedForOtherReplicas(t *testing.T) {
@@ -43,7 +47,7 @@ func TestHeartbeatIsPersistedForOtherReplicas(t *testing.T) {
 	handler := NewHeartbeatHandler(reg, func(_ context.Context, name, version string, _ time.Time) error {
 		recorded = append(recorded, name+"@"+version)
 		return nil
-	}, logr.Discard())
+	}, allowAllHeartbeats, HeartbeatAuthEnforce, logr.Discard())
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost,
@@ -71,7 +75,7 @@ func TestHeartbeatPersistIsThrottled(t *testing.T) {
 	handler := NewHeartbeatHandler(reg, func(context.Context, string, string, time.Time) error {
 		writes++
 		return nil
-	}, logr.Discard())
+	}, allowAllHeartbeats, HeartbeatAuthEnforce, logr.Discard())
 
 	for range 5 {
 		rec := httptest.NewRecorder()
@@ -93,7 +97,7 @@ func TestHeartbeatFailsWhenPersistFails(t *testing.T) {
 
 	handler := NewHeartbeatHandler(reg, func(context.Context, string, string, time.Time) error {
 		return fmt.Errorf("kcp unavailable")
-	}, logr.Discard())
+	}, allowAllHeartbeats, HeartbeatAuthEnforce, logr.Discard())
 
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, heartbeatRequestFor("cost"))
@@ -108,7 +112,7 @@ func TestHeartbeatUnknownProviderIsNotPersisted(t *testing.T) {
 	handler := NewHeartbeatHandler(reg, func(context.Context, string, string, time.Time) error {
 		persisted = true
 		return nil
-	}, logr.Discard())
+	}, allowAllHeartbeats, HeartbeatAuthEnforce, logr.Discard())
 
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, heartbeatRequestFor("nope"))
@@ -124,7 +128,7 @@ func TestHeartbeatUnknownProviderIsNotPersisted(t *testing.T) {
 func TestHeartbeatWithoutRecorder(t *testing.T) {
 	reg := NewRegistry()
 	reg.Upsert(Provider{Name: "cost", EndpointsValid: true})
-	handler := NewHeartbeatHandler(reg, nil, logr.Discard())
+	handler := NewHeartbeatHandler(reg, nil, allowAllHeartbeats, HeartbeatAuthEnforce, logr.Discard())
 
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, heartbeatRequestFor("cost"))

--- a/pkg/hub/providers/registry_scope_test.go
+++ b/pkg/hub/providers/registry_scope_test.go
@@ -11,9 +11,13 @@ You may obtain a copy of the License at
 package providers
 
 import (
+	"context"
+	"errors"
 	"sort"
 	"testing"
 	"time"
+
+	authnv1 "k8s.io/api/authentication/v1"
 )
 
 // newScopedRegistry builds a registry holding one platform provider and one
@@ -168,6 +172,45 @@ func TestRegistryHeartbeatIsGlobalOnly(t *testing.T) {
 	}
 	if !reg.Heartbeat("edges", "1.0.0", now) {
 		t.Error("Heartbeat(edges) rejected a beat for a platform provider")
+	}
+}
+
+// A heartbeat must be vouched for by the provider's own service account,
+// reviewed in the provider's own workspace. A token that the hub has verified
+// for one provider must not keep another one alive, and an org-owned provider
+// has no workspace the bare-name endpoint could review in at all.
+func TestHeartbeatRequiresOwnProviderSA(t *testing.T) {
+	reg := newScopedRegistry()
+	reg.Upsert(Provider{Name: "edges", EndpointsValid: true, CatalogEntryCluster: "edges-cluster"})
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true, CatalogEntryCluster: "code-cluster"})
+	f := &tokenReviewFake{status: authnv1.TokenReviewStatus{
+		Authenticated: true, User: authnv1.UserInfo{Username: ProviderSAUsername},
+	}}
+	now := time.Now()
+	a := newTestTokenReviewAuthenticator(reg, f, &now)
+
+	if err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("edges", "edges-token"), "edges"); err != nil {
+		t.Fatalf("edges' own token rejected: %v", err)
+	}
+	if len(f.clusters) != 1 || f.clusters[0] != "edges-cluster" {
+		t.Fatalf("reviewed in %v, want edges' own workspace", f.clusters)
+	}
+
+	// The same token presented for a different provider is reviewed afresh in
+	// THAT provider's workspace, where kcp would not know it; the cache entry
+	// earned for edges does not carry over.
+	if err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("code", "edges-token"), "code"); err != nil {
+		t.Fatalf("Authenticate(code) = %v", err)
+	}
+	if len(f.clusters) != 2 || f.clusters[1] != "code-cluster" {
+		t.Fatalf("reviewed in %v, want a fresh review in code's workspace", f.clusters)
+	}
+
+	// Org-owned providers cannot beat here: the bare-name endpoint only
+	// resolves platform providers, so there is no workspace to review in.
+	err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("vault", "vault-token"), "vault")
+	if !errors.Is(err, ErrHeartbeatAuthUnavailable) {
+		t.Fatalf("Authenticate(vault) = %v, want ErrHeartbeatAuthUnavailable", err)
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -431,14 +431,33 @@ func (s *Server) Run(ctx context.Context) error {
 	// traffic, so the recorder persists it to CatalogEntry.status and the catalog
 	// watch fans it back out. Without that, replicas that never saw the beat
 	// would time a healthy provider out and start refusing to proxy to it.
-	var heartbeatRecorder providers.HeartbeatRecorder
+	//
+	// The endpoint sits on the root router with no auth middleware, so the
+	// handler verifies the bearer itself: it must be the provider's own
+	// service-account token, checked by TokenReview in the provider's
+	// workspace. --provider-heartbeat-auth picks warn (log, accept) or enforce
+	// (reject); warn is this release's default, enforce the next one's.
+	heartbeatAuthMode, err := providers.ParseHeartbeatAuthMode(s.opts.ProviderHeartbeatAuth)
+	if err != nil {
+		return fmt.Errorf("--provider-heartbeat-auth: %w", err)
+	}
+	var (
+		heartbeatRecorder      providers.HeartbeatRecorder
+		heartbeatAuthenticator providers.HeartbeatAuthenticator
+	)
 	if kcpConfig != nil {
 		heartbeatRecorder, err = providers.NewCatalogHeartbeatRecorder(kcpConfig, providerRegistry)
 		if err != nil {
 			return fmt.Errorf("creating provider heartbeat recorder: %w", err)
 		}
+		heartbeatAuthenticator, err = providers.NewTokenReviewHeartbeatAuthenticator(kcpConfig, providerRegistry)
+		if err != nil {
+			return fmt.Errorf("creating provider heartbeat authenticator: %w", err)
+		}
+	} else {
+		logger.Info("no kcp configured; provider heartbeats cannot be authenticated", "mode", heartbeatAuthMode)
 	}
-	router.PathPrefix(providers.PathProviderHeartbeat + "/").Handler(providers.NewHeartbeatHandler(providerRegistry, heartbeatRecorder, logger)).Methods("POST")
+	router.PathPrefix(providers.PathProviderHeartbeat + "/").Handler(providers.NewHeartbeatHandler(providerRegistry, heartbeatRecorder, heartbeatAuthenticator, heartbeatAuthMode, logger)).Methods("POST")
 	// Background sweeper marks providers stale when heartbeats stop. Every
 	// replica runs one: it only reads timestamps the registry already holds, so
 	// all replicas reach the same verdict without coordinating.

--- a/provider-sdk/go.mod
+++ b/provider-sdk/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/provider-sdk/hubclient/token.go
+++ b/provider-sdk/hubclient/token.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hubclient holds the pieces a provider needs to talk to the faros
+// hub itself (as opposed to kcp): today, the credential for the heartbeat.
+package hubclient
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	// EnvHubToken is an explicit bearer token for hub calls. When set it wins
+	// over the kubeconfig-derived token.
+	EnvHubToken = "FAROS_HUB_TOKEN"
+	// EnvProviderKubeconfig is the workspace-scoped kubeconfig the hub minted
+	// for the provider's own service account. Its bearer token is what the
+	// hub verifies heartbeats against, so it doubles as the hub credential.
+	EnvProviderKubeconfig = "FAROS_PROVIDER_KUBECONFIG"
+)
+
+// ResolveHubToken returns the bearer token a provider should present to the
+// hub, e.g. on POST /api/providers/{name}/heartbeat. The hub authenticates
+// that call as the provider's own service account, so the token is, in order:
+//
+//  1. FAROS_HUB_TOKEN, if set (explicit override; charts that still wire
+//     hub.tokenSecretRef keep working unchanged);
+//  2. the bearer token inside the kubeconfig at FAROS_PROVIDER_KUBECONFIG,
+//     which every provider already mounts.
+//
+// An empty string with a nil error means neither is configured; callers keep
+// sending unauthenticated beats, which the hub logs (warn) or rejects
+// (enforce). A kubeconfig that is set but cannot be read or carries no bearer
+// token is an error so the misconfiguration surfaces in the provider's logs.
+func ResolveHubToken() (string, error) {
+	if t := strings.TrimSpace(os.Getenv(EnvHubToken)); t != "" {
+		return t, nil
+	}
+	path := strings.TrimSpace(os.Getenv(EnvProviderKubeconfig))
+	if path == "" {
+		return "", nil
+	}
+	return TokenFromKubeconfig(path)
+}
+
+// TokenFromKubeconfig loads the kubeconfig at path and returns the bearer
+// token its current context resolves to (inline or via a token file).
+func TokenFromKubeconfig(path string) (string, error) {
+	cfg, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		return "", fmt.Errorf("loading %s=%s: %w", EnvProviderKubeconfig, path, err)
+	}
+	rc, err := clientcmd.NewDefaultClientConfig(*cfg, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return "", fmt.Errorf("resolving %s=%s: %w", EnvProviderKubeconfig, path, err)
+	}
+	if rc.BearerToken != "" {
+		return rc.BearerToken, nil
+	}
+	if rc.BearerTokenFile != "" {
+		b, err := os.ReadFile(rc.BearerTokenFile)
+		if err != nil {
+			return "", fmt.Errorf("reading token file from %s=%s: %w", EnvProviderKubeconfig, path, err)
+		}
+		if t := strings.TrimSpace(string(b)); t != "" {
+			return t, nil
+		}
+	}
+	return "", fmt.Errorf("%s=%s carries no bearer token", EnvProviderKubeconfig, path)
+}

--- a/provider-sdk/hubclient/token.go
+++ b/provider-sdk/hubclient/token.go
@@ -71,8 +71,10 @@ func TokenFromKubeconfig(path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolving %s=%s: %w", EnvProviderKubeconfig, path, err)
 	}
-	if rc.BearerToken != "" {
-		return rc.BearerToken, nil
+	// clientcmd reads a tokenFile into BearerToken verbatim, so trim the
+	// trailing newline a hand-written token file usually carries.
+	if t := strings.TrimSpace(rc.BearerToken); t != "" {
+		return t, nil
 	}
 	if rc.BearerTokenFile != "" {
 		b, err := os.ReadFile(rc.BearerTokenFile)

--- a/provider-sdk/hubclient/token_test.go
+++ b/provider-sdk/hubclient/token_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hubclient
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const kubeconfigWithToken = `apiVersion: v1
+kind: Config
+clusters:
+- name: hub
+  cluster:
+    server: https://hub.example.test/clusters/abc123
+    insecure-skip-tls-verify: true
+contexts:
+- name: hub
+  context:
+    cluster: hub
+    user: provider
+current-context: hub
+users:
+- name: provider
+  user:
+    token: sa-token-from-kubeconfig
+`
+
+func writeKubeconfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestResolveHubTokenPrefersExplicitToken(t *testing.T) {
+	t.Setenv(EnvHubToken, "explicit")
+	t.Setenv(EnvProviderKubeconfig, writeKubeconfig(t, kubeconfigWithToken))
+	got, err := ResolveHubToken()
+	if err != nil || got != "explicit" {
+		t.Fatalf("ResolveHubToken() = %q, %v; want the explicit token", got, err)
+	}
+}
+
+func TestResolveHubTokenFallsBackToProviderKubeconfig(t *testing.T) {
+	t.Setenv(EnvHubToken, "")
+	t.Setenv(EnvProviderKubeconfig, writeKubeconfig(t, kubeconfigWithToken))
+	got, err := ResolveHubToken()
+	if err != nil || got != "sa-token-from-kubeconfig" {
+		t.Fatalf("ResolveHubToken() = %q, %v; want the kubeconfig bearer", got, err)
+	}
+}
+
+func TestResolveHubTokenWithNothingConfigured(t *testing.T) {
+	t.Setenv(EnvHubToken, "")
+	t.Setenv(EnvProviderKubeconfig, "")
+	got, err := ResolveHubToken()
+	if err != nil || got != "" {
+		t.Fatalf("ResolveHubToken() = %q, %v; want empty and no error", got, err)
+	}
+}
+
+func TestResolveHubTokenReportsBrokenKubeconfig(t *testing.T) {
+	t.Setenv(EnvHubToken, "")
+	t.Setenv(EnvProviderKubeconfig, filepath.Join(t.TempDir(), "missing"))
+	if _, err := ResolveHubToken(); err == nil {
+		t.Fatal("missing kubeconfig accepted")
+	}
+
+	noToken := `apiVersion: v1
+kind: Config
+clusters:
+- name: hub
+  cluster:
+    server: https://hub.example.test
+contexts:
+- name: hub
+  context:
+    cluster: hub
+    user: provider
+current-context: hub
+users:
+- name: provider
+  user: {}
+`
+	t.Setenv(EnvProviderKubeconfig, writeKubeconfig(t, noToken))
+	if _, err := ResolveHubToken(); err == nil {
+		t.Fatal("kubeconfig without a bearer token accepted")
+	}
+}
+
+func TestTokenFromKubeconfigReadsTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte("from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	kc := `apiVersion: v1
+kind: Config
+clusters:
+- name: hub
+  cluster:
+    server: https://hub.example.test
+contexts:
+- name: hub
+  context:
+    cluster: hub
+    user: provider
+current-context: hub
+users:
+- name: provider
+  user:
+    tokenFile: ` + tokenFile + `
+`
+	got, err := TokenFromKubeconfig(writeKubeconfig(t, kc))
+	if err != nil || got != "from-file" {
+		t.Fatalf("TokenFromKubeconfig() = %q, %v; want from-file", got, err)
+	}
+}

--- a/providers/agents/heartbeat.go
+++ b/providers/agents/heartbeat.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/faroshq/provider-sdk/hubclient"
 )
 
 const (
@@ -31,12 +33,16 @@ const (
 // Env:
 //
 //	FAROS_HUB_URL        - hub base URL (https://localhost:9443 in dev)
-//	FAROS_HUB_TOKEN      - bearer token for the heartbeat request
+//	FAROS_HUB_TOKEN      - bearer token for the heartbeat request (default: the
+//	                       provider SA token in FAROS_PROVIDER_KUBECONFIG)
 //	FAROS_PROVIDER_NAME  - this provider's CatalogEntry name (default: agents)
 //	FAROS_HUB_INSECURE   - "true" → skip TLS verification (dev self-signed certs)
 func runHeartbeat(ctx context.Context) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token := os.Getenv("FAROS_HUB_TOKEN")
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "agents"

--- a/providers/agents/heartbeat.go
+++ b/providers/agents/heartbeat.go
@@ -39,10 +39,6 @@ const (
 //	FAROS_HUB_INSECURE   - "true" → skip TLS verification (dev self-signed certs)
 func runHeartbeat(ctx context.Context) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token, err := hubclient.ResolveHubToken()
-	if err != nil {
-		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
-	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "agents"
@@ -51,6 +47,15 @@ func runHeartbeat(ctx context.Context) {
 		log.Printf("heartbeat disabled (set FAROS_HUB_URL to enable)")
 		return
 	}
+
+	// Resolved only once the beat is actually going to be sent: reading the
+	// provider kubeconfig for a heartbeat that is disabled is wasted work, and
+	// its failure logs a misleading token error in tests and local runs.
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
+
 	url := hub + "/api/providers/" + name + "/heartbeat"
 	body, _ := json.Marshal(map[string]string{"version": heartbeatVersion, "status": "healthy"})
 

--- a/providers/app-studio/heartbeat.go
+++ b/providers/app-studio/heartbeat.go
@@ -33,10 +33,6 @@ const (
 // nil/omitted health dependency remains compatible with REST-only callers.
 func runHeartbeat(ctx context.Context, healthStates ...*controllerHealth) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token, err := hubclient.ResolveHubToken()
-	if err != nil {
-		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
-	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "app-studio"
@@ -44,6 +40,14 @@ func runHeartbeat(ctx context.Context, healthStates ...*controllerHealth) {
 	if hub == "" {
 		log.Printf("heartbeat disabled (set FAROS_HUB_URL to enable)")
 		return
+	}
+
+	// Resolved only once the beat is actually going to be sent: reading the
+	// provider kubeconfig for a heartbeat that is disabled is wasted work, and
+	// its failure logs a misleading token error in tests and local runs.
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
 	}
 
 	url := hub + "/api/providers/" + name + "/heartbeat"

--- a/providers/app-studio/heartbeat.go
+++ b/providers/app-studio/heartbeat.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/faroshq/provider-sdk/hubclient"
 )
 
 const (
@@ -31,7 +33,10 @@ const (
 // nil/omitted health dependency remains compatible with REST-only callers.
 func runHeartbeat(ctx context.Context, healthStates ...*controllerHealth) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token := os.Getenv("FAROS_HUB_TOKEN")
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "app-studio"

--- a/providers/code/heartbeat.go
+++ b/providers/code/heartbeat.go
@@ -38,10 +38,6 @@ const (
 //	FAROS_HUB_INSECURE   - "true" → skip TLS verification (dev with self-signed certs)
 func runHeartbeat(ctx context.Context) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token, err := hubclient.ResolveHubToken()
-	if err != nil {
-		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
-	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "code"
@@ -50,6 +46,15 @@ func runHeartbeat(ctx context.Context) {
 		log.Printf("heartbeat disabled (set FAROS_HUB_URL to enable)")
 		return
 	}
+
+	// Resolved only once the beat is actually going to be sent: reading the
+	// provider kubeconfig for a heartbeat that is disabled is wasted work, and
+	// its failure logs a misleading token error in tests and local runs.
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
+
 	url := hub + "/api/providers/" + name + "/heartbeat"
 	body, _ := json.Marshal(map[string]string{"version": heartbeatVersion, "status": "healthy"})
 

--- a/providers/code/heartbeat.go
+++ b/providers/code/heartbeat.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/faroshq/provider-sdk/hubclient"
 )
 
 const (
@@ -30,12 +32,16 @@ const (
 // Env:
 //
 //	FAROS_HUB_URL        - hub base URL (https://localhost:9443 in dev)
-//	FAROS_HUB_TOKEN      - bearer token for the heartbeat request
+//	FAROS_HUB_TOKEN      - bearer token for the heartbeat request (default: the
+//	                       provider SA token in FAROS_PROVIDER_KUBECONFIG)
 //	FAROS_PROVIDER_NAME  - this provider's CatalogEntry name (default: code)
 //	FAROS_HUB_INSECURE   - "true" → skip TLS verification (dev with self-signed certs)
 func runHeartbeat(ctx context.Context) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token := os.Getenv("FAROS_HUB_TOKEN")
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "code"

--- a/providers/databricks/main.go
+++ b/providers/databricks/main.go
@@ -383,15 +383,20 @@ func heartbeatCanSend(health *controllerHealth) bool {
 
 func runHeartbeat(ctx context.Context, healthStates ...*controllerHealth) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token, err := hubclient.ResolveHubToken()
-	if err != nil {
-		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
-	}
 	name := envOr("FAROS_PROVIDER_NAME", "databricks")
 	if hub == "" {
 		log.Printf("heartbeat disabled (set FAROS_HUB_URL to enable)")
 		return
 	}
+
+	// Resolved only once the beat is actually going to be sent: reading the
+	// provider kubeconfig for a heartbeat that is disabled is wasted work, and
+	// its failure logs a misleading token error in tests and local runs.
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
+
 	url := strings.TrimRight(hub, "/") + "/api/providers/" + name + "/heartbeat"
 	var health *controllerHealth
 	if len(healthStates) > 0 {

--- a/providers/databricks/main.go
+++ b/providers/databricks/main.go
@@ -37,6 +37,8 @@ import (
 	"github.com/faroshq/provider-databricks/queryapi"
 	databricksscheme "github.com/faroshq/provider-databricks/scheme"
 	"github.com/faroshq/provider-databricks/tenant"
+
+	"github.com/faroshq/provider-sdk/hubclient"
 )
 
 type statusResponse struct {
@@ -381,7 +383,10 @@ func heartbeatCanSend(health *controllerHealth) bool {
 
 func runHeartbeat(ctx context.Context, healthStates ...*controllerHealth) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token := os.Getenv("FAROS_HUB_TOKEN")
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
 	name := envOr("FAROS_PROVIDER_NAME", "databricks")
 	if hub == "" {
 		log.Printf("heartbeat disabled (set FAROS_HUB_URL to enable)")

--- a/providers/edges/heartbeat.go
+++ b/providers/edges/heartbeat.go
@@ -32,10 +32,6 @@ const (
 // FAROS_HUB_INSECURE.
 func runHeartbeat(ctx context.Context, log logr.Logger) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token, err := hubclient.ResolveHubToken()
-	if err != nil {
-		log.Error(err, "resolving heartbeat token; beats will be unauthenticated")
-	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "edges"
@@ -44,6 +40,15 @@ func runHeartbeat(ctx context.Context, log logr.Logger) {
 		log.Info("heartbeat disabled (set FAROS_HUB_URL to enable)")
 		return
 	}
+
+	// Resolved only once the beat is actually going to be sent: reading the
+	// provider kubeconfig for a heartbeat that is disabled is wasted work, and
+	// its failure logs a misleading token error in tests and local runs.
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Error(err, "resolving heartbeat token; beats will be unauthenticated")
+	}
+
 	url := hub + "/api/providers/" + name + "/heartbeat"
 	body, _ := json.Marshal(map[string]string{"version": heartbeatVersion, "status": "healthy"})
 

--- a/providers/edges/heartbeat.go
+++ b/providers/edges/heartbeat.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+
+	"github.com/faroshq/provider-sdk/hubclient"
 )
 
 const (
@@ -30,7 +32,10 @@ const (
 // FAROS_HUB_INSECURE.
 func runHeartbeat(ctx context.Context, log logr.Logger) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token := os.Getenv("FAROS_HUB_TOKEN")
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Error(err, "resolving heartbeat token; beats will be unauthenticated")
+	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "edges"

--- a/providers/infrastructure/heartbeat.go
+++ b/providers/infrastructure/heartbeat.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/faroshq/provider-sdk/hubclient"
 )
 
 const (
@@ -33,12 +35,16 @@ const (
 // Env:
 //
 //	FAROS_HUB_URL        - hub base URL (https://localhost:9443 in dev)
-//	FAROS_HUB_TOKEN      - bearer token for the heartbeat request
+//	FAROS_HUB_TOKEN      - bearer token for the heartbeat request (default: the
+//	                       provider SA token in FAROS_PROVIDER_KUBECONFIG)
 //	FAROS_PROVIDER_NAME  - this provider's CatalogEntry name (default: infrastructure)
 //	FAROS_HUB_INSECURE   - "true" → skip TLS verification (dev with self-signed certs)
 func runHeartbeat(ctx context.Context) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token := os.Getenv("FAROS_HUB_TOKEN")
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "infrastructure"

--- a/providers/infrastructure/heartbeat.go
+++ b/providers/infrastructure/heartbeat.go
@@ -41,10 +41,6 @@ const (
 //	FAROS_HUB_INSECURE   - "true" → skip TLS verification (dev with self-signed certs)
 func runHeartbeat(ctx context.Context) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token, err := hubclient.ResolveHubToken()
-	if err != nil {
-		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
-	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "infrastructure"
@@ -53,6 +49,15 @@ func runHeartbeat(ctx context.Context) {
 		log.Printf("heartbeat disabled (set FAROS_HUB_URL to enable)")
 		return
 	}
+
+	// Resolved only once the beat is actually going to be sent: reading the
+	// provider kubeconfig for a heartbeat that is disabled is wasted work, and
+	// its failure logs a misleading token error in tests and local runs.
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
+
 	url := hub + "/api/providers/" + name + "/heartbeat"
 	body, _ := json.Marshal(map[string]string{"version": heartbeatVersion, "status": "healthy"})
 

--- a/providers/kuery/main.go
+++ b/providers/kuery/main.go
@@ -320,10 +320,6 @@ const (
 //	FAROS_HUB_INSECURE   - "true" → skip TLS verification (dev with self-signed certs)
 func runHeartbeat(ctx context.Context) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token, err := hubclient.ResolveHubToken()
-	if err != nil {
-		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
-	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "kuery"
@@ -332,6 +328,15 @@ func runHeartbeat(ctx context.Context) {
 		log.Printf("heartbeat disabled (set FAROS_HUB_URL to enable)")
 		return
 	}
+
+	// Resolved only once the beat is actually going to be sent: reading the
+	// provider kubeconfig for a heartbeat that is disabled is wasted work, and
+	// its failure logs a misleading token error in tests and local runs.
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
+
 	url := hub + "/api/providers/" + name + "/heartbeat"
 	body, _ := json.Marshal(map[string]string{"version": heartbeatVersion, "status": "healthy"})
 

--- a/providers/kuery/main.go
+++ b/providers/kuery/main.go
@@ -54,6 +54,8 @@ import (
 	"github.com/faroshq/provider-kuery/engagement"
 	"github.com/faroshq/provider-kuery/mcpserver"
 	"github.com/faroshq/provider-kuery/queryapi"
+
+	"github.com/faroshq/provider-sdk/hubclient"
 )
 
 // envOr returns the env value or a default.
@@ -275,7 +277,8 @@ func runServe() {
 	// Heartbeat goroutine — POSTs to the hub every 30s so the catalog
 	// controller's TTL doesn't flip us to NotReady. Configurable via env:
 	//   FAROS_HUB_URL   - base URL of the hub (e.g. http://localhost:19443)
-	//   FAROS_HUB_TOKEN - bearer token for the heartbeat request
+	//   FAROS_HUB_TOKEN - bearer token for the heartbeat request (default: the
+	//                   provider SA token in FAROS_PROVIDER_KUBECONFIG)
 	//   FAROS_PROVIDER_NAME - this provider's CatalogEntry name (default: kuery)
 	// All empty → heartbeats disabled (useful for tests / dry-run).
 	go runHeartbeat(ctx)
@@ -311,12 +314,16 @@ const (
 // Env:
 //
 //	FAROS_HUB_URL        - hub base URL (https://localhost:9443 in dev)
-//	FAROS_HUB_TOKEN      - bearer token for the heartbeat request
+//	FAROS_HUB_TOKEN      - bearer token for the heartbeat request (default: the
+//	                       provider SA token in FAROS_PROVIDER_KUBECONFIG)
 //	FAROS_PROVIDER_NAME  - this provider's CatalogEntry name (default: kuery)
 //	FAROS_HUB_INSECURE   - "true" → skip TLS verification (dev with self-signed certs)
 func runHeartbeat(ctx context.Context) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token := os.Getenv("FAROS_HUB_TOKEN")
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "kuery"

--- a/providers/quickstart/main.go
+++ b/providers/quickstart/main.go
@@ -40,6 +40,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/faroshq/provider-sdk/hubclient"
 )
 
 type helloResponse struct {
@@ -226,7 +228,8 @@ func runServe() {
 	// Heartbeat goroutine — POSTs to the hub every 30s so the catalog
 	// controller's TTL doesn't flip us to NotReady. Configurable via env:
 	//   FAROS_HUB_URL   - base URL of the hub (e.g. http://localhost:19443)
-	//   FAROS_HUB_TOKEN - bearer token for the heartbeat request
+	//   FAROS_HUB_TOKEN - bearer token for the heartbeat request (default: the
+	//                   provider SA token in FAROS_PROVIDER_KUBECONFIG)
 	//   FAROS_PROVIDER_NAME - this provider's CatalogEntry name (default: quickstart)
 	// All empty → heartbeats disabled (useful for tests / dry-run).
 	go runHeartbeat(ctx)
@@ -262,12 +265,16 @@ const (
 // Env:
 //
 //	FAROS_HUB_URL        - hub base URL (https://localhost:9443 in dev)
-//	FAROS_HUB_TOKEN      - bearer token for the heartbeat request
+//	FAROS_HUB_TOKEN      - bearer token for the heartbeat request (default: the
+//	                       provider SA token in FAROS_PROVIDER_KUBECONFIG)
 //	FAROS_PROVIDER_NAME  - this provider's CatalogEntry name (default: quickstart)
 //	FAROS_HUB_INSECURE   - "true" → skip TLS verification (dev with self-signed certs)
 func runHeartbeat(ctx context.Context) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token := os.Getenv("FAROS_HUB_TOKEN")
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "quickstart"

--- a/providers/quickstart/main.go
+++ b/providers/quickstart/main.go
@@ -271,10 +271,6 @@ const (
 //	FAROS_HUB_INSECURE   - "true" → skip TLS verification (dev with self-signed certs)
 func runHeartbeat(ctx context.Context) {
 	hub := os.Getenv("FAROS_HUB_URL")
-	token, err := hubclient.ResolveHubToken()
-	if err != nil {
-		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
-	}
 	name := os.Getenv("FAROS_PROVIDER_NAME")
 	if name == "" {
 		name = "quickstart"
@@ -283,6 +279,15 @@ func runHeartbeat(ctx context.Context) {
 		log.Printf("heartbeat disabled (set FAROS_HUB_URL to enable)")
 		return
 	}
+
+	// Resolved only once the beat is actually going to be sent: reading the
+	// provider kubeconfig for a heartbeat that is disabled is wasted work, and
+	// its failure logs a misleading token error in tests and local runs.
+	token, err := hubclient.ResolveHubToken()
+	if err != nil {
+		log.Printf("heartbeat token: %v (beats will be unauthenticated)", err)
+	}
+
 	url := hub + "/api/providers/" + name + "/heartbeat"
 	body, _ := json.Marshal(map[string]string{"version": heartbeatVersion, "status": "healthy"})
 


### PR DESCRIPTION
Implements item 1.3 (provider heartbeat authentication) of `docs/security-remediation-plan.md`.

## Problem

`POST /api/providers/{name}/heartbeat` is registered on the root router with no auth middleware in front of it (`pkg/hub/server.go`); the tenant middlewares only cover the `/api`, `/api/orgs` and `/api/admin` subrouters. The handler never read `Authorization`, yet its doc comment claimed auth was enforced upstream. Anyone able to reach the hub could therefore keep a dead provider `Ready` (`Provider.Ready()` is `!HeartbeatStale`) and forge its `reportedVersion`, and because the recorder patches `CatalogEntry.status`, the fake liveness fanned out to every hub replica.

## Change

- **Hub** (`pkg/hub/providers/heartbeat_auth.go`): new `HeartbeatAuthenticator`. The TokenReview-backed implementation extracts the bearer, resolves the provider's workspace via `Registry.CatalogEntryCluster`, runs a `TokenReview` in that cluster and requires `Status.Authenticated` plus username `system:serviceaccount:default:provider` (`ProviderSAUsername`, built from the existing `ProviderSAName` / `ProviderSANamespace`). Typed errors map to 401 (no or unrecognised token), 403 (other identity) and 503 (cannot verify: no kcp, workspace not yet known, TokenReview failed). Successful verifications are cached for `HeartbeatTTL/2` (45s) keyed by sha256(token)+provider, so a 30s cadence costs one TokenReview every other beat and a revoked token cannot outlive one liveness window.
- **Audience**: the provider kubeconfig token is a legacy `kubernetes.io/service-account-token` Secret token (`ensureLegacySAToken`), which carries no `aud` claim and validates only for the API server's implicit audience. The TokenReview is therefore issued **without** a requested audience; asking for `WorkloadIdentityTokenAudience` (as the plan sketched) would reject the very token the hub minted. The fake-clientset test asserts no audience is requested. Scoping comes from running the review inside the provider's own logical cluster: kcp binds SA tokens to the cluster that issued them, so a `provider` SA token from another workspace does not authenticate there at all.
- `NewHeartbeatHandler` takes the authenticator and a `HeartbeatAuthMode`; the false "auth enforced upstream" comment is replaced. A nil authenticator (no kcp) behaves as an always-failing check, so `enforce` fails closed.
- **Provider side**: new `provider-sdk/hubclient.ResolveHubToken()` returns `FAROS_HUB_TOKEN` if set, otherwise the bearer inside `FAROS_PROVIDER_KUBECONFIG` (via `clientcmd`). All eight heartbeat clients (agents, app-studio, code, databricks, edges, infrastructure, kuery, quickstart) call it; nothing else in those copies was touched (consolidation is a separate item). `provider-sdk/go.mod` gains an indirect `spf13/pflag` line from `go mod tidy`.
- **Docs**: AGENTS.md §5.2 and `docs/providers.md` now describe the beat as authenticated as the provider's service account (and correct the stale "24h short-lived token" note).

## Compatibility

New hub flag `--provider-heartbeat-auth=warn|enforce` (`Options.ProviderHeartbeatAuth`), **default `warn` for this release**: a beat that fails verification is logged at V(0) with the provider name and reason and is still recorded. **The next release flips the default to `enforce`**, where such beats are rejected.

Providers built from this PR need no chart change: every provider already mounts the workspace-scoped kubeconfig, and the SDK helper reads the token from it. Providers still running an older image keep sending unauthenticated beats; under `warn` they keep working (with a log line per beat), under `enforce` they get 401 and go stale after `HeartbeatTTL` (90s), which is the intended outcome. Charts that wire `hub.tokenSecretRef` keep working: `FAROS_HUB_TOKEN` still wins when set.

## Tests

- `pkg/hub/providers/heartbeat_auth_test.go`: enforce mode returns 401 with no bearer and leaves the registry and recorder untouched; 403 for a wrong identity; 503 when verification is unavailable (including a nil authenticator); the provider's own identity is recorded; warn mode records and logs (captured via `funcr`); mode parsing. TokenReview authenticator with a fake clientset reactor: authenticated-wrong-user (403, not cached), unauthenticated token (401), right user accepted and cached (one review for three beats, distinct tokens reviewed separately, expiry re-reviews, cache TTL < heartbeat TTL), missing cluster (503), bearer parsing.
- `registry_scope_test.go`: `TestHeartbeatRequiresOwnProviderSA` (review runs in the provider's own cluster; a token verified for one provider is re-reviewed for another; org-owned providers cannot beat).
- `provider-sdk/hubclient/token_test.go`: explicit token wins, kubeconfig fallback with a temp kubeconfig, nothing configured, broken and tokenless kubeconfig errors, `tokenFile` support.
- Existing `TestHeartbeat*` updated for the new signature.
- Commands: `GOWORK=off go build ./... && go vet ./pkg/... && go test -count=1 ./pkg/hub/...` (pass), `make fix-lint && make lint` (0 issues), `go build ./... && go vet ./... && go test -count=1 ./...` in `provider-sdk` and in each of the eight provider modules (pass; the seven modules with a gitignored `portal/dist` need a placeholder file there for `//go:embed all:portal/dist` to compile in a fresh checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
