### PR TITLE
fix(hub): verify bearer before federating MCP aggregate requests

### DIFF
--- a/docs/mcp-architecture.md
+++ b/docs/mcp-architecture.md
@@ -158,6 +158,22 @@ AI client ──Bearer T──▶ hub aggregate VW              (T = the MCPServ
                           → acts AS the caller, authorized by the caller's RBAC
 ```
 
+**The hub verifies the bearer before federating.** The aggregate handler
+(`pkg/hub/mcpaggregate`) never forwards an unverified token. Before it builds
+the per-request server it runs a `TokenReview` in the tenant cluster named by
+the URL and requires the reviewed identity to be that MCPServer's own
+ServiceAccount (`system:serviceaccount:default:{name}-mcp`, the account the
+`MCPServer` controller provisions). A hub user bearer (static token or OIDC,
+as used by `faros mcp` and the e2e suites) is accepted instead when the hub's
+normal identity path resolves it and the user holds a live Membership covering
+the cluster's Organization or Workspace per the `UserMembershipIndex`. Anything
+else is answered with `401` (unrecognised) or `403` (valid, but for another
+tenant or MCPServer) and no provider is contacted. Successful verifications
+are cached by `sha256(token)+cluster+name` for 60 seconds, and uncached
+attempts are rate-limited per client address with the same limiter that
+protects `/api/auth/token-login`, so the endpoint cannot be used as a token
+oracle against providers.
+
 Two consequences:
 
 - **Per-MCPServer credentials.** The bearer token a client uses is a per-server,

--- a/pkg/hub/controllers/mcpserver/controller.go
+++ b/pkg/hub/controllers/mcpserver/controller.go
@@ -50,8 +50,9 @@ import (
 )
 
 // mcpIdentityNamespace is the tenant-workspace namespace the per-MCPServer
-// ServiceAccount + token Secret live in.
-const mcpIdentityNamespace = "default"
+// ServiceAccount + token Secret live in. Shared with the aggregate handler,
+// which verifies bearers against exactly this identity.
+const mcpIdentityNamespace = mcpaggregate.MCPIdentityNamespace
 
 // toolsRefreshInterval is how often a Ready MCPServer re-discovers its federated
 // providers' tools and restamps status. Kept modest so the portal reflects newly
@@ -199,8 +200,8 @@ func (r *Reconciler) tenantConfig(clusterName string) *rest.Config {
 // kcp's token controller has populated it yet (a short poll; if still empty the
 // caller requeues rather than blocking).
 func ensureMCPIdentity(ctx context.Context, cs kubernetes.Interface, srv *farosv1alpha1.MCPServer) (*corev1.SecretReference, string, bool, error) {
-	saName := srv.Name + "-mcp"
-	secretName := srv.Name + "-mcp-token"
+	saName := mcpaggregate.ServiceAccountName(srv.Name)
+	secretName := saName + "-token"
 
 	owner := metav1.OwnerReference{
 		APIVersion: farosv1alpha1.SchemeGroupVersion.String(),

--- a/pkg/hub/mcpaggregate/handler.go
+++ b/pkg/hub/mcpaggregate/handler.go
@@ -23,23 +23,40 @@ limitations under the License.
 // in exactly like every other provider (kuery, code, infrastructure, …).
 //
 // Per request the handler parses the tenant cluster + MCPServer name out of the
-// path, authenticates the caller's bearer, builds a fresh stateless mcp.Server,
-// federates every Ready provider's own /mcp endpoint into it, and serves the
-// MCP protocol over streamable HTTP.
+// path, verifies the caller's bearer against that tenant (see BearerVerifier),
+// builds a fresh stateless mcp.Server, federates every Ready provider's own
+// /mcp endpoint into it, and serves the MCP protocol over streamable HTTP.
+// Nothing is federated for a bearer that fails verification.
 package mcpaggregate
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/faroshq/faros/pkg/apiurl"
 )
+
+// DefaultVerifyCacheTTL is how long a successful bearer verification is
+// reused for the same (bearer, cluster, MCPServer) before it is re-checked.
+const DefaultVerifyCacheTTL = 60 * time.Second
+
+// RateLimiter admits or rejects a pre-authentication verification attempt
+// for one client address. The hub's token-login limiter satisfies it.
+type RateLimiter interface {
+	Allow(clientIP string) bool
+}
 
 // impl is the MCP Implementation advertised on `initialize`.
 var impl = &mcp.Implementation{
@@ -57,42 +74,162 @@ type Options struct {
 	ExternalURL string
 	// Logger is used for federation diagnostics. Optional.
 	Logger logr.Logger
+	// Verifier checks the bearer against the tenant cluster and MCPServer
+	// named by the request before anything is federated. Required: without
+	// one every request is refused with 503 rather than forwarded unverified.
+	Verifier BearerVerifier
+	// VerifyCacheTTL bounds how long a successful verification is reused for
+	// the same bearer, cluster and MCPServer. Defaults to DefaultVerifyCacheTTL.
+	VerifyCacheTTL time.Duration
+	// RateLimiter, when set, caps uncached verification attempts per client
+	// address; cache hits are never counted so verified clients are not
+	// throttled. Optional.
+	RateLimiter RateLimiter
+	// ClientIP derives the address the rate limiter keys on. Defaults to the
+	// host part of RemoteAddr; the hub passes its proxy-header-aware helper.
+	ClientIP func(*http.Request) string
 }
 
 // New returns the http.Handler mounted at apiurl.PathPrefixMCPServer. The
 // handler expects the prefix to have been stripped, so it sees
 // /{cluster}/apis/faros.sh/v1alpha1/mcpservers/{name}/mcp.
 func New(opts Options) http.Handler {
-	log := opts.Logger
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cluster, name, ok := parseMCPServerPath(r.URL.Path)
-		if !ok {
-			http.Error(w, "invalid path: expected /{cluster}/apis/faros.sh/v1alpha1/mcpservers/{name}/mcp", http.StatusBadRequest)
-			return
-		}
-		token := extractBearer(r)
-		if token == "" {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
+	h := &handler{opts: opts, verified: make(map[string]time.Time)}
+	if h.opts.VerifyCacheTTL <= 0 {
+		h.opts.VerifyCacheTTL = DefaultVerifyCacheTTL
+	}
+	if h.opts.ClientIP == nil {
+		h.opts.ClientIP = remoteHost
+	}
+	return h
+}
 
-		// Fresh, stateless server per request so a provider that just became
-		// Ready shows up on the very next tools/list.
-		handler := mcp.NewStreamableHTTPHandler(
-			func(req *http.Request) *mcp.Server {
-				return buildServer(req.Context(), buildParams{
-					cluster:     cluster,
-					name:        name,
-					token:       token,
-					externalURL: opts.ExternalURL,
-					enumerate:   opts.Providers,
-					log:         log,
-				})
-			},
-			&mcp.StreamableHTTPOptions{Stateless: true},
-		)
-		handler.ServeHTTP(w, r)
-	})
+type handler struct {
+	opts Options
+
+	mu       sync.Mutex
+	verified map[string]time.Time // verification cache key -> expiry
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	cluster, name, ok := parseMCPServerPath(r.URL.Path)
+	if !ok {
+		http.Error(w, "invalid path: expected /{cluster}/apis/faros.sh/v1alpha1/mcpservers/{name}/mcp", http.StatusBadRequest)
+		return
+	}
+	token := extractBearer(r)
+	if token == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if !h.authorize(w, r, token, cluster, name) {
+		return
+	}
+
+	// Fresh, stateless server per request so a provider that just became
+	// Ready shows up on the very next tools/list.
+	handler := mcp.NewStreamableHTTPHandler(
+		func(req *http.Request) *mcp.Server {
+			return buildServer(req.Context(), buildParams{
+				cluster:     cluster,
+				name:        name,
+				token:       token,
+				externalURL: h.opts.ExternalURL,
+				enumerate:   h.opts.Providers,
+				log:         h.opts.Logger,
+			})
+		},
+		&mcp.StreamableHTTPOptions{Stateless: true},
+	)
+	handler.ServeHTTP(w, r)
+}
+
+// authorize verifies the bearer for (cluster, name), writing the rejection
+// and returning false on failure. Successful verifications are cached by
+// sha256(bearer)+cluster+name for VerifyCacheTTL; only uncached attempts are
+// counted against the per-address rate limit, so the pre-auth path is what
+// gets throttled, never an already-verified client.
+func (h *handler) authorize(w http.ResponseWriter, r *http.Request, token, cluster, name string) bool {
+	key := verifyCacheKey(token, cluster, name)
+	if h.cached(key) {
+		return true
+	}
+	if h.opts.RateLimiter != nil && !h.opts.RateLimiter.Allow(h.opts.ClientIP(r)) {
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "rate limit exceeded - too many requests", http.StatusTooManyRequests)
+		return false
+	}
+	if h.opts.Verifier == nil {
+		http.Error(w, "bearer verification is not configured", http.StatusServiceUnavailable)
+		return false
+	}
+	if err := h.opts.Verifier.Verify(r, token, cluster, name); err != nil {
+		status, msg := http.StatusServiceUnavailable, "bearer verification unavailable"
+		switch {
+		case errors.Is(err, ErrUnauthenticated):
+			status, msg = http.StatusUnauthorized, "Unauthorized"
+		case errors.Is(err, ErrForbidden):
+			status, msg = http.StatusForbidden, "Forbidden"
+		}
+		h.opts.Logger.Info("mcp aggregate: bearer rejected",
+			"cluster", cluster, "mcpserver", name, "client", h.opts.ClientIP(r), "status", status, "reason", err.Error())
+		http.Error(w, msg, status)
+		return false
+	}
+	h.remember(key)
+	return true
+}
+
+func (h *handler) cached(key string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	exp, ok := h.verified[key]
+	if !ok {
+		return false
+	}
+	if time.Now().After(exp) {
+		delete(h.verified, key)
+		return false
+	}
+	return true
+}
+
+// maxVerifiedEntries bounds the cache; expired entries are swept once it is
+// exceeded so a flood of distinct bearers cannot grow it without limit.
+const maxVerifiedEntries = 4096
+
+func (h *handler) remember(key string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	now := time.Now()
+	if len(h.verified) >= maxVerifiedEntries {
+		for k, exp := range h.verified {
+			if now.After(exp) {
+				delete(h.verified, k)
+			}
+		}
+	}
+	if len(h.verified) >= maxVerifiedEntries {
+		return
+	}
+	h.verified[key] = now.Add(h.opts.VerifyCacheTTL)
+}
+
+// verifyCacheKey never stores the bearer itself: only its digest, bound to
+// the cluster and MCPServer it was verified for.
+func verifyCacheKey(token, cluster, name string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:]) + "|" + cluster + "|" + name
+}
+
+// remoteHost is the default ClientIP: the connection's peer address with no
+// proxy headers consulted.
+func remoteHost(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
 }
 
 type buildParams struct {

--- a/pkg/hub/mcpaggregate/handler_test.go
+++ b/pkg/hub/mcpaggregate/handler_test.go
@@ -23,10 +23,232 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 const testMCPPath = "/some-cluster/apis/faros.sh/v1alpha1/mcpservers/default/mcp"
+
+// allowAll is the verifier the federation-focused tests use so they exercise
+// the aggregate itself rather than bearer verification.
+var allowAll = BearerVerifierFunc(func(*http.Request, string, string, string) error { return nil })
+
+// countingVerifier records every verification attempt and answers with a
+// fixed error (nil = allow).
+type countingVerifier struct {
+	calls atomic.Int32
+	err   error
+	last  struct{ token, cluster, name string }
+}
+
+func (c *countingVerifier) Verify(_ *http.Request, token, cluster, name string) error {
+	c.calls.Add(1)
+	c.last.token, c.last.cluster, c.last.name = token, cluster, name
+	return c.err
+}
+
+// countingProvider is a fake upstream provider /mcp endpoint that counts how
+// many federated calls reach it.
+func countingProvider(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+// toolsList POSTs tools/list with the given bearer and returns the status.
+func toolsList(h http.Handler, bearer string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, testMCPPath, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.RemoteAddr = "203.0.113.7:4242"
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestGarbageBearerNeverReachesProviders is the finding-4 regression: a
+// bearer the verifier rejects gets 401 and no provider is contacted.
+func TestGarbageBearerNeverReachesProviders(t *testing.T) {
+	provider, upstream := countingProvider(t)
+	v := &countingVerifier{err: ErrUnauthenticated}
+	h := New(Options{
+		Providers: func(context.Context) []ProviderTarget {
+			return []ProviderTarget{{Name: "infra", MCPURL: provider.URL}}
+		},
+		Verifier: v,
+	})
+
+	rr := toolsList(h, "garbage")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("garbage bearer: status = %d, want 401", rr.Code)
+	}
+	if got := v.calls.Load(); got != 1 {
+		t.Fatalf("verifier calls = %d, want 1", got)
+	}
+	if v.last.token != "garbage" || v.last.cluster != "some-cluster" || v.last.name != "default" {
+		t.Fatalf("verifier saw %+v, want (garbage, some-cluster, default)", v.last)
+	}
+	if got := upstream.Load(); got != 0 {
+		t.Fatalf("upstream provider received %d calls for a rejected bearer, want 0", got)
+	}
+}
+
+// TestValidTokenForOtherClusterForbidden: a real credential that does not
+// belong to the addressed tenant is 403 and never federated.
+func TestValidTokenForOtherClusterForbidden(t *testing.T) {
+	provider, upstream := countingProvider(t)
+	h := New(Options{
+		Providers: func(context.Context) []ProviderTarget {
+			return []ProviderTarget{{Name: "infra", MCPURL: provider.URL}}
+		},
+		Verifier: &countingVerifier{err: ErrForbidden},
+	})
+
+	if rr := toolsList(h, "other-tenant-token"); rr.Code != http.StatusForbidden {
+		t.Fatalf("foreign bearer: status = %d, want 403", rr.Code)
+	}
+	if got := upstream.Load(); got != 0 {
+		t.Fatalf("upstream provider received %d calls for a forbidden bearer, want 0", got)
+	}
+}
+
+// TestVerifierOutageIsNotBypassed: an infrastructure error from the verifier
+// fails closed with 503 rather than forwarding.
+func TestVerifierOutageIsNotBypassed(t *testing.T) {
+	provider, upstream := countingProvider(t)
+	h := New(Options{
+		Providers: func(context.Context) []ProviderTarget {
+			return []ProviderTarget{{Name: "infra", MCPURL: provider.URL}}
+		},
+		Verifier: &countingVerifier{err: context.DeadlineExceeded},
+	})
+	if rr := toolsList(h, "t"); rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("verifier error: status = %d, want 503", rr.Code)
+	}
+	if got := upstream.Load(); got != 0 {
+		t.Fatalf("upstream provider received %d calls during verifier outage, want 0", got)
+	}
+
+	// No verifier at all is the same: fail closed.
+	h = New(Options{Providers: func(context.Context) []ProviderTarget { return nil }})
+	if rr := toolsList(h, "t"); rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("nil verifier: status = %d, want 503", rr.Code)
+	}
+}
+
+// TestValidTokenProceedsAndIsCached: a verified bearer federates, and the
+// second request within the TTL reuses the verification instead of asking
+// the verifier (and thus kcp) again. A different bearer is verified afresh.
+func TestValidTokenProceedsAndIsCached(t *testing.T) {
+	provider, upstream := countingProvider(t)
+	v := &countingVerifier{}
+	h := New(Options{
+		Providers: func(context.Context) []ProviderTarget {
+			return []ProviderTarget{{Name: "infra", MCPURL: provider.URL}}
+		},
+		Verifier: v,
+	})
+
+	for i := 0; i < 2; i++ {
+		if rr := toolsList(h, "sa-token"); rr.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200 (body %s)", i, rr.Code, rr.Body.String())
+		}
+	}
+	if got := v.calls.Load(); got != 1 {
+		t.Fatalf("verifier calls after two requests = %d, want 1 (cache hit)", got)
+	}
+	if got := upstream.Load(); got == 0 {
+		t.Fatal("verified bearer was never federated to the provider")
+	}
+	if rr := toolsList(h, "another-sa-token"); rr.Code != http.StatusOK {
+		t.Fatalf("second bearer: status = %d, want 200", rr.Code)
+	}
+	if got := v.calls.Load(); got != 2 {
+		t.Fatalf("verifier calls after a new bearer = %d, want 2", got)
+	}
+}
+
+// TestVerificationCacheExpires: once the TTL lapses the bearer is re-verified.
+func TestVerificationCacheExpires(t *testing.T) {
+	v := &countingVerifier{}
+	h := New(Options{
+		Providers:      func(context.Context) []ProviderTarget { return nil },
+		Verifier:       v,
+		VerifyCacheTTL: time.Nanosecond,
+	})
+	for i := 0; i < 2; i++ {
+		if rr := toolsList(h, "sa-token"); rr.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200", i, rr.Code)
+		}
+	}
+	if got := v.calls.Load(); got != 2 {
+		t.Fatalf("verifier calls with expired cache = %d, want 2", got)
+	}
+}
+
+// fixedLimiter admits the first n attempts from any address.
+type fixedLimiter struct {
+	n    int
+	seen []string
+}
+
+func (l *fixedLimiter) Allow(ip string) bool {
+	l.seen = append(l.seen, ip)
+	l.n--
+	return l.n >= 0
+}
+
+// TestRateLimitCoversOnlyUncachedVerifications: unverified attempts consume
+// the per-address budget and get 429 when it is exhausted; a cached bearer
+// is never counted.
+func TestRateLimitCoversOnlyUncachedVerifications(t *testing.T) {
+	provider, upstream := countingProvider(t)
+	lim := &fixedLimiter{n: 2}
+	h := New(Options{
+		Providers: func(context.Context) []ProviderTarget {
+			return []ProviderTarget{{Name: "infra", MCPURL: provider.URL}}
+		},
+		Verifier: BearerVerifierFunc(func(_ *http.Request, token, _, _ string) error {
+			if token == "good" {
+				return nil
+			}
+			return ErrUnauthenticated
+		}),
+		RateLimiter: lim,
+	})
+
+	if rr := toolsList(h, "good"); rr.Code != http.StatusOK {
+		t.Fatalf("good bearer: status = %d, want 200", rr.Code)
+	}
+	if rr := toolsList(h, "bad-1"); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("bad-1: status = %d, want 401", rr.Code)
+	}
+	if rr := toolsList(h, "bad-2"); rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("bad-2 over budget: status = %d, want 429", rr.Code)
+	}
+	if rr := toolsList(h, "good"); rr.Code != http.StatusOK {
+		t.Fatalf("cached good bearer while throttled: status = %d, want 200", rr.Code)
+	}
+	if len(lim.seen) != 3 {
+		t.Fatalf("limiter consulted %d times, want 3 (cache hit not counted)", len(lim.seen))
+	}
+	for _, ip := range lim.seen {
+		if ip != "203.0.113.7" {
+			t.Fatalf("limiter keyed on %q, want RemoteAddr host 203.0.113.7", ip)
+		}
+	}
+	if got := upstream.Load(); got == 0 {
+		t.Fatal("good bearer was never federated")
+	}
+}
 
 func TestParseMCPServerPath(t *testing.T) {
 	cluster, name, ok := parseMCPServerPath(testMCPPath)
@@ -80,7 +302,7 @@ func jsonrpc(t *testing.T, h http.Handler, method string, params string) (json.R
 // TestAlwaysOnEmptyAggregate is the core guarantee: with zero providers the
 // endpoint still initializes and serves an (empty) tools/list — never 501.
 func TestAlwaysOnEmptyAggregate(t *testing.T) {
-	h := New(Options{Providers: func(context.Context) []ProviderTarget { return nil }})
+	h := New(Options{Providers: func(context.Context) []ProviderTarget { return nil }, Verifier: allowAll})
 
 	if _, code := jsonrpc(t, h, "initialize", `{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"t","version":"1"}}`); code != http.StatusOK {
 		t.Fatalf("initialize status = %d, want 200 (endpoint must be always-on)", code)
@@ -105,7 +327,7 @@ func TestAlwaysOnEmptyAggregate(t *testing.T) {
 
 // TestUnauthorizedAndBadPath covers the two request-level guards.
 func TestUnauthorizedAndBadPath(t *testing.T) {
-	h := New(Options{Providers: func(context.Context) []ProviderTarget { return nil }})
+	h := New(Options{Providers: func(context.Context) []ProviderTarget { return nil }, Verifier: allowAll})
 
 	noAuth := httptest.NewRequest(http.MethodPost, testMCPPath, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
 	rr := httptest.NewRecorder()
@@ -147,7 +369,7 @@ func TestFederatesReadyProvider(t *testing.T) {
 
 	h := New(Options{Providers: func(context.Context) []ProviderTarget {
 		return []ProviderTarget{{Name: "infra", DisplayName: "Infrastructure", MCPURL: provider.URL}}
-	}})
+	}, Verifier: allowAll})
 
 	result, code := jsonrpc(t, h, "tools/list", `{}`)
 	if code != http.StatusOK {

--- a/pkg/hub/mcpaggregate/identity.go
+++ b/pkg/hub/mcpaggregate/identity.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpaggregate
+
+// MCPIdentityNamespace is the tenant-workspace namespace the per-MCPServer
+// ServiceAccount and token Secret live in. The mcpserver controller provisions
+// the identity here and the aggregate handler verifies bearers against it, so
+// the two sides share one definition.
+const MCPIdentityNamespace = "default"
+
+// ServiceAccountName returns the name of the ServiceAccount the mcpserver
+// controller provisions for the named MCPServer.
+func ServiceAccountName(mcpServerName string) string {
+	return mcpServerName + "-mcp"
+}
+
+// ServiceAccountUsername returns the Kubernetes username a TokenReview reports
+// for the named MCPServer's ServiceAccount token.
+func ServiceAccountUsername(mcpServerName string) string {
+	return "system:serviceaccount:" + MCPIdentityNamespace + ":" + ServiceAccountName(mcpServerName)
+}

--- a/pkg/hub/mcpaggregate/verifier.go
+++ b/pkg/hub/mcpaggregate/verifier.go
@@ -1,0 +1,318 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpaggregate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	authnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
+)
+
+// BearerVerifier decides whether the bearer presented on an aggregate MCP
+// request may act in the tenant cluster and MCPServer named by the request
+// path. It runs before any federation, so a rejected bearer never reaches a
+// provider.
+//
+// Implementations return nil to allow, ErrUnauthenticated when the bearer is
+// not a credential the hub recognises, ErrForbidden when it is a valid
+// credential for a different tenant or identity, and any other error when
+// verification itself could not be performed (the handler answers 503).
+type BearerVerifier interface {
+	Verify(r *http.Request, token, cluster, mcpServerName string) error
+}
+
+// BearerVerifierFunc adapts a function to BearerVerifier.
+type BearerVerifierFunc func(r *http.Request, token, cluster, mcpServerName string) error
+
+// Verify implements BearerVerifier.
+func (f BearerVerifierFunc) Verify(r *http.Request, token, cluster, mcpServerName string) error {
+	return f(r, token, cluster, mcpServerName)
+}
+
+var (
+	// ErrUnauthenticated means the bearer is not a credential the hub or the
+	// tenant cluster recognises.
+	ErrUnauthenticated = errors.New("bearer is not authenticated")
+	// ErrForbidden means the bearer is a valid credential but not for the
+	// tenant cluster and MCPServer addressed by the request.
+	ErrForbidden = errors.New("bearer is not authorized for this MCPServer")
+)
+
+// serviceAccountPrefix is the username prefix kube reports for SA tokens.
+const serviceAccountPrefix = "system:serviceaccount:"
+
+// tenantPathRoot is the kcp path every Organization and child Workspace
+// lives under (mirrors orgWorkspaceParent in the organization controller and
+// workspacePathRoot in the hub's provider tenant resolver).
+const tenantPathRoot = "root:faros:tenants:"
+
+// clusterPathTTL bounds how long a resolved cluster ID to workspace path
+// mapping is reused. Paths are set once at workspace creation and never
+// reassigned, so a long TTL is safe.
+const clusterPathTTL = 5 * time.Minute
+
+// logicalClusterGVR addresses the per-workspace LogicalCluster singleton whose
+// kcp.io/path annotation carries the workspace path.
+var logicalClusterGVR = schema.GroupVersionResource{
+	Group: "core.kcp.io", Version: "v1alpha1", Resource: "logicalclusters",
+}
+
+// Verifier is the production BearerVerifier. It accepts exactly two kinds of
+// bearer:
+//
+//  1. The MCPServer's own ServiceAccount token, which the mcpserver controller
+//     mints and the portal / REST API hand to the user for long-lived MCP
+//     client configuration. It is verified online with a TokenReview in the
+//     tenant cluster named by the request, and the reviewed username must be
+//     ServiceAccountUsername(name) for the MCPServer named by the request.
+//  2. A hub user bearer (static token or OIDC id_token) as resolved by the
+//     hub's normal identity path; the CLI's `faros mcp` and the e2e suites
+//     use these. The user must hold a live Membership covering the tenant
+//     the cluster belongs to, per the UserMembershipIndex.
+//
+// Signatures and claims are never trusted offline; both paths are online
+// checks against kcp.
+type Verifier struct {
+	// clusterConfig returns a rest.Config addressing the named tenant cluster.
+	clusterConfig func(cluster string) *rest.Config
+	// newKube builds the kube client used for TokenReview (test seam).
+	newKube func(*rest.Config) (kubernetes.Interface, error)
+	// clusterPath resolves a logical-cluster ID to its kcp workspace path.
+	clusterPath func(ctx context.Context, cluster string) (string, error)
+
+	mu         sync.RWMutex
+	identify   func(*http.Request) (string, error)
+	membership func(ctx context.Context, user string) (*tenancyv1alpha1.UserMembershipIndex, error)
+
+	pathMu sync.RWMutex
+	paths  map[string]pathEntry
+}
+
+type pathEntry struct {
+	path      string
+	expiresAt time.Time
+}
+
+// VerifierOption customises a Verifier.
+type VerifierOption func(*Verifier)
+
+// WithKubeClientFactory overrides how the TokenReview client is built.
+func WithKubeClientFactory(f func(*rest.Config) (kubernetes.Interface, error)) VerifierOption {
+	return func(v *Verifier) { v.newKube = f }
+}
+
+// WithClusterPathResolver overrides how a logical-cluster ID is mapped to its
+// workspace path.
+func WithClusterPathResolver(f func(ctx context.Context, cluster string) (string, error)) VerifierOption {
+	return func(v *Verifier) { v.clusterPath = f }
+}
+
+// NewVerifier builds a Verifier. clusterConfig must return a rest.Config whose
+// Host addresses the named tenant cluster (apiurl.KCPClusterURL); returning
+// nil makes every verification fail closed.
+func NewVerifier(clusterConfig func(cluster string) *rest.Config, opts ...VerifierOption) *Verifier {
+	v := &Verifier{
+		clusterConfig: clusterConfig,
+		newKube: func(cfg *rest.Config) (kubernetes.Interface, error) {
+			return kubernetes.NewForConfig(cfg)
+		},
+		paths: make(map[string]pathEntry),
+	}
+	v.clusterPath = v.lookupClusterPath
+	for _, o := range opts {
+		o(v)
+	}
+	return v
+}
+
+// SetUserIdentity enables the hub-user branch. identify resolves a request's
+// bearer to a User name (KCPProxy.IdentifyUser); membership reads that user's
+// UserMembershipIndex. Until both are set only MCPServer ServiceAccount
+// tokens are accepted.
+func (v *Verifier) SetUserIdentity(
+	identify func(*http.Request) (string, error),
+	membership func(ctx context.Context, user string) (*tenancyv1alpha1.UserMembershipIndex, error),
+) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.identify = identify
+	v.membership = membership
+}
+
+// Verify implements BearerVerifier.
+func (v *Verifier) Verify(r *http.Request, token, cluster, mcpServerName string) error {
+	if v == nil || r == nil {
+		return errors.New("bearer verifier unavailable")
+	}
+	if strings.TrimSpace(token) == "" || strings.ContainsAny(token, "\r\n") {
+		return ErrUnauthenticated
+	}
+	ctx := r.Context()
+
+	// Hub user bearers first: identification is an offline JWT / constant-time
+	// compare, so a non-user token falls through cheaply to the online path.
+	v.mu.RLock()
+	identify, membership := v.identify, v.membership
+	v.mu.RUnlock()
+	if identify != nil && membership != nil {
+		user, err := identify(r)
+		if err == nil && !strings.HasPrefix(user, serviceAccountPrefix) {
+			return v.verifyMember(ctx, user, cluster)
+		}
+	}
+
+	return v.verifyServiceAccount(ctx, token, cluster, mcpServerName)
+}
+
+// verifyServiceAccount runs a TokenReview in the tenant cluster and requires
+// the reviewed identity to be the MCPServer's own ServiceAccount. No audience
+// is requested: the controller mints legacy Secret-backed tokens, which carry
+// the API server's implicit audience only.
+func (v *Verifier) verifyServiceAccount(ctx context.Context, token, cluster, mcpServerName string) error {
+	cfg := v.clusterConfig(cluster)
+	if cfg == nil {
+		return fmt.Errorf("no kcp configuration for cluster %q", cluster)
+	}
+	cs, err := v.newKube(cfg)
+	if err != nil {
+		return fmt.Errorf("building TokenReview client for cluster %q: %w", cluster, err)
+	}
+	review, err := cs.AuthenticationV1().TokenReviews().Create(ctx, &authnv1.TokenReview{
+		Spec: authnv1.TokenReviewSpec{Token: token},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("reviewing bearer in cluster %q: %w", cluster, err)
+	}
+	if !review.Status.Authenticated {
+		return ErrUnauthenticated
+	}
+	if review.Status.User.Username != ServiceAccountUsername(mcpServerName) {
+		return fmt.Errorf("%w: reviewed identity %q is not the MCPServer service account", ErrForbidden, review.Status.User.Username)
+	}
+	return nil
+}
+
+// verifyMember requires user to hold a live Membership covering the tenant
+// the cluster belongs to. An org-scope entry covers every child workspace;
+// a workspace-scope entry covers only that workspace.
+func (v *Verifier) verifyMember(ctx context.Context, user, cluster string) error {
+	v.mu.RLock()
+	membership := v.membership
+	v.mu.RUnlock()
+
+	path, err := v.resolvePath(ctx, cluster)
+	if err != nil {
+		return err
+	}
+	orgUUID, wsUUID, ok := tenantFromPath(path)
+	if !ok {
+		return fmt.Errorf("%w: cluster %q is not a tenant workspace", ErrForbidden, cluster)
+	}
+	idx, err := membership(ctx, user)
+	if err != nil {
+		return fmt.Errorf("reading membership index for %q: %w", user, err)
+	}
+	if idx != nil {
+		for _, e := range idx.Spec.Entries {
+			if e.OrgUUID != orgUUID || e.SoftDeletedAt != nil {
+				continue
+			}
+			if e.WorkspaceUUID == "" || e.WorkspaceUUID == wsUUID {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("%w: user %q has no membership in (org=%s, workspace=%s)", ErrForbidden, user, orgUUID, wsUUID)
+}
+
+// resolvePath returns the workspace path for cluster. A cluster containing
+// ':' is already a path; a bare logical-cluster ID is resolved through the
+// cluster's LogicalCluster singleton and cached.
+func (v *Verifier) resolvePath(ctx context.Context, cluster string) (string, error) {
+	if strings.Contains(cluster, ":") {
+		return cluster, nil
+	}
+	now := time.Now()
+	v.pathMu.RLock()
+	e, ok := v.paths[cluster]
+	v.pathMu.RUnlock()
+	if ok && now.Before(e.expiresAt) {
+		return e.path, nil
+	}
+	path, err := v.clusterPath(ctx, cluster)
+	if err != nil {
+		return "", err
+	}
+	v.pathMu.Lock()
+	v.paths[cluster] = pathEntry{path: path, expiresAt: now.Add(clusterPathTTL)}
+	v.pathMu.Unlock()
+	return path, nil
+}
+
+// lookupClusterPath is the default clusterPath: read kcp.io/path off the
+// LogicalCluster singleton in the addressed cluster.
+func (v *Verifier) lookupClusterPath(ctx context.Context, cluster string) (string, error) {
+	cfg := v.clusterConfig(cluster)
+	if cfg == nil {
+		return "", fmt.Errorf("no kcp configuration for cluster %q", cluster)
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return "", fmt.Errorf("dynamic client for cluster %q: %w", cluster, err)
+	}
+	lc, err := dyn.Resource(logicalClusterGVR).Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting LogicalCluster for cluster %q: %w", cluster, err)
+	}
+	path := lc.GetAnnotations()["kcp.io/path"]
+	if path == "" {
+		return "", fmt.Errorf("LogicalCluster for cluster %q has no kcp.io/path annotation", cluster)
+	}
+	return path, nil
+}
+
+// tenantFromPath splits a tenant workspace path into its Organization UUID
+// and optional child Workspace UUID. Paths outside root:faros:tenants, or
+// nested deeper than one child workspace, are not tenant workspaces users
+// can hold Memberships in.
+func tenantFromPath(path string) (orgUUID, wsUUID string, ok bool) {
+	if !strings.HasPrefix(path, tenantPathRoot) {
+		return "", "", false
+	}
+	parts := strings.Split(strings.TrimPrefix(path, tenantPathRoot), ":")
+	switch {
+	case len(parts) == 1 && parts[0] != "":
+		return parts[0], "", true
+	case len(parts) == 2 && parts[0] != "" && parts[1] != "":
+		return parts[0], parts[1], true
+	default:
+		return "", "", false
+	}
+}

--- a/pkg/hub/mcpaggregate/verifier_test.go
+++ b/pkg/hub/mcpaggregate/verifier_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpaggregate
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	authnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+
+	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
+)
+
+// saToken -> (cluster it is valid in, username kube reports).
+type fakeToken struct {
+	cluster  string
+	username string
+}
+
+// fakeKCP fakes TokenReview per tenant cluster: a token authenticates only
+// in the cluster it was issued for, mirroring kcp's per-logical-cluster
+// ServiceAccount validation. reviews counts TokenReview calls.
+type fakeKCP struct {
+	tokens  map[string]fakeToken
+	reviews int
+}
+
+func (f *fakeKCP) clusterConfig(cluster string) *rest.Config {
+	return &rest.Config{Host: "https://kcp.test/clusters/" + cluster}
+}
+
+func (f *fakeKCP) newClient(cfg *rest.Config) (kubernetes.Interface, error) {
+	cluster := strings.TrimPrefix(cfg.Host, "https://kcp.test/clusters/")
+	cs := kubefake.NewClientset()
+	cs.PrependReactor("create", "tokenreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		f.reviews++
+		review := action.(clienttesting.CreateAction).GetObject().(*authnv1.TokenReview)
+		out := &authnv1.TokenReview{}
+		if tok, ok := f.tokens[review.Spec.Token]; ok && tok.cluster == cluster {
+			out.Status = authnv1.TokenReviewStatus{Authenticated: true, User: authnv1.UserInfo{Username: tok.username}}
+		} else {
+			out.Status = authnv1.TokenReviewStatus{Authenticated: false, Error: "invalid bearer token"}
+		}
+		return true, out, nil
+	})
+	return cs, nil
+}
+
+func newTestVerifier(t *testing.T, opts ...VerifierOption) (*Verifier, *fakeKCP) {
+	t.Helper()
+	kcp := &fakeKCP{tokens: map[string]fakeToken{
+		"sa-tenant-a":    {cluster: "tenant-a", username: ServiceAccountUsername("default")},
+		"sa-other-a":     {cluster: "tenant-a", username: ServiceAccountUsername("other")},
+		"workload-a":     {cluster: "tenant-a", username: "system:serviceaccount:default:wl-abc"},
+		"sa-tenant-b":    {cluster: "tenant-b", username: ServiceAccountUsername("default")},
+		"user-shaped-sa": {cluster: "tenant-a", username: "alice"},
+	}}
+	all := append([]VerifierOption{WithKubeClientFactory(kcp.newClient)}, opts...)
+	return NewVerifier(kcp.clusterConfig, all...), kcp
+}
+
+func request(t *testing.T, bearer string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, testMCPPath, nil)
+	r.Header.Set("Authorization", "Bearer "+bearer)
+	return r
+}
+
+func TestVerifierServiceAccountToken(t *testing.T) {
+	cases := []struct {
+		name    string
+		token   string
+		cluster string
+		mcpName string
+		wantErr error // nil = allow
+	}{
+		{name: "own SA in its cluster", token: "sa-tenant-a", cluster: "tenant-a", mcpName: "default"},
+		{name: "garbage bearer", token: "nope", cluster: "tenant-a", mcpName: "default", wantErr: ErrUnauthenticated},
+		{name: "token from another tenant cluster", token: "sa-tenant-b", cluster: "tenant-a", mcpName: "default", wantErr: ErrUnauthenticated},
+		{name: "another MCPServer's SA", token: "sa-other-a", cluster: "tenant-a", mcpName: "default", wantErr: ErrForbidden},
+		{name: "workload identity SA", token: "workload-a", cluster: "tenant-a", mcpName: "default", wantErr: ErrForbidden},
+		{name: "non-SA identity from TokenReview", token: "user-shaped-sa", cluster: "tenant-a", mcpName: "default", wantErr: ErrForbidden},
+		{name: "empty bearer", token: "", cluster: "tenant-a", mcpName: "default", wantErr: ErrUnauthenticated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, kcp := newTestVerifier(t)
+			err := v.Verify(request(t, tc.token), tc.token, tc.cluster, tc.mcpName)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("Verify() = %v, want nil", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Verify() = %v, want %v", err, tc.wantErr)
+			}
+			if tc.token != "" && kcp.reviews != 1 {
+				t.Fatalf("TokenReview calls = %d, want 1", kcp.reviews)
+			}
+		})
+	}
+}
+
+// TestVerifierFailsClosedWithoutClusterConfig: no kcp config means no
+// verification, never a pass-through.
+func TestVerifierFailsClosedWithoutClusterConfig(t *testing.T) {
+	v := NewVerifier(func(string) *rest.Config { return nil })
+	err := v.Verify(request(t, "sa-tenant-a"), "sa-tenant-a", "tenant-a", "default")
+	if err == nil || errors.Is(err, ErrUnauthenticated) || errors.Is(err, ErrForbidden) {
+		t.Fatalf("Verify() = %v, want an infrastructure error", err)
+	}
+}
+
+func membershipIndex(entries ...tenancyv1alpha1.MembershipIndexEntry) *tenancyv1alpha1.UserMembershipIndex {
+	return &tenancyv1alpha1.UserMembershipIndex{Spec: tenancyv1alpha1.UserMembershipIndexSpec{Entries: entries}}
+}
+
+func TestVerifierHubUserMembership(t *testing.T) {
+	const (
+		org  = "11111111-1111-1111-1111-111111111111"
+		ws   = "22222222-2222-2222-2222-222222222222"
+		ws2  = "33333333-3333-3333-3333-333333333333"
+		gone = "44444444-4444-4444-4444-444444444444"
+	)
+	deleted := metav1.Now()
+	idx := membershipIndex(
+		tenancyv1alpha1.MembershipIndexEntry{OrgUUID: org, WorkspaceUUID: ws, Role: "member"},
+		tenancyv1alpha1.MembershipIndexEntry{OrgUUID: gone, Role: "admin", SoftDeletedAt: &deleted},
+	)
+	orgAdmin := membershipIndex(tenancyv1alpha1.MembershipIndexEntry{OrgUUID: org, Role: "admin"})
+
+	cases := []struct {
+		name    string
+		cluster string
+		index   *tenancyv1alpha1.UserMembershipIndex
+		wantErr error
+	}{
+		{name: "workspace member by path", cluster: tenantPathRoot + org + ":" + ws, index: idx},
+		{name: "workspace member by cluster id", cluster: "lc-ws", index: idx},
+		{name: "member of a different workspace", cluster: tenantPathRoot + org + ":" + ws2, index: idx, wantErr: ErrForbidden},
+		{name: "workspace member addressing the org cluster", cluster: tenantPathRoot + org, index: idx, wantErr: ErrForbidden},
+		{name: "org admin covers every workspace", cluster: tenantPathRoot + org + ":" + ws2, index: orgAdmin},
+		{name: "org admin covers the org cluster", cluster: tenantPathRoot + org, index: orgAdmin},
+		{name: "soft-deleted membership", cluster: tenantPathRoot + gone, index: idx, wantErr: ErrForbidden},
+		{name: "cluster outside the tenants tree", cluster: "root:faros:providers:infra", index: orgAdmin, wantErr: ErrForbidden},
+		{name: "no index at all", cluster: tenantPathRoot + org, index: nil, wantErr: ErrForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, kcp := newTestVerifier(t, WithClusterPathResolver(func(_ context.Context, cluster string) (string, error) {
+				if cluster == "lc-ws" {
+					return tenantPathRoot + org + ":" + ws, nil
+				}
+				return "", errors.New("unknown cluster " + cluster)
+			}))
+			v.SetUserIdentity(
+				func(*http.Request) (string, error) { return "alice", nil },
+				func(context.Context, string) (*tenancyv1alpha1.UserMembershipIndex, error) { return tc.index, nil },
+			)
+			err := v.Verify(request(t, "user-token"), "user-token", tc.cluster, "default")
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("Verify() = %v, want nil", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Verify() = %v, want %v", err, tc.wantErr)
+			}
+			if kcp.reviews != 0 {
+				t.Fatalf("a hub user bearer was sent to TokenReview %d times, want 0", kcp.reviews)
+			}
+		})
+	}
+}
+
+// TestVerifierUnknownUserFallsThroughToServiceAccount: when the hub does not
+// recognise the bearer as a user, the SA path decides — so SA tokens keep
+// working with the user branch enabled, and a stranger is still 401.
+func TestVerifierUnknownUserFallsThroughToServiceAccount(t *testing.T) {
+	v, kcp := newTestVerifier(t)
+	v.SetUserIdentity(
+		func(*http.Request) (string, error) { return "", errors.New("not a hub user token") },
+		func(context.Context, string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+			t.Fatal("membership must not be consulted for an unidentified bearer")
+			return nil, nil
+		},
+	)
+	if err := v.Verify(request(t, "sa-tenant-a"), "sa-tenant-a", "tenant-a", "default"); err != nil {
+		t.Fatalf("SA token with user branch enabled: %v, want nil", err)
+	}
+	if err := v.Verify(request(t, "junk"), "junk", "tenant-a", "default"); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("junk with user branch enabled: %v, want ErrUnauthenticated", err)
+	}
+	if kcp.reviews != 2 {
+		t.Fatalf("TokenReview calls = %d, want 2", kcp.reviews)
+	}
+
+	// An SA-shaped identity from the hub's user path is never treated as a
+	// member; it must pass the online SA check instead.
+	v.SetUserIdentity(
+		func(*http.Request) (string, error) { return "system:serviceaccount:default:other-mcp", nil },
+		func(context.Context, string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+			t.Fatal("membership must not be consulted for an SA identity")
+			return nil, nil
+		},
+	)
+	if err := v.Verify(request(t, "sa-other-a"), "sa-other-a", "tenant-a", "default"); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("SA-shaped user identity: %v, want ErrForbidden", err)
+	}
+}
+
+// TestVerifierCachesClusterPath: the cluster-ID to path lookup is reused.
+func TestVerifierCachesClusterPath(t *testing.T) {
+	const org = "11111111-1111-1111-1111-111111111111"
+	lookups := 0
+	v, _ := newTestVerifier(t, WithClusterPathResolver(func(context.Context, string) (string, error) {
+		lookups++
+		return tenantPathRoot + org, nil
+	}))
+	v.SetUserIdentity(
+		func(*http.Request) (string, error) { return "alice", nil },
+		func(context.Context, string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+			return membershipIndex(tenancyv1alpha1.MembershipIndexEntry{OrgUUID: org, Role: "member"}), nil
+		},
+	)
+	for i := 0; i < 3; i++ {
+		if err := v.Verify(request(t, "u"), "u", "lc-org", "default"); err != nil {
+			t.Fatalf("Verify #%d: %v", i, err)
+		}
+	}
+	if lookups != 1 {
+		t.Fatalf("cluster path lookups = %d, want 1", lookups)
+	}
+}
+
+func TestTenantFromPath(t *testing.T) {
+	cases := []struct {
+		path    string
+		org, ws string
+		ok      bool
+	}{
+		{path: "root:faros:tenants:org1", org: "org1", ok: true},
+		{path: "root:faros:tenants:org1:ws1", org: "org1", ws: "ws1", ok: true},
+		{path: "root:faros:tenants:org1:ws1:edge"},
+		{path: "root:faros:tenants:"},
+		{path: "root:faros:tenants:org1:"},
+		{path: "root:faros:providers:infra"},
+		{path: "root"},
+		{path: ""},
+	}
+	for _, tc := range cases {
+		org, ws, ok := tenantFromPath(tc.path)
+		if org != tc.org || ws != tc.ws || ok != tc.ok {
+			t.Errorf("tenantFromPath(%q) = (%q, %q, %v), want (%q, %q, %v)", tc.path, org, ws, ok, tc.org, tc.ws, tc.ok)
+		}
+	}
+}
+
+func TestServiceAccountNaming(t *testing.T) {
+	if got := ServiceAccountUsername("default"); got != "system:serviceaccount:default:default-mcp" {
+		t.Fatalf("ServiceAccountUsername = %q", got)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -84,6 +84,13 @@ const (
 	// and authorization-code records. Readers already refuse expired entries,
 	// so this cadence only affects storage, never correctness.
 	sharedStoreGCInterval = 10 * time.Minute
+
+	// mcpVerifyBurst is how many uncached aggregate-MCP bearer verifications
+	// one client address may start before the bucket (refilled one per second)
+	// throttles it. Verified bearers are cached and never counted, and
+	// providers such as app-studio call the aggregate for many users from one
+	// pod address, so this is deliberately looser than token-login.
+	mcpVerifyBurst = 60
 )
 
 // Server is the faros hub server orchestrator.
@@ -480,10 +487,31 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 		return out
 	}
+	// Every aggregate request is verified against the tenant cluster named in
+	// its path before anything is federated: a TokenReview must prove the
+	// bearer is that MCPServer's own ServiceAccount, or (wired below once the
+	// kcp proxy exists) a hub user who is a member of that tenant. Uncached
+	// verifications share the token-login limiter's per-address bucket;
+	// dev mode skips it for the same reason token-login does.
+	mcpVerifier := mcpaggregate.NewVerifier(func(cluster string) *rest.Config {
+		if kcpConfig == nil {
+			return nil
+		}
+		cfg := rest.CopyConfig(kcpConfig)
+		cfg.Host = apiurl.KCPClusterURL(kcpConfig.Host, cluster)
+		return cfg
+	})
+	var mcpRateLimiter mcpaggregate.RateLimiter
+	if !s.opts.DevMode {
+		mcpRateLimiter = proxy.NewIPRateLimiter(time.Second, mcpVerifyBurst)
+	}
 	mcpAggregate := mcpaggregate.New(mcpaggregate.Options{
 		ExternalURL: s.opts.HubExternalURL,
 		Logger:      logger,
 		Providers:   mcpProviderEnumerator,
+		Verifier:    mcpVerifier,
+		RateLimiter: mcpRateLimiter,
+		ClientIP:    proxy.ClientIP,
 	})
 	router.PathPrefix(apiurl.PathPrefixMCPServer + "/").Handler(
 		http.StripPrefix(apiurl.PathPrefixMCPServer, mcpAggregate))
@@ -657,6 +685,9 @@ func (s *Server) Run(ctx context.Context) error {
 			membershipLookup := tenant.MembershipLookupFunc(func(ctx context.Context, userName string) (*tenancyv1alpha1.UserMembershipIndex, error) {
 				return userClient.UserMembershipIndices().Get(ctx, userName, metav1.GetOptions{})
 			})
+			// Let hub users (CLI `faros mcp`, e2e) reach the aggregate MCP
+			// endpoint with their own bearer, gated on tenant membership.
+			mcpVerifier.SetUserIdentity(kcpProxy.IdentifyUser, membershipLookup.GetUserMembershipIndex)
 
 			// GET /api/providers: authenticated, Org optional. The catalog
 			// describes what this deployment runs, so it is not enumerable

--- a/pkg/server/proxy/proxy.go
+++ b/pkg/server/proxy/proxy.go
@@ -162,6 +162,33 @@ func (rl *rateLimiter) middleware(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// IPRateLimiter is the per-client-address token bucket the hub uses on its
+// pre-authentication endpoints (token-login, the aggregate MCP bearer check).
+// It is the same limiter HandleTokenLoginRateLimited applies, exposed so other
+// packages can share one implementation without importing its internals.
+type IPRateLimiter struct {
+	rl *rateLimiter
+}
+
+// NewIPRateLimiter returns a limiter that admits burstSize requests per client
+// address immediately and refills one token per interval up to burstSize.
+func NewIPRateLimiter(interval time.Duration, burstSize int) *IPRateLimiter {
+	return &IPRateLimiter{rl: newRateLimiter(interval, burstSize)}
+}
+
+// Allow reports whether a request from clientIP may proceed, consuming one
+// token when it may.
+func (l *IPRateLimiter) Allow(clientIP string) bool {
+	return l.rl.isAllowed(clientIP)
+}
+
+// ClientIP derives the client address the hub keys rate limits on. It trusts
+// X-Forwarded-For and X-Real-IP the same way the token-login limiter does,
+// falling back to the connection's RemoteAddr.
+func ClientIP(r *http.Request) string {
+	return getClientIP(r)
+}
+
 // getClientIP extracts the client IP from the request.
 func getClientIP(r *http.Request) string {
 	// Check X-Forwarded-For header


### PR DESCRIPTION
## Problem

`/services/mcpserver/{cluster}/apis/faros.sh/v1alpha1/mcpservers/{name}/mcp` (`pkg/hub/server.go`) only required a non-empty `Authorization` header. `pkg/hub/mcpaggregate/handler.go` then federated the request, bearer included, to every platform provider's `/mcp` endpoint with `X-Faros-Tenant` / `X-Faros-Cluster` taken straight from the URL. The hub was an oracle that relayed arbitrary bearers to providers and let anyone trigger provider-side work in any tenant. This is item 1.4 (finding 4) of the security remediation plan.

## Change

- **Verify before federating.** `mcpaggregate` gains a `BearerVerifier`; the handler runs it before building the per-request server, so a rejected bearer never reaches a provider. Rejections are `401` (unrecognised), `403` (valid, but for another tenant or identity); a verifier outage or a missing verifier fails closed with `503`.
- **Accepted identities** (`pkg/hub/mcpaggregate/verifier.go`):
  1. The MCPServer's own ServiceAccount token: a `TokenReview` in the tenant cluster named by the path (cluster-scoped `rest.Config` via `apiurl.KCPClusterURL`) must report `system:serviceaccount:default:{name}-mcp`. The naming constants now live in `mcpaggregate` (`MCPIdentityNamespace`, `ServiceAccountName`, `ServiceAccountUsername`) and the mcpserver controller consumes them, so the two sides cannot drift. No audience is requested because the controller mints legacy Secret-backed tokens.
  2. A hub user bearer (static token / OIDC) resolved through `KCPProxy.IdentifyUser`, when the user holds a live (not soft-deleted) Membership covering the cluster's Organization or Workspace in the `UserMembershipIndex`. Org-scope entries cover every child workspace, matching the provider tenant resolver. The cluster is either a path or a logical-cluster ID resolved via the `LogicalCluster` `kcp.io/path` annotation (cached 5 min). This branch is needed because `faros mcp` (`pkg/cli/cmd/mcp.go`) and the e2e suite (`test/e2e/suites/edgesconn/mcp_test.go`) call the aggregate with user / static tokens. It is wired only once the kcp proxy exists (`SetUserIdentity`); otherwise only SA tokens are accepted.
- **Caching.** Successful verifications are cached by `sha256(token)+cluster+name` for 60s (bounded map, expired entries swept).
- **Rate limiting.** Uncached verification attempts are limited per client address (60 burst, 1/s refill) using the token-login limiter, exported from `pkg/server/proxy` as `IPRateLimiter` / `ClientIP` (same `X-Forwarded-For` / `X-Real-IP` handling the hub already trusts). Cache hits are never counted, so verified clients are not throttled; dev mode skips the limiter exactly as token-login does.
- Docs: one paragraph in `docs/mcp-architecture.md`.

## Compatibility

- Existing MCP client configurations (the SA token from the portal / `GET .../mcpservers/{name}/connect`) keep working unchanged.
- `faros mcp` users and e2e continue to work through the membership branch.
- Requests whose bearer is not one of the above now get 401/403 instead of being forwarded; that is the intended outcome.
- `server.go` edits are confined to the aggregate wiring and one line after `membershipLookup`, to stay clear of the concurrent heartbeat work (1.3).
- After 2.1 lands the scoped account keeps the same SA name, so no change is needed here.

## Tests

- `pkg/hub/mcpaggregate/handler_test.go`: garbage bearer gives 401 with zero upstream calls; foreign-tenant bearer gives 403 with zero upstream calls; verifier error / nil verifier give 503; valid bearer federates and the second request is a cache hit; cache expiry re-verifies; rate limit counts only uncached attempts and keys on `RemoteAddr`.
- `pkg/hub/mcpaggregate/verifier_test.go`: TokenReview-backed verifier with `k8s.io/client-go/kubernetes/fake` and a `tokenreviews` reactor (own SA allowed; garbage / other-cluster token 401; other MCPServer SA, workload SA, non-SA identity 403; fail-closed without kcp config); hub-user membership matrix (workspace member, org admin, wrong workspace, soft-deleted, non-tenant path, no index, cluster-ID resolution); unidentified user falls through to the SA path; cluster-path cache; `tenantFromPath` table.
- Ran: `GOWORK=off go build ./...`, `go vet ./pkg/...`, `go test -count=1 ./pkg/hub/...` (all pass), `make fix-lint && make lint` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
