### PR TITLE
fix(edges): remove the static-token authorization bypass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,6 @@ run-provider-edges: build-edges-provider ## Run the edges provider (needs: hub +
 	FAROS_HUB_INSECURE=true \
 	FAROS_PROVIDER_NAME=edges \
 	FAROS_PROVIDER_KUBECONFIG=$(EDGES_RUNTIME_KUBECONFIG) \
-	FAROS_STATIC_TOKENS=$(EDGES_TOKEN) \
 	FAROS_DEV_MODE=true \
 		$(BINDIR)/edges-provider serve
 

--- a/providers/edges/deploy/chart/README.md
+++ b/providers/edges/deploy/chart/README.md
@@ -52,7 +52,6 @@ helm upgrade --install edges oci://ghcr.io/faroshq/charts/faros-edges-provider \
 | `hub.caData` | `""` | Hub CA bundle (PEM) embedded into per-agent kubeconfigs so agents trust the hub serving cert. Provide EITHER caData (inline PEM) or caSecretRef. |
 | `hub.caSecretRef.name` | `""` |  |
 | `hub.caSecretRef.key` | `ca.crt` |  |
-| `staticTokens` | `""` | Comma-separated static bearer tokens accepted by the tunnel token validator (dev/testing only — real agents authenticate via join token + kcp SAR). |
 | `devMode` | `false` | Enables dev-mode shortcuts in the controllers (e.g. relaxed kubeconfig CA). |
 | `providerKubeconfig` |  | Secret holding the workspace-admin kubeconfig minted via /bonkers (admin onboarding). Used by BOTH the init container (bootstrap APIExport/schemas) and the serve container (token validation + cross-tenant controllers). Key must be "kubeconfig". |
 | `providerKubeconfig.secretName` | `faros-provider-kubeconfig` |  |

--- a/providers/edges/deploy/chart/templates/deployment.yaml
+++ b/providers/edges/deploy/chart/templates/deployment.yaml
@@ -105,10 +105,6 @@ spec:
             {{- end }}
             - name: FAROS_PROVIDER_KUBECONFIG
               value: /var/run/secrets/faros/kubeconfig
-            {{- if .Values.staticTokens }}
-            - name: FAROS_STATIC_TOKENS
-              value: {{ .Values.staticTokens | quote }}
-            {{- end }}
             {{- if .Values.devMode }}
             - name: FAROS_DEV_MODE
               value: "true"

--- a/providers/edges/deploy/chart/values.yaml
+++ b/providers/edges/deploy/chart/values.yaml
@@ -52,10 +52,6 @@ hub:
     name: ""
     key: ca.crt
 
-# Comma-separated static bearer tokens accepted by the tunnel token validator
-# (dev/testing only — real agents authenticate via join token + kcp SAR).
-staticTokens: ""
-
 # Enables dev-mode shortcuts in the controllers (e.g. relaxed kubeconfig CA).
 devMode: false
 

--- a/providers/edges/internal/ssh/ssh_teardown_test.go
+++ b/providers/edges/internal/ssh/ssh_teardown_test.go
@@ -169,13 +169,17 @@ func TestSSHSessionTeardown(t *testing.T) {
 	// Create a WebSocket server/client pair (in-process).
 	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 
-	var serverConn *websocket.Conn
+	// The handler runs on the httptest server's goroutine; hand the upgraded
+	// conn over a channel rather than a shared variable so the test is
+	// race-free under -race.
+	serverConnCh := make(chan *websocket.Conn, 1)
 	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var err error
-		serverConn, err = upgrader.Upgrade(w, r, nil)
+		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			t.Errorf("upgrading: %v", err)
+			return
 		}
+		serverConnCh <- conn
 	}))
 	defer wsServer.Close()
 
