### PR TITLE
fix(hub): bind MCPServer tokens to a generated role instead of cluster-admin

### DIFF
--- a/docs/mcp-architecture.md
+++ b/docs/mcp-architecture.md
@@ -181,7 +181,23 @@ Two consequences:
   `MCPServer.status.tokenSecretRef` (the token itself never lands in the CR; the
   portal reads the Secret to render the connect command). A user OIDC token
   would expire and silently break a long-lived MCP connection — see the
-  `MCPServer` controller in [`providers/mcp/controllers/`](https://github.com/faroshq/faros/blob/main/providers/mcp/controllers/).
+  `MCPServer` controller in [`pkg/hub/controllers/mcpserver/`](https://github.com/faroshq/faros/blob/main/pkg/hub/controllers/mcpserver/).
+- **Scoped token permissions.** The ServiceAccount is bound to a generated
+  ClusterRole `faros:mcpserver:<name>` in the tenant workspace, never to
+  `cluster-admin`. The controller regenerates the role on every reconcile
+  (including the 60s tools refresh) from the tenant's `APIBindings`: each
+  `status.boundResources[]` group/resource gets `get,list,watch` plus
+  `create,update,patch,delete`; `spec.readOnly` drops the write verbs. On top
+  of that it grants the RBAC coordinates provider data planes check via
+  SubjectAccessReview as the caller — verb `proxy` on `edges.faros.sh` objects
+  (tunnel `k8s`/`ssh`/`mcp` subresources, kept for readOnly servers because
+  read-only tools cannot reach an edge without it), `create` on
+  `infrastructure.faros.sh` `<instance>/exec` (dropped for readOnly), and
+  `create` on `<resource>/<action>` for every action declared in the platform
+  provider catalog whose resource is bound (read-only actions survive
+  readOnly) — plus read-only `core.kcp.io/logicalclusters` and
+  `selfsubjectaccessreviews` create. Nothing grants secrets, service accounts,
+  RBAC, or APIBinding access, so a leaked token cannot escalate.
 - **No provider-wide identity.** A federated provider must perform its tenant
   work as the forwarded caller token, scoped to the workspace from
   `X-Faros-Tenant`. The infrastructure provider does this in
@@ -272,4 +288,4 @@ each provider separately.
 | Backend proxy (header/token forwarding) | `pkg/hub/providers/proxy.go` |
 | Example out-of-process provider MCP | `providers/infrastructure/mcpserver/` |
 | Caller-scoped tenant client | `providers/infrastructure/tenant/client.go` |
-| Per-MCPServer SA token | `providers/mcp/controllers/`, `apis/faros/v1alpha1/types_mcpserver.go` (`status.tokenSecretRef`) |
+| Per-MCPServer SA token + scoped role | `pkg/hub/controllers/mcpserver/` (`rbac.go`), `apis/faros/v1alpha1/types_mcpserver.go` (`status.tokenSecretRef`) |

--- a/pkg/hub/controllers/mcpserver/controller.go
+++ b/pkg/hub/controllers/mcpserver/controller.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"time"
 
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -70,6 +71,10 @@ type Reconciler struct {
 	kcpConfig      *rest.Config
 	hubExternalURL string
 	enumerate      ProviderEnumerator
+	// actionGrants lists the provider-action RBAC coordinates declared in the
+	// platform catalog (see rbac.go). Defaults to reading CatalogEntries from
+	// the system providers workspace; tests inject a stub.
+	actionGrants ActionGrantSource
 }
 
 // SetupWithManager registers the MCPServer controller with the core.faros.sh
@@ -80,6 +85,7 @@ type Reconciler struct {
 // Ready MCP-exposing providers each server discovers its tools from.
 func SetupWithManager(mgr mcmanager.Manager, kcpConfig *rest.Config, hubExternalURL string, enumerate ProviderEnumerator) error {
 	r := &Reconciler{mgr: mgr, kcpConfig: kcpConfig, hubExternalURL: hubExternalURL, enumerate: enumerate}
+	r.actionGrants = catalogActionGrants(kcpConfig)
 	return mcbuilder.ControllerManagedBy(mgr).
 		Named("mcpserver").
 		For(&farosv1alpha1.MCPServer{}).
@@ -115,12 +121,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ct
 
 	// Direct typed client to the tenant workspace — the proven path for legacy
 	// SA-token provisioning (mirrors pkg/hub/providers ensureLegacySAToken).
-	kube, err := kubernetes.NewForConfig(r.tenantConfig(string(req.ClusterName)))
+	tenantCfg := r.tenantConfig(string(req.ClusterName))
+	kube, err := kubernetes.NewForConfig(tenantCfg)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("building tenant client for %s: %w", req.ClusterName, err)
 	}
+	kcp, err := kcpclientset.NewForConfig(tenantCfg)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("building tenant kcp client for %s: %w", req.ClusterName, err)
+	}
 
-	ref, token, tokenReady, provErr := ensureMCPIdentity(ctx, kube, &srv)
+	// The role is regenerated on every reconcile (including the periodic tools
+	// refresh), so a provider enabled after the server was created gets its
+	// rules within one refresh interval.
+	rules, provErr := r.desiredRules(ctx, kcp, &srv)
+	var (
+		ref        *corev1.SecretReference
+		token      string
+		tokenReady bool
+	)
+	if provErr == nil {
+		ref, token, tokenReady, provErr = ensureMCPIdentity(ctx, kube, &srv, rules)
+	}
 	switch {
 	case provErr != nil:
 		srv.Status.Phase = farosv1alpha1.MCPServerPhaseError
@@ -194,12 +216,35 @@ func (r *Reconciler) tenantConfig(clusterName string) *rest.Config {
 	return cfg
 }
 
+// desiredRules computes the ClusterRole rules for one server from the tenant's
+// APIBindings and the platform action catalog (see rbac.go).
+func (r *Reconciler) desiredRules(ctx context.Context, kcp kcpclientset.Interface, srv *farosv1alpha1.MCPServer) ([]rbacv1.PolicyRule, error) {
+	bound, err := listBoundResources(ctx, kcp)
+	if err != nil {
+		return nil, fmt.Errorf("listing bound resources: %w", err)
+	}
+	var actions []ActionGrant
+	if r.actionGrants != nil {
+		actions, err = r.actionGrants(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("listing provider action grants: %w", err)
+		}
+	}
+	return buildRules(bound, actions, srv.Spec.ReadOnly), nil
+}
+
 // ensureMCPIdentity provisions, idempotently, the per-MCPServer ServiceAccount,
-// its long-lived (legacy) token Secret, and a ClusterRoleBinding — all owned by
-// the MCPServer for GC. It returns a reference to the token Secret and whether
-// kcp's token controller has populated it yet (a short poll; if still empty the
-// caller requeues rather than blocking).
-func ensureMCPIdentity(ctx context.Context, cs kubernetes.Interface, srv *farosv1alpha1.MCPServer) (*corev1.SecretReference, string, bool, error) {
+// its long-lived (legacy) token Secret, and a generated ClusterRole plus the
+// ClusterRoleBinding to it — all owned by the MCPServer for GC. It returns a
+// reference to the token Secret and whether kcp's token controller has
+// populated it yet (a short poll; if still empty the caller requeues rather
+// than blocking).
+//
+// TODO(security-remediation-plan 2.1 follow-up): replace the non-expiring
+// token Secret with a TokenRequest issued through EnsureWorkloadIdentity once
+// the portal has a rotation flow — the token is user-held, so it cannot be
+// rotated silently.
+func ensureMCPIdentity(ctx context.Context, cs kubernetes.Interface, srv *farosv1alpha1.MCPServer, rules []rbacv1.PolicyRule) (*corev1.SecretReference, string, bool, error) {
 	saName := mcpaggregate.ServiceAccountName(srv.Name)
 	secretName := saName + "-token"
 
@@ -230,16 +275,8 @@ func ensureMCPIdentity(ctx context.Context, cs kubernetes.Interface, srv *farosv
 		return nil, "", false, fmt.Errorf("ensuring token Secret %s/%s: %w", mcpIdentityNamespace, secretName, err)
 	}
 
-	// TODO(scope-down): cluster-admin is a placeholder so the endpoint works
-	// end-to-end. Replace with a narrowly-scoped role once the federated tools'
-	// exact needs are pinned, so a leaked token can't act as admin.
-	crb := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{Name: saName, OwnerReferences: []metav1.OwnerReference{owner}},
-		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: saName, Namespace: mcpIdentityNamespace}},
-		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "cluster-admin"},
-	}
-	if _, err := cs.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
-		return nil, "", false, fmt.Errorf("ensuring ClusterRoleBinding %s: %w", saName, err)
+	if err := ensureMCPRBAC(ctx, cs, srv, owner, saName, rules); err != nil {
+		return nil, "", false, err
 	}
 
 	ref := &corev1.SecretReference{Namespace: mcpIdentityNamespace, Name: secretName}

--- a/pkg/hub/controllers/mcpserver/controller_test.go
+++ b/pkg/hub/controllers/mcpserver/controller_test.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpserver
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	kcpfake "github.com/kcp-dev/sdk/client/clientset/versioned/fake"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	farosv1alpha1 "github.com/faroshq/faros/apis/faros/v1alpha1"
+	providersv1alpha1 "github.com/faroshq/faros/apis/providers/v1alpha1"
+)
+
+func newServer(name string, readOnly bool) *farosv1alpha1.MCPServer {
+	return &farosv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID("uid-" + name)},
+		Spec:       farosv1alpha1.MCPServerSpec{ReadOnly: readOnly},
+	}
+}
+
+func newBinding(name string, bound ...apisv1alpha2.BoundAPIResource) *apisv1alpha2.APIBinding {
+	return &apisv1alpha2.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     apisv1alpha2.APIBindingStatus{BoundResources: bound},
+	}
+}
+
+func bound(group, resource string) apisv1alpha2.BoundAPIResource {
+	return apisv1alpha2.BoundAPIResource{Group: group, Resource: resource}
+}
+
+// populatedTokenSecret is the token Secret as kcp's token controller leaves
+// it, so ensureMCPIdentity's poll returns immediately.
+func populatedTokenSecret(srvName string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: srvName + "-mcp-token", Namespace: mcpIdentityNamespace},
+		Type:       corev1.SecretTypeServiceAccountToken,
+		Data:       map[string][]byte{corev1.ServiceAccountTokenKey: []byte("tok")},
+	}
+}
+
+func findRule(t *testing.T, rules []rbacv1.PolicyRule, group string, resource string) *rbacv1.PolicyRule {
+	t.Helper()
+	for i := range rules {
+		if slices.Contains(rules[i].APIGroups, group) && slices.Contains(rules[i].Resources, resource) {
+			return &rules[i]
+		}
+	}
+	return nil
+}
+
+func assertNoWildcards(t *testing.T, rules []rbacv1.PolicyRule) {
+	t.Helper()
+	for _, r := range rules {
+		if slices.Contains(r.APIGroups, "*") || slices.Contains(r.Resources, "*") || slices.Contains(r.Verbs, "*") || len(r.NonResourceURLs) > 0 {
+			t.Fatalf("rule grants a wildcard or non-resource URL: %+v", r)
+		}
+	}
+}
+
+func TestBuildRules_MatchesBoundResources(t *testing.T) {
+	rules := buildRules([]apisv1alpha2.BoundAPIResource{
+		bound("code.faros.sh", "repositories"),
+		bound("code.faros.sh", "connections"),
+		bound("edges.faros.sh", "kubernetesclusters"),
+		bound("infrastructure.faros.sh", "templates"),
+		bound("infrastructure.faros.sh", "instances"),
+	}, []ActionGrant{
+		{Group: "databricks.faros.sh", Resource: "tables", Name: "query_table", ReadOnly: true}, // not bound: ignored
+		{Group: "infrastructure.faros.sh", Resource: "instances", Name: "restart"},
+	}, false)
+	assertNoWildcards(t, rules)
+
+	code := findRule(t, rules, "code.faros.sh", "repositories")
+	if code == nil || !slices.Equal(code.Resources, []string{"connections", "repositories"}) {
+		t.Fatalf("code rule = %+v, want sorted connections+repositories", code)
+	}
+	wantVerbs := []string{"get", "list", "watch", "create", "update", "patch", "delete"}
+	if !slices.Equal(code.Verbs, wantVerbs) {
+		t.Fatalf("code verbs = %v, want %v", code.Verbs, wantVerbs)
+	}
+
+	if r := findRule(t, rules, "edges.faros.sh", "kubernetesclusters"); r == nil {
+		t.Fatal("missing edges rule")
+	}
+	var proxy bool
+	for _, r := range rules {
+		if slices.Contains(r.APIGroups, "edges.faros.sh") && slices.Equal(r.Verbs, []string{"proxy"}) {
+			proxy = true
+		}
+	}
+	if !proxy {
+		t.Fatalf("missing proxy verb on edges resources: %+v", rules)
+	}
+
+	exec := findRule(t, rules, "infrastructure.faros.sh", "instances/exec")
+	if exec == nil || !slices.Equal(exec.Verbs, []string{"create"}) {
+		t.Fatalf("exec rule = %+v, want create", exec)
+	}
+	action := findRule(t, rules, "infrastructure.faros.sh", "instances/restart")
+	if action == nil || !slices.Equal(action.Verbs, []string{"create"}) {
+		t.Fatalf("action rule = %+v, want create", action)
+	}
+	if r := findRule(t, rules, "databricks.faros.sh", "tables/query_table"); r != nil {
+		t.Fatalf("action for an unbound resource must not be granted: %+v", r)
+	}
+
+	lc := findRule(t, rules, "core.kcp.io", "logicalclusters")
+	if lc == nil || !slices.Equal(lc.Verbs, []string{"get", "list", "watch"}) {
+		t.Fatalf("logicalclusters rule = %+v, want read-only", lc)
+	}
+	for _, forbidden := range []string{"secrets", "serviceaccounts", "clusterroles", "clusterrolebindings", "apibindings"} {
+		for _, r := range rules {
+			if slices.Contains(r.Resources, forbidden) {
+				t.Fatalf("rule must not grant %s: %+v", forbidden, r)
+			}
+		}
+	}
+}
+
+func TestBuildRules_ReadOnlyStripsWriteVerbs(t *testing.T) {
+	rules := buildRules([]apisv1alpha2.BoundAPIResource{
+		bound("code.faros.sh", "repositories"),
+		bound("edges.faros.sh", "kubernetesclusters"),
+		bound("infrastructure.faros.sh", "instances"),
+	}, []ActionGrant{
+		{Group: "infrastructure.faros.sh", Resource: "instances", Name: "describe", ReadOnly: true},
+		{Group: "infrastructure.faros.sh", Resource: "instances", Name: "restart"},
+	}, true)
+	assertNoWildcards(t, rules)
+
+	for _, r := range rules {
+		for _, v := range writeVerbs {
+			if slices.Contains(r.Verbs, v) && !slices.Equal(r.Verbs, []string{"create"}) {
+				t.Fatalf("readOnly rule carries write verb %q: %+v", v, r)
+			}
+		}
+	}
+	code := findRule(t, rules, "code.faros.sh", "repositories")
+	if code == nil || !slices.Equal(code.Verbs, []string{"get", "list", "watch"}) {
+		t.Fatalf("code verbs = %+v, want read-only", code)
+	}
+	if r := findRule(t, rules, "infrastructure.faros.sh", "instances/exec"); r != nil {
+		t.Fatalf("readOnly must not grant exec: %+v", r)
+	}
+	if r := findRule(t, rules, "infrastructure.faros.sh", "instances/restart"); r != nil {
+		t.Fatalf("readOnly must not grant a mutating action: %+v", r)
+	}
+	if r := findRule(t, rules, "infrastructure.faros.sh", "instances/describe"); r == nil {
+		t.Fatal("readOnly should keep read-only actions")
+	}
+	// Only create rules allowed in readOnly are the SSAR plumbing and
+	// read-only actions.
+	for _, r := range rules {
+		if slices.Equal(r.Verbs, []string{"create"}) {
+			for _, res := range r.Resources {
+				if res != "selfsubjectaccessreviews" && res != "instances/describe" {
+					t.Fatalf("unexpected create grant in readOnly: %+v", r)
+				}
+			}
+		}
+	}
+}
+
+func TestBuildRules_EmptyBindingsStillYieldsRole(t *testing.T) {
+	rules := buildRules(nil, nil, false)
+	assertNoWildcards(t, rules)
+	if findRule(t, rules, "core.kcp.io", "logicalclusters") == nil {
+		t.Fatalf("baseline rules missing: %+v", rules)
+	}
+	for _, r := range rules {
+		for _, g := range r.APIGroups {
+			if g != "core.kcp.io" && g != "authorization.k8s.io" {
+				t.Fatalf("no provider rule expected without bindings: %+v", r)
+			}
+		}
+	}
+}
+
+func TestActionGrantsFromSpec(t *testing.T) {
+	got := actionGrantsFromSpec([]providersv1alpha1.ProviderActionSpec{
+		{ID: "query_table/v1", ReadOnly: true, BoundResource: providersv1alpha1.ProviderActionBoundResource{APIVersion: "databricks.faros.sh/v1alpha1", Resource: "tables"}},
+		{ID: "bad", BoundResource: providersv1alpha1.ProviderActionBoundResource{APIVersion: "x/v1"}}, // no resource
+	})
+	want := []ActionGrant{{Group: "databricks.faros.sh", Resource: "tables", Name: "query_table", ReadOnly: true}}
+	if !slices.Equal(got, want) {
+		t.Fatalf("grants = %+v, want %+v", got, want)
+	}
+}
+
+func TestEnsureMCPIdentity_NeverBindsClusterAdmin(t *testing.T) {
+	ctx := context.Background()
+	srv := newServer("default", false)
+	kube := kubefake.NewSimpleClientset(populatedTokenSecret(srv.Name))
+	kcp := kcpfake.NewSimpleClientset(newBinding("code", bound("code.faros.sh", "repositories")))
+
+	r := &Reconciler{actionGrants: func(context.Context) ([]ActionGrant, error) { return nil, nil }}
+	rules, err := r.desiredRules(ctx, kcp, srv)
+	if err != nil {
+		t.Fatalf("desiredRules: %v", err)
+	}
+	ref, token, ready, err := ensureMCPIdentity(ctx, kube, srv, rules)
+	if err != nil {
+		t.Fatalf("ensureMCPIdentity: %v", err)
+	}
+	if !ready || token != "tok" || ref == nil || ref.Name != "default-mcp-token" {
+		t.Fatalf("ref=%v token=%q ready=%v", ref, token, ready)
+	}
+
+	crb, err := kube.RbacV1().ClusterRoleBindings().Get(ctx, "default-mcp", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get binding: %v", err)
+	}
+	if crb.RoleRef.Name == "cluster-admin" {
+		t.Fatal("binding references cluster-admin")
+	}
+	if crb.RoleRef.Name != "faros:mcpserver:default" || crb.RoleRef.Kind != "ClusterRole" {
+		t.Fatalf("roleRef = %+v", crb.RoleRef)
+	}
+	if len(crb.OwnerReferences) != 1 || crb.OwnerReferences[0].UID != srv.UID {
+		t.Fatalf("binding not owned by the MCPServer: %+v", crb.OwnerReferences)
+	}
+	role, err := kube.RbacV1().ClusterRoles().Get(ctx, "faros:mcpserver:default", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get role: %v", err)
+	}
+	if len(role.OwnerReferences) != 1 || role.OwnerReferences[0].UID != srv.UID {
+		t.Fatalf("role not owned by the MCPServer: %+v", role.OwnerReferences)
+	}
+	assertNoWildcards(t, role.Rules)
+	if findRule(t, role.Rules, "code.faros.sh", "repositories") == nil {
+		t.Fatalf("role rules = %+v, want repositories", role.Rules)
+	}
+}
+
+func TestEnsureMCPRBAC_ReplacesClusterAdminBinding(t *testing.T) {
+	ctx := context.Background()
+	srv := newServer("default", false)
+	owner := metav1.OwnerReference{Kind: "MCPServer", Name: srv.Name, UID: srv.UID}
+	legacy := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-mcp"},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "default-mcp", Namespace: mcpIdentityNamespace}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "cluster-admin"},
+	}
+	kube := kubefake.NewSimpleClientset(legacy)
+	var deleted, created int
+	kube.PrependReactor("delete", "clusterrolebindings", func(clienttesting.Action) (bool, runtime.Object, error) {
+		deleted++
+		return false, nil, nil
+	})
+	kube.PrependReactor("create", "clusterrolebindings", func(clienttesting.Action) (bool, runtime.Object, error) {
+		created++
+		return false, nil, nil
+	})
+
+	if err := ensureMCPRBAC(ctx, kube, srv, owner, "default-mcp", buildRules(nil, nil, false)); err != nil {
+		t.Fatalf("ensureMCPRBAC: %v", err)
+	}
+	if deleted != 1 || created != 1 {
+		t.Fatalf("deleted=%d created=%d, want 1/1", deleted, created)
+	}
+	crb, err := kube.RbacV1().ClusterRoleBindings().Get(ctx, "default-mcp", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get binding: %v", err)
+	}
+	if crb.RoleRef.Name != "faros:mcpserver:default" {
+		t.Fatalf("roleRef = %+v, want generated role", crb.RoleRef)
+	}
+	if len(crb.OwnerReferences) != 1 || crb.OwnerReferences[0].UID != srv.UID {
+		t.Fatalf("recreated binding not owned by the MCPServer: %+v", crb.OwnerReferences)
+	}
+
+	// A second pass with the correct roleRef is a no-op on the binding.
+	if err := ensureMCPRBAC(ctx, kube, srv, owner, "default-mcp", buildRules(nil, nil, false)); err != nil {
+		t.Fatalf("second ensureMCPRBAC: %v", err)
+	}
+	if deleted != 1 || created != 1 {
+		t.Fatalf("second pass touched the binding: deleted=%d created=%d", deleted, created)
+	}
+}
+
+func TestEnsureMCPRBAC_SecondReconcileAddsRulesForNewBinding(t *testing.T) {
+	ctx := context.Background()
+	srv := newServer("default", false)
+	owner := metav1.OwnerReference{Kind: "MCPServer", Name: srv.Name, UID: srv.UID}
+	var kube kubernetes.Interface = kubefake.NewSimpleClientset()
+	kcp := kcpfake.NewSimpleClientset(newBinding("code", bound("code.faros.sh", "repositories")))
+	r := &Reconciler{actionGrants: func(context.Context) ([]ActionGrant, error) { return nil, nil }}
+
+	reconcileRBAC := func() *rbacv1.ClusterRole {
+		t.Helper()
+		rules, err := r.desiredRules(ctx, kcp, srv)
+		if err != nil {
+			t.Fatalf("desiredRules: %v", err)
+		}
+		if err := ensureMCPRBAC(ctx, kube, srv, owner, "default-mcp", rules); err != nil {
+			t.Fatalf("ensureMCPRBAC: %v", err)
+		}
+		role, err := kube.RbacV1().ClusterRoles().Get(ctx, "faros:mcpserver:default", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get role: %v", err)
+		}
+		return role
+	}
+
+	role := reconcileRBAC()
+	if findRule(t, role.Rules, "edges.faros.sh", "kubernetesclusters") != nil {
+		t.Fatalf("edges granted before the binding exists: %+v", role.Rules)
+	}
+
+	// A provider is enabled: its APIBinding appears with bound resources.
+	if _, err := kcp.ApisV1alpha2().APIBindings().Create(ctx, newBinding("edges", bound("edges.faros.sh", "kubernetesclusters")), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create binding: %v", err)
+	}
+	role = reconcileRBAC()
+	if findRule(t, role.Rules, "edges.faros.sh", "kubernetesclusters") == nil {
+		t.Fatalf("edges not granted after the binding appeared: %+v", role.Rules)
+	}
+	if findRule(t, role.Rules, "code.faros.sh", "repositories") == nil {
+		t.Fatalf("existing grant lost: %+v", role.Rules)
+	}
+	assertNoWildcards(t, role.Rules)
+}
+
+func TestListBoundResources(t *testing.T) {
+	kcp := kcpfake.NewSimpleClientset(
+		newBinding("a", bound("code.faros.sh", "repositories"), bound("code.faros.sh", "connections")),
+		newBinding("pending"), // not yet bound
+	)
+	got, err := listBoundResources(context.Background(), kcp)
+	if err != nil {
+		t.Fatalf("listBoundResources: %v", err)
+	}
+	var names []string
+	for _, b := range got {
+		names = append(names, b.Group+"/"+b.Resource)
+	}
+	slices.Sort(names)
+	if want := "code.faros.sh/connections,code.faros.sh/repositories"; strings.Join(names, ",") != want {
+		t.Fatalf("bound = %v, want %s", names, want)
+	}
+}

