### PR TITLE
fix(hub): stop forwarding user bearers to org-owned providers

### DIFF
--- a/apis/tenancy/v1alpha1/types_organization.go
+++ b/apis/tenancy/v1alpha1/types_organization.go
@@ -158,11 +158,22 @@ type OrganizationSpec struct {
 	// +kubebuilder:validation:Enum=members;admin
 	WorkspaceCreation string `json:"workspaceCreation,omitempty"`
 
-	// CatalogEntryCreation controls who can publish Org-Private CatalogEntries
-	// (see docs/provider-scoping.md). Same enum + default as WorkspaceCreation.
+	// CatalogEntryCreation controls who can register an org-owned provider
+	// (POST /api/orgs/{org}/providers, see docs/byo-providers.md):
+	//   admin   — only Org admins may register (default).
+	//   members — any Org Membership may register.
+	//
+	// The default is stricter than WorkspaceCreation's because registration
+	// mints a long-lived cluster-admin credential for the provider workspace
+	// and routes every org user's traffic for that provider name — possibly
+	// shadowing a platform provider — into whichever cluster the registrant
+	// chose. Unset is treated as admin by the hub. Organizations that predate
+	// the admin default carry an explicit "members", written once by the
+	// organization controller and recorded in the
+	// tenants.faros.sh/catalog-entry-creation-migrated annotation.
 	//
 	// +optional
-	// +kubebuilder:default=members
+	// +kubebuilder:default=admin
 	// +kubebuilder:validation:Enum=members;admin
 	CatalogEntryCreation string `json:"catalogEntryCreation,omitempty"`
 

--- a/config/crds/tenants.faros.sh_organizations.yaml
+++ b/config/crds/tenants.faros.sh_organizations.yaml
@@ -62,10 +62,21 @@ spec:
             description: OrganizationSpec defines the desired state of an Organization.
             properties:
               catalogEntryCreation:
-                default: members
+                default: admin
                 description: |-
-                  CatalogEntryCreation controls who can publish Org-Private CatalogEntries
-                  (see docs/provider-scoping.md). Same enum + default as WorkspaceCreation.
+                  CatalogEntryCreation controls who can register an org-owned provider
+                  (POST /api/orgs/{org}/providers, see docs/byo-providers.md):
+                    admin   — only Org admins may register (default).
+                    members — any Org Membership may register.
+
+                  The default is stricter than WorkspaceCreation's because registration
+                  mints a long-lived cluster-admin credential for the provider workspace
+                  and routes every org user's traffic for that provider name — possibly
+                  shadowing a platform provider — into whichever cluster the registrant
+                  chose. Unset is treated as admin by the hub. Organizations that predate
+                  the admin default carry an explicit "members", written once by the
+                  organization controller and recorded in the
+                  tenants.faros.sh/catalog-entry-creation-migrated annotation.
                 enum:
                 - members
                 - admin

--- a/config/kcp/apiexport-tenants.faros.sh.yaml
+++ b/config/kcp/apiexport-tenants.faros.sh.yaml
@@ -11,7 +11,7 @@ spec:
       crd: {}
   - group: tenants.faros.sh
     name: organizations
-    schema: v260615-5246b68.organizations.tenants.faros.sh
+    schema: v260904-9ab06b67.organizations.tenants.faros.sh
     storage:
       crd: {}
   - group: tenants.faros.sh

--- a/config/kcp/apiresourceschema-organizations.tenants.faros.sh.yaml
+++ b/config/kcp/apiresourceschema-organizations.tenants.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260615-5246b68.organizations.tenants.faros.sh
+  name: v260904-9ab06b67.organizations.tenants.faros.sh
 spec:
   group: tenants.faros.sh
   names:
@@ -58,10 +58,21 @@ spec:
           description: OrganizationSpec defines the desired state of an Organization.
           properties:
             catalogEntryCreation:
-              default: members
+              default: admin
               description: |-
-                CatalogEntryCreation controls who can publish Org-Private CatalogEntries
-                (see docs/provider-scoping.md). Same enum + default as WorkspaceCreation.
+                CatalogEntryCreation controls who can register an org-owned provider
+                (POST /api/orgs/{org}/providers, see docs/byo-providers.md):
+                  admin   — only Org admins may register (default).
+                  members — any Org Membership may register.
+
+                The default is stricter than WorkspaceCreation's because registration
+                mints a long-lived cluster-admin credential for the provider workspace
+                and routes every org user's traffic for that provider name — possibly
+                shadowing a platform provider — into whichever cluster the registrant
+                chose. Unset is treated as admin by the hub. Organizations that predate
+                the admin default carry an explicit "members", written once by the
+                organization controller and recorded in the
+                tenants.faros.sh/catalog-entry-creation-migrated annotation.
               enum:
               - members
               - admin

--- a/docs/byo-providers.md
+++ b/docs/byo-providers.md
@@ -370,9 +370,17 @@ GET    /api/orgs/{org}/providers/{name}/kubeconfig    re-fetch the install kubec
 ```
 
 Mutating calls honour `Organization.spec.catalogEntryCreation` (decision O-7):
-`members` (the default) lets any Org member register a provider, `admin`
-restricts it to Org admins. An unrecognized policy value is treated as the
-restrictive setting rather than silently widening access.
+`admin` (the default) restricts registration to Org admins, `members` opens it
+to any Org member. An unset or unrecognized policy value is treated as the
+restrictive setting rather than silently widening access. The default is
+stricter than `workspaceCreation`'s on purpose: registration mints a
+cluster-admin credential and, under a platform provider's name, redirects every
+org user's traffic for that provider into the registrant's cluster. That is an
+admin's call. Organizations created before the default flipped were stamped
+with an explicit `members` by a one-time backfill in the organization
+controller (recorded in the `tenants.faros.sh/catalog-entry-creation-migrated`
+annotation), so their behaviour did not change; an admin can tighten them with
+`PATCH /api/orgs/{org}`.
 
 The kubeconfig endpoint counts as mutating — it hands out a credential.
 It re-mints from the ServiceAccount's existing token Secret, so it returns the
@@ -397,6 +405,28 @@ What an Org gets is deliberately narrow.
   the same consent gate platform providers pass.
 - **Enable is hub-mediated**, so it resolves through `GetForOrg` and an Org can
   only ever enable its own providers or platform ones.
+- **An org-owned provider never receives a user's hub token.** The backend
+  proxy strips the caller's `Authorization` before the request enters the edge
+  tunnel and replaces it with a *delegated user token*: a ServiceAccount token
+  minted in the caller's current team workspace (`faros-du-<hash>` in the
+  `default` namespace, one deterministic account per workspace, user, and
+  provider), audience-bound, valid for ten minutes, cached hub-side for five,
+  and annotated with the user it stands in for
+  (`faros.sh/delegated-user`, `-org`, `-workspace`, `-provider`). kcp scopes
+  it to that one workspace, so the worst a tenant-run provider can do with it
+  is what the user could already do in that workspace with `kubectl`. The
+  account is bound to the same ClusterRole workspace members hold today
+  (`cluster-admin` in the workspace, granted by the bootstrap); narrowing that
+  is the workspace RBAC's job, not the proxy's. `X-Faros-User` and
+  `X-Faros-Tenant` still name the human. When the provider calls back into the
+  hub with the token — `/clusters/{id}` or another provider's backend, with
+  `X-Faros-Org`/`X-Faros-Workspace` naming its workspace — the tenant resolver
+  verifies it online and resolves it to the human user again. A request the
+  hub cannot mint a token for (no resolvable caller, no workspace selection,
+  issuer unavailable) is refused; it never falls back to forwarding the bearer.
+  Anonymous probes carry no credential at all. Platform providers still receive
+  the caller's own bearer; moving them to delegated tokens is a separate
+  change (security remediation plan, item 3.3).
 
 What is **not** yet isolated is the raw kcp `bind` verb — see *Known gaps*.
 
@@ -457,7 +487,10 @@ Resolution prefers the Org's own provider, so the copy shadows the platform one
 **for that Org and no one else**. `Registry.Get` stays platform-only, so an org
 copy can never capture a platform provider's proxy or heartbeat route by name;
 only the tenant-scoped lookups (`GetForOrg`, `ListForOrg`) see it. Tests pin both
-halves.
+halves. `ListForOrg` flags such a copy with `shadowsPlatform: true` on the
+catalog DTO, and the portal shows an **Overrides platform provider** tag next
+to **Self-managed**, so the override is visible to the Org rather than being
+inferred from a card that quietly changed.
 
 Names must be RFC1123 labels: the name becomes a kcp workspace name and appears
 in URL paths.

--- a/docs/organizations.md
+++ b/docs/organizations.md
@@ -51,7 +51,7 @@ Don't re-litigate; the doc body assumes these.
 | O-4 | **Switcher disambiguation = always show secondary line** (`created {date} by {first admin}`) under every Org row in the portal switcher. Not just when ambiguous. | Unambiguous always, no client-side "is this name a duplicate?" logic. The `UserMembershipIndex` carries the extra fields. |
 | O-5 | **Org quota = soft cap, admin-overridable per User.** Default 10 Orgs per User. `User.spec.orgQuota` overrides. 4xx on 11th create with a clear message. | Avoids accidental tree bloat; admins handle real edge cases by hand. |
 | O-6 | **Workspace quota = soft cap, admin-overridable per Org.** Default 50 Workspaces per Org. `Organization.spec.workspaceQuota` overrides. | Symmetric with O-5. Tunable when a real team hits it. |
-| O-7 | **CatalogEntry creation gating = configurable per Org**, `Organization.spec.catalogEntryCreation: members\|admin`, default `members` (matches `workspaceCreation`). Enforced at the **hub REST endpoint** (`POST /api/orgs/{uuid}/catalog`), not via kcp RBAC — see O-10. | Lets cautious Orgs gate the catalog; default trusts members. |
+| O-7 | **CatalogEntry creation gating = configurable per Org**, `Organization.spec.catalogEntryCreation: members\|admin`, default `admin` (stricter than `workspaceCreation`; it was `members` until the September 2026 security review, and Organizations from before then were backfilled with an explicit `members`). Enforced at the **hub REST endpoint** (`POST /api/orgs/{uuid}/providers`), not via kcp RBAC — see O-10. | Registering a provider mints a cluster-admin credential and can shadow a platform provider for the whole Org; that is an admin decision. Orgs that trust members opt in. |
 | O-10 | **Org workspaces are hub-mediated only.** Tenants never receive a kubeconfig that targets `root:faros:orgs:{uuid}` directly. All Org-workspace operations (CatalogEntry CRUD, Membership CRUD, child Workspace create) flow through hub REST endpoints. The faros kcp proxy ([pkg/server/proxy/proxy.go](../pkg/server/proxy/proxy.go)) refuses to issue exec-credentials for paths that resolve to a workspace of type `organization`. Child Workspaces (`root:faros:orgs:{org-uuid}:{ws-uuid}`) are user-facing as today. The companion `DefaultCluster` access gate this same proxy enforces — which today funnels user-token traffic to a single workspace and 403s the rest — is revisited in [hub-proxy-workspace-access.md](./hub-proxy-workspace-access.md). | Network-level enforcement of \"no APIBindings in Org workspace\" (see [provider-scoping.md](./provider-scoping.md) P-2). Removes the need for any kcp admission webhook or MaximalPermissionPolicy scoping. |
 | O-8 | **User delete = soft-delete with 30-day grace.** `User.status.deletionRequestedAt`; controller cascades personal Org + Memberships after the grace expires. Recoverable inside the window. | Protects against accidental delete; defers the "sole admin elsewhere" question until cascade time. |
 | O-9 | **Membership removal = block Org removal if user has child Workspace Memberships.** Admin must revoke (or transfer) each Workspace Membership first. UI offers a "remove from all" shortcut that does it as one call. | Explicit; avoids the "why does Bob still see acme/data?" surprise. |
@@ -259,10 +259,11 @@ type OrganizationSpec struct {
     // +kubebuilder:validation:Enum=members;admin
     WorkspaceCreation string `json:"workspaceCreation,omitempty"`
 
-    // CatalogEntryCreation controls who can publish Org-Private
-    // CatalogEntries (see provider-scoping.md). Same enum + default as
-    // WorkspaceCreation.
-    // +kubebuilder:default=members
+    // CatalogEntryCreation controls who can register an org-owned
+    // provider (see byo-providers.md). Same enum as WorkspaceCreation,
+    // but defaults to admin: registration mints a cluster-admin
+    // credential and can shadow a platform provider for the Org.
+    // +kubebuilder:default=admin
     // +kubebuilder:validation:Enum=members;admin
     CatalogEntryCreation string `json:"catalogEntryCreation,omitempty"`
 
@@ -657,7 +658,7 @@ through ClusterRoles in the workspace).
 | Scope + Role | Hub-API capabilities (Org workspace, via REST) | Direct-kcp capabilities (child Workspace) |
 |---|---|---|
 | Org admin | create/delete child Workspaces, manage Org Memberships, manage Workspace Memberships in any child, publish Org-Private CatalogEntries, edit Organization.spec | implicit admin in all child Workspaces (see UX item 10) |
-| Org member | list child Workspaces visible to them, see catalog, create child Workspaces if `workspaceCreation=members`, publish CatalogEntries if `catalogEntryCreation=members` | nothing — must be added to each Workspace explicitly |
+| Org member | list child Workspaces visible to them, see catalog, create child Workspaces if `workspaceCreation=members`, register org-owned providers only if the Org opted in with `catalogEntryCreation=members` (default `admin`) | nothing — must be added to each Workspace explicitly |
 | Workspace admin | (none specific to Org workspace beyond what they have as Org member, if any) | full access, manage Workspace Memberships |
 | Workspace member | (none specific) | edit objects in the Workspace |
 

--- a/pkg/hub/bootstrap/crds/tenants.faros.sh_organizations.yaml
+++ b/pkg/hub/bootstrap/crds/tenants.faros.sh_organizations.yaml
@@ -62,10 +62,21 @@ spec:
             description: OrganizationSpec defines the desired state of an Organization.
             properties:
               catalogEntryCreation:
-                default: members
+                default: admin
                 description: |-
-                  CatalogEntryCreation controls who can publish Org-Private CatalogEntries
-                  (see docs/provider-scoping.md). Same enum + default as WorkspaceCreation.
+                  CatalogEntryCreation controls who can register an org-owned provider
+                  (POST /api/orgs/{org}/providers, see docs/byo-providers.md):
+                    admin   — only Org admins may register (default).
+                    members — any Org Membership may register.
+
+                  The default is stricter than WorkspaceCreation's because registration
+                  mints a long-lived cluster-admin credential for the provider workspace
+                  and routes every org user's traffic for that provider name — possibly
+                  shadowing a platform provider — into whichever cluster the registrant
+                  chose. Unset is treated as admin by the hub. Organizations that predate
+                  the admin default carry an explicit "members", written once by the
+                  organization controller and recorded in the
+                  tenants.faros.sh/catalog-entry-creation-migrated annotation.
                 enum:
                 - members
                 - admin

--- a/pkg/hub/controllers/organization/catalog_entry_creation_migration.go
+++ b/pkg/hub/controllers/organization/catalog_entry_creation_migration.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package organization
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
+)
+
+// AnnotationCatalogEntryCreationMigrated marks an Organization the one-time
+// catalogEntryCreation backfill has visited. Its absence is what identifies
+// an Organization that predates the admin default.
+const AnnotationCatalogEntryCreationMigrated = "tenants.faros.sh/catalog-entry-creation-migrated"
+
+// BackfillCatalogEntryCreation pins the pre-flip behaviour onto every
+// Organization created before spec.catalogEntryCreation defaulted to admin.
+//
+// The hub used to read an empty field as "members"; it now reads it as
+// "admin". Organizations that never set the field relied on the old reading,
+// so each one without the migrated annotation gets an explicit "members"
+// written — an Organization that already carries a value keeps it — and the
+// annotation stamped, after which the backfill never touches it again. New
+// Organizations are created with an explicit value and are simply stamped on
+// first sight.
+//
+// Returns the number of Organizations updated. Errors are returned after the
+// first failed write; the caller retries, and every write is idempotent.
+func BackfillCatalogEntryCreation(ctx context.Context, c client.Client) (int, error) {
+	var orgs tenancyv1alpha1.OrganizationList
+	if err := c.List(ctx, &orgs); err != nil {
+		return 0, fmt.Errorf("listing Organizations: %w", err)
+	}
+	updated := 0
+	for i := range orgs.Items {
+		org := &orgs.Items[i]
+		if org.Annotations[AnnotationCatalogEntryCreationMigrated] != "" {
+			continue
+		}
+		patch := client.MergeFrom(org.DeepCopy())
+		if org.Spec.CatalogEntryCreation == "" {
+			org.Spec.CatalogEntryCreation = tenancyv1alpha1.CatalogEntryCreationMembers
+		}
+		if org.Annotations == nil {
+			org.Annotations = map[string]string{}
+		}
+		org.Annotations[AnnotationCatalogEntryCreationMigrated] = time.Now().UTC().Format(time.RFC3339)
+		if err := c.Patch(ctx, org, patch); err != nil {
+			return updated, fmt.Errorf("backfilling catalogEntryCreation on Organization %s: %w", org.Name, err)
+		}
+		updated++
+	}
+	return updated, nil
+}
+
+// catalogEntryCreationBackfill runs BackfillCatalogEntryCreation once the
+// manager's caches are synced, retrying until it succeeds or the manager
+// stops. It is registered from SetupWithManager so the hub needs no extra
+// wiring, and it never fails the manager: a transient apiserver error must
+// not take the whole controller down.
+func catalogEntryCreationBackfill(mgr manager.Manager) manager.RunnableFunc {
+	return func(ctx context.Context) error {
+		logger := klog.FromContext(ctx).WithName("catalog-entry-creation-backfill")
+		return wait.PollUntilContextCancel(ctx, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			updated, err := BackfillCatalogEntryCreation(ctx, mgr.GetClient())
+			if err != nil {
+				logger.Error(err, "backfill failed; retrying")
+				return false, nil
+			}
+			if updated > 0 {
+				logger.Info("pinned catalogEntryCreation on pre-existing Organizations", "updated", updated)
+			}
+			return true, nil
+		})
+	}
+}

--- a/pkg/hub/controllers/organization/catalog_entry_creation_migration.go
+++ b/pkg/hub/controllers/organization/catalog_entry_creation_migration.go
@@ -45,11 +45,15 @@ const AnnotationCatalogEntryCreationMigrated = "tenants.faros.sh/catalog-entry-c
 // Organizations are created with an explicit value and are simply stamped on
 // first sight.
 //
+// reader supplies the Organization list and MUST NOT be cache-backed: an
+// empty list from a cold cache is indistinguishable from an empty cluster, and
+// this backfill treats "nothing to do" as final. writer applies the patches.
+//
 // Returns the number of Organizations updated. Errors are returned after the
 // first failed write; the caller retries, and every write is idempotent.
-func BackfillCatalogEntryCreation(ctx context.Context, c client.Client) (int, error) {
+func BackfillCatalogEntryCreation(ctx context.Context, reader client.Reader, writer client.Client) (int, error) {
 	var orgs tenancyv1alpha1.OrganizationList
-	if err := c.List(ctx, &orgs); err != nil {
+	if err := reader.List(ctx, &orgs); err != nil {
 		return 0, fmt.Errorf("listing Organizations: %w", err)
 	}
 	updated := 0
@@ -66,7 +70,7 @@ func BackfillCatalogEntryCreation(ctx context.Context, c client.Client) (int, er
 			org.Annotations = map[string]string{}
 		}
 		org.Annotations[AnnotationCatalogEntryCreationMigrated] = time.Now().UTC().Format(time.RFC3339)
-		if err := c.Patch(ctx, org, patch); err != nil {
+		if err := writer.Patch(ctx, org, patch); err != nil {
 			return updated, fmt.Errorf("backfilling catalogEntryCreation on Organization %s: %w", org.Name, err)
 		}
 		updated++
@@ -79,11 +83,34 @@ func BackfillCatalogEntryCreation(ctx context.Context, c client.Client) (int, er
 // stops. It is registered from SetupWithManager so the hub needs no extra
 // wiring, and it never fails the manager: a transient apiserver error must
 // not take the whole controller down.
+//
+// The backfill stops after one successful pass, so that pass has to see every
+// Organization that exists. Two things make that true, and both are needed:
+//
+//   - The list goes through mgr.GetAPIReader(), which reads the apiserver
+//     directly. mgr.GetClient() would read the informer cache, and a cache
+//     that has not been populated yet answers with an empty list — a result
+//     this runnable cannot tell apart from "no Organizations exist", after
+//     which it would exit having silently migrated nothing. Every remaining
+//     Organization would keep an empty spec.catalogEntryCreation, which now
+//     reads as "admin", quietly taking provider registration away from
+//     members.
+//   - It blocks on cache sync first anyway. mgr.Add puts a plain
+//     RunnableFunc in the leader-election group, which controller-runtime
+//     starts only after the cache group has synced — but that is a property
+//     of how this runnable happens to be classified, not something the code
+//     states, and it would change the moment someone gave it a
+//     NeedLeaderElection method. The explicit wait keeps the guarantee local.
 func catalogEntryCreationBackfill(mgr manager.Manager) manager.RunnableFunc {
 	return func(ctx context.Context) error {
 		logger := klog.FromContext(ctx).WithName("catalog-entry-creation-backfill")
+		if !mgr.GetCache().WaitForCacheSync(ctx) {
+			// Only returns false when ctx is done — the manager is stopping.
+			logger.V(2).Info("cache sync interrupted; skipping backfill")
+			return nil
+		}
 		return wait.PollUntilContextCancel(ctx, 10*time.Second, true, func(ctx context.Context) (bool, error) {
-			updated, err := BackfillCatalogEntryCreation(ctx, mgr.GetClient())
+			updated, err := BackfillCatalogEntryCreation(ctx, mgr.GetAPIReader(), mgr.GetClient())
 			if err != nil {
 				logger.Error(err, "backfill failed; retrying")
 				return false, nil

--- a/pkg/hub/controllers/organization/catalog_entry_creation_migration_test.go
+++ b/pkg/hub/controllers/organization/catalog_entry_creation_migration_test.go
@@ -18,10 +18,12 @@ package organization
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
@@ -55,7 +57,7 @@ func TestBackfillCatalogEntryCreation(t *testing.T) {
 		Build()
 	ctx := context.Background()
 
-	updated, err := BackfillCatalogEntryCreation(ctx, c)
+	updated, err := BackfillCatalogEntryCreation(ctx, c, c)
 	if err != nil {
 		t.Fatalf("backfill: %v", err)
 	}
@@ -81,11 +83,93 @@ func TestBackfillCatalogEntryCreation(t *testing.T) {
 	}
 
 	// Idempotent: a second run finds nothing to do.
-	updated, err = BackfillCatalogEntryCreation(ctx, c)
+	updated, err = BackfillCatalogEntryCreation(ctx, c, c)
 	if err != nil {
 		t.Fatalf("second backfill: %v", err)
 	}
 	if updated != 0 {
 		t.Errorf("second run updated %d, want 0", updated)
 	}
+}
+
+// coldCacheReader stands in for a cache-backed client.Reader that has not been
+// populated: List answers with an empty set and no error. The backfill stops
+// after one successful pass, so reading through such a client would leave
+// every legacy Organization with an empty spec.catalogEntryCreation — which
+// now reads as "admin", silently taking provider registration away from
+// members. The runnable therefore lists through mgr.GetAPIReader().
+type coldCacheReader struct {
+	client.Reader
+	lists int
+}
+
+func (r *coldCacheReader) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	r.lists++
+	orgs, ok := list.(*tenancyv1alpha1.OrganizationList)
+	if !ok {
+		return fmt.Errorf("unexpected list type %T", list)
+	}
+	orgs.Items = nil
+	return nil
+}
+
+func TestBackfillCatalogEntryCreationDependsOnTheReaderNotACache(t *testing.T) {
+	legacy := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "legacy-unset"},
+		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "Legacy"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(legacy).
+		Build()
+	ctx := context.Background()
+
+	// A cold cache reports success with nothing in it, and the caller cannot
+	// tell that apart from an empty cluster — which is exactly why the
+	// runnable must not use one.
+	cold := &coldCacheReader{}
+	updated, err := BackfillCatalogEntryCreation(ctx, cold, c)
+	if err != nil || updated != 0 {
+		t.Fatalf("cold read = %d, %v; want 0, nil (the failure mode being guarded against)", updated, err)
+	}
+	var org tenancyv1alpha1.Organization
+	if err := c.Get(ctx, types.NamespacedName{Name: "legacy-unset"}, &org); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if org.Spec.CatalogEntryCreation != "" {
+		t.Fatalf("cold read migrated %q; the test's premise is wrong", org.Spec.CatalogEntryCreation)
+	}
+
+	// The live reader sees it and pins the pre-flip behaviour.
+	updated, err = BackfillCatalogEntryCreation(ctx, c, c)
+	if err != nil {
+		t.Fatalf("live backfill: %v", err)
+	}
+	if updated != 1 {
+		t.Fatalf("live backfill updated %d, want 1", updated)
+	}
+	if err := c.Get(ctx, types.NamespacedName{Name: "legacy-unset"}, &org); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if org.Spec.CatalogEntryCreation != tenancyv1alpha1.CatalogEntryCreationMembers {
+		t.Errorf("catalogEntryCreation = %q, want members", org.Spec.CatalogEntryCreation)
+	}
+	if org.Annotations[AnnotationCatalogEntryCreationMigrated] == "" {
+		t.Error("migrated annotation not stamped")
+	}
+}
+
+// A List error must not be mistaken for "nothing to do": the runnable's poll
+// keeps retrying until a pass actually succeeds.
+func TestBackfillCatalogEntryCreationRetriesOnListError(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
+	if _, err := BackfillCatalogEntryCreation(context.Background(), failingReader{}, c); err == nil {
+		t.Fatal("a failed list reported success; the backfill would exit without visiting anything")
+	}
+}
+
+type failingReader struct{ client.Reader }
+
+func (failingReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return fmt.Errorf("apiserver unavailable")
 }

--- a/pkg/hub/controllers/organization/catalog_entry_creation_migration_test.go
+++ b/pkg/hub/controllers/organization/catalog_entry_creation_migration_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package organization
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
+)
+
+// Organizations created before catalogEntryCreation defaulted to admin relied
+// on an empty field meaning "members". The backfill pins that reading onto
+// them explicitly, once, and leaves every other Organization's choice alone.
+func TestBackfillCatalogEntryCreation(t *testing.T) {
+	legacyUnset := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "legacy-unset"},
+		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "Legacy"},
+	}
+	legacyAdmin := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "legacy-admin"},
+		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "Locked", CatalogEntryCreation: tenancyv1alpha1.CatalogEntryCreationAdmin},
+	}
+	alreadyMigrated := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "migrated",
+			Annotations: map[string]string{AnnotationCatalogEntryCreationMigrated: "2026-09-01T00:00:00Z"},
+		},
+		// Unset AND annotated: created after the flip by something that
+		// stamped it, so the empty field genuinely means admin now. The
+		// backfill must not rewrite it to members.
+		Spec: tenancyv1alpha1.OrganizationSpec{DisplayName: "New"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(legacyUnset, legacyAdmin, alreadyMigrated).
+		Build()
+	ctx := context.Background()
+
+	updated, err := BackfillCatalogEntryCreation(ctx, c)
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if updated != 2 {
+		t.Fatalf("updated = %d, want 2 (the two unannotated Organizations)", updated)
+	}
+
+	get := func(name string) tenancyv1alpha1.Organization {
+		var org tenancyv1alpha1.Organization
+		if err := c.Get(ctx, types.NamespacedName{Name: name}, &org); err != nil {
+			t.Fatalf("get %s: %v", name, err)
+		}
+		return org
+	}
+	if got := get("legacy-unset"); got.Spec.CatalogEntryCreation != tenancyv1alpha1.CatalogEntryCreationMembers || got.Annotations[AnnotationCatalogEntryCreationMigrated] == "" {
+		t.Errorf("legacy-unset = %q / %v, want members pinned and annotated", got.Spec.CatalogEntryCreation, got.Annotations)
+	}
+	if got := get("legacy-admin"); got.Spec.CatalogEntryCreation != tenancyv1alpha1.CatalogEntryCreationAdmin || got.Annotations[AnnotationCatalogEntryCreationMigrated] == "" {
+		t.Errorf("legacy-admin = %q / %v, want admin kept and annotated", got.Spec.CatalogEntryCreation, got.Annotations)
+	}
+	if got := get("migrated"); got.Spec.CatalogEntryCreation != "" || got.Annotations[AnnotationCatalogEntryCreationMigrated] != "2026-09-01T00:00:00Z" {
+		t.Errorf("migrated = %q / %v, want untouched", got.Spec.CatalogEntryCreation, got.Annotations)
+	}
+
+	// Idempotent: a second run finds nothing to do.
+	updated, err = BackfillCatalogEntryCreation(ctx, c)
+	if err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if updated != 0 {
+		t.Errorf("second run updated %d, want 0", updated)
+	}
+}

--- a/pkg/hub/controllers/organization/controller.go
+++ b/pkg/hub/controllers/organization/controller.go
@@ -161,6 +161,11 @@ func SetupWithManager(mgr manager.Manager, provisioner WorkspaceProvisioner) err
 		provisioner: provisioner,
 	}
 	klog.Info("Registering organization bootstrap controller")
+	// One-time backfill for the catalogEntryCreation default flip; see
+	// catalog_entry_creation_migration.go.
+	if err := mgr.Add(catalogEntryCreationBackfill(mgr)); err != nil {
+		return fmt.Errorf("registering catalogEntryCreation backfill: %w", err)
+	}
 	return builder.ControllerManagedBy(mgr).
 		Named(controllerName).
 		For(&tenancyv1alpha1.User{}).
@@ -305,10 +310,14 @@ func (r *Reconciler) createPersonalOrg(ctx context.Context, user *tenancyv1alpha
 			},
 		},
 		Spec: tenancyv1alpha1.OrganizationSpec{
-			DisplayName:          displayName,
-			Personal:             true,
-			WorkspaceCreation:    tenancyv1alpha1.WorkspaceCreationMembers,
-			CatalogEntryCreation: tenancyv1alpha1.CatalogEntryCreationMembers,
+			DisplayName:       displayName,
+			Personal:          true,
+			WorkspaceCreation: tenancyv1alpha1.WorkspaceCreationMembers,
+			// Admin-only, the platform default: registering a provider hands
+			// out a cluster-admin credential and routes the Org's traffic to
+			// it. The owner is the personal Org's admin, so this costs them
+			// nothing and keeps anyone they later invite from registering.
+			CatalogEntryCreation: tenancyv1alpha1.CatalogEntryCreationAdmin,
 		},
 	}
 	if err := r.client.Create(ctx, org); err != nil {

--- a/pkg/hub/provider_tenant_resolver.go
+++ b/pkg/hub/provider_tenant_resolver.go
@@ -229,9 +229,21 @@ func (r *kcpTenantResolver) resolveWorkloadServiceAccount(req *http.Request) (st
 	}
 	tenantPath := workspacePathRoot + ":" + orgUUID + ":" + wsUUID
 	cfg := r.workloadConfig.ChildWorkspaceConfig(orgUUID, wsUUID)
-	username, err := serviceaccounts.VerifyWorkloadServiceAccount(req.Context(), cfg, token, tenantPath)
+	username, sa, err := serviceaccounts.VerifyWorkloadServiceAccountDetails(req.Context(), cfg, token, tenantPath)
 	if err != nil {
 		return "", "", err
+	}
+	// A delegated user token (the credential the backend proxy hands an
+	// org-owned provider in place of the caller's bearer) stands in for a
+	// person. Surface the person as X-Faros-User, so a provider calling back
+	// into the hub with it attributes the work to the user, not to the
+	// faros-du-* account. The tenant binding was verified above.
+	if serviceaccounts.IsDelegatedUserServiceAccount(sa) {
+		identity, err := serviceaccounts.DelegatedUserFromServiceAccount(sa)
+		if err != nil {
+			return "", "", err
+		}
+		return identity.User, tenantPath, nil
 	}
 	return username, tenantPath, nil
 }

--- a/pkg/hub/provider_tenant_resolver.go
+++ b/pkg/hub/provider_tenant_resolver.go
@@ -76,6 +76,11 @@ type kcpTenantResolver struct {
 	// workloadConfig enables online verification of Faros-audience workload
 	// tokens in the concrete tenant selected by X-Faros-Org/Workspace.
 	workloadConfig serviceaccounts.WorkspaceConfigBuilder
+	// proofKeys yields the key that establishes a delegated user identity.
+	// Nil rejects every delegated token: the identity annotations on those
+	// accounts are written inside the tenant's own workspace and prove
+	// nothing on their own.
+	proofKeys serviceaccounts.ProofKeySource
 
 	mu  sync.RWMutex
 	hot map[string]kcpResolverEntry
@@ -95,17 +100,16 @@ const kcpResolverTTL = 5 * time.Minute
 // for unauthenticated requests; the backend proxy maps that to
 // "forward without injecting X-Faros-*" so anonymous /healthz reads
 // keep working.
-func newKCPTenantResolver(kcpProxy *kcpproxy.KCPProxy, client *farosclient.Client, workloadConfig ...serviceaccounts.WorkspaceConfigBuilder) providers.TenantResolver {
+func newKCPTenantResolver(kcpProxy *kcpproxy.KCPProxy, client *farosclient.Client, workloadConfig serviceaccounts.WorkspaceConfigBuilder, proofKeys serviceaccounts.ProofKeySource) providers.TenantResolver {
 	r := &kcpTenantResolver{
-		kcpProxy: kcpProxy,
-		client:   client,
-		hot:      make(map[string]kcpResolverEntry),
+		kcpProxy:       kcpProxy,
+		client:         client,
+		workloadConfig: workloadConfig,
+		proofKeys:      proofKeys,
+		hot:            make(map[string]kcpResolverEntry),
 	}
 	if kcpProxy != nil {
 		r.identifyUser = kcpProxy.IdentifyUser
-	}
-	if len(workloadConfig) > 0 {
-		r.workloadConfig = workloadConfig[0]
 	}
 	return providers.TenantResolverFunc(r.resolve)
 }
@@ -229,7 +233,7 @@ func (r *kcpTenantResolver) resolveWorkloadServiceAccount(req *http.Request) (st
 	}
 	tenantPath := workspacePathRoot + ":" + orgUUID + ":" + wsUUID
 	cfg := r.workloadConfig.ChildWorkspaceConfig(orgUUID, wsUUID)
-	username, sa, err := serviceaccounts.VerifyWorkloadServiceAccountDetails(req.Context(), cfg, token, tenantPath)
+	username, sa, err := serviceaccounts.VerifyWorkloadServiceAccountDetails(req.Context(), cfg, token, tenantPath, r.proofKeys)
 	if err != nil {
 		return "", "", err
 	}
@@ -237,9 +241,11 @@ func (r *kcpTenantResolver) resolveWorkloadServiceAccount(req *http.Request) (st
 	// org-owned provider in place of the caller's bearer) stands in for a
 	// person. Surface the person as X-Faros-User, so a provider calling back
 	// into the hub with it attributes the work to the user, not to the
-	// faros-du-* account. The tenant binding was verified above.
+	// faros-du-* account. The tenant binding was verified above, and so was
+	// the hub's keyed proof — without it this account is just an object any
+	// workspace member could have written, naming anyone they chose.
 	if serviceaccounts.IsDelegatedUserServiceAccount(sa) {
-		identity, err := serviceaccounts.DelegatedUserFromServiceAccount(sa)
+		identity, err := serviceaccounts.DelegatedUserFromServiceAccount(req.Context(), r.proofKeys, sa)
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/hub/provider_tenant_resolver_test.go
+++ b/pkg/hub/provider_tenant_resolver_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hub
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -26,7 +28,9 @@ import (
 	"testing"
 
 	authnv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 
 	"github.com/faroshq/faros/pkg/hub/serviceaccounts"
@@ -44,39 +48,57 @@ func (b *resolverConfigBuilder) ChildWorkspaceConfig(orgUUID, wsUUID string) *re
 	return b.cfg
 }
 
+// resolverProofKeys is the delegated-identity signing key the resolver tests
+// verify against. Production reads it from a Secret in a hub-internal kcp
+// workspace; a tenant never sees it, which is the whole point.
+var resolverProofKeys = serviceaccounts.StaticProofKeySource(bytes.Repeat([]byte{0x11}, 32))
+
 type workloadResolverRoundTripper struct {
 	token, serviceAccount, tenantPath string
 	// delegatedUser, when set, makes the ServiceAccount a delegated user
 	// identity standing in for that user instead of a workload identity.
 	delegatedUser string
+	// forged builds the delegated account exactly as a tenant member would:
+	// every field the hub writes except the one it cannot, the keyed proof.
+	forged bool
 }
 
-func (rt workloadResolverRoundTripper) serviceAccountObject() map[string]any {
-	labels := map[string]string{serviceaccounts.LabelWorkloadIdentity: "true"}
-	annotations := map[string]string{serviceaccounts.AnnotationWorkloadIdentityTenantPath: rt.tenantPath}
-	if rt.delegatedUser != "" {
-		labels[serviceaccounts.LabelDelegatedUser] = "true"
-		rest := strings.TrimPrefix(rt.tenantPath, workspacePathRoot+":")
-		org, ws, _ := strings.Cut(rest, ":")
-		annotations[serviceaccounts.AnnotationDelegatedUser] = rt.delegatedUser
-		annotations[serviceaccounts.AnnotationDelegatedOrg] = org
-		annotations[serviceaccounts.AnnotationDelegatedWorkspace] = ws
-		annotations[serviceaccounts.AnnotationDelegatedProvider] = "infrastructure"
-	} else {
-		annotations[serviceaccounts.AnnotationWorkloadIdentityScope] = strings.Repeat("0", 64)
-		annotations[serviceaccounts.AnnotationWorkloadIdentityProject] = "project"
-		annotations[serviceaccounts.AnnotationWorkloadIdentityProjectUID] = "project-uid"
-		annotations[serviceaccounts.AnnotationWorkloadIdentityEnvironment] = "development"
-		annotations[serviceaccounts.AnnotationWorkloadIdentityInstance] = "project-dev"
-	}
-	return map[string]any{
-		"apiVersion": "v1", "kind": "ServiceAccount",
-		"metadata": map[string]any{
-			"name": rt.serviceAccount, "namespace": serviceaccounts.Namespace,
-			"labels":      labels,
-			"annotations": annotations,
+func (rt workloadResolverRoundTripper) serviceAccountObject() *corev1.ServiceAccount {
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rt.serviceAccount, Namespace: serviceaccounts.Namespace,
+			UID:         "uid-" + types.UID(rt.serviceAccount),
+			Labels:      map[string]string{serviceaccounts.LabelWorkloadIdentity: "true"},
+			Annotations: map[string]string{serviceaccounts.AnnotationWorkloadIdentityTenantPath: rt.tenantPath},
 		},
 	}
+	if rt.delegatedUser != "" {
+		sa.Labels[serviceaccounts.LabelDelegatedUser] = "true"
+		rest := strings.TrimPrefix(rt.tenantPath, workspacePathRoot+":")
+		org, ws, _ := strings.Cut(rest, ":")
+		sa.Annotations[serviceaccounts.AnnotationDelegatedUser] = rt.delegatedUser
+		sa.Annotations[serviceaccounts.AnnotationDelegatedOrg] = org
+		sa.Annotations[serviceaccounts.AnnotationDelegatedWorkspace] = ws
+		sa.Annotations[serviceaccounts.AnnotationDelegatedProvider] = "infrastructure"
+		if !rt.forged {
+			key, err := resolverProofKeys.DelegatedProofKey(context.Background())
+			if err != nil {
+				panic(err)
+			}
+			if err := serviceaccounts.SignDelegatedUserServiceAccount(key, sa, rt.tenantPath,
+				serviceaccounts.Identity{User: rt.delegatedUser}, "infrastructure"); err != nil {
+				panic(err)
+			}
+		}
+	} else {
+		sa.Annotations[serviceaccounts.AnnotationWorkloadIdentityScope] = strings.Repeat("0", 64)
+		sa.Annotations[serviceaccounts.AnnotationWorkloadIdentityProject] = "project"
+		sa.Annotations[serviceaccounts.AnnotationWorkloadIdentityProjectUID] = "project-uid"
+		sa.Annotations[serviceaccounts.AnnotationWorkloadIdentityEnvironment] = "development"
+		sa.Annotations[serviceaccounts.AnnotationWorkloadIdentityInstance] = "project-dev"
+	}
+	return sa
 }
 
 func (rt workloadResolverRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -176,6 +198,7 @@ func TestKCPTenantResolverResolvesDelegatedUserTokenToTheHumanUser(t *testing.T)
 	}}
 	r := &kcpTenantResolver{
 		workloadConfig: builder,
+		proofKeys:      resolverProofKeys,
 		identifyUser: func(*http.Request) (string, error) {
 			return "system:serviceaccount:default:" + serviceAccount, nil
 		},
@@ -204,6 +227,61 @@ func TestKCPTenantResolverResolvesDelegatedUserTokenToTheHumanUser(t *testing.T)
 	other.Header.Set(headerFarosWorkspace, "other-workspace")
 	if _, _, err := r.resolve(other); err == nil {
 		t.Fatal("delegated token accepted for a workspace it was not minted in")
+	}
+}
+
+// A delegated ServiceAccount lives in namespace "default" of the tenant's own
+// team workspace, where the bootstrap binds every member — not just admins —
+// to cluster-admin. So an ordinary member can create the object themselves,
+// label it delegated, annotate it with a colleague's username, and mint a
+// token for it with TokenRequest. The resolver must refuse it: without the
+// hub's keyed proof, nothing on that object distinguishes it from one the hub
+// minted, and accepting it would send the provider X-Faros-User naming the
+// victim.
+func TestKCPTenantResolverRejectsTenantForgedDelegatedServiceAccount(t *testing.T) {
+	const token = "attacker-minted-token"
+	const serviceAccount = "faros-du-forged"
+	const tenantPath = "root:faros:tenants:org:workspace"
+	builder := &resolverConfigBuilder{cfg: &rest.Config{
+		Host: "https://workload.test",
+		Transport: workloadResolverRoundTripper{
+			token: token, serviceAccount: serviceAccount, tenantPath: tenantPath,
+			delegatedUser: "victim@example.com", forged: true,
+		},
+	}}
+	r := &kcpTenantResolver{
+		workloadConfig: builder,
+		proofKeys:      resolverProofKeys,
+		identifyUser: func(*http.Request) (string, error) {
+			return "system:serviceaccount:default:" + serviceAccount, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/services/providers/infrastructure/x", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set(headerFarosOrg, "org")
+	req.Header.Set(headerFarosWorkspace, "workspace")
+	user, gotPath, err := r.resolve(req)
+	if err == nil {
+		t.Fatalf("a tenant-forged delegated ServiceAccount resolved as %q in %q", user, gotPath)
+	}
+
+	// A hub with no proof key configured must also refuse rather than fall
+	// back to reading the annotations.
+	unkeyed := &kcpTenantResolver{
+		workloadConfig: &resolverConfigBuilder{cfg: &rest.Config{
+			Host: "https://workload.test",
+			Transport: workloadResolverRoundTripper{
+				token: token, serviceAccount: serviceAccount, tenantPath: tenantPath,
+				delegatedUser: "victim@example.com",
+			},
+		}},
+		identifyUser: func(*http.Request) (string, error) {
+			return "system:serviceaccount:default:" + serviceAccount, nil
+		},
+	}
+	if user, _, err := unkeyed.resolve(req); err == nil {
+		t.Fatalf("a delegated token resolved as %q with no proof key source", user)
 	}
 }
 

--- a/pkg/hub/provider_tenant_resolver_test.go
+++ b/pkg/hub/provider_tenant_resolver_test.go
@@ -46,6 +46,37 @@ func (b *resolverConfigBuilder) ChildWorkspaceConfig(orgUUID, wsUUID string) *re
 
 type workloadResolverRoundTripper struct {
 	token, serviceAccount, tenantPath string
+	// delegatedUser, when set, makes the ServiceAccount a delegated user
+	// identity standing in for that user instead of a workload identity.
+	delegatedUser string
+}
+
+func (rt workloadResolverRoundTripper) serviceAccountObject() map[string]any {
+	labels := map[string]string{serviceaccounts.LabelWorkloadIdentity: "true"}
+	annotations := map[string]string{serviceaccounts.AnnotationWorkloadIdentityTenantPath: rt.tenantPath}
+	if rt.delegatedUser != "" {
+		labels[serviceaccounts.LabelDelegatedUser] = "true"
+		rest := strings.TrimPrefix(rt.tenantPath, workspacePathRoot+":")
+		org, ws, _ := strings.Cut(rest, ":")
+		annotations[serviceaccounts.AnnotationDelegatedUser] = rt.delegatedUser
+		annotations[serviceaccounts.AnnotationDelegatedOrg] = org
+		annotations[serviceaccounts.AnnotationDelegatedWorkspace] = ws
+		annotations[serviceaccounts.AnnotationDelegatedProvider] = "infrastructure"
+	} else {
+		annotations[serviceaccounts.AnnotationWorkloadIdentityScope] = strings.Repeat("0", 64)
+		annotations[serviceaccounts.AnnotationWorkloadIdentityProject] = "project"
+		annotations[serviceaccounts.AnnotationWorkloadIdentityProjectUID] = "project-uid"
+		annotations[serviceaccounts.AnnotationWorkloadIdentityEnvironment] = "development"
+		annotations[serviceaccounts.AnnotationWorkloadIdentityInstance] = "project-dev"
+	}
+	return map[string]any{
+		"apiVersion": "v1", "kind": "ServiceAccount",
+		"metadata": map[string]any{
+			"name": rt.serviceAccount, "namespace": serviceaccounts.Namespace,
+			"labels":      labels,
+			"annotations": annotations,
+		},
+	}
 }
 
 func (rt workloadResolverRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -79,21 +110,7 @@ func (rt workloadResolverRoundTripper) RoundTrip(r *http.Request) (*http.Respons
 			},
 		})
 	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/namespaces/default/serviceaccounts/"+rt.serviceAccount:
-		return response(http.StatusOK, map[string]any{
-			"apiVersion": "v1", "kind": "ServiceAccount",
-			"metadata": map[string]any{
-				"name": rt.serviceAccount, "namespace": serviceaccounts.Namespace,
-				"labels": map[string]string{serviceaccounts.LabelWorkloadIdentity: "true"},
-				"annotations": map[string]string{
-					serviceaccounts.AnnotationWorkloadIdentityTenantPath:  rt.tenantPath,
-					serviceaccounts.AnnotationWorkloadIdentityScope:       strings.Repeat("0", 64),
-					serviceaccounts.AnnotationWorkloadIdentityProject:     "project",
-					serviceaccounts.AnnotationWorkloadIdentityProjectUID:  "project-uid",
-					serviceaccounts.AnnotationWorkloadIdentityEnvironment: "development",
-					serviceaccounts.AnnotationWorkloadIdentityInstance:    "project-dev",
-				},
-			},
-		})
+		return response(http.StatusOK, rt.serviceAccountObject())
 	default:
 		return response(http.StatusNotFound, map[string]string{"error": "not found"})
 	}
@@ -139,6 +156,54 @@ func TestKCPTenantResolverRoutesServiceAccountIdentityThroughWorkloadVerificatio
 				t.Fatalf("workspace config selected %q/%q", builder.gotOrg, builder.gotWS)
 			}
 		})
+	}
+}
+
+// A delegated user token — what the backend proxy hands an org-owned provider
+// in place of the caller's bearer — resolves to the HUMAN it stands in for,
+// so a provider calling back into the hub with it gets X-Faros-User=alice, not
+// the faros-du-* account name, and the same tenant binding every workload
+// token is held to.
+func TestKCPTenantResolverResolvesDelegatedUserTokenToTheHumanUser(t *testing.T) {
+	const token = "delegated-token"
+	const serviceAccount = "faros-du-test"
+	const tenantPath = "root:faros:tenants:org:workspace"
+	builder := &resolverConfigBuilder{cfg: &rest.Config{
+		Host: "https://workload.test",
+		Transport: workloadResolverRoundTripper{
+			token: token, serviceAccount: serviceAccount, tenantPath: tenantPath, delegatedUser: "alice",
+		},
+	}}
+	r := &kcpTenantResolver{
+		workloadConfig: builder,
+		identifyUser: func(*http.Request) (string, error) {
+			return "system:serviceaccount:default:" + serviceAccount, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/services/providers/infrastructure/x", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set(headerFarosOrg, "org")
+	req.Header.Set(headerFarosWorkspace, "workspace")
+	user, gotPath, err := r.resolve(req)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if user != "alice" || gotPath != tenantPath {
+		t.Fatalf("resolved identity = %q/%q, want alice/%s", user, gotPath, tenantPath)
+	}
+	if builder.gotOrg != "org" || builder.gotWS != "workspace" {
+		t.Fatalf("workspace config selected %q/%q", builder.gotOrg, builder.gotWS)
+	}
+
+	// The token is bound to the workspace it was minted in; another
+	// selection is refused exactly as it is for a workload token.
+	other := httptest.NewRequest(http.MethodGet, "/services/providers/infrastructure/x", nil)
+	other.Header.Set("Authorization", "Bearer "+token)
+	other.Header.Set(headerFarosOrg, "org")
+	other.Header.Set(headerFarosWorkspace, "other-workspace")
+	if _, _, err := r.resolve(other); err == nil {
+		t.Fatal("delegated token accepted for a workspace it was not minted in")
 	}
 }
 

--- a/pkg/hub/providers/api.go
+++ b/pkg/hub/providers/api.go
@@ -53,8 +53,13 @@ type providerDTO struct {
 	// users can tell what their own organization operates from what faros does.
 	Scope string `json:"scope"`
 	// OwnerOrg is the owning Org's UUID for Scope=="org", empty for global.
-	OwnerOrg    string `json:"ownerOrg,omitempty"`
-	DisplayName string `json:"displayName"`
+	OwnerOrg string `json:"ownerOrg,omitempty"`
+	// ShadowsPlatform is true for an org-owned provider whose name matches a
+	// platform provider: the Org's copy is what its users reach, and the
+	// platform one is hidden from this catalog. The portal badges it so the
+	// override is visible rather than silent.
+	ShadowsPlatform bool   `json:"shadowsPlatform,omitempty"`
+	DisplayName     string `json:"displayName"`
 	// Description is CatalogEntry.spec.description — the one-line "what is
 	// this" the portal shows on catalog cards and in the first-run welcome
 	// flow. Empty for entries that declare none.
@@ -351,6 +356,7 @@ func listHandlerFunc(reg *Registry) http.Handler {
 				Name:             p.Name,
 				Scope:            scope,
 				OwnerOrg:         p.OrgUUID,
+				ShadowsPlatform:  p.ShadowsPlatform,
 				DisplayName:      displayName,
 				Description:      p.Description,
 				Version:          p.Version,

--- a/pkg/hub/providers/proxy.go
+++ b/pkg/hub/providers/proxy.go
@@ -89,8 +89,10 @@ func (f TenantResolverFunc) Resolve(r *http.Request) (string, string, error) {
 }
 
 // NewBackendProxy returns an http.Handler serving /services/providers/{name}/*
-// by reverse proxying to the provider's spec.backend.url. The user's
-// Authorization header is forwarded as-is. If a TenantResolver is
+// by reverse proxying to the provider's spec.backend.url. For a platform
+// provider the user's Authorization header is forwarded as-is; for an
+// org-owned provider it is replaced with a short-lived delegated token (see
+// serveOverEdge and SetDelegatedTokenIssuer). If a TenantResolver is
 // installed via SetTenantResolver, the proxy resolves the caller's
 // identity and injects X-Faros-User + X-Faros-Tenant so the provider can
 // scope work without re-parsing the bearer token. Incoming
@@ -123,7 +125,7 @@ func NewBackendProxy(reg *Registry, log logr.Logger) *ProviderProxy {
 			p.log.V(2).Info("no tenant resolver wired; forwarding without X-Faros-* headers", "provider", name)
 			return
 		}
-		user, tenantPath, err := p.tenantResolver.Resolve(req)
+		user, tenantPath, err := p.resolveCaller(req)
 		if err != nil {
 			// Anonymous (no bearer) is common on /healthz probes
 			// and isn't worth screaming about — keep at V(2). Real
@@ -166,6 +168,42 @@ func NewBackendProxy(reg *Registry, log logr.Logger) *ProviderProxy {
 		}
 	}
 	return p
+}
+
+// resolvedCallerKey memoizes one tenant resolution per request in its context.
+// The backend proxy needs the caller's identity at three points on the
+// org-provider path — scope resolution, delegated-token issuance, and header
+// injection — and each resolution costs a token verify plus an apiserver
+// round-trip, so it is done once in ServeHTTP and read back here.
+type resolvedCallerKey struct{}
+
+type resolvedCaller struct {
+	user, tenantPath string
+	err              error
+}
+
+// resolveCaller returns the caller's identity for req, from the request
+// context when ServeHTTP already resolved it and from the tenant resolver
+// otherwise. httputil.ReverseProxy clones the outbound request with the
+// inbound context, so the Director sees the same memo.
+func (p *ProviderProxy) resolveCaller(req *http.Request) (string, string, error) {
+	if memo, ok := req.Context().Value(resolvedCallerKey{}).(resolvedCaller); ok {
+		return memo.user, memo.tenantPath, memo.err
+	}
+	if p.tenantResolver == nil {
+		return "", "", errors.New("tenant resolver unavailable")
+	}
+	return p.tenantResolver.Resolve(req)
+}
+
+// withResolvedCaller resolves the caller once and stores the outcome — error
+// included, so a failed resolution is not retried per consumer — on r.
+func (p *ProviderProxy) withResolvedCaller(r *http.Request) *http.Request {
+	if p.tenantResolver == nil {
+		return r
+	}
+	user, tenantPath, err := p.tenantResolver.Resolve(r)
+	return r.WithContext(context.WithValue(r.Context(), resolvedCallerKey{}, resolvedCaller{user: user, tenantPath: tenantPath, err: err}))
 }
 
 // SetTenantResolver installs the resolver used to populate
@@ -218,6 +256,12 @@ type ProviderProxy struct {
 	// per-cluster schema lookup only matches a cluster ID. See
 	// SetClusterResolver.
 	clusterResolver func(ctx context.Context, tenantPath string) (string, error)
+
+	// delegatedIssuer mints the token that replaces the caller's bearer on
+	// requests to org-owned providers. Nil means the org-provider path fails
+	// closed: the hub never forwards a user's hub token into a tenant's
+	// cluster. See SetDelegatedTokenIssuer and serveOverEdge.
+	delegatedIssuer DelegatedTokenIssuer
 
 	// denyHubOnlyEndpoints reserves the hub-only path prefixes on a
 	// provider's backend origin. Provider action routes (/actions/*) are a
@@ -277,6 +321,12 @@ func (p *ProviderProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//
 	// UI proxy stays platform-scoped: it serves static assets, and an org's
 	// bundle is not something the hub hosts.
+	//
+	// Resolve the caller once here; resolveProvider, the delegated-token
+	// path, and setHeaders all read the memo (see resolveCaller).
+	if !p.fallbackForSPA {
+		r = p.withResolvedCaller(r)
+	}
 	prov, found := p.resolveProvider(r, name)
 	if !found {
 		http.Error(w, "provider not found: "+name, http.StatusNotFound)

--- a/pkg/hub/providers/proxy_edge.go
+++ b/pkg/hub/providers/proxy_edge.go
@@ -11,12 +11,39 @@ You may obtain a copy of the License at
 package providers
 
 import (
+	"context"
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"time"
 
+	"github.com/faroshq/faros/pkg/hub/serviceaccounts"
 	"github.com/faroshq/faros/pkg/kcppaths"
 )
+
+// DelegatedTokenIssuer mints the credential the hub sends to an org-owned
+// provider in place of the caller's own hub bearer: a ServiceAccount token in
+// the caller's tenant workspace, annotated with the human user it stands in
+// for. Implemented by *serviceaccounts.Manager.
+type DelegatedTokenIssuer interface {
+	IssueDelegatedUserToken(ctx context.Context, orgUUID, wsUUID string, user serviceaccounts.Identity, providerName string) (string, time.Time, error)
+}
+
+// DelegatedTokenIssuerFunc adapts a plain function to DelegatedTokenIssuer.
+type DelegatedTokenIssuerFunc func(ctx context.Context, orgUUID, wsUUID string, user serviceaccounts.Identity, providerName string) (string, time.Time, error)
+
+// IssueDelegatedUserToken satisfies DelegatedTokenIssuer.
+func (f DelegatedTokenIssuerFunc) IssueDelegatedUserToken(ctx context.Context, orgUUID, wsUUID string, user serviceaccounts.Identity, providerName string) (string, time.Time, error) {
+	return f(ctx, orgUUID, wsUUID, user, providerName)
+}
+
+// SetDelegatedTokenIssuer installs the issuer used on the org-owned provider
+// path. Wire alongside SetTenantResolver. Without one, every authenticated
+// request to an org-owned provider is refused rather than forwarded with the
+// caller's hub token.
+func (p *ProviderProxy) SetDelegatedTokenIssuer(i DelegatedTokenIssuer) {
+	p.delegatedIssuer = i
+}
 
 // Org-scoped resolution and edge-fronted transport for the backend proxy.
 //
@@ -51,16 +78,88 @@ func (p *ProviderProxy) resolveProvider(r *http.Request, name string) (Provider,
 // resolution in that case, which is the pre-existing behaviour: unresolvable
 // identity must not silently widen what a request can reach.
 func (p *ProviderProxy) callerOrgUUID(r *http.Request) string {
-	_, tenantPath, err := p.tenantResolver.Resolve(r)
+	_, tenantPath, err := p.resolveCaller(r)
 	if err != nil || tenantPath == "" {
 		return ""
 	}
+	orgUUID, _ := splitTenantPath(tenantPath)
+	return orgUUID
+}
+
+// splitTenantPath takes root:faros:tenants:{org}[:{ws}] apart. Both results
+// are empty when the path is not under the tenants parent; ws is empty for an
+// org-scope path.
+func splitTenantPath(tenantPath string) (orgUUID, wsUUID string) {
 	rest := strings.TrimPrefix(tenantPath, kcppaths.TenantsParent+":")
 	if rest == tenantPath {
+		return "", ""
+	}
+	orgUUID, wsUUID, _ = strings.Cut(rest, ":")
+	return orgUUID, wsUUID
+}
+
+// delegatedAuthorization decides what Authorization an org-owned provider
+// receives for r, writing the response itself when the request must not go
+// on. It returns the delegated bearer, or "" for an anonymous caller (whose
+// request carried nothing to substitute), and whether to proceed.
+//
+// This is the boundary the whole file exists to hold: the far end of the
+// tunnel is a workload in a tenant's cluster, installed by whichever member
+// registered it, so the caller's own hub token — good for every workspace and
+// every REST endpoint they can reach — must never cross it. What crosses
+// instead is a ServiceAccount token scoped by kcp to the caller's current
+// workspace, carrying the caller's name in annotations for the provider to
+// attribute the call. Every failure here is closed: no identity, no
+// workspace, no issuer, or a mint error all refuse rather than fall back to
+// forwarding the bearer.
+func (p *ProviderProxy) delegatedAuthorization(w http.ResponseWriter, r *http.Request, prov Provider) (string, bool) {
+	if strings.TrimSpace(r.Header.Get("Authorization")) == "" {
+		// Anonymous probe (health checks). There is no credential to
+		// protect; the provider sees an unauthenticated request, as today.
+		return "", true
+	}
+	user, tenantPath, err := p.resolveCaller(r)
+	if err != nil || user == "" {
+		p.log.Info("refusing org-owned provider request: caller identity unresolved",
+			"provider", prov.Name, "org", prov.OrgUUID, "err", errString(err))
+		http.Error(w, "caller identity could not be established for provider: "+prov.Name, http.StatusForbidden)
+		return "", false
+	}
+	orgUUID, wsUUID := splitTenantPath(tenantPath)
+	if orgUUID == "" || orgUUID != prov.OrgUUID {
+		// resolveProvider picked this provider from the same resolution, so a
+		// mismatch means the memo is not what routed us. Refuse.
+		http.Error(w, "caller is not in the organization that owns provider: "+prov.Name, http.StatusForbidden)
+		return "", false
+	}
+	if wsUUID == "" {
+		// The delegated account lives in a team workspace; an org-scope
+		// resolution (no X-Faros-Workspace) has nowhere to mint it. The portal
+		// always sends the workspace header on provider calls.
+		http.Error(w, "a workspace selection (X-Faros-Workspace) is required to reach provider: "+prov.Name, http.StatusForbidden)
+		return "", false
+	}
+	if p.delegatedIssuer == nil {
+		p.log.Info("refusing org-owned provider request: no delegated token issuer wired",
+			"provider", prov.Name, "org", prov.OrgUUID)
+		http.Error(w, "delegated identity unavailable for provider: "+prov.Name, http.StatusServiceUnavailable)
+		return "", false
+	}
+	token, _, err := p.delegatedIssuer.IssueDelegatedUserToken(r.Context(), orgUUID, wsUUID, serviceaccounts.Identity{User: user}, prov.Name)
+	if err != nil {
+		p.log.Error(err, "issuing delegated user token",
+			"provider", prov.Name, "org", prov.OrgUUID, "workspace", wsUUID, "user", user)
+		http.Error(w, "delegated identity unavailable for provider: "+prov.Name, http.StatusServiceUnavailable)
+		return "", false
+	}
+	return token, true
+}
+
+func errString(err error) string {
+	if err == nil {
 		return ""
 	}
-	orgUUID, _, _ := strings.Cut(rest, ":")
-	return orgUUID
+	return err.Error()
 }
 
 // serveOverEdge forwards one request to an org-owned provider through the
@@ -70,6 +169,11 @@ func (p *ProviderProxy) callerOrgUUID(r *http.Request) string {
 // rewrites the target to the edges provider's backend and hands it the path its
 // handler expects. One less hop, and the caller's identity headers are injected
 // exactly once, by the same code that injects them for a platform provider.
+//
+// This is also the only route to an org-owned provider's backend — ServeHTTP
+// sends every provider with an OrgUUID here, and a missing edge route is a 503,
+// never a fallback to BackendURL — so the bearer substitution in
+// delegatedAuthorization covers every request such a provider can receive.
 func (p *ProviderProxy) serveOverEdge(w http.ResponseWriter, r *http.Request, prov Provider, rest string) {
 	route := prov.EdgeRoute
 	if !route.Usable() {
@@ -95,6 +199,11 @@ func (p *ProviderProxy) serveOverEdge(w http.ResponseWriter, r *http.Request, pr
 		return
 	}
 
+	delegated, ok := p.delegatedAuthorization(w, r, prov)
+	if !ok {
+		return
+	}
+
 	target := *edges.BackendURL
 	edgePath := route.EdgeProxyPath(rest)
 	basePath := p.pathPrefix + "/" + prov.Name
@@ -115,6 +224,13 @@ func (p *ProviderProxy) serveOverEdge(w http.ResponseWriter, r *http.Request, pr
 			// provider at the far end of the tunnel, and the agent forwards
 			// them untouched (E-6).
 			p.setHeaders(req, prov.Name, basePath)
+			// The caller's hub token stops here. What the tenant's cluster
+			// receives is the delegated ServiceAccount token, or nothing for
+			// an anonymous probe — never the bearer that arrived.
+			req.Header.Del("Authorization")
+			if delegated != "" {
+				req.Header.Set("Authorization", "Bearer "+delegated)
+			}
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			p.log.Error(err, "edge upstream error",

--- a/pkg/hub/providers/proxy_edge_test.go
+++ b/pkg/hub/providers/proxy_edge_test.go
@@ -11,30 +11,70 @@ You may obtain a copy of the License at
 package providers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
+
+	"github.com/faroshq/faros/pkg/hub/serviceaccounts"
 )
 
 const (
 	testOrg     = "86b7f9e7-6fa4-448f-a78f-36a3a5ab8dd9"
+	testWS      = "1f0f1f8c-2b7e-4c2a-9c9e-5b1c2d3e4f50"
 	testCluster = "260dym853j73uupr"
+
+	// callerBearer is the hub credential the browser sends. It must never
+	// reach an org-owned provider.
+	callerBearer   = "hub-oidc-token-of-alice"
+	delegatedToken = "delegated-sa-token"
 )
 
 // edgeUpstream stands in for the platform edges provider and records what the
 // hub asked it to do.
 type edgeUpstream struct {
-	hit    bool
-	path   string
-	user   string
-	tenant string
+	hit           bool
+	path          string
+	user          string
+	tenant        string
+	authorization string
+}
+
+// recordingIssuer is a DelegatedTokenIssuer that records what it was asked
+// for and hands back a fixed token.
+type recordingIssuer struct {
+	calls    int
+	org, ws  string
+	user     string
+	provider string
+	err      error
+}
+
+func (i *recordingIssuer) IssueDelegatedUserToken(_ context.Context, orgUUID, wsUUID string, user serviceaccounts.Identity, providerName string) (string, time.Time, error) {
+	i.calls++
+	i.org, i.ws, i.user, i.provider = orgUUID, wsUUID, user.User, providerName
+	if i.err != nil {
+		return "", time.Time{}, i.err
+	}
+	return delegatedToken, time.Now().Add(10 * time.Minute), nil
 }
 
 func newEdgeBackedProxy(t *testing.T, orgOfCaller string) (*ProviderProxy, *edgeUpstream) {
+	t.Helper()
+	proxy, rec := newEdgeBackedProxyWithTenant(t, orgOfCaller, testWS)
+	proxy.SetDelegatedTokenIssuer(&recordingIssuer{})
+	return proxy, rec
+}
+
+// newEdgeBackedProxyWithTenant builds the proxy without a delegated issuer,
+// resolving the caller to root:faros:tenants:{org}[:{ws}].
+func newEdgeBackedProxyWithTenant(t *testing.T, orgOfCaller, wsOfCaller string) (*ProviderProxy, *edgeUpstream) {
 	t.Helper()
 	rec := &edgeUpstream{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42,6 +82,7 @@ func newEdgeBackedProxy(t *testing.T, orgOfCaller string) (*ProviderProxy, *edge
 		rec.path = r.URL.Path
 		rec.user = r.Header.Get("X-Faros-User")
 		rec.tenant = r.Header.Get("X-Faros-Tenant")
+		rec.authorization = r.Header.Get("Authorization")
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
@@ -71,14 +112,21 @@ func newEdgeBackedProxy(t *testing.T, orgOfCaller string) (*ProviderProxy, *edge
 		if orgOfCaller == "" {
 			return "", "", errors.New("anonymous caller")
 		}
-		return "alice", "root:faros:tenants:" + orgOfCaller, nil
+		path := "root:faros:tenants:" + orgOfCaller
+		if wsOfCaller != "" {
+			path += ":" + wsOfCaller
+		}
+		return "alice", path, nil
 	}))
 	return proxy, rec
 }
 
+// serveProxy sends an authenticated request, the way the portal does.
 func serveProxy(p *ProviderProxy, path string) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
-	p.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	r.Header.Set("Authorization", "Bearer "+callerBearer)
+	p.ServeHTTP(w, r)
 	return w
 }
 
@@ -107,17 +155,166 @@ func TestBackendProxyRoutesOrgProviderOverItsEdge(t *testing.T) {
 
 // E-6: the provider at the far end authorizes the CALLER, so the identity the
 // hub injects has to be the caller's — and injected once, under the org
-// provider's name rather than the edges provider's.
+// provider's name rather than the edges provider's. The credential, though,
+// is not the caller's: it is a delegated token minted for exactly this
+// (workspace, user, provider), and the hub bearer that arrived never crosses.
 func TestBackendProxyEdgeRouteCarriesCallerIdentity(t *testing.T) {
-	proxy, rec := newEdgeBackedProxy(t, testOrg)
+	proxy, rec := newEdgeBackedProxyWithTenant(t, testOrg, testWS)
+	issuer := &recordingIssuer{}
+	proxy.SetDelegatedTokenIssuer(issuer)
 
-	serveProxy(proxy, "/services/providers/infrastructure/dataplane/clusters/x/apps/demo/log")
+	w := serveProxy(proxy, "/services/providers/infrastructure/dataplane/clusters/x/apps/demo/log")
 
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", w.Code, w.Body.String())
+	}
 	if rec.user != "alice" {
 		t.Errorf("X-Faros-User = %q, want alice — the far end cannot authorize without it", rec.user)
 	}
-	if rec.tenant != "root:faros:tenants:"+testOrg {
-		t.Errorf("X-Faros-Tenant = %q, want the caller's org path", rec.tenant)
+	if rec.tenant != "root:faros:tenants:"+testOrg+":"+testWS {
+		t.Errorf("X-Faros-Tenant = %q, want the caller's workspace path", rec.tenant)
+	}
+	if rec.authorization != "Bearer "+delegatedToken {
+		t.Errorf("Authorization = %q, want the delegated token", rec.authorization)
+	}
+	if strings.Contains(rec.authorization, callerBearer) {
+		t.Error("the caller's hub bearer reached the org-owned provider")
+	}
+	if issuer.calls != 1 || issuer.org != testOrg || issuer.ws != testWS || issuer.user != "alice" || issuer.provider != "infrastructure" {
+		t.Errorf("issuer asked for %+v, want (org=%s, ws=%s, user=alice, provider=infrastructure) once", issuer, testOrg, testWS)
+	}
+}
+
+// The property this whole change exists for, stated from the tenant's side:
+// whatever goes wrong on the hub, the caller's hub token is never what an
+// org-owned provider receives. Each failure refuses the request outright
+// rather than falling back to forwarding the bearer.
+func TestBackendProxyOrgProviderNeverSeesUserBearer(t *testing.T) {
+	const path = "/services/providers/infrastructure/dataplane/x"
+
+	t.Run("no issuer wired", func(t *testing.T) {
+		proxy, rec := newEdgeBackedProxyWithTenant(t, testOrg, testWS)
+		w := serveProxy(proxy, path)
+		if w.Code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", w.Code)
+		}
+		if rec.hit {
+			t.Fatalf("request forwarded with Authorization %q despite no issuer", rec.authorization)
+		}
+	})
+
+	t.Run("issuer fails", func(t *testing.T) {
+		proxy, rec := newEdgeBackedProxyWithTenant(t, testOrg, testWS)
+		proxy.SetDelegatedTokenIssuer(&recordingIssuer{err: errors.New("kcp unavailable")})
+		w := serveProxy(proxy, path)
+		if w.Code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", w.Code)
+		}
+		if rec.hit {
+			t.Fatalf("request forwarded with Authorization %q despite mint failure", rec.authorization)
+		}
+	})
+
+	t.Run("org-scope caller with no workspace", func(t *testing.T) {
+		// Nowhere to mint the delegated account. The org provider would
+		// still be resolved (the org is known), so this must refuse rather
+		// than proceed with the bearer.
+		proxy, rec := newEdgeBackedProxyWithTenant(t, testOrg, "")
+		proxy.SetDelegatedTokenIssuer(&recordingIssuer{})
+		w := serveProxy(proxy, path)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", w.Code)
+		}
+		if rec.hit {
+			t.Fatalf("request forwarded with Authorization %q despite no workspace", rec.authorization)
+		}
+	})
+
+	t.Run("resolver error with a bearer present", func(t *testing.T) {
+		proxy, rec := newEdgeBackedProxyWithTenant(t, testOrg, testWS)
+		proxy.SetDelegatedTokenIssuer(&recordingIssuer{})
+		proxy.SetTenantResolver(TenantResolverFunc(func(*http.Request) (string, string, error) {
+			return "", "", errors.New("token verify failed")
+		}))
+		// An unresolvable caller falls back to platform scope in
+		// resolveProvider, so make the platform copy unreachable to prove
+		// the org copy is not reached with the bearer either.
+		proxy.reg.DeleteScoped("", "infrastructure")
+		w := serveProxy(proxy, path)
+		if rec.hit {
+			t.Fatalf("request forwarded with Authorization %q despite unresolved identity", rec.authorization)
+		}
+		if w.Code == http.StatusOK {
+			t.Errorf("status = %d, want a refusal", w.Code)
+		}
+	})
+
+	t.Run("anonymous probe carries no credential at all", func(t *testing.T) {
+		proxy, rec := newEdgeBackedProxyWithTenant(t, testOrg, testWS)
+		issuer := &recordingIssuer{}
+		proxy.SetDelegatedTokenIssuer(issuer)
+		w := httptest.NewRecorder()
+		proxy.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/services/providers/infrastructure/healthz", nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body %q)", w.Code, w.Body.String())
+		}
+		if !rec.hit || rec.authorization != "" {
+			t.Errorf("anonymous probe forwarded with Authorization %q (hit=%v)", rec.authorization, rec.hit)
+		}
+		if issuer.calls != 0 {
+			t.Error("a delegated token was minted for an anonymous request")
+		}
+	})
+}
+
+// Step C of the remediation plan is deliberate future work: a platform
+// provider still receives the caller's own bearer. Pinning it keeps the
+// change to org-owned providers from silently widening.
+func TestBackendProxyPlatformProviderStillReceivesCallerBearer(t *testing.T) {
+	var gotAuthorization string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+	}))
+	t.Cleanup(upstream.Close)
+	backendURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "infrastructure", BackendURL: backendURL, EndpointsValid: true})
+	proxy := NewBackendProxy(reg, logr.Discard())
+	proxy.SetTenantResolver(TenantResolverFunc(func(*http.Request) (string, string, error) {
+		return "alice", "root:faros:tenants:" + testOrg + ":" + testWS, nil
+	}))
+	issuer := &recordingIssuer{}
+	proxy.SetDelegatedTokenIssuer(issuer)
+
+	serveProxy(proxy, "/services/providers/infrastructure/x")
+
+	if gotAuthorization != "Bearer "+callerBearer {
+		t.Errorf("platform provider saw Authorization %q, want the caller's bearer (step C is a separate change)", gotAuthorization)
+	}
+	if issuer.calls != 0 {
+		t.Error("a delegated token was minted for a platform provider")
+	}
+}
+
+// The caller is resolved once per request and shared by scope resolution,
+// token issuance, and header injection. Three verifications per request
+// would triple the apiserver round-trips on every data-plane call.
+func TestBackendProxyResolvesCallerOnce(t *testing.T) {
+	proxy, _ := newEdgeBackedProxyWithTenant(t, testOrg, testWS)
+	proxy.SetDelegatedTokenIssuer(&recordingIssuer{})
+	resolves := 0
+	proxy.SetTenantResolver(TenantResolverFunc(func(*http.Request) (string, string, error) {
+		resolves++
+		return "alice", "root:faros:tenants:" + testOrg + ":" + testWS, nil
+	}))
+
+	serveProxy(proxy, "/services/providers/infrastructure/dataplane/x")
+
+	if resolves != 1 {
+		t.Errorf("tenant resolver called %d times for one request, want 1", resolves)
 	}
 }
 

--- a/pkg/hub/providers/registry.go
+++ b/pkg/hub/providers/registry.go
@@ -127,6 +127,13 @@ type Provider struct {
 	// the tenant's cluster, meaningful there and undialable from here.
 	EdgeRoute *EdgeRoute
 
+	// ShadowsPlatform is true on an org-owned record returned by ListForOrg
+	// when a platform provider of the same name exists: for that Org, this
+	// copy is what /services/providers/{name} reaches, and the platform one
+	// is hidden. Derived at listing time, never stored, so the portal can say
+	// "this overrides a platform provider" without a second lookup.
+	ShadowsPlatform bool
+
 	// LocalUIAssets, when non-nil, is an embedded fs.FS that the UI proxy
 	// serves under /ui/providers/{Name}/* instead of forwarding to UIURL.
 	// Populated for first-party providers whose Vite-built portal/dist is
@@ -545,7 +552,9 @@ func (r *Registry) ListForOrg(orgUUID string) []Provider {
 			continue
 		}
 		shadowed[key.Name] = true
-		out = append(out, cloneProvider(*p))
+		own := cloneProvider(*p)
+		_, own.ShadowsPlatform = r.byKey[providerKey{Name: key.Name}]
+		out = append(out, own)
 	}
 	for key, p := range r.byKey {
 		if key.Org != "" || shadowed[key.Name] {

--- a/pkg/hub/providers/registry_scope_test.go
+++ b/pkg/hub/providers/registry_scope_test.go
@@ -114,10 +114,26 @@ func TestRegistryListForOrgShadowsPlatformProvider(t *testing.T) {
 	if listed[0].DisplayName != "Org1 Edges" {
 		t.Errorf("ListForOrg(org1) = %q, want the Org's own provider to win", listed[0].DisplayName)
 	}
+	// The override is flagged, so the portal can show it rather than have the
+	// platform card silently disappear.
+	if !listed[0].ShadowsPlatform {
+		t.Error("ListForOrg(org1): the Org's edges copy is not flagged as shadowing the platform provider")
+	}
 	// Another Org still sees the platform one.
 	other := reg.ListForOrg("org2")
 	if len(other) != 1 || other[0].DisplayName != "Platform Edges" {
 		t.Errorf("ListForOrg(org2) = %+v, want only the platform provider", names(other))
+	}
+	if other[0].ShadowsPlatform {
+		t.Error("ListForOrg(org2): a platform provider must never be flagged as shadowing")
+	}
+
+	// An org provider with a name of its own shadows nothing.
+	reg.Upsert(Provider{Name: "vault", OrgUUID: "org1", EndpointsValid: true})
+	for _, p := range reg.ListForOrg("org1") {
+		if p.Name == "vault" && p.ShadowsPlatform {
+			t.Error("ListForOrg(org1): vault has no platform counterpart yet is flagged as shadowing")
+		}
 	}
 }
 

--- a/pkg/hub/restapi/org_providers.go
+++ b/pkg/hub/restapi/org_providers.go
@@ -210,8 +210,15 @@ type RegisterOrgProviderResponse struct {
 }
 
 // requireOrgProviderAccess resolves the caller's tenant context and enforces the
-// Org's catalogEntryCreation policy (decision O-7): "members" (the default) lets
-// any Org member register a provider, "admin" restricts it to Org admins.
+// Org's catalogEntryCreation policy (decision O-7): "admin" (the default)
+// restricts registration to Org admins, "members" opens it to any Org member.
+//
+// The default is admin because registration is not a catalog edit: it mints a
+// long-lived cluster-admin credential for a workspace the hub then routes
+// every org user's provider traffic to, under a name that may shadow a
+// platform provider. That is an admin decision. Organizations created before
+// the default flipped were stamped with an explicit "members" by the
+// organization controller's backfill, so nothing they relied on changed.
 //
 // It also fails closed when the org-provider dependencies were not wired, so a
 // hub built without them returns a clean 501 rather than a nil-pointer panic.
@@ -233,11 +240,11 @@ func (h *Handler) requireOrgProviderAccess(w http.ResponseWriter, r *http.Reques
 		writeError(w, err)
 		return tenant.TenantContext{}, false
 	}
-	// Unset means the default, "members". Anything else is treated as the
-	// restrictive setting rather than silently allowing: an unrecognized policy
-	// value must not widen access.
-	if org.Spec.CatalogEntryCreation == "" ||
-		org.Spec.CatalogEntryCreation == tenancyv1alpha1.CatalogEntryCreationMembers {
+	// Only an explicit "members" opens registration. Unset means the default,
+	// "admin", and anything unrecognized is likewise treated as the
+	// restrictive setting rather than silently allowing: a policy value the
+	// hub does not understand must not widen access.
+	if org.Spec.CatalogEntryCreation == tenancyv1alpha1.CatalogEntryCreationMembers {
 		return tc, true
 	}
 

--- a/pkg/hub/restapi/org_providers_test.go
+++ b/pkg/hub/restapi/org_providers_test.go
@@ -105,6 +105,10 @@ func newOrgProviderTestServer(t *testing.T, targets []kcp.EdgeInstallTarget) (*f
 
 // newOrgProviderTestServerAs is the same with an explicit caller and an
 // explicit set of team workspaces to create, for the membership-boundary tests.
+//
+// The Org is created with catalogEntryCreation=members so these tests
+// exercise the edge preflight and membership boundary, not the registration
+// policy; TestRegisterOrgProvider_DefaultsToAdminOnly covers the policy.
 func newOrgProviderTestServerAs(
 	t *testing.T,
 	targets []kcp.EdgeInstallTarget,
@@ -112,9 +116,24 @@ func newOrgProviderTestServerAs(
 	extra []runtime.Object,
 ) (*fakeOrgProviderOps, *fakeCredMinter, func() string) {
 	t.Helper()
+	return newOrgProviderTestServerWithPolicy(t, targets, tc, extra, tenancyv1alpha1.CatalogEntryCreationMembers, tc.Role)
+}
+
+// newOrgProviderTestServerWithPolicy builds the Org with the given
+// spec.catalogEntryCreation ("" leaves it unset) and records orgRole as the
+// caller's org-scope Membership, which is what the registration policy reads
+// — tc.Role is whatever scope the request headers name and may differ.
+func newOrgProviderTestServerWithPolicy(
+	t *testing.T,
+	targets []kcp.EdgeInstallTarget,
+	tc tenant.TenantContext,
+	extra []runtime.Object,
+	policy, orgRole string,
+) (*fakeOrgProviderOps, *fakeCredMinter, func() string) {
+	t.Helper()
 	org := &tenancyv1alpha1.Organization{
 		ObjectMeta: metav1.ObjectMeta{Name: "org-a"},
-		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "A"},
+		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "A", CatalogEntryCreation: policy},
 	}
 	alice := &tenancyv1alpha1.User{
 		ObjectMeta: metav1.ObjectMeta{Name: "alice"},
@@ -131,12 +150,72 @@ func newOrgProviderTestServerAs(
 		seen[target.Workspace] = true
 		_ = wsOps.EnsureChildWorkspace(ctx, "org-a", target.Workspace)
 	}
+	if orgRole != "" {
+		_ = wsOps.EnsureOrgMembership(ctx, "org-a", tc.User, orgRole)
+	}
 	ops := &fakeOrgProviderOps{targets: targets}
 	creds := &fakeCredMinter{}
 	mgr.WithOrgProviders(ops, creds)
 	srv := newTestServer(t, mgr, tc)
 	t.Cleanup(srv.Close)
 	return ops, creds, func() string { return srv.URL }
+}
+
+// An Organization that never set catalogEntryCreation is admin-only: a member
+// cannot register a provider, which mints a cluster-admin credential and can
+// shadow a platform provider for the whole Org; an admin can. Only an explicit
+// "members" opens it, and an unrecognized value stays closed.
+func TestRegisterOrgProvider_DefaultsToAdminOnly(t *testing.T) {
+	edges := []kcp.EdgeInstallTarget{connectedEdge("ws-1", "prod")}
+	body := RegisterOrgProviderRequest{Name: "vault", Edge: &EdgeTargetRef{Workspace: "ws-1", Name: "prod"}}
+	umi := &tenancyv1alpha1.UserMembershipIndex{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice"},
+		Spec: tenancyv1alpha1.UserMembershipIndexSpec{
+			Entries: []tenancyv1alpha1.MembershipIndexEntry{
+				{OrgUUID: "org-a", WorkspaceUUID: "ws-1", Role: tenancyv1alpha1.MembershipRoleMember},
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name       string
+		policy     string
+		caller     tenant.TenantContext
+		wantStatus int
+	}{
+		{"unset refuses a member", "", memberTC("alice", "org-a", "ws-1"), http.StatusForbidden},
+		{"unset admits an org admin", "", adminTC("alice", "org-a", "ws-1"), http.StatusCreated},
+		{"explicit members admits a member", tenancyv1alpha1.CatalogEntryCreationMembers, memberTC("alice", "org-a", "ws-1"), http.StatusCreated},
+		{"explicit admin refuses a member", tenancyv1alpha1.CatalogEntryCreationAdmin, memberTC("alice", "org-a", "ws-1"), http.StatusForbidden},
+		{"unrecognized value refuses a member", "everyone", memberTC("alice", "org-a", "ws-1"), http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ops, creds, url := newOrgProviderTestServerWithPolicy(t, edges, tc.caller, []runtime.Object{umi}, tc.policy, tc.caller.Role)
+			resp := postRegister(t, url(), body)
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status: got %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+			if tc.wantStatus != http.StatusCreated && (len(ops.registered) != 0 || creds.minted != 0) {
+				t.Fatalf("registered %v / minted %d despite refusal", ops.registered, creds.minted)
+			}
+		})
+	}
+
+	// A member who is admin of their own team workspace is still just a
+	// member of the Org: the gate reads the org-scope Membership, not the
+	// workspace-scope role the portal's X-Faros-Workspace header names.
+	t.Run("workspace admin who is only an org member is refused", func(t *testing.T) {
+		ops, creds, url := newOrgProviderTestServerWithPolicy(t, edges, adminTC("alice", "org-a", "ws-1"), []runtime.Object{umi}, "", tenancyv1alpha1.MembershipRoleMember)
+		resp := postRegister(t, url(), body)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("status: got %d, want 403", resp.StatusCode)
+		}
+		if len(ops.registered) != 0 || creds.minted != 0 {
+			t.Fatalf("registered %v / minted %d despite refusal", ops.registered, creds.minted)
+		}
+	})
 }
 
 func postRegister(t *testing.T, base string, body any) *http.Response {

--- a/pkg/hub/restapi/orgs.go
+++ b/pkg/hub/restapi/orgs.go
@@ -32,7 +32,7 @@ import (
 type CreateOrgRequest struct {
 	DisplayName          string `json:"displayName"`
 	WorkspaceCreation    string `json:"workspaceCreation,omitempty"`    // "members" | "admin"; default "members"
-	CatalogEntryCreation string `json:"catalogEntryCreation,omitempty"` // "members" | "admin"; default "members"
+	CatalogEntryCreation string `json:"catalogEntryCreation,omitempty"` // "members" | "admin"; default "admin"
 }
 
 // PatchOrgRequest is the PATCH /api/orgs/{org} body. Empty fields
@@ -112,9 +112,12 @@ func (h *Handler) createOrg(w http.ResponseWriter, r *http.Request) {
 	if wc == "" {
 		wc = tenancyv1alpha1.WorkspaceCreationMembers
 	}
+	// Provider registration mints a cluster-admin credential and can shadow a
+	// platform provider for the whole Org, so the default keeps it with
+	// admins; an Org opts members in explicitly.
 	cec := req.CatalogEntryCreation
 	if cec == "" {
-		cec = tenancyv1alpha1.CatalogEntryCreationMembers
+		cec = tenancyv1alpha1.CatalogEntryCreationAdmin
 	}
 
 	orgUUID := uuid.NewString()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -724,7 +724,17 @@ func (s *Server) Run(ctx context.Context) error {
 			// See pkg/hub/provider_tenant_resolver.go for the concrete
 			// resolver (lives here to avoid a providers→proxy→kcp→providers
 			// import cycle).
-			backendProxy.SetTenantResolver(newKCPTenantResolver(kcpProxy, userClient, bootstrapper))
+			// The delegated-identity proof key. Both ends of delegation need
+			// it: the issuer signs the tuple onto the minted ServiceAccount,
+			// the resolver refuses any delegated account that cannot present
+			// the same MAC. It lives beside the hub's other cross-replica
+			// state in root:faros:system:controllers, so every replica
+			// verifies what any replica minted.
+			delegatedProofKeys, err := serviceaccounts.NewKCPProofKeySource(bootstrapper.ControllersConfig(), kcp.HubSystemNamespace)
+			if err != nil {
+				return fmt.Errorf("creating delegated-identity proof key source: %w", err)
+			}
+			backendProxy.SetTenantResolver(newKCPTenantResolver(kcpProxy, userClient, bootstrapper, delegatedProofKeys))
 			// Inject X-Faros-Cluster (the resolved tenant's logical-cluster
 			// ID) so providers can address per-workspace surfaces that key on
 			// the ID — notably the GraphQL gateway at /graphql/clusters/{id}.
@@ -733,7 +743,7 @@ func (s *Server) Run(ctx context.Context) error {
 			// proxy swaps it for a short-lived ServiceAccount token minted in
 			// the caller's workspace (pkg/hub/serviceaccounts
 			// delegated_user_token.go). Without this the org path refuses.
-			backendProxy.SetDelegatedTokenIssuer(serviceaccounts.NewManager(bootstrapper))
+			backendProxy.SetDelegatedTokenIssuer(serviceaccounts.NewManager(bootstrapper, delegatedProofKeys))
 
 			// Step 10: Org / Workspace / Membership / User REST
 			apiMgr := restapi.NewManager(userClient, bootstrapper)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -729,6 +729,11 @@ func (s *Server) Run(ctx context.Context) error {
 			// ID) so providers can address per-workspace surfaces that key on
 			// the ID — notably the GraphQL gateway at /graphql/clusters/{id}.
 			backendProxy.SetClusterResolver(newClusterIDResolver(kcpConfig))
+			// Org-owned providers never see the caller's hub bearer: the
+			// proxy swaps it for a short-lived ServiceAccount token minted in
+			// the caller's workspace (pkg/hub/serviceaccounts
+			// delegated_user_token.go). Without this the org path refuses.
+			backendProxy.SetDelegatedTokenIssuer(serviceaccounts.NewManager(bootstrapper))
 
 			// Step 10: Org / Workspace / Membership / User REST
 			apiMgr := restapi.NewManager(userClient, bootstrapper)

--- a/pkg/hub/serviceaccounts/delegated_user_proof.go
+++ b/pkg/hub/serviceaccounts/delegated_user_proof.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccounts
+
+// The keyed proof that makes a delegated user identity unforgeable.
+//
+// A delegated ServiceAccount lives in namespace "default" of the caller's own
+// team workspace, and the bootstrap binds every workspace member — not just
+// admins — to cluster-admin there (pkg/hub/kcp/bootstrap.go
+// ensureWorkspaceAdmin, reached for every member via
+// EnsureChildWorkspaceAdmin). A member can therefore create a ServiceAccount,
+// label it delegated, annotate it with any username they like, and mint a
+// token for it with TokenRequest. Every consistency check the hub can make
+// over that object compares inputs the same attacker wrote, so none of them
+// can separate a hub-minted account from a hand-made one.
+//
+// The proof is the one field they cannot produce: an HMAC-SHA256 over the
+// identity tuple, keyed by a secret that lives in a hub-internal kcp workspace
+// no tenant identity can reach. The hub writes it at mint time; verification
+// recomputes it and compares in constant time.
+//
+// The ServiceAccount UID is part of the MAC input on purpose. Without it an
+// attacker could pre-create the account at its (publicly derivable) name, mint
+// a long-lived token against it, and wait for the hub to stamp a valid proof
+// onto that same object the first time the victim legitimately uses the
+// provider — at which point the attacker's token would start resolving as the
+// victim. Binding the UID means the hub must delete and recreate any account
+// it finds unproven, and the recreated object has a UID the attacker's token
+// was never issued against.
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	// AnnotationDelegatedProof carries the hub's keyed proof over the
+	// delegated identity tuple. It is the ONLY field on a delegated
+	// ServiceAccount that a tenant member cannot write for themselves; every
+	// other label, annotation, and even the object name is derived from public
+	// inputs inside a workspace where members hold cluster-admin.
+	AnnotationDelegatedProof = "faros.sh/delegated-user-proof"
+
+	// delegatedProofDomain versions and domain-separates the MAC input, so a
+	// proof can never be replayed into a different keyed construction should
+	// one ever share this key.
+	delegatedProofDomain = "faros.sh/delegated-user-proof/v1"
+
+	// delegatedProofKeySecretName is the Secret holding the HMAC key, in the
+	// hub-internal workspace/namespace the hub already uses for its
+	// cross-replica state (root:faros:system:controllers, namespace
+	// faros-hub — see pkg/hub/kcp.HubSystemNamespace). Nothing grants a
+	// tenant, provider, or user identity access to that workspace.
+	delegatedProofKeySecretName = "faros-delegated-user-proof-key"
+	delegatedProofKeySecretKey  = "key"
+
+	// delegatedProofKeyLength is what a freshly generated key gets. Existing
+	// keys are accepted at delegatedProofKeyMinLength or longer so the key can
+	// be lengthened later without invalidating every account at once.
+	delegatedProofKeyLength    = 32
+	delegatedProofKeyMinLength = 32
+)
+
+// ProofKeySource yields the hub's delegated-identity signing key. It is
+// consulted on the mint path and on every verification; implementations are
+// expected to cache, since both paths are per-request.
+type ProofKeySource interface {
+	DelegatedProofKey(ctx context.Context) ([]byte, error)
+}
+
+// StaticProofKeySource serves a key the caller already holds. Used by tests
+// and by callers that source the key some other way.
+type StaticProofKeySource []byte
+
+// DelegatedProofKey implements ProofKeySource.
+func (s StaticProofKeySource) DelegatedProofKey(context.Context) ([]byte, error) {
+	if len(s) < delegatedProofKeyMinLength {
+		return nil, fmt.Errorf("delegated proof key is too short")
+	}
+	return s, nil
+}
+
+// KCPProofKeySource loads the delegated-identity key from a Secret in a
+// hub-internal kcp workspace, creating it on first use. Every hub replica
+// reads the same Secret, so the proof survives restarts and rescheduling and
+// is identical across replicas — a token minted by one replica verifies at
+// another.
+type KCPProofKeySource struct {
+	client    kubernetes.Interface
+	namespace string
+
+	mu  sync.Mutex
+	key []byte
+}
+
+// NewKCPProofKeySource builds a key source against config, which must already
+// target the hub-internal workspace (its Host carries the /clusters/<path>
+// segment), and the namespace within it.
+//
+// SECURITY: the workspace this config points at must be one no tenant,
+// provider, or user identity can reach. root:faros:system:controllers is that
+// workspace today; it also holds the hub's leader-election Lease and the
+// shared session Secrets, so a leak there is already a total compromise.
+func NewKCPProofKeySource(config *rest.Config, namespace string) (*KCPProofKeySource, error) {
+	if config == nil || strings.TrimSpace(namespace) == "" {
+		return nil, fmt.Errorf("delegated proof key source needs a config and namespace")
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("building delegated proof key client: %w", err)
+	}
+	return &KCPProofKeySource{client: client, namespace: namespace}, nil
+}
+
+// newKCPProofKeySourceWithClient is the test seam for NewKCPProofKeySource.
+func newKCPProofKeySourceWithClient(client kubernetes.Interface, namespace string) *KCPProofKeySource {
+	return &KCPProofKeySource{client: client, namespace: namespace}
+}
+
+// DelegatedProofKey implements ProofKeySource. The key is read once and kept
+// in memory for the process's lifetime; a failure is not cached, so a
+// transient apiserver error is retried on the next request rather than
+// disabling delegation until the hub restarts.
+func (s *KCPProofKeySource) DelegatedProofKey(ctx context.Context) ([]byte, error) {
+	if s == nil {
+		return nil, fmt.Errorf("delegated proof key source is unavailable")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.key) >= delegatedProofKeyMinLength {
+		return s.key, nil
+	}
+
+	secrets := s.client.CoreV1().Secrets(s.namespace)
+	existing, err := secrets.Get(ctx, delegatedProofKeySecretName, metav1.GetOptions{})
+	switch {
+	case err == nil:
+		key, keyErr := proofKeyFromSecret(existing)
+		if keyErr != nil {
+			return nil, keyErr
+		}
+		s.key = key
+		return key, nil
+	case !apierrors.IsNotFound(err):
+		return nil, fmt.Errorf("reading delegated proof key: %w", err)
+	}
+
+	key := make([]byte, delegatedProofKeyLength)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generating delegated proof key: %w", err)
+	}
+	created, err := secrets.Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: delegatedProofKeySecretName, Namespace: s.namespace},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{delegatedProofKeySecretKey: key},
+	}, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		// Another replica created it first; its key is the authoritative one.
+		created, err = secrets.Get(ctx, delegatedProofKeySecretName, metav1.GetOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("creating delegated proof key: %w", err)
+	}
+	stored, err := proofKeyFromSecret(created)
+	if err != nil {
+		return nil, err
+	}
+	s.key = stored
+	return stored, nil
+}
+
+func proofKeyFromSecret(secret *corev1.Secret) ([]byte, error) {
+	key := secret.Data[delegatedProofKeySecretKey]
+	if len(key) < delegatedProofKeyMinLength {
+		return nil, fmt.Errorf("delegated proof key %s/%s is missing or too short",
+			secret.Namespace, secret.Name)
+	}
+	return key, nil
+}
+
+// delegatedProofKey resolves the key from source, treating a nil source as
+// "delegation is not configured here" — which must reject rather than skip.
+func delegatedProofKey(ctx context.Context, source ProofKeySource) ([]byte, error) {
+	if source == nil {
+		return nil, fmt.Errorf("delegated user identities are not accepted: no proof key source configured")
+	}
+	key, err := source.DelegatedProofKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(key) < delegatedProofKeyMinLength {
+		return nil, fmt.Errorf("delegated proof key is too short")
+	}
+	return key, nil
+}
+
+// SignDelegatedUserServiceAccount writes the hub's keyed proof onto sa, which
+// must already carry its identity annotations and its server-assigned UID.
+//
+// Production code mints through Manager.IssueDelegatedUserToken, which calls
+// this as part of creating the account. It is exported so that tests outside
+// this package — the hub's tenant resolver in particular — can build an
+// account that is genuinely hub-minted, and contrast it with one a tenant
+// member forged. Do not call it to bless an object the hub did not create:
+// the whole point of the proof is that only the hub writes it.
+func SignDelegatedUserServiceAccount(key []byte, sa *corev1.ServiceAccount, tenantPath string, user Identity, providerName string) error {
+	if sa == nil || sa.UID == "" {
+		return fmt.Errorf("delegated ServiceAccount needs a UID before it can be signed")
+	}
+	if len(key) < delegatedProofKeyMinLength {
+		return fmt.Errorf("delegated proof key is too short")
+	}
+	if sa.Annotations == nil {
+		sa.Annotations = map[string]string{}
+	}
+	sa.Annotations[AnnotationDelegatedProof] = computeDelegatedProof(key, tenantPath, user, providerName, sa.Name, sa.UID)
+	return nil
+}
+
+// computeDelegatedProof is the MAC over one delegated identity. Fields are
+// NUL-joined; every one of them is validated to be NUL-free before it reaches
+// here (validateDelegatedInputs), so the encoding is unambiguous.
+func computeDelegatedProof(key []byte, tenantPath string, user Identity, providerName, saName string, saUID types.UID) string {
+	mac := hmac.New(sha256.New, key)
+	// Writing to an hmac.Hash never returns an error.
+	_, _ = mac.Write([]byte(strings.Join([]string{
+		delegatedProofDomain,
+		tenantPath,
+		user.User,
+		providerName,
+		saName,
+		string(saUID),
+	}, "\x00")))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// verifyDelegatedProof recomputes the MAC from the ServiceAccount's own
+// annotations and compares it in constant time against the proof it carries.
+//
+// The annotations are attacker-controlled, and that is exactly why they are
+// the MAC input: any edit to the identity they describe changes the expected
+// MAC, and the attacker cannot recompute it. The UID and name are read off the
+// object for the same reason — a copied proof does not travel to another
+// object, and a deleted-and-recreated object does not inherit one.
+func verifyDelegatedProof(key []byte, sa *corev1.ServiceAccount) error {
+	if sa == nil {
+		return fmt.Errorf("delegated ServiceAccount is missing")
+	}
+	if sa.UID == "" {
+		return fmt.Errorf("delegated ServiceAccount has no UID")
+	}
+	presented, err := hex.DecodeString(strings.TrimSpace(sa.Annotations[AnnotationDelegatedProof]))
+	if err != nil || len(presented) != sha256.Size {
+		return fmt.Errorf("delegated ServiceAccount carries no valid hub proof")
+	}
+	want, err := hex.DecodeString(computeDelegatedProof(
+		key,
+		sa.Annotations[AnnotationWorkloadIdentityTenantPath],
+		Identity{User: sa.Annotations[AnnotationDelegatedUser]},
+		sa.Annotations[AnnotationDelegatedProvider],
+		sa.Name,
+		sa.UID,
+	))
+	if err != nil {
+		return fmt.Errorf("computing delegated proof: %w", err)
+	}
+	if !hmac.Equal(presented, want) {
+		return fmt.Errorf("delegated ServiceAccount carries no valid hub proof")
+	}
+	return nil
+}

--- a/pkg/hub/serviceaccounts/delegated_user_proof_test.go
+++ b/pkg/hub/serviceaccounts/delegated_user_proof_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccounts
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const proofTestNamespace = "faros-hub"
+
+// The key has to outlive a hub restart and be identical across replicas, or a
+// token minted by one hub stops verifying at the next. It is therefore stored,
+// not generated per process: created on first use, read verbatim afterwards.
+func TestKCPProofKeySourceCreatesOnceAndIsStable(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset()
+
+	first := newKCPProofKeySourceWithClient(cs, proofTestNamespace)
+	key, err := first.DelegatedProofKey(ctx)
+	if err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if len(key) != delegatedProofKeyLength {
+		t.Fatalf("key length = %d, want %d", len(key), delegatedProofKeyLength)
+	}
+	if bytes.Equal(key, make([]byte, delegatedProofKeyLength)) {
+		t.Fatal("generated key is all zeroes")
+	}
+
+	// A second read on the same source is served from memory.
+	again, err := first.DelegatedProofKey(ctx)
+	if err != nil || !bytes.Equal(again, key) {
+		t.Fatalf("second read = %x, %v; want the same key", again, err)
+	}
+
+	// A second replica — a fresh source over the same store — must arrive at
+	// the same key rather than minting a competing one.
+	second := newKCPProofKeySourceWithClient(cs, proofTestNamespace)
+	other, err := second.DelegatedProofKey(ctx)
+	if err != nil {
+		t.Fatalf("second source: %v", err)
+	}
+	if !bytes.Equal(other, key) {
+		t.Fatalf("second source got a different key (%x vs %x); tokens would not verify across replicas", other, key)
+	}
+
+	secrets, err := cs.CoreV1().Secrets(proofTestNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list secrets: %v", err)
+	}
+	if len(secrets.Items) != 1 || secrets.Items[0].Name != delegatedProofKeySecretName {
+		t.Fatalf("stored secrets = %+v, want one %s", secrets.Items, delegatedProofKeySecretName)
+	}
+}
+
+// A key that is present but unusable must fail rather than be padded, reused,
+// or silently regenerated — regenerating would invalidate every live account.
+func TestKCPProofKeySourceRejectsShortKey(t *testing.T) {
+	cs := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: delegatedProofKeySecretName, Namespace: proofTestNamespace},
+		Data:       map[string][]byte{delegatedProofKeySecretKey: []byte("too-short")},
+	})
+	if _, err := newKCPProofKeySourceWithClient(cs, proofTestNamespace).DelegatedProofKey(context.Background()); err == nil {
+		t.Fatal("accepted a short delegated proof key")
+	}
+}
+
+// A different key must not validate another key's proof: this is what stops a
+// proof from one deployment being replayed into another.
+func TestDelegatedProofIsKeyBound(t *testing.T) {
+	ctx := context.Background()
+	tenantPath := tenantPathFor(delegatedTestOrg, delegatedTestWS)
+	sa := hubMintedDelegatedServiceAccount(t, tenantPath, delegatedTestUser, "uid-keybound")
+
+	otherKey := StaticProofKeySource(bytes.Repeat([]byte{0x01}, delegatedProofKeyLength))
+	if _, err := DelegatedUserFromServiceAccount(ctx, otherKey, sa); err == nil {
+		t.Fatal("a proof made with one key verified under another")
+	}
+}

--- a/pkg/hub/serviceaccounts/delegated_user_token.go
+++ b/pkg/hub/serviceaccounts/delegated_user_token.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccounts
+
+// Delegated user tokens.
+//
+// The hub backend proxy used to forward a caller's own hub bearer — an OIDC
+// id token or the static admin token — to every provider it fronted. For a
+// platform provider that is a (known, accepted) confused deputy. For an
+// org-owned provider it is a credential leak: the provider runs in a tenant's
+// cluster, so any org member who registers one receives the full hub token of
+// every user in the org who touches it, and that token reaches every
+// workspace and every REST endpoint the user can.
+//
+// A delegated user token replaces the bearer on that path. It is a
+// ServiceAccount token minted in the caller's tenant workspace, scoped by kcp
+// to that one workspace (the hub's kcp proxy pins SA tokens to the cluster
+// claim they carry), audience-bound, ten minutes long, and annotated with the
+// human user it stands in for so the far end still knows who is calling.
+//
+// The account is deterministic per (tenant, user, provider), so repeated
+// requests reuse one ServiceAccount rather than accumulating. Nothing deletes
+// them yet: a member leaving the workspace keeps an idle faros-du-* account
+// bound to a role they no longer hold, though any token minted for it is dead
+// within ten minutes. Garbage collection on Membership removal is a follow-up.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	authnv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/faroshq/faros/pkg/kcppaths"
+)
+
+const (
+	// LabelDelegatedUser marks a ServiceAccount minted to stand in for a human
+	// user at an org-owned provider. Such accounts also carry
+	// LabelWorkloadIdentity, so the online verifier treats them as hub-managed
+	// and the user-facing ServiceAccount CRUD surface (LabelFarosSA) never
+	// lists or rotates them.
+	LabelDelegatedUser = "faros.sh/delegated-user"
+
+	// AnnotationDelegatedUser is the User CR name the account stands in for.
+	// The tenant resolver surfaces it as X-Faros-User so a provider at the far
+	// end attributes the call to the person, not to the account.
+	AnnotationDelegatedUser = "faros.sh/delegated-user"
+	// AnnotationDelegatedOrg and AnnotationDelegatedWorkspace record the tenant
+	// the account was minted in. AnnotationWorkloadIdentityTenantPath carries
+	// the same fact as a path and is what the verifier enforces; these exist so
+	// an operator reading the object sees the tuple without parsing a path.
+	AnnotationDelegatedOrg       = "faros.sh/delegated-org"
+	AnnotationDelegatedWorkspace = "faros.sh/delegated-workspace"
+	// AnnotationDelegatedProvider names the org-owned provider the token was
+	// issued for. It participates in the account name, so a token minted for
+	// one provider is a different identity from one minted for another.
+	AnnotationDelegatedProvider = "faros.sh/delegated-provider"
+
+	// DelegatedUserClusterRole is what the delegated account is bound to. It is
+	// the role every workspace member holds today: the bootstrap grants members
+	// and admins alike cluster-admin in their team workspace
+	// (pkg/hub/kcp/bootstrap.go ensureWorkspaceAdmin), so binding anything
+	// narrower here would make the delegated call weaker than the user's own
+	// kubectl. Narrowing is the workspace RBAC's job; when members get a
+	// bounded ClusterRole this constant follows it.
+	DelegatedUserClusterRole = "cluster-admin"
+
+	// DelegatedUserTokenCacheTTL bounds how long an issued token is reused
+	// before a fresh one is minted, independently of the token's own expiry.
+	// Matches kcpResolverTTL in the tenant resolver so a revoked membership is
+	// honoured on the same clock across both caches.
+	DelegatedUserTokenCacheTTL = 5 * time.Minute
+
+	// delegatedUserTokenExpirySlack keeps a cached token from being handed to
+	// a provider moments before it expires mid-request.
+	delegatedUserTokenExpirySlack = time.Minute
+
+	delegatedUserNamePrefix   = "faros-du-"
+	delegatedUserBindingInfix = "-"
+)
+
+// Identity is the caller a delegated token stands in for.
+type Identity struct {
+	// User is the User CR name — the value the backend proxy injects as
+	// X-Faros-User.
+	User string
+}
+
+// DelegatedUserServiceAccountName returns the stable, DNS-safe ServiceAccount
+// name for one (tenant, user, provider) tuple. Hash-only for the same reason
+// WorkloadServiceAccountName is: user names are email-shaped and provider
+// names are tenant-chosen, and neither belongs in an RBAC object name.
+func DelegatedUserServiceAccountName(tenantPath string, user Identity, providerName string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{tenantPath, user.User, providerName}, "\x00")))
+	return delegatedUserNamePrefix + hex.EncodeToString(sum[:20])
+}
+
+// DelegatedUserBindingName returns the ClusterRoleBinding name paired with a
+// delegated ServiceAccount.
+func DelegatedUserBindingName(serviceAccountName string) string {
+	return serviceAccountName + delegatedUserBindingInfix + DelegatedUserClusterRole
+}
+
+type delegatedTokenKey struct {
+	orgUUID, wsUUID, user, provider string
+}
+
+type delegatedTokenEntry struct {
+	token     string
+	expiresAt time.Time
+	// refreshAt is when the cache stops serving this entry: the earlier of
+	// the cache TTL and the token's expiry minus slack.
+	refreshAt time.Time
+}
+
+// IssueDelegatedUserToken returns a short-lived ServiceAccount token that
+// represents user in the tenant workspace (orgUUID, wsUUID) towards the
+// org-owned provider providerName. The account is created on first use, bound
+// to DelegatedUserClusterRole, and reused thereafter; tokens are cached in
+// memory per (tenant, user, provider) for DelegatedUserTokenCacheTTL and
+// re-minted before they expire.
+//
+// The caller is responsible for having authenticated user and verified their
+// membership in the workspace: this method mints on the hub's own authority
+// and does not re-check either.
+func (m *Manager) IssueDelegatedUserToken(ctx context.Context, orgUUID, wsUUID string, user Identity, providerName string) (string, time.Time, error) {
+	if err := validateDelegatedInputs(orgUUID, wsUUID, user, providerName); err != nil {
+		return "", time.Time{}, err
+	}
+	key := delegatedTokenKey{orgUUID: orgUUID, wsUUID: wsUUID, user: user.User, provider: providerName}
+	now := m.clock()
+
+	m.delegatedMu.Lock()
+	if entry, ok := m.delegated[key]; ok && now.Before(entry.refreshAt) {
+		m.delegatedMu.Unlock()
+		return entry.token, entry.expiresAt, nil
+	}
+	m.delegatedMu.Unlock()
+
+	cs, err := m.clientset(orgUUID, wsUUID)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	tenantPath := tenantPathFor(orgUUID, wsUUID)
+	name := DelegatedUserServiceAccountName(tenantPath, user, providerName)
+	if err := ensureDelegatedUserServiceAccount(ctx, cs, name, tenantPath, orgUUID, wsUUID, user, providerName); err != nil {
+		return "", time.Time{}, err
+	}
+	if err := ensureWorkloadClusterRoleBinding(ctx, cs, DelegatedUserBindingName(name), DelegatedUserClusterRole, name); err != nil {
+		return "", time.Time{}, err
+	}
+
+	expirationSeconds := int64(WorkloadIdentityTokenTTL / time.Second)
+	issued, err := cs.CoreV1().ServiceAccounts(Namespace).CreateToken(ctx, name, &authnv1.TokenRequest{Spec: authnv1.TokenRequestSpec{
+		Audiences:         []string{WorkloadIdentityTokenAudience},
+		ExpirationSeconds: &expirationSeconds,
+	}}, metav1.CreateOptions{})
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("issuing delegated user token: %w", err)
+	}
+	if strings.TrimSpace(issued.Status.Token) == "" || issued.Status.ExpirationTimestamp.IsZero() {
+		return "", time.Time{}, fmt.Errorf("delegated user token response was incomplete")
+	}
+	expiresAt := issued.Status.ExpirationTimestamp.Time
+	// Same guard as the workload identity: the API server must not be able to
+	// turn this into a longer-lived credential than policy allows.
+	if expiresAt.After(now.Add(WorkloadIdentityTokenTTL + time.Second)) {
+		return "", time.Time{}, fmt.Errorf("delegated user token exceeds maximum lifetime")
+	}
+
+	refreshAt := now.Add(DelegatedUserTokenCacheTTL)
+	if byExpiry := expiresAt.Add(-delegatedUserTokenExpirySlack); byExpiry.Before(refreshAt) {
+		refreshAt = byExpiry
+	}
+	m.delegatedMu.Lock()
+	if m.delegated == nil {
+		m.delegated = map[delegatedTokenKey]delegatedTokenEntry{}
+	}
+	m.delegated[key] = delegatedTokenEntry{token: issued.Status.Token, expiresAt: expiresAt, refreshAt: refreshAt}
+	m.delegatedMu.Unlock()
+	return issued.Status.Token, expiresAt, nil
+}
+
+// IsDelegatedUserServiceAccount reports whether sa was minted by
+// IssueDelegatedUserToken.
+func IsDelegatedUserServiceAccount(sa *corev1.ServiceAccount) bool {
+	return sa != nil && sa.Labels[LabelDelegatedUser] == "true"
+}
+
+// DelegatedUserFromServiceAccount returns the human identity a verified
+// delegated ServiceAccount stands in for. Callers must have run the object
+// through VerifyWorkloadServiceAccountDetails first; this only reads.
+func DelegatedUserFromServiceAccount(sa *corev1.ServiceAccount) (Identity, error) {
+	if !IsDelegatedUserServiceAccount(sa) {
+		return Identity{}, fmt.Errorf("ServiceAccount is not a delegated user identity")
+	}
+	if err := verifyDelegatedUserAnnotations(sa); err != nil {
+		return Identity{}, err
+	}
+	return Identity{User: sa.Annotations[AnnotationDelegatedUser]}, nil
+}
+
+func verifyDelegatedUserAnnotations(sa *corev1.ServiceAccount) error {
+	for _, key := range []string{
+		AnnotationDelegatedUser,
+		AnnotationDelegatedOrg,
+		AnnotationDelegatedWorkspace,
+		AnnotationDelegatedProvider,
+	} {
+		value := strings.TrimSpace(sa.Annotations[key])
+		if value == "" || strings.ContainsAny(value, "\r\n\x00") {
+			return fmt.Errorf("delegated ServiceAccount has incomplete identity annotations")
+		}
+	}
+	// The path annotation is what the verifier enforced; the org/workspace
+	// annotations must agree with it or the object has been tampered with.
+	if tenantPathFor(sa.Annotations[AnnotationDelegatedOrg], sa.Annotations[AnnotationDelegatedWorkspace]) != sa.Annotations[AnnotationWorkloadIdentityTenantPath] {
+		return fmt.Errorf("delegated ServiceAccount tenant annotations disagree")
+	}
+	return nil
+}
+
+func validateDelegatedInputs(orgUUID, wsUUID string, user Identity, providerName string) error {
+	for name, value := range map[string]string{
+		"orgUUID":      orgUUID,
+		"wsUUID":       wsUUID,
+		"user":         user.User,
+		"providerName": providerName,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", name)
+		}
+		if strings.ContainsAny(value, "\r\n\x00") {
+			return fmt.Errorf("%s contains prohibited characters", name)
+		}
+	}
+	// Org and workspace become path segments of the tenant path; a colon in
+	// either would let one tuple spell another's path.
+	if strings.ContainsAny(orgUUID+wsUUID, ":") {
+		return fmt.Errorf("orgUUID and wsUUID must not contain ':'")
+	}
+	return nil
+}
+
+// tenantPathFor is the workspace path the tenant resolver composes from
+// X-Faros-Org / X-Faros-Workspace, which the verifier compares against
+// AnnotationWorkloadIdentityTenantPath.
+func tenantPathFor(orgUUID, wsUUID string) string {
+	return kcppaths.WorkspacePath(orgUUID, wsUUID)
+}
+
+func delegatedUserAnnotations(tenantPath, orgUUID, wsUUID string, user Identity, providerName string) map[string]string {
+	return map[string]string{
+		AnnotationWorkloadIdentityTenantPath: tenantPath,
+		AnnotationDelegatedUser:              user.User,
+		AnnotationDelegatedOrg:               orgUUID,
+		AnnotationDelegatedWorkspace:         wsUUID,
+		AnnotationDelegatedProvider:          providerName,
+	}
+}
+
+func ensureDelegatedUserServiceAccount(ctx context.Context, cs kubernetes.Interface, name, tenantPath, orgUUID, wsUUID string, user Identity, providerName string) error {
+	sas := cs.CoreV1().ServiceAccounts(Namespace)
+	want := delegatedUserAnnotations(tenantPath, orgUUID, wsUUID, user, providerName)
+	sa, err := sas.Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = sas.Create(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: Namespace,
+			Labels: map[string]string{
+				LabelWorkloadIdentity: "true",
+				LabelDelegatedUser:    "true",
+			},
+			Annotations: want,
+		}}, metav1.CreateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("creating delegated ServiceAccount: %w", err)
+		}
+		sa, err = sas.Get(ctx, name, metav1.GetOptions{})
+	}
+	if err != nil {
+		return fmt.Errorf("getting delegated ServiceAccount: %w", err)
+	}
+	// Every annotation participates in the name, so an existing account that
+	// disagrees on any of them is not ours — refuse rather than adopt it. The
+	// name is a hash of the tuple, so this only trips on a hand-made object.
+	if !IsDelegatedUserServiceAccount(sa) || sa.Labels[LabelWorkloadIdentity] != "true" {
+		return fmt.Errorf("ServiceAccount %q exists and is not a delegated user identity", name)
+	}
+	for key, value := range want {
+		if sa.Annotations[key] != value {
+			return fmt.Errorf("ServiceAccount %q is bound to a different delegated identity", name)
+		}
+	}
+	return nil
+}
+
+// clock is the time source for the token cache; tests override it.
+func (m *Manager) clock() time.Time {
+	if m.now != nil {
+		return m.now()
+	}
+	return time.Now()
+}
+
+// delegatedCache is embedded in Manager so one Manager caches across requests.
+type delegatedCache struct {
+	delegatedMu sync.Mutex
+	delegated   map[delegatedTokenKey]delegatedTokenEntry
+	now         func() time.Time
+}

--- a/pkg/hub/serviceaccounts/delegated_user_token.go
+++ b/pkg/hub/serviceaccounts/delegated_user_token.go
@@ -52,6 +52,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/faroshq/faros/pkg/kcppaths"
 )
@@ -151,22 +152,40 @@ func (m *Manager) IssueDelegatedUserToken(ctx context.Context, orgUUID, wsUUID s
 		return "", time.Time{}, err
 	}
 	key := delegatedTokenKey{orgUUID: orgUUID, wsUUID: wsUUID, user: user.User, provider: providerName}
-	now := m.clock()
 
-	m.delegatedMu.Lock()
-	if entry, ok := m.delegated[key]; ok && now.Before(entry.refreshAt) {
-		m.delegatedMu.Unlock()
-		return entry.token, entry.expiresAt, nil
+	if token, expiresAt, ok := m.cachedDelegatedToken(key); ok {
+		return token, expiresAt, nil
 	}
-	m.delegatedMu.Unlock()
 
+	return m.mintDelegatedUserToken(ctx, key, orgUUID, wsUUID, user, providerName)
+}
+
+// cachedDelegatedToken returns a still-usable cached token for key.
+func (m *Manager) cachedDelegatedToken(key delegatedTokenKey) (string, time.Time, bool) {
+	now := m.clock()
+	m.delegatedMu.Lock()
+	defer m.delegatedMu.Unlock()
+	if entry, ok := m.delegated[key]; ok && now.Before(entry.refreshAt) {
+		return entry.token, entry.expiresAt, true
+	}
+	return "", time.Time{}, false
+}
+
+// mintDelegatedUserToken does the work IssueDelegatedUserToken deduplicates:
+// reconcile the account and its binding, then issue and cache a token.
+func (m *Manager) mintDelegatedUserToken(ctx context.Context, key delegatedTokenKey, orgUUID, wsUUID string, user Identity, providerName string) (string, time.Time, error) {
+	now := m.clock()
+	proofKey, err := delegatedProofKey(ctx, m.proofKeys)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("delegated user token cannot be minted: %w", err)
+	}
 	cs, err := m.clientset(orgUUID, wsUUID)
 	if err != nil {
 		return "", time.Time{}, err
 	}
 	tenantPath := tenantPathFor(orgUUID, wsUUID)
 	name := DelegatedUserServiceAccountName(tenantPath, user, providerName)
-	if err := ensureDelegatedUserServiceAccount(ctx, cs, name, tenantPath, orgUUID, wsUUID, user, providerName); err != nil {
+	if err := ensureDelegatedUserServiceAccount(ctx, cs, proofKey, name, tenantPath, orgUUID, wsUUID, user, providerName); err != nil {
 		return "", time.Time{}, err
 	}
 	if err := ensureWorkloadClusterRoleBinding(ctx, cs, DelegatedUserBindingName(name), DelegatedUserClusterRole, name); err != nil {
@@ -211,26 +230,47 @@ func IsDelegatedUserServiceAccount(sa *corev1.ServiceAccount) bool {
 }
 
 // DelegatedUserFromServiceAccount returns the human identity a verified
-// delegated ServiceAccount stands in for. Callers must have run the object
-// through VerifyWorkloadServiceAccountDetails first; this only reads.
-func DelegatedUserFromServiceAccount(sa *corev1.ServiceAccount) (Identity, error) {
+// delegated ServiceAccount stands in for.
+//
+// SECURITY: everything on this object is tenant-writable except the proof.
+// The account lives in namespace "default" of the tenant's own team
+// workspace, where the bootstrap binds every member — not only admins — to
+// cluster-admin (pkg/hub/kcp/bootstrap.go ensureWorkspaceAdmin). An ordinary
+// member can create a ServiceAccount there, apply LabelDelegatedUser, fill in
+// all four identity annotations naming anyone they like, give it the name the
+// hub would have derived (the name is a hash of public inputs), and mint a
+// token for it with TokenRequest. Every consistency check over those fields
+// compares inputs that same member wrote, so none of them prove anything.
+// AnnotationDelegatedProof is the sole field they cannot produce — a MAC over
+// the identity tuple and the ServiceAccount UID, keyed by a secret held in a
+// workspace no tenant identity can reach. Do not add an identity path here
+// that does not require it.
+func DelegatedUserFromServiceAccount(ctx context.Context, keys ProofKeySource, sa *corev1.ServiceAccount) (Identity, error) {
 	if !IsDelegatedUserServiceAccount(sa) {
 		return Identity{}, fmt.Errorf("ServiceAccount is not a delegated user identity")
 	}
-	if err := verifyDelegatedUserAnnotations(sa); err != nil {
+	key, err := delegatedProofKey(ctx, keys)
+	if err != nil {
+		return Identity{}, err
+	}
+	if err := verifyDelegatedUserAnnotations(key, sa); err != nil {
 		return Identity{}, err
 	}
 	return Identity{User: sa.Annotations[AnnotationDelegatedUser]}, nil
 }
 
-func verifyDelegatedUserAnnotations(sa *corev1.ServiceAccount) error {
-	for _, key := range []string{
+// verifyDelegatedUserAnnotations checks the shape of a delegated identity and
+// then the one thing that actually establishes it: the hub's keyed proof.
+// The shape checks are hygiene — they keep a malformed annotation out of a
+// response header — not authorization. The proof is the authorization.
+func verifyDelegatedUserAnnotations(key []byte, sa *corev1.ServiceAccount) error {
+	for _, annotation := range []string{
 		AnnotationDelegatedUser,
 		AnnotationDelegatedOrg,
 		AnnotationDelegatedWorkspace,
 		AnnotationDelegatedProvider,
 	} {
-		value := strings.TrimSpace(sa.Annotations[key])
+		value := strings.TrimSpace(sa.Annotations[annotation])
 		if value == "" || strings.ContainsAny(value, "\r\n\x00") {
 			return fmt.Errorf("delegated ServiceAccount has incomplete identity annotations")
 		}
@@ -240,7 +280,7 @@ func verifyDelegatedUserAnnotations(sa *corev1.ServiceAccount) error {
 	if tenantPathFor(sa.Annotations[AnnotationDelegatedOrg], sa.Annotations[AnnotationDelegatedWorkspace]) != sa.Annotations[AnnotationWorkloadIdentityTenantPath] {
 		return fmt.Errorf("delegated ServiceAccount tenant annotations disagree")
 	}
-	return nil
+	return verifyDelegatedProof(key, sa)
 }
 
 func validateDelegatedInputs(orgUUID, wsUUID string, user Identity, providerName string) error {
@@ -282,41 +322,87 @@ func delegatedUserAnnotations(tenantPath, orgUUID, wsUUID string, user Identity,
 	}
 }
 
-func ensureDelegatedUserServiceAccount(ctx context.Context, cs kubernetes.Interface, name, tenantPath, orgUUID, wsUUID string, user Identity, providerName string) error {
+// ensureDelegatedServiceAccountAttempts bounds the create/replace loop. Each
+// iteration makes progress (create, or delete an unproven object), so a small
+// number covers replicas racing on the same tuple.
+const ensureDelegatedServiceAccountAttempts = 4
+
+func ensureDelegatedUserServiceAccount(ctx context.Context, cs kubernetes.Interface, proofKey []byte, name, tenantPath, orgUUID, wsUUID string, user Identity, providerName string) error {
 	sas := cs.CoreV1().ServiceAccounts(Namespace)
 	want := delegatedUserAnnotations(tenantPath, orgUUID, wsUUID, user, providerName)
-	sa, err := sas.Get(ctx, name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		_, err = sas.Create(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: Namespace,
-			Labels: map[string]string{
-				LabelWorkloadIdentity: "true",
-				LabelDelegatedUser:    "true",
-			},
-			Annotations: want,
-		}}, metav1.CreateOptions{})
-		if err == nil {
+	for attempt := 0; attempt < ensureDelegatedServiceAccountAttempts; attempt++ {
+		sa, err := sas.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			created, createErr := sas.Create(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: Namespace,
+				Labels: map[string]string{
+					LabelWorkloadIdentity: "true",
+					LabelDelegatedUser:    "true",
+				},
+				Annotations: want,
+			}}, metav1.CreateOptions{})
+			if apierrors.IsAlreadyExists(createErr) {
+				// Lost a race with another replica; re-read and evaluate it.
+				continue
+			}
+			if createErr != nil {
+				return fmt.Errorf("creating delegated ServiceAccount: %w", createErr)
+			}
+			// The proof binds the UID, which only exists once the object does.
+			return stampDelegatedProof(ctx, sas, created, proofKey, tenantPath, user, providerName)
+		}
+		if err != nil {
+			return fmt.Errorf("getting delegated ServiceAccount: %w", err)
+		}
+		// Every annotation participates in the name, so an existing account
+		// that disagrees on any of them is not ours — refuse rather than adopt
+		// it. The name is a hash of the tuple, so this only trips on a
+		// hand-made object.
+		if !IsDelegatedUserServiceAccount(sa) || sa.Labels[LabelWorkloadIdentity] != "true" {
+			return fmt.Errorf("ServiceAccount %q exists and is not a delegated user identity", name)
+		}
+		for key, value := range want {
+			if sa.Annotations[key] != value {
+				return fmt.Errorf("ServiceAccount %q is bound to a different delegated identity", name)
+			}
+		}
+		if verifyDelegatedProof(proofKey, sa) == nil {
 			return nil
 		}
-		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("creating delegated ServiceAccount: %w", err)
+		// The object describes the right identity but carries no proof from
+		// this hub. It is either a squatter — a tenant member can create this
+		// exact object and mint a token for it, then wait for the hub to bless
+		// it — or an account left by a key that no longer applies. Either way
+		// it must not be adopted: stamping a proof onto it would validate a
+		// token the attacker already holds. Deleting it changes the UID, and
+		// the UID is in the MAC, so every token issued against the old object
+		// dies with it.
+		if err := sas.Delete(ctx, name, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{
+			UID:             &sa.UID,
+			ResourceVersion: &sa.ResourceVersion,
+		}}); err != nil && !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
+			return fmt.Errorf("replacing unproven delegated ServiceAccount %q: %w", name, err)
 		}
-		sa, err = sas.Get(ctx, name, metav1.GetOptions{})
 	}
-	if err != nil {
-		return fmt.Errorf("getting delegated ServiceAccount: %w", err)
+	return fmt.Errorf("delegated ServiceAccount %q could not be reconciled", name)
+}
+
+// stampDelegatedProof writes the hub's proof onto a freshly created account.
+// If the write fails the account is removed rather than left unproven: an
+// unproven account is useless to the hub and, left behind, is one the next
+// mint has to delete anyway.
+func stampDelegatedProof(ctx context.Context, sas corev1typed.ServiceAccountInterface, sa *corev1.ServiceAccount, proofKey []byte, tenantPath string, user Identity, providerName string) error {
+	if sa.UID == "" {
+		return fmt.Errorf("delegated ServiceAccount %q was created without a UID", sa.Name)
 	}
-	// Every annotation participates in the name, so an existing account that
-	// disagrees on any of them is not ours — refuse rather than adopt it. The
-	// name is a hash of the tuple, so this only trips on a hand-made object.
-	if !IsDelegatedUserServiceAccount(sa) || sa.Labels[LabelWorkloadIdentity] != "true" {
-		return fmt.Errorf("ServiceAccount %q exists and is not a delegated user identity", name)
+	sa = sa.DeepCopy()
+	if err := SignDelegatedUserServiceAccount(proofKey, sa, tenantPath, user, providerName); err != nil {
+		return err
 	}
-	for key, value := range want {
-		if sa.Annotations[key] != value {
-			return fmt.Errorf("ServiceAccount %q is bound to a different delegated identity", name)
-		}
+	if _, err := sas.Update(ctx, sa, metav1.UpdateOptions{}); err != nil {
+		_ = sas.Delete(ctx, sa.Name, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &sa.UID}})
+		return fmt.Errorf("stamping delegated ServiceAccount proof: %w", err)
 	}
 	return nil
 }

--- a/pkg/hub/serviceaccounts/delegated_user_token.go
+++ b/pkg/hub/serviceaccounts/delegated_user_token.go
@@ -47,6 +47,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
 	authnv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -129,6 +130,12 @@ type delegatedTokenKey struct {
 	orgUUID, wsUUID, user, provider string
 }
 
+// String is the singleflight key. Every component is NUL-free by
+// validateDelegatedInputs, so distinct tuples cannot collide on one string.
+func (k delegatedTokenKey) String() string {
+	return strings.Join([]string{k.orgUUID, k.wsUUID, k.user, k.provider}, "\x00")
+}
+
 type delegatedTokenEntry struct {
 	token     string
 	expiresAt time.Time
@@ -157,7 +164,33 @@ func (m *Manager) IssueDelegatedUserToken(ctx context.Context, orgUUID, wsUUID s
 		return token, expiresAt, nil
 	}
 
-	return m.mintDelegatedUserToken(ctx, key, orgUUID, wsUUID, user, providerName)
+	// Deduplicate the mint per tuple. Without this every concurrent request
+	// for the same (org, workspace, user, provider) that misses the cache
+	// mints its own token and reconciles the same ServiceAccount and
+	// ClusterRoleBinding in parallel — a burst of TokenRequests and writes
+	// against one object for a result they all share. singleflight collapses
+	// the burst into one mint whose result every waiter receives.
+	type mintResult struct {
+		token     string
+		expiresAt time.Time
+	}
+	value, err, _ := m.delegatedFlight.Do(key.String(), func() (any, error) {
+		// The winner re-checks the cache: a request that queued behind an
+		// in-flight mint for a *different* key may still find a fresh entry.
+		if token, expiresAt, ok := m.cachedDelegatedToken(key); ok {
+			return mintResult{token: token, expiresAt: expiresAt}, nil
+		}
+		token, expiresAt, err := m.mintDelegatedUserToken(ctx, key, orgUUID, wsUUID, user, providerName)
+		if err != nil {
+			return nil, err
+		}
+		return mintResult{token: token, expiresAt: expiresAt}, nil
+	})
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	result := value.(mintResult)
+	return result.token, result.expiresAt, nil
 }
 
 // cachedDelegatedToken returns a still-usable cached token for key.
@@ -419,5 +452,10 @@ func (m *Manager) clock() time.Time {
 type delegatedCache struct {
 	delegatedMu sync.Mutex
 	delegated   map[delegatedTokenKey]delegatedTokenEntry
-	now         func() time.Time
+	// delegatedFlight collapses concurrent cache misses for one tuple into a
+	// single mint. Process-local: it removes the stampede within a replica,
+	// which is where it happens — a burst is one user's browser opening
+	// several provider requests at once, and those all land on one replica.
+	delegatedFlight singleflight.Group
+	now             func() time.Time
 }

--- a/pkg/hub/serviceaccounts/delegated_user_token_test.go
+++ b/pkg/hub/serviceaccounts/delegated_user_token_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccounts
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	authnv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+const (
+	delegatedTestOrg      = "org"
+	delegatedTestWS       = "workspace"
+	delegatedTestProvider = "infrastructure"
+)
+
+var delegatedTestUser = Identity{User: "alice"}
+
+// delegatedTokenReactor answers TokenRequests with a token that names the
+// mint count, so a test can tell a cached token from a fresh one, and returns
+// the issued expiry it was configured with.
+func delegatedTokenReactor(m *Manager, ttl time.Duration) (*int, clienttesting.ReactionFunc) {
+	mints := 0
+	return &mints, func(action clienttesting.Action) (bool, runtime.Object, error) {
+		mints++
+		return true, &authnv1.TokenRequest{Status: authnv1.TokenRequestStatus{
+			Token:               "delegated-" + strings.Repeat("x", mints),
+			ExpirationTimestamp: metav1.NewTime(m.clock().Add(ttl)),
+		}}, nil
+	}
+}
+
+func TestIssueDelegatedUserTokenCreatesOneAccountBoundToMemberRole(t *testing.T) {
+	m, cs := managerFor(t)
+	defer resetTestClientset()
+	var gotAudience []string
+	var gotTTL int64
+	cs.PrependReactor("create", "serviceaccounts/token", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		request := action.(clienttesting.CreateAction).GetObject().(*authnv1.TokenRequest)
+		gotAudience = append([]string(nil), request.Spec.Audiences...)
+		gotTTL = *request.Spec.ExpirationSeconds
+		return true, &authnv1.TokenRequest{Status: authnv1.TokenRequestStatus{
+			Token:               "delegated-token",
+			ExpirationTimestamp: metav1.NewTime(time.Now().Add(WorkloadIdentityTokenTTL)),
+		}}, nil
+	})
+
+	ctx := context.Background()
+	token, expiry, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider)
+	if err != nil {
+		t.Fatalf("IssueDelegatedUserToken: %v", err)
+	}
+	if token != "delegated-token" || expiry.IsZero() {
+		t.Fatalf("token/expiry = %q/%v", token, expiry)
+	}
+	if len(gotAudience) != 1 || gotAudience[0] != WorkloadIdentityTokenAudience {
+		t.Errorf("TokenRequest audiences = %v, want [%q]", gotAudience, WorkloadIdentityTokenAudience)
+	}
+	if gotTTL != int64(WorkloadIdentityTokenTTL/time.Second) {
+		t.Errorf("TokenRequest TTL = %d, want %d", gotTTL, int64(WorkloadIdentityTokenTTL/time.Second))
+	}
+
+	tenantPath := tenantPathFor(delegatedTestOrg, delegatedTestWS)
+	name := DelegatedUserServiceAccountName(tenantPath, delegatedTestUser, delegatedTestProvider)
+	if !strings.HasPrefix(name, delegatedUserNamePrefix) || len(name) > 63 {
+		t.Fatalf("service account name %q is not a short faros-du-* label", name)
+	}
+	sa, err := cs.CoreV1().ServiceAccounts(Namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get delegated ServiceAccount: %v", err)
+	}
+	if sa.Labels[LabelDelegatedUser] != "true" || sa.Labels[LabelWorkloadIdentity] != "true" {
+		t.Errorf("labels = %v, want delegated-user and workload-identity", sa.Labels)
+	}
+	if _, isUserManaged := sa.Labels[LabelFarosSA]; isUserManaged {
+		t.Error("delegated ServiceAccount carries the user-managed SA label and would be listable/rotatable by tenants")
+	}
+	for key, want := range map[string]string{
+		AnnotationWorkloadIdentityTenantPath: tenantPath,
+		AnnotationDelegatedUser:              "alice",
+		AnnotationDelegatedOrg:               delegatedTestOrg,
+		AnnotationDelegatedWorkspace:         delegatedTestWS,
+		AnnotationDelegatedProvider:          delegatedTestProvider,
+	} {
+		if got := sa.Annotations[key]; got != want {
+			t.Errorf("annotation %q = %q, want %q", key, got, want)
+		}
+	}
+
+	binding, err := cs.RbacV1().ClusterRoleBindings().Get(ctx, DelegatedUserBindingName(name), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get delegated ClusterRoleBinding: %v", err)
+	}
+	if binding.RoleRef.Kind != "ClusterRole" || binding.RoleRef.Name != DelegatedUserClusterRole {
+		t.Errorf("binding role = %+v, want ClusterRole %s (what workspace members hold today)", binding.RoleRef, DelegatedUserClusterRole)
+	}
+	if len(binding.Subjects) != 1 || binding.Subjects[0].Kind != "ServiceAccount" || binding.Subjects[0].Name != name || binding.Subjects[0].Namespace != Namespace {
+		t.Errorf("binding subjects = %+v, want only the delegated ServiceAccount", binding.Subjects)
+	}
+
+	// Second issuance for the same tuple after the cache is dropped reuses
+	// the account: nothing accumulates per request.
+	m.delegated = nil
+	if _, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider); err != nil {
+		t.Fatalf("IssueDelegatedUserToken (repeat): %v", err)
+	}
+	list, err := cs.CoreV1().ServiceAccounts(Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list ServiceAccounts: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("ServiceAccounts after two issuances = %d, want 1", len(list.Items))
+	}
+}
+
+func TestIssueDelegatedUserTokenCachesAndRefreshesOnExpiry(t *testing.T) {
+	m, cs := managerFor(t)
+	defer resetTestClientset()
+	now := time.Now()
+	m.now = func() time.Time { return now }
+	mints, reactor := delegatedTokenReactor(m, WorkloadIdentityTokenTTL)
+	cs.PrependReactor("create", "serviceaccounts/token", reactor)
+	ctx := context.Background()
+
+	first, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider)
+	if err != nil {
+		t.Fatalf("first issue: %v", err)
+	}
+	second, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider)
+	if err != nil {
+		t.Fatalf("second issue: %v", err)
+	}
+	if first != second || *mints != 1 {
+		t.Fatalf("back-to-back issuance minted %d tokens (%q, %q), want one cached token", *mints, first, second)
+	}
+
+	// A different user, workspace, or provider is a different identity and
+	// must not share the cache entry.
+	if _, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, Identity{User: "bob"}, delegatedTestProvider); err != nil {
+		t.Fatalf("issue for bob: %v", err)
+	}
+	if _, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, "vault"); err != nil {
+		t.Fatalf("issue for vault: %v", err)
+	}
+	if *mints != 3 {
+		t.Fatalf("mints after distinct tuples = %d, want 3", *mints)
+	}
+
+	// Past the cache TTL the token is re-minted even though it has not
+	// expired yet.
+	now = now.Add(DelegatedUserTokenCacheTTL + time.Second)
+	third, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider)
+	if err != nil {
+		t.Fatalf("issue after cache TTL: %v", err)
+	}
+	if third == first || *mints != 4 {
+		t.Fatalf("token after cache TTL = %q (mints %d), want a fresh one", third, *mints)
+	}
+}
+
+func TestIssueDelegatedUserTokenRefreshesBeforeShortExpiry(t *testing.T) {
+	m, cs := managerFor(t)
+	defer resetTestClientset()
+	now := time.Now()
+	m.now = func() time.Time { return now }
+	// The API server caps the token to 2 minutes, well under the cache TTL:
+	// the cache must follow the token's expiry, not its own clock.
+	mints, reactor := delegatedTokenReactor(m, 2*time.Minute)
+	cs.PrependReactor("create", "serviceaccounts/token", reactor)
+	ctx := context.Background()
+
+	if _, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider); err != nil {
+		t.Fatalf("first issue: %v", err)
+	}
+	now = now.Add(90 * time.Second)
+	if _, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider); err != nil {
+		t.Fatalf("issue near expiry: %v", err)
+	}
+	if *mints != 2 {
+		t.Fatalf("mints = %d, want a refresh once the token is within %v of expiry", *mints, delegatedUserTokenExpirySlack)
+	}
+}
+
+func TestIssueDelegatedUserTokenRejectsOverlongTokenAndBadInput(t *testing.T) {
+	m, cs := managerFor(t)
+	defer resetTestClientset()
+	cs.PrependReactor("create", "serviceaccounts/token", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, &authnv1.TokenRequest{Status: authnv1.TokenRequestStatus{
+			Token:               "too-long",
+			ExpirationTimestamp: metav1.NewTime(time.Now().Add(WorkloadIdentityTokenTTL + 2*time.Second)),
+		}}, nil
+	})
+	ctx := context.Background()
+	if _, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider); err == nil {
+		t.Fatal("accepted a token longer than policy allows")
+	}
+	for name, call := range map[string]func() error{
+		"empty user": func() error {
+			_, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, Identity{}, delegatedTestProvider)
+			return err
+		},
+		"empty workspace": func() error {
+			_, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, "", delegatedTestUser, delegatedTestProvider)
+			return err
+		},
+		"colon in org": func() error {
+			_, _, err := m.IssueDelegatedUserToken(ctx, "org:evil", delegatedTestWS, delegatedTestUser, delegatedTestProvider)
+			return err
+		},
+		"empty provider": func() error {
+			_, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, "")
+			return err
+		},
+	} {
+		if err := call(); err == nil {
+			t.Errorf("%s: accepted", name)
+		}
+	}
+}
+
+func TestIssueDelegatedUserTokenRefusesForeignAccountOfSameName(t *testing.T) {
+	tenantPath := tenantPathFor(delegatedTestOrg, delegatedTestWS)
+	name := DelegatedUserServiceAccountName(tenantPath, delegatedTestUser, delegatedTestProvider)
+	// A hand-made account squatting on the deterministic name, without the
+	// hub's labels: never adopt it, never mint for it.
+	m, _ := managerFor(t, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: Namespace}})
+	defer resetTestClientset()
+	if _, _, err := m.IssueDelegatedUserToken(context.Background(), delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider); err == nil {
+		t.Fatal("minted a token for a ServiceAccount the hub did not create")
+	}
+}
+
+func TestVerifyDelegatedUserAnnotationsAcceptsHubMintedAndRejectsTampered(t *testing.T) {
+	tenantPath := tenantPathFor(delegatedTestOrg, delegatedTestWS)
+	good := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name: "faros-du-x", Namespace: Namespace,
+		Labels:      map[string]string{LabelWorkloadIdentity: "true", LabelDelegatedUser: "true"},
+		Annotations: delegatedUserAnnotations(tenantPath, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider),
+	}}
+	if err := verifyWorkloadServiceAccountAnnotations(good, tenantPath); err != nil {
+		t.Fatalf("hub-minted delegated account rejected: %v", err)
+	}
+	identity, err := DelegatedUserFromServiceAccount(good)
+	if err != nil || identity.User != "alice" {
+		t.Fatalf("DelegatedUserFromServiceAccount = %+v, %v", identity, err)
+	}
+
+	otherTenant := good.DeepCopy()
+	otherTenant.Annotations[AnnotationDelegatedWorkspace] = "elsewhere"
+	if err := verifyWorkloadServiceAccountAnnotations(otherTenant, tenantPath); err == nil {
+		t.Error("accepted a delegated account whose workspace annotation disagrees with its tenant path")
+	}
+	noUser := good.DeepCopy()
+	delete(noUser.Annotations, AnnotationDelegatedUser)
+	if err := verifyWorkloadServiceAccountAnnotations(noUser, tenantPath); err == nil {
+		t.Error("accepted a delegated account with no user annotation")
+	}
+	if err := verifyWorkloadServiceAccountAnnotations(good, "root:faros:tenants:org:other"); err == nil {
+		t.Error("accepted a delegated account for a tenant it was not minted in")
+	}
+	// A workload identity is still held to the full Project tuple.
+	notDelegated := good.DeepCopy()
+	delete(notDelegated.Labels, LabelDelegatedUser)
+	if err := verifyWorkloadServiceAccountAnnotations(notDelegated, tenantPath); err == nil {
+		t.Error("a non-delegated account with only delegated annotations passed the workload check")
+	}
+}

--- a/pkg/hub/serviceaccounts/delegated_user_token_test.go
+++ b/pkg/hub/serviceaccounts/delegated_user_token_test.go
@@ -19,6 +19,7 @@ package serviceaccounts
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -434,5 +435,62 @@ func TestIssueDelegatedUserTokenFailsClosedWithoutProofKey(t *testing.T) {
 	m.proofKeys = nil
 	if _, _, err := m.IssueDelegatedUserToken(context.Background(), delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider); err == nil {
 		t.Fatal("minted a delegated token with no proof key source")
+	}
+}
+
+// TestIssueDelegatedUserTokenMintsOnceUnderConcurrency: concurrent callers for
+// one tuple share a single mint instead of each issuing their own token and
+// racing on the same ServiceAccount and binding.
+func TestIssueDelegatedUserTokenMintsOnceUnderConcurrency(t *testing.T) {
+	m, cs := managerFor(t)
+	defer resetTestClientset()
+
+	var mu sync.Mutex
+	mints := 0
+	release := make(chan struct{})
+	cs.PrependReactor("create", "serviceaccounts/token", func(clienttesting.Action) (bool, runtime.Object, error) {
+		mu.Lock()
+		mints++
+		mu.Unlock()
+		// Hold the mint open until every caller has arrived, so a
+		// non-deduplicated implementation cannot pass by being fast enough
+		// for later callers to hit the cache.
+		<-release
+		return true, &authnv1.TokenRequest{Status: authnv1.TokenRequestStatus{
+			Token:               "delegated-token",
+			ExpirationTimestamp: metav1.NewTime(time.Now().Add(WorkloadIdentityTokenTTL)),
+		}}, nil
+	})
+
+	const callers = 8
+	ctx := context.Background()
+	tokens := make([]string, callers)
+	errs := make([]error, callers)
+	var wg sync.WaitGroup
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tokens[i], _, errs[i] = m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider)
+		}()
+	}
+	// Give every caller time to reach the singleflight before the one that
+	// won it completes.
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i := range callers {
+		if errs[i] != nil {
+			t.Fatalf("caller %d: %v", i, errs[i])
+		}
+		if tokens[i] != "delegated-token" {
+			t.Fatalf("caller %d got token %q", i, tokens[i])
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if mints != 1 {
+		t.Fatalf("concurrent callers for one tuple minted %d tokens, want 1", mints)
 	}
 }

--- a/pkg/hub/serviceaccounts/delegated_user_token_test.go
+++ b/pkg/hub/serviceaccounts/delegated_user_token_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clienttesting "k8s.io/client-go/testing"
 )
 
@@ -251,38 +252,187 @@ func TestIssueDelegatedUserTokenRefusesForeignAccountOfSameName(t *testing.T) {
 	}
 }
 
-func TestVerifyDelegatedUserAnnotationsAcceptsHubMintedAndRejectsTampered(t *testing.T) {
-	tenantPath := tenantPathFor(delegatedTestOrg, delegatedTestWS)
-	good := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
-		Name: "faros-du-x", Namespace: Namespace,
+// hubMintedDelegatedServiceAccount is what the hub writes: the account plus
+// the keyed proof it stamps once the object (and its UID) exists.
+func hubMintedDelegatedServiceAccount(t *testing.T, tenantPath string, user Identity, uid types.UID) *corev1.ServiceAccount {
+	t.Helper()
+	name := DelegatedUserServiceAccountName(tenantPath, user, delegatedTestProvider)
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: Namespace, UID: uid,
 		Labels:      map[string]string{LabelWorkloadIdentity: "true", LabelDelegatedUser: "true"},
-		Annotations: delegatedUserAnnotations(tenantPath, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider),
+		Annotations: delegatedUserAnnotations(tenantPath, delegatedTestOrg, delegatedTestWS, user, delegatedTestProvider),
 	}}
-	if err := verifyWorkloadServiceAccountAnnotations(good, tenantPath); err != nil {
+	key, err := testProofKeySource.DelegatedProofKey(context.Background())
+	if err != nil {
+		t.Fatalf("test proof key: %v", err)
+	}
+	sa.Annotations[AnnotationDelegatedProof] = computeDelegatedProof(key, tenantPath, user, delegatedTestProvider, name, uid)
+	return sa
+}
+
+func TestVerifyDelegatedUserAnnotationsAcceptsHubMintedAndRejectsTampered(t *testing.T) {
+	ctx := context.Background()
+	tenantPath := tenantPathFor(delegatedTestOrg, delegatedTestWS)
+	good := hubMintedDelegatedServiceAccount(t, tenantPath, delegatedTestUser, "uid-good")
+	if err := verifyWorkloadServiceAccountAnnotations(ctx, good, tenantPath, testProofKeySource); err != nil {
 		t.Fatalf("hub-minted delegated account rejected: %v", err)
 	}
-	identity, err := DelegatedUserFromServiceAccount(good)
+	identity, err := DelegatedUserFromServiceAccount(ctx, testProofKeySource, good)
 	if err != nil || identity.User != "alice" {
 		t.Fatalf("DelegatedUserFromServiceAccount = %+v, %v", identity, err)
 	}
 
 	otherTenant := good.DeepCopy()
 	otherTenant.Annotations[AnnotationDelegatedWorkspace] = "elsewhere"
-	if err := verifyWorkloadServiceAccountAnnotations(otherTenant, tenantPath); err == nil {
+	if err := verifyWorkloadServiceAccountAnnotations(ctx, otherTenant, tenantPath, testProofKeySource); err == nil {
 		t.Error("accepted a delegated account whose workspace annotation disagrees with its tenant path")
 	}
 	noUser := good.DeepCopy()
 	delete(noUser.Annotations, AnnotationDelegatedUser)
-	if err := verifyWorkloadServiceAccountAnnotations(noUser, tenantPath); err == nil {
+	if err := verifyWorkloadServiceAccountAnnotations(ctx, noUser, tenantPath, testProofKeySource); err == nil {
 		t.Error("accepted a delegated account with no user annotation")
 	}
-	if err := verifyWorkloadServiceAccountAnnotations(good, "root:faros:tenants:org:other"); err == nil {
+	if err := verifyWorkloadServiceAccountAnnotations(ctx, good, "root:faros:tenants:org:other", testProofKeySource); err == nil {
 		t.Error("accepted a delegated account for a tenant it was not minted in")
 	}
 	// A workload identity is still held to the full Project tuple.
 	notDelegated := good.DeepCopy()
 	delete(notDelegated.Labels, LabelDelegatedUser)
-	if err := verifyWorkloadServiceAccountAnnotations(notDelegated, tenantPath); err == nil {
+	if err := verifyWorkloadServiceAccountAnnotations(ctx, notDelegated, tenantPath, testProofKeySource); err == nil {
 		t.Error("a non-delegated account with only delegated annotations passed the workload check")
+	}
+}
+
+// TestDelegatedIdentityRejectsTenantForgedServiceAccount is the privilege
+// escalation this proof exists to close.
+//
+// A delegated ServiceAccount lives in namespace "default" of the tenant's own
+// team workspace, and the bootstrap binds every workspace member to
+// cluster-admin there. An ordinary member can therefore create exactly the
+// object the hub would have created — right name (it is a hash of the tenant
+// path, the user, and the provider, all public), right label, all four
+// identity annotations naming whoever they choose — mint a token for it with
+// TokenRequest, and hand it to the provider proxy. Before the proof, every
+// check the hub made compared inputs that member had written, so the far end
+// received X-Faros-User naming the victim.
+func TestDelegatedIdentityRejectsTenantForgedServiceAccount(t *testing.T) {
+	ctx := context.Background()
+	tenantPath := tenantPathFor(delegatedTestOrg, delegatedTestWS)
+	victim := Identity{User: "victim@example.com"}
+
+	// Built exactly as a malicious workspace member would build it, and given
+	// a UID as the apiserver would on create. Everything here is genuine
+	// except that no hub ever touched it.
+	forged := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name:      DelegatedUserServiceAccountName(tenantPath, victim, delegatedTestProvider),
+		Namespace: Namespace,
+		UID:       "uid-attacker-made",
+		Labels:    map[string]string{LabelWorkloadIdentity: "true", LabelDelegatedUser: "true"},
+		Annotations: delegatedUserAnnotations(
+			tenantPath, delegatedTestOrg, delegatedTestWS, victim, delegatedTestProvider),
+	}}
+
+	if err := verifyWorkloadServiceAccountAnnotations(ctx, forged, tenantPath, testProofKeySource); err == nil {
+		t.Error("a tenant-forged delegated ServiceAccount passed workload verification")
+	}
+	if identity, err := DelegatedUserFromServiceAccount(ctx, testProofKeySource, forged); err == nil {
+		t.Errorf("a tenant-forged delegated ServiceAccount resolved as %q", identity.User)
+	}
+
+	// Nor can the attacker lift a valid proof off a real account: the MAC
+	// covers the user, the provider, the object name, and the object UID.
+	legitimate := hubMintedDelegatedServiceAccount(t, tenantPath, delegatedTestUser, "uid-legit")
+	stolen := forged.DeepCopy()
+	stolen.Annotations[AnnotationDelegatedProof] = legitimate.Annotations[AnnotationDelegatedProof]
+	if _, err := DelegatedUserFromServiceAccount(ctx, testProofKeySource, stolen); err == nil {
+		t.Error("a proof copied from another account was accepted")
+	}
+
+	// Nor can they take over a real account by recreating it under the same
+	// name: the UID is part of the MAC, so the copied proof dies with the
+	// original object.
+	recreated := legitimate.DeepCopy()
+	recreated.UID = "uid-attacker-recreated"
+	if _, err := DelegatedUserFromServiceAccount(ctx, testProofKeySource, recreated); err == nil {
+		t.Error("a delegated account recreated under a new UID kept its proof")
+	}
+
+	// Rewriting the user on a real account invalidates its proof too.
+	rewritten := legitimate.DeepCopy()
+	rewritten.Annotations[AnnotationDelegatedUser] = victim.User
+	if identity, err := DelegatedUserFromServiceAccount(ctx, testProofKeySource, rewritten); err == nil {
+		t.Errorf("a rewritten user annotation resolved as %q", identity.User)
+	}
+
+	// And the label alone must not open a path that skips the proof: with no
+	// key source configured the identity is refused outright rather than
+	// falling through to some other reading of the object.
+	if err := verifyWorkloadServiceAccountAnnotations(ctx, legitimate, tenantPath, nil); err == nil {
+		t.Error("a delegated account was accepted with no proof key source configured")
+	}
+
+	// Positive control: the hub's own account still resolves.
+	if identity, err := DelegatedUserFromServiceAccount(ctx, testProofKeySource, legitimate); err != nil || identity.User != delegatedTestUser.User {
+		t.Fatalf("hub-minted account did not resolve: %+v, %v", identity, err)
+	}
+}
+
+// TestIssueDelegatedUserTokenStampsProofAndReplacesSquatter covers the mint
+// side: the hub writes a proof, and it refuses to bless an unproven account
+// that a member pre-created and already holds a token for. Adopting one would
+// hand the attacker's existing token the victim's identity, so the account is
+// replaced — the new UID makes the old token dead.
+func TestIssueDelegatedUserTokenStampsProofAndReplacesSquatter(t *testing.T) {
+	ctx := context.Background()
+	tenantPath := tenantPathFor(delegatedTestOrg, delegatedTestWS)
+	name := DelegatedUserServiceAccountName(tenantPath, delegatedTestUser, delegatedTestProvider)
+
+	// The squatter: the object a member would create, with a UID they hold a
+	// token against, and no proof.
+	squatter := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: Namespace, UID: "uid-squatter",
+		Labels: map[string]string{LabelWorkloadIdentity: "true", LabelDelegatedUser: "true"},
+		Annotations: delegatedUserAnnotations(
+			tenantPath, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider),
+	}}
+	m, cs := managerFor(t, squatter)
+	defer resetTestClientset()
+	cs.PrependReactor("create", "serviceaccounts/token", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, &authnv1.TokenRequest{Status: authnv1.TokenRequestStatus{
+			Token:               "delegated-token",
+			ExpirationTimestamp: metav1.NewTime(time.Now().Add(WorkloadIdentityTokenTTL)),
+		}}, nil
+	})
+
+	if _, _, err := m.IssueDelegatedUserToken(ctx, delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider); err != nil {
+		t.Fatalf("IssueDelegatedUserToken: %v", err)
+	}
+	sa, err := cs.CoreV1().ServiceAccounts(Namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get delegated ServiceAccount: %v", err)
+	}
+	if sa.UID == squatter.UID {
+		t.Fatal("the hub adopted the pre-created account; a token the attacker already holds now resolves as the victim")
+	}
+	key, err := testProofKeySource.DelegatedProofKey(ctx)
+	if err != nil {
+		t.Fatalf("test proof key: %v", err)
+	}
+	if err := verifyDelegatedProof(key, sa); err != nil {
+		t.Fatalf("hub-minted account carries no valid proof: %v", err)
+	}
+	if _, err := DelegatedUserFromServiceAccount(ctx, testProofKeySource, sa); err != nil {
+		t.Fatalf("hub-minted account does not resolve: %v", err)
+	}
+}
+
+// TestIssueDelegatedUserTokenFailsClosedWithoutProofKey: a Manager that cannot
+// sign must not mint an account whose identity nothing can later establish.
+func TestIssueDelegatedUserTokenFailsClosedWithoutProofKey(t *testing.T) {
+	m, _ := managerFor(t)
+	defer resetTestClientset()
+	m.proofKeys = nil
+	if _, _, err := m.IssueDelegatedUserToken(context.Background(), delegatedTestOrg, delegatedTestWS, delegatedTestUser, delegatedTestProvider); err == nil {
+		t.Fatal("minted a delegated token with no proof key source")
 	}
 }

--- a/pkg/hub/serviceaccounts/manager_test.go
+++ b/pkg/hub/serviceaccounts/manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package serviceaccounts
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -27,6 +28,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -52,11 +55,46 @@ func (fakeConfigBuilder) ChildWorkspaceConfig(_, _ string) *rest.Config {
 // helper uses an internal alternate Manager constructor.
 func managerFor(_ *testing.T, objects ...runtime.Object) (*Manager, *fake.Clientset) {
 	cs := fake.NewSimpleClientset(objects...)
-	m := &Manager{cfg: fakeConfigBuilder{}}
+	assignServiceAccountUIDs(cs)
+	m := &Manager{cfg: fakeConfigBuilder{}, proofKeys: testProofKeySource}
 	// Override the clientset method via the testClientset variable
 	// hook in serviceaccounts.go (see below).
 	testClientset = func() (kubernetes.Interface, bool) { return cs, true }
 	return m, cs
+}
+
+// testProofKeySource is the delegated-identity signing key used across the
+// package's tests. Production reads it from a Secret in a hub-internal
+// workspace; the value only has to be stable and long enough.
+var testProofKeySource = StaticProofKeySource(bytes.Repeat([]byte{0x5a}, delegatedProofKeyLength))
+
+var serviceAccountGVR = schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}
+
+// assignServiceAccountUIDs makes the fake clientset behave like a real
+// apiserver in the one respect the delegated-identity proof depends on: a
+// created ServiceAccount comes back with a UID. The fake's object tracker
+// stores whatever it is handed, UID and all, so without this every account
+// would share the empty UID and the proof would not be object-bound.
+func assignServiceAccountUIDs(cs *fake.Clientset) {
+	cs.PrependReactor("create", "serviceaccounts", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "" {
+			return false, nil, nil
+		}
+		create, ok := action.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		sa, ok := create.GetObject().(*corev1.ServiceAccount)
+		if !ok || sa.UID != "" {
+			return false, nil, nil
+		}
+		sa = sa.DeepCopy()
+		sa.UID = types.UID("uid-" + sa.Name)
+		if err := cs.Tracker().Create(serviceAccountGVR, sa, create.GetNamespace()); err != nil {
+			return true, nil, err
+		}
+		return true, sa, nil
+	})
 }
 
 func TestCreate_HappyPath(t *testing.T) {

--- a/pkg/hub/serviceaccounts/serviceaccounts.go
+++ b/pkg/hub/serviceaccounts/serviceaccounts.go
@@ -127,15 +127,26 @@ type WorkspaceConfigBuilder interface {
 // clientset targeting the requested (orgUUID, wsUUID).
 type Manager struct {
 	cfg WorkspaceConfigBuilder
+	// proofKeys yields the key the hub signs delegated user identities with.
+	// Nil disables delegation entirely — IssueDelegatedUserToken fails rather
+	// than minting an account whose identity nothing can later prove. See
+	// delegated_user_proof.go.
+	proofKeys ProofKeySource
 	// delegatedCache backs IssueDelegatedUserToken; see
 	// delegated_user_token.go.
 	delegatedCache
 }
 
-// NewManager constructs a Manager backed by the given workspace
-// config builder.
-func NewManager(cfg WorkspaceConfigBuilder) *Manager {
-	return &Manager{cfg: cfg}
+// NewManager constructs a Manager backed by the given workspace config
+// builder. Pass a ProofKeySource to enable delegated user tokens; without one
+// the delegated path fails closed and the rest of the SA surface is
+// unaffected.
+func NewManager(cfg WorkspaceConfigBuilder, proofKeys ...ProofKeySource) *Manager {
+	m := &Manager{cfg: cfg}
+	if len(proofKeys) > 0 {
+		m.proofKeys = proofKeys[0]
+	}
+	return m
 }
 
 // SA is the REST-layer projection of a faros ServiceAccount. The

--- a/pkg/hub/serviceaccounts/serviceaccounts.go
+++ b/pkg/hub/serviceaccounts/serviceaccounts.go
@@ -127,6 +127,9 @@ type WorkspaceConfigBuilder interface {
 // clientset targeting the requested (orgUUID, wsUUID).
 type Manager struct {
 	cfg WorkspaceConfigBuilder
+	// delegatedCache backs IssueDelegatedUserToken; see
+	// delegated_user_token.go.
+	delegatedCache
 }
 
 // NewManager constructs a Manager backed by the given workspace

--- a/pkg/hub/serviceaccounts/workload_identity.go
+++ b/pkg/hub/serviceaccounts/workload_identity.go
@@ -208,8 +208,10 @@ func (m *Manager) EnsureWorkloadIdentity(ctx context.Context, orgUUID, wsUUID st
 // selected child workspace and verifies that the reviewed ServiceAccount is a
 // hub-managed workload identity bound to expectedTenantPath. JWT signatures
 // and claims are intentionally never trusted offline.
+// It accepts workload identities only: a delegated user identity is rejected,
+// because this entry point has no proof key with which to establish one.
 func VerifyWorkloadServiceAccount(ctx context.Context, cfg *rest.Config, token, expectedTenantPath string) (string, error) {
-	username, _, err := VerifyWorkloadServiceAccountDetails(ctx, cfg, token, expectedTenantPath)
+	username, _, err := VerifyWorkloadServiceAccountDetails(ctx, cfg, token, expectedTenantPath, nil)
 	return username, err
 }
 
@@ -217,7 +219,12 @@ func VerifyWorkloadServiceAccount(ctx context.Context, cfg *rest.Config, token, 
 // verifier used by both tenant resolution and action-grant authorization. It
 // returns the reviewed ServiceAccount only after TokenReview, audience,
 // subject, label, tenant, and required identity annotations have all passed.
-func VerifyWorkloadServiceAccountDetails(ctx context.Context, cfg *rest.Config, token, expectedTenantPath string) (string, *corev1.ServiceAccount, error) {
+//
+// proofKeys is consulted only for delegated user identities, whose annotations
+// are tenant-writable and therefore mean nothing without the hub's keyed proof
+// (see delegated_user_proof.go). A nil source rejects them outright; that is
+// the right answer for any caller that is not the delegated-token path.
+func VerifyWorkloadServiceAccountDetails(ctx context.Context, cfg *rest.Config, token, expectedTenantPath string, proofKeys ProofKeySource) (string, *corev1.ServiceAccount, error) {
 	if cfg == nil || strings.TrimSpace(token) == "" || strings.TrimSpace(expectedTenantPath) == "" {
 		return "", nil, fmt.Errorf("workload token, tenant path, and workspace config are required")
 	}
@@ -243,7 +250,7 @@ func VerifyWorkloadServiceAccountDetails(ctx context.Context, cfg *rest.Config, 
 	if err != nil {
 		return "", nil, fmt.Errorf("getting workload ServiceAccount: %w", err)
 	}
-	if err := verifyWorkloadServiceAccountAnnotations(sa, expectedTenantPath); err != nil {
+	if err := verifyWorkloadServiceAccountAnnotations(ctx, sa, expectedTenantPath, proofKeys); err != nil {
 		return "", nil, err
 	}
 	return review.Status.User.Username, sa, nil
@@ -334,7 +341,7 @@ func workloadIdentityAnnotations(scope WorkloadIdentityScope) map[string]string 
 	}
 }
 
-func verifyWorkloadServiceAccountAnnotations(sa *corev1.ServiceAccount, expectedTenantPath string) error {
+func verifyWorkloadServiceAccountAnnotations(ctx context.Context, sa *corev1.ServiceAccount, expectedTenantPath string, proofKeys ProofKeySource) error {
 	if sa == nil || sa.Labels[LabelWorkloadIdentity] != "true" || sa.Annotations[AnnotationWorkloadIdentityTenantPath] != expectedTenantPath {
 		return fmt.Errorf("workload ServiceAccount is not bound to selected tenant")
 	}
@@ -343,8 +350,17 @@ func verifyWorkloadServiceAccountAnnotations(sa *corev1.ServiceAccount, expected
 	// It never has a scope marker, so an action-grant check comparing markers
 	// fails closed on it — which is right: delegation reaches a provider's
 	// data plane as the user, not the action runtime.
+	//
+	// Note the label alone is tenant-writable, so this branch is reachable by
+	// anyone; it is also terminal, so a hand-made object cannot fall through
+	// to the workload-identity checks below and be read as some other
+	// identity. Without a valid hub proof it is rejected outright.
 	if IsDelegatedUserServiceAccount(sa) {
-		return verifyDelegatedUserAnnotations(sa)
+		key, err := delegatedProofKey(ctx, proofKeys)
+		if err != nil {
+			return err
+		}
+		return verifyDelegatedUserAnnotations(key, sa)
 	}
 	for _, key := range []string{
 		AnnotationWorkloadIdentityScope,

--- a/pkg/hub/serviceaccounts/workload_identity.go
+++ b/pkg/hub/serviceaccounts/workload_identity.go
@@ -338,6 +338,14 @@ func verifyWorkloadServiceAccountAnnotations(sa *corev1.ServiceAccount, expected
 	if sa == nil || sa.Labels[LabelWorkloadIdentity] != "true" || sa.Annotations[AnnotationWorkloadIdentityTenantPath] != expectedTenantPath {
 		return fmt.Errorf("workload ServiceAccount is not bound to selected tenant")
 	}
+	// A delegated user identity is hub-managed and tenant-bound like a
+	// workload identity, but carries a human user instead of a Project tuple.
+	// It never has a scope marker, so an action-grant check comparing markers
+	// fails closed on it — which is right: delegation reaches a provider's
+	// data plane as the user, not the action runtime.
+	if IsDelegatedUserServiceAccount(sa) {
+		return verifyDelegatedUserAnnotations(sa)
+	}
 	for _, key := range []string{
 		AnnotationWorkloadIdentityScope,
 		AnnotationWorkloadIdentityProject,
@@ -449,29 +457,35 @@ func ensureWorkloadRBAC(ctx context.Context, cs kubernetes.Interface, serviceAcc
 		}
 	}
 
+	return ensureWorkloadClusterRoleBinding(ctx, cs, roleName, roleName, serviceAccount)
+}
+
+// ensureWorkloadClusterRoleBinding reconciles the hub-managed
+// ClusterRoleBinding bindingName so that exactly the default-namespace
+// ServiceAccount serviceAccount is bound to the ClusterRole roleName. Shared by
+// the workload identity (which binds its own narrow ClusterRole) and the
+// delegated user identity (which binds the role the workspace already grants
+// its members).
+func ensureWorkloadClusterRoleBinding(ctx context.Context, cs kubernetes.Interface, bindingName, roleName, serviceAccount string) error {
 	bindings := cs.RbacV1().ClusterRoleBindings()
 	wantSubjects := []rbacv1.Subject{{Kind: "ServiceAccount", Name: serviceAccount, Namespace: Namespace}}
-	binding, err := bindings.Get(ctx, roleName, metav1.GetOptions{})
+	wantRoleRef := rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: roleName}
+	binding, err := bindings.Get(ctx, bindingName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		binding, err = bindings.Create(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{
-			Name:   roleName,
+			Name:   bindingName,
 			Labels: map[string]string{LabelWorkloadIdentity: "true"},
-		}, Subjects: wantSubjects, RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     roleName,
-		}}, metav1.CreateOptions{})
+		}, Subjects: wantSubjects, RoleRef: wantRoleRef}, metav1.CreateOptions{})
 		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("creating workload ClusterRoleBinding: %w", err)
 		}
 		if err != nil {
-			binding, err = bindings.Get(ctx, roleName, metav1.GetOptions{})
+			binding, err = bindings.Get(ctx, bindingName, metav1.GetOptions{})
 		}
 	}
 	if err != nil {
 		return fmt.Errorf("getting workload ClusterRoleBinding: %w", err)
 	}
-	wantRoleRef := rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: roleName}
 	if !reflect.DeepEqual(binding.Subjects, wantSubjects) || !reflect.DeepEqual(binding.RoleRef, wantRoleRef) || binding.Labels[LabelWorkloadIdentity] != "true" {
 		updated := binding.DeepCopy()
 		updated.Subjects = wantSubjects
@@ -479,11 +493,11 @@ func ensureWorkloadRBAC(ctx context.Context, cs kubernetes.Interface, serviceAcc
 		// existing binding points at something else; normal reconciliation uses
 		// a metadata/subject update.
 		if !reflect.DeepEqual(updated.RoleRef, wantRoleRef) {
-			if err := bindings.Delete(ctx, roleName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			if err := bindings.Delete(ctx, bindingName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				return fmt.Errorf("deleting stale workload ClusterRoleBinding: %w", err)
 			}
 			_, err := bindings.Create(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{
-				Name: roleName, Labels: map[string]string{LabelWorkloadIdentity: "true"},
+				Name: bindingName, Labels: map[string]string{LabelWorkloadIdentity: "true"},
 			}, Subjects: wantSubjects, RoleRef: wantRoleRef}, metav1.CreateOptions{})
 			if err != nil && !apierrors.IsAlreadyExists(err) {
 				return fmt.Errorf("recreating workload ClusterRoleBinding: %w", err)

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -838,6 +838,13 @@ function dependencyNotice(p: ProviderDTO): string {
             >
               Self-managed
             </span>
+            <span
+              v-if="providers.isSelfManaged(p) && p.shadowsPlatform"
+              class="rounded-md border border-warning/30 bg-warning-subtle px-1.5 py-0.5 text-warning"
+              title="A platform provider with this name exists; your organization's copy is the one your workspaces reach"
+            >
+              Overrides platform provider
+            </span>
             <span v-if="p.hasUI" class="rounded-md border border-border-subtle px-1.5 py-0.5">UI</span>
             <span v-if="p.hasBackend" class="rounded-md border border-border-subtle px-1.5 py-0.5">Backend</span>
             <span v-if="p.apiExportName" class="rounded-md border border-border-subtle px-1.5 py-0.5">API</span>

--- a/portal/src/stores/providers.ts
+++ b/portal/src/stores/providers.ts
@@ -16,6 +16,10 @@ export interface ProviderDTO {
   scope?: ProviderScope
   // UUID of the owning organization when scope === 'org'.
   ownerOrg?: string
+  // True when this org-owned provider has the same name as a platform
+  // provider: the organization's copy is what its users reach, and the
+  // platform one is hidden from this catalog.
+  shadowsPlatform?: boolean
   displayName: string
   // Short "what is this" blurb from CatalogEntry.spec.description. The
   // catalog cards and the first-run welcome flow render it; may be absent


### PR DESCRIPTION
Security remediation plan item 1.2, steps A and B (finding 2). Step C (platform providers) is a later PR.

## Problem

`pkg/hub/providers/proxy.go` forwarded the caller's `Authorization` header as-is to every provider; `setHeaders` stripped only `X-Faros-*`. `serveOverEdge` reused it, so an org-owned provider running in a tenant's cluster received the caller's hub OIDC or static token over the edge tunnel. Providers treat that bearer as a full credential and never TokenReview it (`providers/infrastructure/dataplane/identity.go`, `provider-sdk/tenantaccess`). `GetForOrg` prefers the org record for every backend-proxy call, and `restapi/org_providers.go` treated an empty `CatalogEntryCreation` as `members`, so any org member could register a provider named `infrastructure` and have every org user's request to it — token included — land in the member's cluster.

## Change

**Step A — delegated tokens for org-owned providers**

- `pkg/hub/serviceaccounts/delegated_user_token.go`: `IssueDelegatedUserToken(ctx, orgUUID, wsUUID, user Identity, providerName)` mints a ten-minute, audience-bound TokenRequest for a deterministic `faros-du-<sha256[:20]>` ServiceAccount in the caller's team workspace (`default` namespace). Labels: `faros.sh/workload-identity` (so the existing verifier treats it as hub-managed and the user SA CRUD never lists it) and `faros.sh/delegated-user`. Annotations: `faros.sh/workload-identity-tenant` (the path the verifier enforces) plus `faros.sh/delegated-user|-org|-workspace|-provider`. Tokens are cached in memory per (tenant, user, provider) for 5 minutes, refreshed earlier if the token is within 60 s of expiry. The ClusterRoleBinding half of `ensureWorkloadRBAC` was extracted into `ensureWorkloadClusterRoleBinding` and is shared.
- **Binding.** The account is bound to `cluster-admin` in the workspace, because that is what every workspace member and admin holds today (`pkg/hub/kcp/bootstrap.go` `ensureWorkspaceAdmin` / `EnsureChildWorkspaceAdmin`). Binding anything narrower would make the delegated call weaker than the user's own kubectl. Narrowing is the workspace RBAC's job, not this PR's; `DelegatedUserClusterRole` is the single place to follow it. The win is scope: the user's hub token reaches every workspace and REST endpoint they can; the delegated token is pinned by kcp (and by the hub's SA proxy path) to one workspace.
- **GC.** Accounts are deterministic so they do not accumulate per request; nothing deletes them on Membership removal yet (noted in the file header as a follow-up; any outstanding token dies within ten minutes).
- `pkg/hub/providers/proxy_edge.go`: `delegatedAuthorization` runs before the reverse proxy is built; the Director deletes `Authorization` after `setHeaders` and sets `Bearer <delegated>`. `X-Faros-User`/`X-Faros-Tenant`/`X-Faros-Cluster` are unchanged. Fail-closed on every path: unresolved caller → 403, org-scope tenant path with no workspace → 403 (the portal always sends `X-Faros-Workspace`), no issuer wired → 503, mint error → 503. Anonymous probes (no `Authorization`) forward with no credential. There is no non-edge org-provider path: `ServeHTTP` routes every `OrgUUID != ""` provider to `serveOverEdge`, which 503s without a usable route and never falls back to `BackendURL`, so the substitution covers every request an org provider can receive.
- `pkg/hub/providers/proxy.go`: the caller is resolved once per request and memoized on the request context (`resolveCaller`/`withResolvedCaller`); scope resolution, token issuance, and header injection all read it. Previously each was a separate token verify plus apiserver round-trip.
- `pkg/hub/provider_tenant_resolver.go`: `resolveWorkloadServiceAccount` now uses `VerifyWorkloadServiceAccountDetails` and, for a delegated account, returns the human user from the annotation as `X-Faros-User`. `verifyWorkloadServiceAccountAnnotations` branches on the delegated label; a delegated SA has no scope marker, so any action-grant comparison fails closed on it, as it should.
- `pkg/hub/server.go`: one line wiring `SetDelegatedTokenIssuer(serviceaccounts.NewManager(bootstrapper))` next to the existing resolver wiring.
- SDK/provider check: `provider-sdk/tenantaccess` and `providers/infrastructure/dataplane` build kcp clients to `{hub}/clusters/{id}` with the bearer, which works with an SA token (the hub proxy's `serveServiceAccount` pins it to the token's cluster claim; the edges provider's `serveService` SARs and reads the Service as the caller, both satisfied by the workspace binding). No code under `providers/` or `provider-sdk/` parses the bearer as a JWT for claims (`grep ParseUnverified|jwt.Parse|ParseSigned` is empty), so no SDK tolerance change was needed. Nothing under `providers/` was touched.

**Step B — registration default and shadow flag**

- `apis/tenancy/v1alpha1/types_organization.go`: `+kubebuilder:default=admin`, doc rewritten; `make crds` regenerated `config/crds`, `config/kcp` (schema name bumped to `v260904-9ab06b67`), and `pkg/hub/bootstrap/crds`.
- `restapi/org_providers.go`: only an explicit `members` opens registration; unset and unrecognized values are admin-only. `restapi/orgs.go` create default and the personal-org default in `controllers/organization` are `admin`.
- `pkg/hub/controllers/organization/catalog_entry_creation_migration.go`: `BackfillCatalogEntryCreation` writes `members` onto Organizations that have no `tenants.faros.sh/catalog-entry-creation-migrated` annotation and an empty field, stamps the annotation on every unannotated Organization, and is registered from `SetupWithManager` as a manager runnable that retries until it succeeds (no `server.go` change). Annotation domain is `tenants.faros.sh/` to match the repo's existing tenancy annotations.
- `Provider.ShadowsPlatform` is set by `ListForOrg` when a platform record of the same name exists, projected as `shadowsPlatform` on the `/api/providers` DTO; `ProvidersPage.vue` shows an "Overrides platform provider" tag next to "Self-managed". `portal/node_modules` is absent in this checkout, so the portal typecheck was not run; the change is a `?: boolean` field and one `v-if` span.
- Docs: `docs/byo-providers.md` (Isolation bullet on what an org-owned provider receives, registration default, shadow tag) and `docs/organizations.md` (O-7, type snippet, permissions table).

## Compatibility

- **Existing orgs.** The backfill runs once at hub start and pins `members` on every Organization that never set the field, so no existing tenant loses the ability to register. Orgs that already carry a value keep it. The previous CRD default was `members`, so in practice most stored objects already carry it; the backfill covers any that do not. An admin can tighten an org with `PATCH /api/orgs/{org} {"catalogEntryCreation":"admin"}`.
- **New orgs** (REST, personal-org bootstrap, or the CRD default) are admin-only for registration.
- **What an org-provider backend sees now.** `Authorization: Bearer <kcp SA token>` for `system:serviceaccount:default:faros-du-<hash>`, valid ten minutes, scoped to the caller's current workspace; `X-Faros-User`/`X-Faros-Tenant`/`X-Faros-Cluster` unchanged. Calling back into the hub with it (`/clusters/{id}`, or another provider's backend with `X-Faros-Org`/`X-Faros-Workspace` set, as workload tokens already require) works and resolves to the human user. Requests to an org provider without a workspace selection are now refused (403) instead of forwarded; the portal always sends the header.
- **Platform providers** still receive the caller's bearer (pinned by `TestBackendProxyPlatformProviderStillReceivesCallerBearer`). Moving them to delegated tokens once every `tenantaccess` consumer is confirmed to need only `/clusters/{id}` is step C, plan item 3.3.

## Tests

- `pkg/hub/providers/proxy_edge_test.go`: `TestBackendProxyEdgeRouteCarriesCallerIdentity` extended to assert the outbound `Authorization` is the delegated token and never contains the caller's bearer (fake issuer records the tuple it was asked for). New `TestBackendProxyOrgProviderNeverSeesUserBearer` (no issuer, issuer error, org-scope caller without workspace, resolver error, anonymous probe), `TestBackendProxyPlatformProviderStillReceivesCallerBearer`, `TestBackendProxyResolvesCallerOnce`. `serveProxy` now sends a bearer like the portal does.
- `pkg/hub/serviceaccounts/delegated_user_token_test.go`: SA created once with the right labels/annotations and bound to `cluster-admin` with only the SA as subject; token cached across calls and per distinct (user, provider); refresh after the cache TTL and before a short server-capped expiry; over-long token, bad input, and a squatted account refused; annotation verification accepts hub-minted and rejects tampered objects.
- `pkg/hub/provider_tenant_resolver_test.go`: `TestKCPTenantResolverResolvesDelegatedUserTokenToTheHumanUser`, including refusal for a different workspace selection.
- `pkg/hub/restapi/org_providers_test.go`: `TestRegisterOrgProvider_DefaultsToAdminOnly` (unset refuses member/admits admin, explicit members admits, explicit admin and unknown value refuse, workspace-admin-but-org-member refused, nothing minted on refusal). Existing edge-preflight tests build their Org with explicit `members` so they keep testing what they tested.
- `pkg/hub/controllers/organization/catalog_entry_creation_migration_test.go`: legacy unset → members + annotation; explicit admin kept + annotation; already-annotated untouched; second run is a no-op.
- `registry_scope_test.go`: `ShadowsPlatform` set only on the org copy that shadows a platform provider.

Commands: `GOWORK=off go build ./... && GOWORK=off go vet ./pkg/... && GOWORK=off go test -count=1 ./pkg/hub/... ./pkg/server/...` (all ok), `GOWORK=off make crds`, `make fix-lint && make lint` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