@@ -187,8 +191,10 @@ func TestSSHSessionTeardown(t *testing.T) {
 	defer clientConn.Close() //nolint:errcheck
 
 	// Wait until the handler has upgraded.
-	time.Sleep(50 * time.Millisecond)
-	if serverConn == nil {
+	var serverConn *websocket.Conn
+	select {
+	case serverConn = <-serverConnCh:
+	case <-time.After(5 * time.Second):
 		t.Fatal("server WebSocket conn not set")
 	}
 

--- a/providers/edges/internal/tunnel/agent_proxy_builder_v2.go
+++ b/providers/edges/internal/tunnel/agent_proxy_builder_v2.go
@@ -119,10 +119,15 @@ func (p *Server) buildEdgeAgentProxyHandler() http.Handler {
 		}
 		gvr, _, _ := p.gvrForResource(resource)
 
-		// 3. Authentication: static tokens bypass JWT SA requirement.
-		//    SA tokens go through kcp delegated authorization.
-		//    Bootstrap join tokens are accepted if they match edge.Status.JoinToken.
-		_, isStaticToken := p.staticTokens[token]
+		// 3. Authentication: SA tokens go through kcp delegated authorization;
+		//    bootstrap join tokens are accepted if they match edge.Status.JoinToken.
+		//    The test-only static-token set only stands in for an agent credential
+		//    when there is no kcp config at all (see Config.AllowStaticTokenBypass);
+		//    with kcp configured every token is validated by kcp.
+		isStaticToken := false
+		if p.kcpConfig == nil {
+			_, isStaticToken = p.staticTokens[token]
+		}
 		// authenticatedByJoinToken tracks whether the agent was authenticated via a
 		// bootstrap join token. When true, the hub echoes the token back in the
 		// X-Faros-Agent-Token upgrade response header so the agent can persist it

--- a/providers/edges/internal/tunnel/edges_proxy_auth_test.go
+++ b/providers/edges/internal/tunnel/edges_proxy_auth_test.go
@@ -19,6 +19,7 @@ package tunnel
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -48,49 +49,50 @@ func newAuthTestServer(t *testing.T, authorizeErr error, calls *[]string) *Serve
 	return s
 }
 
-func TestEdgesProxyHandlerAuthorizesEveryToken(t *testing.T) {
-	const edgePath = "/clusters/ws-1/apis/edges.faros.sh/v1alpha1/linuxservers/edge-1/ssh"
-	const servicePath = "/clusters/ws-1/apis/edges.faros.sh/v1alpha1/services/svc-1/proxy/"
+const (
+	authTestEdgePath    = "/clusters/ws-1/apis/edges.faros.sh/v1alpha1/linuxservers/edge-1/ssh"
+	authTestServicePath = "/clusters/ws-1/apis/edges.faros.sh/v1alpha1/services/svc-1/proxy/"
+)
 
+func TestEdgesProxyHandlerAuthorizesEveryToken(t *testing.T) {
 	cases := []struct {
 		name         string
 		token        string
 		path         string
 		authorizeErr error
-		wantStatus   int
 		wantCall     string
 	}{
 		{
-			// Allowed by kcp: the handler proceeds to the tunnel lookup and, with
-			// no agent connected, answers 502 — proving authorize ran and passed.
-			name:       "static token is authorized like any other token",
-			token:      "static-secret",
-			path:       edgePath,
-			wantStatus: http.StatusBadGateway,
-			wantCall:   "static-secret proxy edges.faros.sh/linuxservers/edge-1@ws-1",
+			name:     "static token is authorized like any other token",
+			token:    "static-secret",
+			path:     authTestEdgePath,
+			wantCall: "static-secret proxy edges.faros.sh/linuxservers/edge-1@ws-1",
 		},
 		{
 			name:         "static token denied by kcp is forbidden",
 			token:        "static-secret",
-			path:         edgePath,
+			path:         authTestEdgePath,
 			authorizeErr: errors.New("access denied"),
-			wantStatus:   http.StatusForbidden,
 			wantCall:     "static-secret proxy edges.faros.sh/linuxservers/edge-1@ws-1",
 		},
 		{
-			name:       "user token is authorized",
-			token:      "user-token",
-			path:       edgePath,
-			wantStatus: http.StatusBadGateway,
-			wantCall:   "user-token proxy edges.faros.sh/linuxservers/edge-1@ws-1",
+			name:     "user token is authorized",
+			token:    "user-token",
+			path:     authTestEdgePath,
+			wantCall: "user-token proxy edges.faros.sh/linuxservers/edge-1@ws-1",
 		},
 		{
 			name:         "static token on the service proxy is authorized too",
 			token:        "static-secret",
-			path:         servicePath,
+			path:         authTestServicePath,
 			authorizeErr: errors.New("access denied"),
-			wantStatus:   http.StatusForbidden,
 			wantCall:     "static-secret proxy edges.faros.sh/services/svc-1@ws-1",
+		},
+		{
+			name:     "user token on the service proxy is authorized",
+			token:    "user-token",
+			path:     authTestServicePath,
+			wantCall: "user-token proxy edges.faros.sh/services/svc-1@ws-1",
 		},
 	}
 
@@ -104,16 +106,130 @@ func TestEdgesProxyHandlerAuthorizesEveryToken(t *testing.T) {
 			rr := httptest.NewRecorder()
 			s.buildEdgesProxyHandler().ServeHTTP(rr, req)
 
-			if rr.Code != tc.wantStatus {
-				t.Fatalf("status = %d, want %d (body %q)", rr.Code, tc.wantStatus, rr.Body.String())
-			}
+			// The authorization side-effect is the behaviour under test: exactly
+			// one delegated check, with the caller's own token and the edge's
+			// coordinates. Downstream status codes belong to whatever the handler
+			// does after the check and are deliberately not asserted here.
 			if len(calls) != 1 {
 				t.Fatalf("authorize called %d times, want exactly once: %v", len(calls), calls)
 			}
 			if calls[0] != tc.wantCall {
 				t.Fatalf("authorize call = %q, want %q", calls[0], tc.wantCall)
 			}
+
+			if tc.authorizeErr != nil {
+				if rr.Code != http.StatusForbidden {
+					t.Fatalf("status = %d, want %d (body %q)", rr.Code, http.StatusForbidden, rr.Body.String())
+				}
+				return
+			}
+			// Allowed: only assert the request was not rejected by the auth
+			// layer, whatever the downstream outcome is.
+			switch rr.Code {
+			case http.StatusUnauthorized, http.StatusForbidden, http.StatusServiceUnavailable:
+				t.Fatalf("authorized request rejected with %d (body %q)", rr.Code, rr.Body.String())
+			}
 		})
+	}
+}
+
+// recordingDialer is a tunnel Dialer that records whether the data plane ever
+// reached it. Registering one lets a test prove a request was refused BEFORE
+// the tunnel lookup rather than merely failing downstream.
+type recordingDialer struct{ dialed bool }
+
+func (d *recordingDialer) Dial(context.Context) (net.Conn, error) {
+	d.dialed = true
+	return nil, errors.New("recordingDialer: no connection")
+}
+
+// newNoKCPTestServer builds a Server with NO kcp credential and no test bypass —
+// the posture of a provider whose FAROS_PROVIDER_KUBECONFIG is missing or
+// unreadable — with a live tunnel already registered for both the edge and the
+// Service's edge.
+func newNoKCPTestServer(t *testing.T, calls *[]string) (*Server, *recordingDialer) {
+	t.Helper()
+	s := testServer("/services/providers/edges/edgeproxy")
+	s.kcpConfig = nil
+	s.tenantConfig = nil
+	s.edgeConnManager = NewConnManager()
+	s.logger = klog.Background()
+	s.authorizeFn = func(_ context.Context, _, _ *rest.Config, token, cluster, verb, group, resource, name string) error {
+		*calls = append(*calls, token+" "+verb+" "+group+"/"+resource+"/"+name+"@"+cluster)
+		return nil
+	}
+	d := &recordingDialer{}
+	s.edgeConnManager.dials[edgeConnKey("linuxservers", "ws-1", "edge-1")] = d
+	return s, d
+}
+
+// Without a kcp credential there is nothing to TokenReview a bearer against, so
+// the consumer data plane must refuse the request instead of skipping the check
+// and proxying. The handlers are mounted unconditionally, so this is the only
+// thing standing between a misconfigured provider and an unauthorized proxy.
+func TestEdgesProxyFailsClosedWithoutKCPConfig(t *testing.T) {
+	for _, path := range []string{authTestEdgePath, authTestServicePath} {
+		t.Run(path, func(t *testing.T) {
+			var calls []string
+			s, dialer := newNoKCPTestServer(t, &calls)
+
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer any-token")
+			rr := httptest.NewRecorder()
+			s.buildEdgesProxyHandler().ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want %d (body %q)", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
+			}
+			if dialer.dialed {
+				t.Fatal("request reached the tunnel dialer with no kcp authorization available")
+			}
+			if len(calls) != 0 {
+				t.Fatalf("authorize called with no kcp config: %v", calls)
+			}
+		})
+	}
+}
+
+// serveService carries the same guard independently of the edgeproxy entry
+// point, so a future caller cannot reintroduce the fail-open path.
+func TestServeServiceFailsClosedWithoutKCPConfig(t *testing.T) {
+	var calls []string
+	s, dialer := newNoKCPTestServer(t, &calls)
+
+	req := httptest.NewRequest(http.MethodGet, authTestServicePath, nil)
+	rr := httptest.NewRecorder()
+	s.serveService(rr, req, "any-token", "ws-1", "svc-1", "proxy", "")
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d (body %q)", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
+	}
+	if dialer.dialed {
+		t.Fatal("serveService reached the tunnel dialer with no kcp authorization available")
+	}
+	if len(calls) != 0 {
+		t.Fatalf("authorize called with no kcp config: %v", calls)
+	}
+}
+
+// The test-only bypass (AllowStaticTokenBypass, which main.go never sets) is
+// the single exception: unit tests exercise the tunnel plane with no kcp at
+// all, so those requests must still be served.
+func TestEdgesProxyServesUnderTestOnlyBypass(t *testing.T) {
+	var calls []string
+	s, dialer := newNoKCPTestServer(t, &calls)
+	s.allowStaticTokenBypass = true
+
+	req := httptest.NewRequest(http.MethodGet, "/clusters/ws-1/apis/edges.faros.sh/v1alpha1/linuxservers/edge-1/k8s", nil)
+	req.Header.Set("Authorization", "Bearer any-token")
+	rr := httptest.NewRecorder()
+	s.buildEdgesProxyHandler().ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusServiceUnavailable {
+		t.Fatalf("test bypass refused the request: %d (body %q)", rr.Code, rr.Body.String())
+	}
+	if !dialer.dialed {
+		t.Fatal("test bypass did not reach the tunnel dialer")
 	}
 }
 