--- a/pkg/hub/controllers/mcpserver/rbac.go
+++ b/pkg/hub/controllers/mcpserver/rbac.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	apisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
+	kcpclientset "github.com/kcp-dev/sdk/client/clientset/versioned"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	farosv1alpha1 "github.com/faroshq/faros/apis/faros/v1alpha1"
+	providersv1alpha1 "github.com/faroshq/faros/apis/providers/v1alpha1"
+	"github.com/faroshq/faros/pkg/apiurl"
+	"github.com/faroshq/faros/pkg/kcppaths"
+)
+
+// roleNamePrefix prefixes the generated per-server ClusterRole name:
+// faros:mcpserver:<MCPServer name>.
+const roleNamePrefix = "faros:mcpserver:"
+
+var (
+	// readVerbs is granted on every bound provider resource.
+	readVerbs = []string{"get", "list", "watch"}
+	// writeVerbs is granted on every bound provider resource unless the server
+	// is spec.readOnly.
+	writeVerbs = []string{"create", "update", "patch", "delete"}
+)
+
+// dataPlaneGrant describes RBAC coordinates a provider data plane checks with
+// a SubjectAccessReview as the caller instead of serving through the API
+// server. They exist purely as authorization coordinates, so the tenant's
+// APIBindings never list them and they have to be spelled out here.
+type dataPlaneGrant struct {
+	// verbs are extra verbs granted on the bound resources themselves. They
+	// gate access to a data plane rather than a mutation of the object, so
+	// they survive readOnly: without them the read-only tools cannot reach
+	// the data plane at all.
+	verbs []string
+	// subresources are virtual subresources granted with "create". They
+	// invoke something (a shell, a job) and are dropped for readOnly servers.
+	subresources []string
+}
+
+// dataPlaneGrants is keyed by API group of the bound resources.
+var dataPlaneGrants = map[string]dataPlaneGrant{
+	// The edges tunnel authorizes verb "proxy" on the edge object before
+	// serving its k8s/ssh/mcp subresources (providers/edges/internal/tunnel).
+	"edges.faros.sh": {verbs: []string{"proxy"}},
+	// The infrastructure data plane authorizes "create" on
+	// <instance resource>/exec before running a command in a dev instance
+	// (providers/infrastructure/dataplane/authorizer.go).
+	"infrastructure.faros.sh": {subresources: []string{"exec"}},
+}
+
+// ActionGrant is one provider action from the platform catalog, expressed as
+// the RBAC coordinate a provider checks before invoking it: "create" on
+// <Resource>/<Name> in Group (e.g. tables/query_table).
+type ActionGrant struct {
+	Group    string
+	Resource string
+	// Name is the action name without its version suffix — the subresource
+	// the provider's SelfSubjectAccessReview names.
+	Name string
+	// ReadOnly mirrors the catalog's declaration; read-only actions stay
+	// granted on readOnly servers.
+	ReadOnly bool
+}
+
+// ActionGrantSource lists the action grants declared by platform providers.
+type ActionGrantSource func(ctx context.Context) ([]ActionGrant, error)
+
+// buildRules derives the ClusterRole rules for one server: every resource the
+// tenant has bound gets read (and, unless readOnly, write) verbs; data-plane
+// coordinates and catalog actions are added for bound resources only; plus the
+// read-only kcp/authz plumbing every tool path needs. Output is deterministic
+// so reconcile-time comparison is stable.
+func buildRules(bound []apisv1alpha2.BoundAPIResource, actions []ActionGrant, readOnly bool) []rbacv1.PolicyRule {
+	byGroup := map[string]map[string]struct{}{}
+	for _, b := range bound {
+		if b.Resource == "" {
+			continue
+		}
+		if byGroup[b.Group] == nil {
+			byGroup[b.Group] = map[string]struct{}{}
+		}
+		byGroup[b.Group][b.Resource] = struct{}{}
+	}
+
+	// Action coordinates, keyed by group, only for resources that are bound.
+	actionSubs := map[string]map[string]struct{}{}
+	for _, a := range actions {
+		if a.Name == "" || a.Resource == "" {
+			continue
+		}
+		if _, ok := byGroup[a.Group][a.Resource]; !ok {
+			continue
+		}
+		if readOnly && !a.ReadOnly {
+			continue
+		}
+		if actionSubs[a.Group] == nil {
+			actionSubs[a.Group] = map[string]struct{}{}
+		}
+		actionSubs[a.Group][a.Resource+"/"+a.Name] = struct{}{}
+	}
+
+	groups := make([]string, 0, len(byGroup))
+	for g := range byGroup {
+		groups = append(groups, g)
+	}
+	sort.Strings(groups)
+
+	verbs := append([]string{}, readVerbs...)
+	if !readOnly {
+		verbs = append(verbs, writeVerbs...)
+	}
+
+	var rules []rbacv1.PolicyRule
+	for _, g := range groups {
+		resources := sortedKeys(byGroup[g])
+		rules = append(rules, rbacv1.PolicyRule{APIGroups: []string{g}, Resources: resources, Verbs: verbs})
+
+		if dp, ok := dataPlaneGrants[g]; ok {
+			if len(dp.verbs) > 0 {
+				rules = append(rules, rbacv1.PolicyRule{APIGroups: []string{g}, Resources: resources, Verbs: dp.verbs})
+			}
+			if !readOnly && len(dp.subresources) > 0 {
+				subs := make([]string, 0, len(resources)*len(dp.subresources))
+				for _, r := range resources {
+					for _, s := range dp.subresources {
+						subs = append(subs, r+"/"+s)
+					}
+				}
+				rules = append(rules, rbacv1.PolicyRule{APIGroups: []string{g}, Resources: subs, Verbs: []string{"create"}})
+			}
+		}
+		if subs := actionSubs[g]; len(subs) > 0 {
+			rules = append(rules, rbacv1.PolicyRule{APIGroups: []string{g}, Resources: sortedKeys(subs), Verbs: []string{"create"}})
+		}
+	}
+
+	// Path lookup: tools resolve the workspace path from the LogicalCluster.
+	rules = append(rules, rbacv1.PolicyRule{
+		APIGroups: []string{"core.kcp.io"}, Resources: []string{"logicalclusters"}, Verbs: readVerbs,
+	})
+	// Provider data planes and action gates run a SelfSubjectAccessReview as
+	// the caller; the review only ever answers for the token itself.
+	rules = append(rules, rbacv1.PolicyRule{
+		APIGroups: []string{"authorization.k8s.io"}, Resources: []string{"selfsubjectaccessreviews"}, Verbs: []string{"create"},
+	})
+	return rules
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// listBoundResources collects status.boundResources across the tenant's
+// APIBindings. Bindings still being bound contribute nothing yet; the next
+// reconcile picks them up.
+func listBoundResources(ctx context.Context, kcp kcpclientset.Interface) ([]apisv1alpha2.BoundAPIResource, error) {
+	list, err := kcp.ApisV1alpha2().APIBindings().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var out []apisv1alpha2.BoundAPIResource
+	for i := range list.Items {
+		out = append(out, list.Items[i].Status.BoundResources...)
+	}
+	return out, nil
+}
+
+// ensureMCPRBAC converges the generated ClusterRole and the ClusterRoleBinding
+// pointing at it. RoleRef is immutable, so a binding left over from the
+// cluster-admin era (or any other role) is deleted and recreated.
+func ensureMCPRBAC(ctx context.Context, cs kubernetes.Interface, srv *farosv1alpha1.MCPServer, owner metav1.OwnerReference, saName string, rules []rbacv1.PolicyRule) error {
+	roleName := roleNamePrefix + srv.Name
+	if rules == nil {
+		rules = []rbacv1.PolicyRule{}
+	}
+
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: roleName, OwnerReferences: []metav1.OwnerReference{owner}},
+		Rules:      rules,
+	}
+	existing, err := cs.RbacV1().ClusterRoles().Get(ctx, roleName, metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(err):
+		if _, err := cs.RbacV1().ClusterRoles().Create(ctx, role, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("ensuring ClusterRole %s: %w", roleName, err)
+		}
+	case err != nil:
+		return fmt.Errorf("getting ClusterRole %s: %w", roleName, err)
+	case !equality.Semantic.DeepEqual(existing.Rules, rules):
+		existing.Rules = rules
+		if _, err := cs.RbacV1().ClusterRoles().Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("updating ClusterRole %s: %w", roleName, err)
+		}
+	}
+
+	roleRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: roleName}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: saName, OwnerReferences: []metav1.OwnerReference{owner}},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: saName, Namespace: mcpIdentityNamespace}},
+		RoleRef:    roleRef,
+	}
+	got, err := cs.RbacV1().ClusterRoleBindings().Get(ctx, saName, metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(err):
+	case err != nil:
+		return fmt.Errorf("getting ClusterRoleBinding %s: %w", saName, err)
+	case got.RoleRef == roleRef:
+		return nil
+	default:
+		klog.FromContext(ctx).Info("replacing MCPServer ClusterRoleBinding with a different roleRef", "binding", saName, "from", got.RoleRef.Name, "to", roleName)
+		if err := cs.RbacV1().ClusterRoleBindings().Delete(ctx, saName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting stale ClusterRoleBinding %s: %w", saName, err)
+		}
+	}
+	if _, err := cs.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("ensuring ClusterRoleBinding %s: %w", saName, err)
+	}
+	return nil
+}
+
+var catalogEntryGVR = schema.GroupVersionResource{
+	Group: providersv1alpha1.GroupName, Version: providersv1alpha1.Version, Resource: "catalogentries",
+}
+
+// catalogActionGrants returns an ActionGrantSource that reads the platform
+// providers' CatalogEntries from the system providers workspace. Only platform
+// providers federate into the aggregate (see the enumerator in server.go), so
+// org-owned catalogs are not consulted.
+func catalogActionGrants(kcpConfig *rest.Config) ActionGrantSource {
+	return func(ctx context.Context) ([]ActionGrant, error) {
+		if kcpConfig == nil {
+			return nil, nil
+		}
+		cfg := rest.CopyConfig(kcpConfig)
+		cfg.Host = apiurl.KCPClusterURL(kcpConfig.Host, kcppaths.SystemProviders)
+		dyn, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("building system providers client: %w", err)
+		}
+		list, err := dyn.Resource(catalogEntryGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("listing CatalogEntries in %s: %w", kcppaths.SystemProviders, err)
+		}
+		var out []ActionGrant
+		for i := range list.Items {
+			var entry providersv1alpha1.CatalogEntry
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[i].Object, &entry); err != nil {
+				return nil, fmt.Errorf("decoding CatalogEntry %s: %w", list.Items[i].GetName(), err)
+			}
+			out = append(out, actionGrantsFromSpec(entry.Spec.Actions)...)
+		}
+		return out, nil
+	}
+}
+
+// actionGrantsFromSpec maps catalog action declarations to RBAC coordinates.
+// Action IDs are "<name>/<version>"; the provider reviews the unversioned
+// name as the subresource.
+func actionGrantsFromSpec(actions []providersv1alpha1.ProviderActionSpec) []ActionGrant {
+	out := make([]ActionGrant, 0, len(actions))
+	for _, a := range actions {
+		name, _, _ := strings.Cut(strings.TrimSpace(a.ID), "/")
+		if name == "" || a.BoundResource.Resource == "" {
+			continue
+		}
+		gv, err := schema.ParseGroupVersion(a.BoundResource.APIVersion)
+		if err != nil {
+			continue
+		}
+		out = append(out, ActionGrant{
+			Group:    gv.Group,
+			Resource: a.BoundResource.Resource,
+			Name:     name,
+			ReadOnly: a.ReadOnly,
+		})
+	}
+	return out
+}