--- a/providers/edges/internal/tunnel/edges_proxy_auth_test.go
+++ b/providers/edges/internal/tunnel/edges_proxy_auth_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+// newAuthTestServer builds a Server with a kcp config present (so delegated
+// authorization is active), an injected authorize func, and a static-token set
+// populated the way a legacy FAROS_STATIC_TOKENS config would have — to prove
+// that set no longer short-circuits authorization anywhere.
+func newAuthTestServer(t *testing.T, authorizeErr error, calls *[]string) *Server {
+	t.Helper()
+	kcp := &rest.Config{Host: "https://kcp.invalid"}
+	s := testServer("/services/providers/edges/edgeproxy")
+	s.kcpConfig = kcp
+	s.tenantConfig = func(context.Context, string) (*rest.Config, error) { return kcp, nil }
+	s.edgeConnManager = NewConnManager()
+	s.logger = klog.Background()
+	s.staticTokens = map[string]struct{}{"static-secret": {}}
+	s.authorizeFn = func(_ context.Context, _, _ *rest.Config, token, cluster, verb, group, resource, name string) error {
+		*calls = append(*calls, token+" "+verb+" "+group+"/"+resource+"/"+name+"@"+cluster)
+		return authorizeErr
+	}
+	return s
+}
+
+func TestEdgesProxyHandlerAuthorizesEveryToken(t *testing.T) {
+	const edgePath = "/clusters/ws-1/apis/edges.faros.sh/v1alpha1/linuxservers/edge-1/ssh"
+	const servicePath = "/clusters/ws-1/apis/edges.faros.sh/v1alpha1/services/svc-1/proxy/"
+
+	cases := []struct {
+		name         string
+		token        string
+		path         string
+		authorizeErr error
+		wantStatus   int
+		wantCall     string
+	}{
+		{
+			// Allowed by kcp: the handler proceeds to the tunnel lookup and, with
+			// no agent connected, answers 502 — proving authorize ran and passed.
+			name:       "static token is authorized like any other token",
+			token:      "static-secret",
+			path:       edgePath,
+			wantStatus: http.StatusBadGateway,
+			wantCall:   "static-secret proxy edges.faros.sh/linuxservers/edge-1@ws-1",
+		},
+		{
+			name:         "static token denied by kcp is forbidden",
+			token:        "static-secret",
+			path:         edgePath,
+			authorizeErr: errors.New("access denied"),
+			wantStatus:   http.StatusForbidden,
+			wantCall:     "static-secret proxy edges.faros.sh/linuxservers/edge-1@ws-1",
+		},
+		{
+			name:       "user token is authorized",
+			token:      "user-token",
+			path:       edgePath,
+			wantStatus: http.StatusBadGateway,
+			wantCall:   "user-token proxy edges.faros.sh/linuxservers/edge-1@ws-1",
+		},
+		{
+			name:         "static token on the service proxy is authorized too",
+			token:        "static-secret",
+			path:         servicePath,
+			authorizeErr: errors.New("access denied"),
+			wantStatus:   http.StatusForbidden,
+			wantCall:     "static-secret proxy edges.faros.sh/services/svc-1@ws-1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls []string
+			s := newAuthTestServer(t, tc.authorizeErr, &calls)
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+tc.token)
+			rr := httptest.NewRecorder()
+			s.buildEdgesProxyHandler().ServeHTTP(rr, req)
+
+			if rr.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body %q)", rr.Code, tc.wantStatus, rr.Body.String())
+			}
+			if len(calls) != 1 {
+				t.Fatalf("authorize called %d times, want exactly once: %v", len(calls), calls)
+			}
+			if calls[0] != tc.wantCall {
+				t.Fatalf("authorize call = %q, want %q", calls[0], tc.wantCall)
+			}
+		})
+	}
+}
+
+// New refuses the test-only static-token set unless explicitly opted in, and
+// never alongside a kcp config.
+func TestNewRejectsStaticTokensOutsideTestBypass(t *testing.T) {
+	kind := KindConfig{
+		GVR:  schema.GroupVersionResource{Group: "edges.faros.sh", Version: "v1alpha1", Resource: "linuxservers"},
+		Kind: "LinuxServer",
+	}
+	base := Config{Kinds: []KindConfig{kind}, AgentPickupPath: "/agent/proxy", Logger: klog.Background()}
+
+	cfg := base
+	cfg.StaticTokens = []string{"static-secret"}
+	if _, err := New(cfg); err == nil {
+		t.Fatal("New accepted StaticTokens without AllowStaticTokenBypass")
+	}
+
+	cfg = base
+	cfg.StaticTokens = []string{"static-secret"}
+	cfg.AllowStaticTokenBypass = true
+	cfg.KCPConfig = &rest.Config{Host: "https://kcp.invalid"}
+	if _, err := New(cfg); err == nil {
+		t.Fatal("New accepted AllowStaticTokenBypass alongside a KCPConfig")
+	}
+
+	cfg = base
+	cfg.StaticTokens = []string{"static-secret"}
+	cfg.AllowStaticTokenBypass = true
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New with test bypass and no kcp config: %v", err)
+	}
+	if _, ok := s.staticTokens["static-secret"]; !ok {
+		t.Fatal("test bypass did not register the static token")
+	}
+}

--- a/providers/edges/internal/tunnel/edges_proxy_builder.go
+++ b/providers/edges/internal/tunnel/edges_proxy_builder.go
@@ -78,11 +78,10 @@ func (p *Server) buildEdgesProxyHandler() http.Handler {
 			return
 		}
 
-		// 3. Delegated authorization via kcp (if configured).
-		// Static tokens bypass authorizeFn entirely — they are pre-authenticated
-		// server-side credentials that do not go through kcp SubjectAccessReview.
-		_, isStaticToken := p.staticTokens[token]
-		if !isStaticToken && p.kcpConfig != nil {
+		// 3. Delegated authorization via kcp (if configured). Every bearer goes
+		// through authorizeFn — hub static-token users are ordinary kcp identities
+		// (faros:static:<hash>) and pass TokenReview + SAR like any other caller.
+		if p.kcpConfig != nil {
 			tenantCfg, err := p.tenantConfigFor(r.Context(), cluster)
 			if err != nil {
 				p.logger.Error(err, "edges proxy authorization: resolving tenant config failed",

--- a/providers/edges/internal/tunnel/edges_proxy_builder.go
+++ b/providers/edges/internal/tunnel/edges_proxy_builder.go
@@ -63,6 +63,13 @@ func (p *Server) buildEdgesProxyHandler() http.Handler {
 			return
 		}
 
+		// 1a. Fail closed when kcp delegated authorization is unavailable: no
+		// credential means no TokenReview + SAR, and this handler is mounted
+		// whether or not kcp is wired.
+		if p.denyIfAuthorizationUnavailable(w, r) {
+			return
+		}
+
 		// 1b. Service subresources (proxy/mcp) are branched here BEFORE
 		// parseEdgesProxyPath: "services" is not a tunnel Kind, so that
 		// parser (which validates against gvrForResource) would reject it.
@@ -78,9 +85,11 @@ func (p *Server) buildEdgesProxyHandler() http.Handler {
 			return
 		}
 
-		// 3. Delegated authorization via kcp (if configured). Every bearer goes
-		// through authorizeFn — hub static-token users are ordinary kcp identities
+		// 3. Delegated authorization via kcp. Every bearer goes through
+		// authorizeFn — hub static-token users are ordinary kcp identities
 		// (faros:static:<hash>) and pass TokenReview + SAR like any other caller.
+		// Step 1a already refused the request if there is no kcp credential, so
+		// a nil kcpConfig here only happens under the test-only bypass.
 		if p.kcpConfig != nil {
 			tenantCfg, err := p.tenantConfigFor(r.Context(), cluster)
 			if err != nil {

--- a/providers/edges/internal/tunnel/server.go
+++ b/providers/edges/internal/tunnel/server.go
@@ -228,10 +228,10 @@ func New(cfg Config) (*Server, error) {
 		kinds[k.GVR.Resource] = k
 	}
 	if len(cfg.StaticTokens) > 0 && !cfg.AllowStaticTokenBypass {
-		return nil, fmt.Errorf("tunnel: StaticTokens are test-only and require AllowStaticTokenBypass")
+		return nil, fmt.Errorf("tunnel: the StaticTokens field is test-only and requires AllowStaticTokenBypass")
 	}
 	if cfg.AllowStaticTokenBypass && cfg.KCPConfig != nil {
-		return nil, fmt.Errorf("tunnel: AllowStaticTokenBypass is only valid without a KCPConfig (kcp validates every token)")
+		return nil, fmt.Errorf("tunnel: the AllowStaticTokenBypass field is only valid without a KCPConfig (kcp validates every token)")
 	}
 	tokenSet := make(map[string]struct{}, len(cfg.StaticTokens))
 	if cfg.AllowStaticTokenBypass {

--- a/providers/edges/internal/tunnel/server.go
+++ b/providers/edges/internal/tunnel/server.go
@@ -97,7 +97,13 @@ type Server struct {
 	// TenantConfigGetter.
 	tenantConfig TenantConfigGetter
 
-	// staticTokens bypass the SA/join-token requirement (dev / static-auth hubs).
+	// staticTokens is a TEST-ONLY set of bearer tokens the agent-ingress handler
+	// accepts in place of an agent credential when there is no kcp config to
+	// validate one against. It is only populated through
+	// Config.AllowStaticTokenBypass, which main.go never sets; consumer-egress
+	// authorization (edgeproxy / services) never consults it. Every caller of the
+	// data plane goes through authorizeFn (TokenReview + SubjectAccessReview),
+	// including hub static-token users, whose identity kcp resolves natively.
 	staticTokens map[string]struct{}
 
 	// hubExternalURL is embedded into agent kubeconfigs. hubInternalURL is used
@@ -186,10 +192,16 @@ type Config struct {
 	// no URL to externalize).
 	EdgeProxyPublicPath string
 	KCPConfig           *rest.Config
-	StaticTokens        []string
-	HubExternalURL      string
-	HubInternalURL      string
-	Logger              klog.Logger
+	// StaticTokens are TEST-ONLY bearer tokens accepted as an agent credential
+	// on the agent-ingress path when KCPConfig is nil. They are rejected unless
+	// AllowStaticTokenBypass is set, and never combine with a KCPConfig: with a
+	// kcp credential present every token is validated by kcp. main.go never sets
+	// either field.
+	StaticTokens           []string
+	AllowStaticTokenBypass bool
+	HubExternalURL         string
+	HubInternalURL         string
+	Logger                 klog.Logger
 }
 
 // New constructs the tunnel Server for one or more connectable kinds.
@@ -208,9 +220,17 @@ func New(cfg Config) (*Server, error) {
 		}
 		kinds[k.GVR.Resource] = k
 	}
+	if len(cfg.StaticTokens) > 0 && !cfg.AllowStaticTokenBypass {
+		return nil, fmt.Errorf("tunnel: StaticTokens are test-only and require AllowStaticTokenBypass")
+	}
+	if cfg.AllowStaticTokenBypass && cfg.KCPConfig != nil {
+		return nil, fmt.Errorf("tunnel: AllowStaticTokenBypass is only valid without a KCPConfig (kcp validates every token)")
+	}
 	tokenSet := make(map[string]struct{}, len(cfg.StaticTokens))
-	for _, t := range cfg.StaticTokens {
-		tokenSet[t] = struct{}{}
+	if cfg.AllowStaticTokenBypass {
+		for _, t := range cfg.StaticTokens {
+			tokenSet[t] = struct{}{}
+		}
 	}
 	return &Server{
 		kinds:               kinds,

--- a/providers/edges/internal/tunnel/server.go
+++ b/providers/edges/internal/tunnel/server.go
@@ -106,6 +106,13 @@ type Server struct {
 	// including hub static-token users, whose identity kcp resolves natively.
 	staticTokens map[string]struct{}
 
+	// allowStaticTokenBypass mirrors Config.AllowStaticTokenBypass. It is the
+	// ONLY thing that lets the consumer-egress data plane serve without a kcp
+	// credential: with it unset and kcpConfig nil the edgeproxy / service
+	// handlers refuse every request (503) rather than serving unauthorized
+	// bearers. main.go never sets it, so production always fails closed.
+	allowStaticTokenBypass bool
+
 	// hubExternalURL is embedded into agent kubeconfigs. hubInternalURL is used
 	// for internal MCP→edgeproxy calls to avoid CDN loops; falls back to
 	// hubExternalURL when empty.
@@ -233,18 +240,19 @@ func New(cfg Config) (*Server, error) {
 		}
 	}
 	return &Server{
-		kinds:               kinds,
-		group:               group,
-		version:             version,
-		edgeConnManager:     NewConnManager(),
-		kcpConfig:           cfg.KCPConfig,
-		staticTokens:        tokenSet,
-		hubExternalURL:      cfg.HubExternalURL,
-		hubInternalURL:      cfg.HubInternalURL,
-		agentPickupPath:     cfg.AgentPickupPath,
-		edgeProxyPublicPath: cfg.EdgeProxyPublicPath,
-		authorizeFn:         authorize,
-		logger:              cfg.Logger.WithName("edge-tunnel"),
+		kinds:                  kinds,
+		group:                  group,
+		version:                version,
+		edgeConnManager:        NewConnManager(),
+		kcpConfig:              cfg.KCPConfig,
+		staticTokens:           tokenSet,
+		allowStaticTokenBypass: cfg.AllowStaticTokenBypass,
+		hubExternalURL:         cfg.HubExternalURL,
+		hubInternalURL:         cfg.HubInternalURL,
+		agentPickupPath:        cfg.AgentPickupPath,
+		edgeProxyPublicPath:    cfg.EdgeProxyPublicPath,
+		authorizeFn:            authorize,
+		logger:                 cfg.Logger.WithName("edge-tunnel"),
 	}, nil
 }
 
@@ -269,6 +277,33 @@ func (p *Server) tenantConfigFor(ctx context.Context, cluster string) (*rest.Con
 	cfg := rest.CopyConfig(p.kcpConfig)
 	cfg.Host = kcpurl.ClusterURL(cfg.Host, cluster)
 	return cfg, nil
+}
+
+// denyIfAuthorizationUnavailable fails the consumer-egress data plane CLOSED
+// when there is no kcp credential to run the delegated TokenReview +
+// SubjectAccessReview against.
+//
+// Without it the edgeproxy / service handlers wrapped their authorization in
+// `if p.kcpConfig != nil`, so a provider that started without a usable kcp
+// kubeconfig — including one whose FAROS_PROVIDER_KUBECONFIG is set but
+// unreadable, which loadKCPConfig silently degrades to nil — served the data
+// plane to any non-empty bearer. The handlers are mounted unconditionally, so
+// "no kcp config" must mean "refuse traffic", not "skip the check".
+//
+// The single exception is the test-only AllowStaticTokenBypass, which main.go
+// never sets: unit tests exercise the tunnel plane with no kcp at all.
+//
+// Returns true when the request was answered and the caller must stop.
+func (p *Server) denyIfAuthorizationUnavailable(w http.ResponseWriter, r *http.Request) bool {
+	if p.kcpConfig != nil || p.allowStaticTokenBypass {
+		return false
+	}
+	// V(0): an operator needs to see this without raising verbosity — the data
+	// plane is up but rejecting everything.
+	p.logger.Info("refusing data-plane request: kcp delegated authorization is unavailable (no kcp credential)",
+		"method", r.Method, "path", r.URL.Path)
+	http.Error(w, "authorization unavailable", http.StatusServiceUnavailable)
+	return true
 }
 
 // gvrForResource resolves a URL resource segment to its GVR + Kind. ok is false

--- a/providers/edges/internal/tunnel/service_proxy.go
+++ b/providers/edges/internal/tunnel/service_proxy.go
@@ -185,7 +185,16 @@ func (p *Server) serveService(w http.ResponseWriter, r *http.Request, token, clu
 	ctx := r.Context()
 	logger := klog.FromContext(ctx).WithName("edgeservice-proxy")
 
+	// Fail closed when kcp delegated authorization is unavailable, as in
+	// buildEdgesProxyHandler: without a kcp credential there is nothing to
+	// TokenReview the bearer against, so refuse instead of proceeding to the
+	// Service fetch and proxy.
+	if p.denyIfAuthorizationUnavailable(w, r) {
+		return
+	}
+
 	// Delegated authorization for every bearer, as in buildEdgesProxyHandler.
+	// A nil kcpConfig here only happens under the test-only bypass.
 	if p.kcpConfig != nil {
 		tenantCfg, err := p.tenantConfigFor(ctx, cluster)
 		if err != nil {

--- a/providers/edges/internal/tunnel/service_proxy.go
+++ b/providers/edges/internal/tunnel/service_proxy.go
@@ -185,9 +185,8 @@ func (p *Server) serveService(w http.ResponseWriter, r *http.Request, token, clu
 	ctx := r.Context()
 	logger := klog.FromContext(ctx).WithName("edgeservice-proxy")
 
-	// Delegated authorization (static tokens bypass, as in buildEdgesProxyHandler).
-	_, isStaticToken := p.staticTokens[token]
-	if !isStaticToken && p.kcpConfig != nil {
+	// Delegated authorization for every bearer, as in buildEdgesProxyHandler.
+	if p.kcpConfig != nil {
 		tenantCfg, err := p.tenantConfigFor(ctx, cluster)
 		if err != nil {
 			logger.Error(err, "edgeservice authorization: resolving tenant config failed", "cluster", cluster, "name", name)

--- a/providers/edges/main.go
+++ b/providers/edges/main.go
@@ -115,6 +115,21 @@ func runServe() error {
 	kcpConfig := loadKCPConfig(log)
 	hubExternalURL := os.Getenv("FAROS_HUB_EXTERNAL_URL")
 
+	// FAROS_STATIC_TOKENS used to let listed bearers skip TokenReview/SAR on
+	// every data-plane path. The bypass is gone: kcp validates every token, and
+	// hub static-token users are ordinary kcp identities that pass that check.
+	// A set value with a kcp credential present is a misconfiguration that
+	// would silently expect the old behaviour, so refuse to start rather than
+	// run with a different security posture than the operator assumed.
+	if v := os.Getenv("FAROS_STATIC_TOKENS"); v != "" {
+		if kcpConfig != nil {
+			err := errors.New("FAROS_STATIC_TOKENS is set but the static-token authorization bypass has been removed; every token is validated by kcp — unset the variable")
+			log.Error(err, "refusing to start")
+			return err
+		}
+		log.Info("WARNING: FAROS_STATIC_TOKENS is set but ignored: the static-token authorization bypass has been removed")
+	}
+
 	// Tunnel plane. The provider owns the ConnManager and terminates agent
 	// reverse tunnels in-process; with replica routing enabled below, peer
 	// replicas relay to whichever replica holds a tunnel. Both prefixes sit
@@ -127,7 +142,6 @@ func runServe() error {
 		AgentPickupPath:     agentPickupPath,
 		EdgeProxyPublicPath: edgeProxyPublicPath,
 		KCPConfig:           kcpConfig,
-		StaticTokens:        splitEnv(os.Getenv("FAROS_STATIC_TOKENS")),
 		HubExternalURL:      hubExternalURL,
 		HubInternalURL:      os.Getenv("FAROS_HUB_INTERNAL_URL"),
 		Logger:              log,
@@ -318,21 +332,6 @@ func hubCAData(log logr.Logger) []byte {
 		return []byte(d)
 	}
 	return nil
-}
-
-// splitEnv splits a comma-separated env value into a trimmed, non-empty slice.
-func splitEnv(v string) []string {
-	if v == "" {
-		return nil
-	}
-	parts := strings.Split(v, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if p = strings.TrimSpace(p); p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
 }
 
 // envOrHostname returns the named env var (the chart sets POD_NAME via the

--- a/providers/edges/main.go
+++ b/providers/edges/main.go
@@ -123,11 +123,12 @@ func runServe() error {
 	// run with a different security posture than the operator assumed.
 	if v := os.Getenv("FAROS_STATIC_TOKENS"); v != "" {
 		if kcpConfig != nil {
-			err := errors.New("FAROS_STATIC_TOKENS is set but the static-token authorization bypass has been removed; every token is validated by kcp — unset the variable")
+			err := errors.New("FAROS_STATIC_TOKENS is set but the static-token authorization bypass has been removed; every token is validated by kcp, so unset the variable")
 			log.Error(err, "refusing to start")
 			return err
 		}
-		log.Info("WARNING: FAROS_STATIC_TOKENS is set but ignored: the static-token authorization bypass has been removed")
+		log.Info("static-token authorization bypass has been removed; the environment variable is ignored",
+			"envVar", "FAROS_STATIC_TOKENS", "ignored", true, "severity", "warning")
 	}
 
 	// Tunnel plane. The provider owns the ConnManager and terminates agent

--- a/providers/edges/main.go
+++ b/providers/edges/main.go
@@ -295,7 +295,14 @@ func runServe() error {
 // kubeconfig) for token validation and Edge reads/writes. Best-effort: returns
 // nil (with a warning) when no kubeconfig is available, so the binary still
 // serves /healthz in environments where kcp isn't wired yet. Resolution order:
-// FAROS_PROVIDER_KUBECONFIG, KUBECONFIG, in-cluster.
+// FAROS_PROVIDER_KUBECONFIG, KUBECONFIG, in-cluster; note that a
+// FAROS_PROVIDER_KUBECONFIG that is set but unusable falls through the same
+// chain and can end in nil.
+//
+// A nil result does NOT unmount the data plane: the tunnel handlers are always
+// mounted and instead refuse every consumer-egress request with 503, because
+// there is no kcp credential to authorize bearers against (see
+// tunnel.Server.denyIfAuthorizationUnavailable).
 func loadKCPConfig(log logr.Logger) *rest.Config {
 	if p := os.Getenv("FAROS_PROVIDER_KUBECONFIG"); p != "" {
 		if c, err := clientcmd.BuildConfigFromFlags("", p); err == nil {
@@ -312,7 +319,7 @@ func loadKCPConfig(log logr.Logger) *rest.Config {
 	if c, err := rest.InClusterConfig(); err == nil {
 		return c
 	}
-	log.Info("no kcp kubeconfig available; tunnel token validation + Edge reads disabled (healthz only)")
+	log.Info("no kcp kubeconfig available; edge controllers are disabled and the tunnel data plane refuses every request with 503 (delegated authorization unavailable) - only /healthz and the static portal serve")
 	return nil
 }
 

--- a/test/e2e/suites/edges/main_test.go
+++ b/test/e2e/suites/edges/main_test.go
@@ -200,7 +200,6 @@ func TestMain(m *testing.M) {
 		"FAROS_HUB_INSECURE=true",
 		"FAROS_PROVIDER_NAME=edges",
 		"FAROS_PROVIDER_KUBECONFIG="+runtimeKubeconfig,
-		"FAROS_STATIC_TOKENS="+staticToken,
 		"FAROS_DEV_MODE=true",
 	)
 	provCmd.Stdout = provLog

--- a/test/e2e/suites/edgesconn/connectivity_test.go
+++ b/test/e2e/suites/edgesconn/connectivity_test.go
@@ -219,13 +219,20 @@ func TestKubectlThroughTunnel(t *testing.T) {
 
 func enableEdges(t *testing.T, tenant dynamic.Interface) {
 	t.Helper()
-	claim := func(group, resource string) map[string]any {
+	claimVerbs := func(group, resource string, verbs ...string) map[string]any {
+		vs := make([]any, 0, len(verbs))
+		for _, v := range verbs {
+			vs = append(vs, v)
+		}
 		return map[string]any{
 			"group": group, "resource": resource,
-			"verbs":    []any{"get", "list", "watch", "create", "update", "patch", "delete"},
+			"verbs":    vs,
 			"selector": map[string]any{"matchAll": true},
 			"state":    "Accepted",
 		}
+	}
+	claim := func(group, resource string) map[string]any {
+		return claimVerbs(group, resource, "get", "list", "watch", "create", "update", "patch", "delete")
 	}
 	binding := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apis.kcp.io/v1alpha2",
@@ -233,9 +240,21 @@ func enableEdges(t *testing.T, tenant dynamic.Interface) {
 		"metadata":   map[string]any{"name": "edges"},
 		"spec": map[string]any{
 			"reference": map[string]any{"export": map[string]any{"path": edgesWorkspacePath, "name": edgesAPIExportName}},
+			// Mirror the claim set the hub's Enable flow accepts for this
+			// provider (providers/edges/manifest.yaml). The two review claims
+			// are what let the provider run delegated TokenReview +
+			// SubjectAccessReview for a CALLER's token against this workspace
+			// through its APIExport virtual workspace — the consumer-egress
+			// authorization path (edgeproxy k8s/ssh and the service proxy).
+			// Without them every user-token request to the data plane is
+			// denied, while agents keep working because join-token
+			// registration never uses the review APIs. Built-in review APIs:
+			// verb create only, no identityHash.
 			"permissionClaims": []any{
 				claim("", "namespaces"), claim("", "serviceaccounts"), claim("", "secrets"),
 				claim("rbac.authorization.k8s.io", "clusterroles"), claim("rbac.authorization.k8s.io", "clusterrolebindings"),
+				claimVerbs("authentication.k8s.io", "tokenreviews", "create"),
+				claimVerbs("authorization.k8s.io", "subjectaccessreviews", "create"),
 			},
 		},
 	}}

--- a/test/e2e/suites/edgesconn/main_test.go
+++ b/test/e2e/suites/edgesconn/main_test.go
@@ -231,7 +231,6 @@ func TestMain(m *testing.M) {
 		"FAROS_HUB_INSECURE=true",
 		"FAROS_PROVIDER_NAME=edges",
 		"FAROS_PROVIDER_KUBECONFIG="+runtimeKubeconfig,
-		"FAROS_STATIC_TOKENS="+staticToken,
 		"FAROS_DEV_MODE=true",
 	)
 	provCmd.Stdout = provLog


### PR DESCRIPTION
Security remediation plan item 2.2 (finding 6).

## Problem

`providers/edges/internal/tunnel/{edges_proxy_builder,service_proxy,agent_proxy_builder_v2}.go` skipped TokenReview and SubjectAccessReview whenever the bearer was listed in `FAROS_STATIC_TOKENS` (chart value `staticTokens`). Hub static-token users are ordinary kcp identities (`faros:static:<hash>`) that pass TokenReview and the tenant-workspace SAR normally (the tenant bootstrap grants the caller cluster-admin under that same identity), so the bypass had no legitimate purpose and left a "skip kcp entirely" switch in the chart.

## Change

- Delete the three short-circuits: every token on the edgeproxy, service-proxy and agent-ingress paths now goes through `authorize` (TokenReview + SAR).
- The static-token set survives only as a test-only stand-in for an agent credential on the agent-ingress path when there is no kcp config at all, behind an explicit `Config.AllowStaticTokenBypass`. `New` refuses `StaticTokens` without it and refuses the bypass alongside a `KCPConfig`; `main.go` never sets either.
- `main.go` refuses to start when `FAROS_STATIC_TOKENS` is set alongside a kcp credential (V(0) error) and warns that it is ignored when there is none.
- Remove the chart value, its `deployment.yaml` plumbing and the chart README row. Stop passing the variable from the Makefile `run-provider-edges` target and from the `edges` / `edgesconn` e2e launchers (both suites use the static token as a real hub identity, which kcp validates).
- Fix the test-only data race in `TestSSHSessionTeardown` (`internal/ssh/ssh_teardown_test.go`): the httptest handler wrote `serverConn` while the test read it after a sleep. The upgraded conn is now handed over a channel. This unblocks `-race` for the edges module in CI (PR #624 dropped it for this module).

## Compatibility

- Deployments that set `staticTokens` in the edges chart, or `FAROS_STATIC_TOKENS` in the environment, must unset it: the provider now refuses to start with it set alongside a kcp config. The shipped install flows never set it.
- Callers that relied on the bypass must hold a kcp identity with `proxy` on the target resource in the tenant workspace, which every tenant owner already has.
- No API or CRD changes.

## Tests

- New `internal/tunnel/edges_proxy_auth_test.go`: table test on `buildEdgesProxyHandler` with a static token in the (legacy) static set and an injected authorize func, asserting authorize is invoked exactly once with the right verb/resource for both the edge and service paths and that a denial yields 403; plus `New` rejecting `StaticTokens` without the bypass and the bypass alongside a `KCPConfig`. No existing fixture relied on the bypass (`edge_proxy_url_test.go` never set `staticTokens`).
- `GOWORK=off go build ./...` and `go test -race -count=1 ./internal/tunnel/ ./internal/ssh/...` in `providers/edges` pass; the ssh package was run three times under `-race`.
- `go vet` on the two e2e suites, `gofmt -l` on changed files clean; `golangci-lint run` on the module reports only the 14 issues already present on `main`.


## Follow-up: the edgesconn e2e failure (fixed in fc6101e6)

Removing the bypass first turned the `edgesconn` job red (403 on the service proxy, `Forbidden` through the kubectl tunnel, `bad handshake` on SSH). **The product is correct; the suite's fixture was wrong — so this is direction (b), a test-framework fix, not a product change or a new RBAC grant.**

Root cause: `test/e2e/suites/edgesconn/connectivity_test.go` (`enableEdges`) hand-rolls the edges `APIBinding` rather than going through the hub's Enable flow, and its claim set omitted the two review APIs the CatalogEntry declares (`providers/edges/manifest.yaml`): `authentication.k8s.io/tokenreviews` and `authorization.k8s.io/subjectaccessreviews`, verb `create`. Those claims are what let the provider run delegated TokenReview + SubjectAccessReview for a *caller's* token against the tenant workspace through its APIExport virtual workspace — the whole consumer-egress authorization path. Agents were unaffected because join-token registration reads `edge.status` directly and never touches the review APIs, so the gap stayed invisible while the static-token bypass skipped authorization for exactly the token this suite calls with.

Evidence (probed against a running dev stack, whose tenant binding was created by the real Enable flow and does carry both claims, `verbs: ["create"]`):

- `kubectl auth can-i proxy linuxservers.edges.faros.sh` as the static token in its tenant workspace → **yes** (the hub binds `cluster-admin` to `faros:static:<hash>` via `ensureWorkspaceAdmin`), so no RBAC grant is missing and direction (a) does not apply.
- TokenReview of the caller token through the tenant VW → `authenticated: true`, user `faros:static:<hash>`, groups `[system:authenticated]`.
- SubjectAccessReview for that identity through the same VW, verb `proxy` on `linuxservers` / `services` / `kubernetesclusters` → `allowed: true, reason: "access granted"`.

So `authorize()` succeeds for a static-token caller wherever the binding carries the claims. The sibling `edges` suite already accepts all seven claims (`edges_test.go`) and its job stays green, which is why only `edgesconn` broke. The fix accepts both claims with verb `create`, matching byte-for-byte what the Enable flow writes into a real tenant binding.

The suite could not be re-run locally: it needs embedded-kcp etcd port 2380, held by a long-running dev hub on this machine that must not be disturbed. CI verifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