### PR DESCRIPTION
## Problem

Security remediation plan §2.1 (finding 5). `pkg/hub/controllers/mcpserver` provisions a non-expiring ServiceAccount token per `MCPServer` and bound it with a ClusterRoleBinding to `cluster-admin` in the tenant workspace (`TODO(scope-down)`). That token is handed to end users (`restapi/mcp.go`) as the bearer for `/services/mcp/...`, forwarded to every platform provider's `/mcp` (`mcpaggregate/federation.go`), and used there as a kube credential in the tenant workspace. A leaked token acted as workspace admin: it could read Secrets, mint identities, and rewrite RBAC and APIBindings.

## Change

- New `pkg/hub/controllers/mcpserver/rbac.go`: the binding now targets a generated ClusterRole `faros:mcpserver:<name>`, regenerated on every reconcile (including the existing 60s tools refresh, so a provider enabled later gets rules within one interval):
  - For each tenant `APIBinding` `status.boundResources[]` group/resource: `get,list,watch` + `create,update,patch,delete`; `spec.readOnly` drops the write verbs. An empty bound set still produces the role (baseline rules only).
  - Data-plane coordinates providers check via SubjectAccessReview as the caller (found while auditing the tools; not in the plan text):
    - verb `proxy` on `edges.faros.sh` objects — the tunnel authorizes this before serving the `k8s`/`ssh`/`mcp` subresources the edge kube tools use. Kept for `readOnly` servers, otherwise read-only kube tools cannot reach an edge at all (the edge agent's own identity bounds what happens there).
    - `create` on `infrastructure.faros.sh` `<instance>/exec` (dev-instance exec); dropped for `readOnly`.
    - `create` on `<resource>/<action>` for every action declared in the platform provider catalog (`CatalogEntry.spec.actions`, e.g. `tables/query_table`) whose resource is bound; catalog `readOnly` actions survive `readOnly`.
  - Read-only `core.kcp.io/logicalclusters` (path lookup) and `authorization.k8s.io/selfsubjectaccessreviews` create (the exec/action gates SSAR as the caller; kcp's bootstrap policy has no `system:basic-user`).
  - Nothing grants Secrets, ServiceAccounts, RBAC, or APIBindings; no wildcards.
- `controller.go`: builds a kcp clientset on the tenant config to list APIBindings, reads catalog actions from the system providers workspace (injected as `ActionGrantSource`, stubbed in tests), removes the `TODO(scope-down)` and the cluster-admin binding.
- Token Secret unchanged in this PR: it is user-held and needs a portal rotation flow first. A `TODO` references the plan's §2.1 follow-up (TokenRequest via `EnsureWorkloadIdentity`).
- `docs/mcp-architecture.md`: documents the scoped role and fixes the stale controller path.

## Compatibility

- Upgrade path: existing MCPServers already have a binding to `cluster-admin`. RoleRef is immutable, so on the first reconcile after upgrade the controller creates the role, deletes the old binding and recreates it pointing at the generated role (logged). Both objects stay owned by the MCPServer for GC. No user action; tokens keep working.
- The hub's kcp admin config (`system:kcp:admin` → `cluster-admin`) already creates cluster-admin bindings in tenant workspaces, so creating ClusterRoles and listing APIBindings there needs no new grants. Local in-scope ServiceAccounts bypass kcp's workspace `access` gate and go straight to local RBAC, so no non-resource `access` rule is needed.
- No API type or CRD changes.

## Tests

- New `pkg/hub/controllers/mcpserver/controller_test.go` (kubernetes fake + kcp sdk fake clientset): binding never references `cluster-admin` and is owned by the MCPServer; rules match bound resources (incl. proxy/exec/action grants, unbound actions ignored, no secrets/RBAC/APIBinding grants); `readOnly` strips write verbs, exec and mutating actions; an existing cluster-admin binding is deleted and recreated exactly once and a second pass is a no-op; a second reconcile with a new APIBinding adds rules; empty bindings still yield a role.
- `GOWORK=off go build ./... && go vet ./pkg/... && go test -count=1 ./pkg/hub/...` clean; `make fix-lint && make lint` 0 issues.
- e2e: the only MCP aggregate assertion (`test/e2e/suites/edgesconn/mcp_test.go`) is `tools/list`, which needs no tenant verbs. Not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
