### PR TITLE
Add provider CRUD toast coverage

### DIFF
--- a/providers/code/portal/src/oauth-config.behavior.test.ts
+++ b/providers/code/portal/src/oauth-config.behavior.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
     connect: vi.fn(),
     createRepository: vi.fn(),
   },
+  toast: vi.fn(),
 }))
 
 vi.mock('./api', () => ({
@@ -22,6 +23,7 @@ vi.mock('./api', () => ({
   normalizeResourceName: (value: string) => value.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 253) || 'x',
 }))
 vi.mock('./portalkit/confirm', () => ({ confirmDialog: vi.fn() }))
+vi.mock('./portalkit/toast', () => ({ toast: mocks.toast }))
 vi.mock('./portalkit/ResourceTable.vue', async () => {
   const { h } = await import('vue')
   type StubSlots = Record<string, () => VNode[]>
@@ -365,6 +367,27 @@ describe('connection creation authority fencing', () => {
     await handler({ preventDefault() {} })
   }
 
+  it('emits one informational toast after a current connection create succeeds', async () => {
+    const created = vi.fn()
+    const { app, root } = mount(ConnectionCreateView, {
+      method: 'token',
+      deletions: createResourceDeletions(),
+      onCreated: created,
+    })
+    await settle()
+    setInput(root, 'my-github', 'new-connection')
+    setInput(root, 'acme', 'octocat')
+    setInput(root, 'ghp_…', 'new-secret')
+
+    await submit(root)
+    await settle()
+
+    expect(mocks.toast).toHaveBeenCalledTimes(1)
+    expect(mocks.toast).toHaveBeenCalledWith('info', 'Connection creation requested for created.')
+    expect(created).toHaveBeenCalledWith('created')
+    app.unmount()
+  })
+
   it('reports required connection fields and focuses the first invalid input', async () => {
     mocks.api.listConnections.mockResolvedValue([])
     const { app, root } = mount(ConnectionCreateView, {
@@ -500,6 +523,32 @@ describe('connection creation authority fencing', () => {
     await settle()
 
     expect(mocks.api.connect).not.toHaveBeenCalled()
+    expect(mocks.toast).not.toHaveBeenCalled()
+    expect(created).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('does not toast or navigate when connection creation resolves after the workspace changes', async () => {
+    const mutation = deferred<{ name: string }>()
+    mocks.api.connect.mockReturnValueOnce(mutation.promise)
+    const created = vi.fn()
+    const { app, root, contextGeneration } = mount(ConnectionCreateView, {
+      method: 'token',
+      deletions: createResourceDeletions(),
+      onCreated: created,
+    })
+    await settle()
+    setInput(root, 'my-github', 'new-connection')
+    setInput(root, 'acme', 'octocat')
+    setInput(root, 'ghp_…', 'new-secret')
+
+    const pendingSubmit = submit(root)
+    await settle()
+    contextGeneration.value += 1
+    mutation.resolve({ name: 'new-connection' })
+    await pendingSubmit
+
+    expect(mocks.toast).not.toHaveBeenCalled()
     expect(created).not.toHaveBeenCalled()
     app.unmount()
   })

--- a/providers/code/portal/src/resource-detail.behavior.test.ts
+++ b/providers/code/portal/src/resource-detail.behavior.test.ts
@@ -20,10 +20,12 @@ const mocks = vi.hoisted(() => ({
     deleteConnection: vi.fn(),
   },
   confirmDialog: vi.fn(),
+  toast: vi.fn(),
 }))
 
 vi.mock('./api', () => ({ api: mocks.api }))
 vi.mock('./portalkit/confirm', () => ({ confirmDialog: mocks.confirmDialog }))
+vi.mock('./portalkit/toast', () => ({ toast: mocks.toast }))
 vi.mock('./portalkit/ActionMenu.vue', async () => {
   const { h, ref } = await import('vue')
   type ActionItem = { id: string; label: string; disabled?: boolean; busy?: boolean }
@@ -439,7 +441,28 @@ describe('mounted resource deletion state', () => {
     expect(textContent(root)).toContain('GraphQLError: delete failed')
     expect(textContent(root)).toContain('github')
     expect(back).not.toHaveBeenCalled()
+    expect(mocks.toast).not.toHaveBeenCalled()
     expect(findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More connection actions')?.props.disabled).toBe(false)
+    app.unmount()
+  })
+
+  it('emits one informational toast before leaving a successfully deleted connection', async () => {
+    const back = vi.fn()
+    const { app, root } = mount(ConnectionDetailView, {
+      name: connection.name,
+      deletions: createResourceDeletions(),
+      onBack: back,
+    })
+    await settle()
+
+    click(findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More connection actions')!)
+    await settle()
+    click(findNode(root, node => node.type === 'button' && textContent(node).trim() === 'Delete connection')!)
+    await settle()
+
+    expect(mocks.toast).toHaveBeenCalledTimes(1)
+    expect(mocks.toast).toHaveBeenCalledWith('info', 'Connection deletion requested for github.')
+    expect(back).toHaveBeenCalledTimes(1)
     app.unmount()
   })
 
@@ -461,6 +484,7 @@ describe('mounted resource deletion state', () => {
 
     expect(mocks.confirmDialog).toHaveBeenCalledTimes(1)
     expect(mocks.api.deleteConnection).not.toHaveBeenCalled()
+    expect(mocks.toast).not.toHaveBeenCalled()
     expect(findNode(root, node => node.props.role === 'menu')).toBeUndefined()
     expect(textContent(root)).not.toContain('Deleting this connection.')
     expect(findNode(root, node => node.type === 'button' && node.props['aria-label'] === 'More connection actions')?.props.disabled).toBe(false)

--- a/providers/code/portal/src/toast-adoption.test.ts
+++ b/providers/code/portal/src/toast-adoption.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import connectionCreate from './views/ConnectionCreateView.vue?raw'
+import connectionDetail from './views/ConnectionDetailView.vue?raw'
+import connections from './views/ConnectionsView.vue?raw'
+import repositoryCreate from './views/RepositoryCreateView.vue?raw'
+import repositoryDetail from './views/RepoDetailView.vue?raw'
+import repositories from './views/RepositoriesView.vue?raw'
+
+const sources = [connectionCreate, connectionDetail, connections, repositoryCreate, repositoryDetail, repositories]
+
+describe('Code toast adoption', () => {
+  it('covers every silent-success mutation entry point with the Vue transport', () => {
+    for (const source of sources) expect(source).toContain("import { toast } from '../portalkit/toast'")
+    expect(sources.join('\n').match(/\btoast\(/g)).toHaveLength(11)
+    expect(connectionCreate).toContain("toast('info', `Connection creation requested for ${created.name}.`)")
+    expect(repositoryCreate).toContain("toast('info', `Repository creation requested for ${created.name}.`)")
+    expect(repositoryDetail).toContain("toast('info', `Repository connection update requested for ${current.name}.`)")
+    expect(repositoryDetail.match(/toast\('info', `Deploy key update requested/g)).toHaveLength(2)
+    expect(repositoryDetail.match(/toast\('info', `Collaborator update requested/g)).toHaveLength(2)
+  })
+
+  it('uses accepted-request language and never duplicates contextual failures as error toasts', () => {
+    const source = sources.join('\n')
+    expect(source).not.toContain("toast('error'")
+    expect(source.match(/deletion requested/g)).toHaveLength(4)
+    expect(source).not.toMatch(/toast\([^\n]+(deleted|created successfully)/i)
+  })
+})

--- a/providers/code/portal/src/views/ConnectionCreateView.vue
+++ b/providers/code/portal/src/views/ConnectionCreateView.vue
@@ -7,6 +7,7 @@ import type { Connection, ErrorResponse } from '../types'
 import type { ConnectionCreateMethod } from '../routes'
 import type { ResourceDeletions } from '../refresh'
 import CreateGuidance from '../portalkit/CreateGuidance.vue'
+import { toast } from '../portalkit/toast'
 
 const props = defineProps<{
   method: ConnectionCreateMethod
@@ -300,6 +301,7 @@ async function submit(): Promise<void> {
     if (!isCurrentMutation(generation, expectedContext)) return
     const created = await api.connect(payload)
     if (!isCurrentMutation(generation, expectedContext)) return
+    toast('info', `Connection creation requested for ${created.name}.`)
     emit('created', created.name)
   } catch (e) {
     if (isCurrentMutation(generation, expectedContext)) formError.value = errMessage(e)

--- a/providers/code/portal/src/views/ConnectionDetailView.vue
+++ b/providers/code/portal/src/views/ConnectionDetailView.vue
@@ -11,6 +11,7 @@ import ResourceSectionCard from '../portalkit/ResourceSectionCard.vue'
 import ResourceStatCards, { type ResourceStatCard } from '../portalkit/ResourceStatCards.vue'
 import StatusBadge from '../portalkit/StatusBadge.vue'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import {
   FAST_REFRESH_MS,
   STABLE_REFRESH_MS,
@@ -183,7 +184,9 @@ async function deleteConnection() {
   mutationError.value = null
   try {
     await api.deleteConnection(current.name)
+    if (!mounted || conn.value?.name !== current.name || conn.value?.uid !== current.uid) return
     props.deletions.acknowledge(deletionScope, current.name, current.uid)
+    toast('info', `Connection deletion requested for ${current.name}.`)
     emit('back')
   } catch (e) {
     mutationError.value = errMessage(e)

--- a/providers/code/portal/src/views/ConnectionsView.vue
+++ b/providers/code/portal/src/views/ConnectionsView.vue
@@ -9,6 +9,7 @@ import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
 import StatusBadge from '../portalkit/StatusBadge.vue'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import {
   FAST_REFRESH_MS,
   STABLE_REFRESH_MS,
@@ -123,7 +124,9 @@ async function remove(row: Record<string, unknown>) {
   mutationError.value = null
   try {
     await api.deleteConnection(connection.name)
+    if (!mounted) return
     props.deletions.acknowledge(deletionScope, connection.name, connection.uid)
+    toast('info', `Connection deletion requested for ${connection.name}.`)
     load()
   } catch (e) {
     mutationError.value = errMessage(e)

--- a/providers/code/portal/src/views/RepoDetailView.vue
+++ b/providers/code/portal/src/views/RepoDetailView.vue
@@ -13,6 +13,7 @@ import ResourceSectionCard from '../portalkit/ResourceSectionCard.vue'
 import ResourceStatCards, { type ResourceStatCard } from '../portalkit/ResourceStatCards.vue'
 import StatusBadge from '../portalkit/StatusBadge.vue'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import { isCompleteFirstCursorPage, type ResourceTableChange } from '../portalkit/table'
 import {
   FAST_REFRESH_MS,
@@ -387,8 +388,9 @@ async function deleteRepository() {
   repositoryMutationError.value = null
   try {
     await api.deleteRepository(current.name)
-    if (!mounted) return
+    if (!mounted || repo.value?.name !== current.name || repo.value?.uid !== current.uid) return
     props.deletions.acknowledge(repositoryScope, current.name, current.uid)
+    toast('info', `Repository deletion requested for ${current.name}.`)
     loadRepository()
   } catch (e) {
     repositoryMutationError.value = errMessage(e)
@@ -524,8 +526,10 @@ async function changeConnection() {
   connError.value = null
   try {
     const updated = await api.updateRepositoryConnection(current.name, selectedConn.value)
+    if (!mounted || repo.value?.name !== current.name || repo.value?.uid !== current.uid) return
     repo.value = { ...current, ...updated, conditions: current.conditions }
     connectionExpanded.value = false
+    toast('info', `Repository connection update requested for ${current.name}.`)
     loadRepository()
   } catch (e) {
     connError.value = errMessage(e)
@@ -543,16 +547,19 @@ async function addKey() {
     return
   }
   keySubmitting.value = true
+  const repositoryName = props.name
   try {
     const created = await api.createDeployKey({
-      repositoryRef: props.name,
+      repositoryRef: repositoryName,
       title: keyTitle.value || undefined,
       publicKey: keyPublic.value || undefined,
       readOnly: keyReadOnly.value,
     })
+    if (!mounted || props.name !== repositoryName) return
     keys.value = [...keys.value.filter(item => item.name !== created.name), created]
     keysLoaded.value = true
     keyTitle.value = keyPublic.value = ''
+    toast('info', `Deploy key update requested for ${repositoryName}.`)
     loadKeys()
   } catch (e) {
     keyError.value = errMessage(e)
@@ -571,7 +578,9 @@ async function removeKey(row: Record<string, unknown>) {
   keyDeleteError.value = null
   try {
     await api.deleteDeployKey(key.name)
+    if (!mounted || props.name !== key.repositoryRef) return
     props.deletions.acknowledge(keyScope, key.name, key.uid)
+    toast('info', `Deploy key update requested for ${props.name}.`)
     loadKeys()
   } catch (e) {
     keyDeleteError.value = errMessage(e)
@@ -592,11 +601,14 @@ async function addCollab() {
     return
   }
   collabSubmitting.value = true
+  const repositoryName = props.name
   try {
-    const created = await api.createCollaborator({ repositoryRef: props.name, username: collabUser.value, permission: collabPerm.value })
+    const created = await api.createCollaborator({ repositoryRef: repositoryName, username: collabUser.value, permission: collabPerm.value })
+    if (!mounted || props.name !== repositoryName) return
     collabs.value = [...collabs.value.filter(item => item.name !== created.name), created]
     collabsLoaded.value = true
     collabUser.value = ''
+    toast('info', `Collaborator update requested for ${repositoryName}.`)
     loadCollaborators()
   } catch (e) {
     collabError.value = errMessage(e)
@@ -615,7 +627,9 @@ async function removeCollab(row: Record<string, unknown>) {
   collabDeleteError.value = null
   try {
     await api.deleteCollaborator(collab.name)
+    if (!mounted || props.name !== collab.repositoryRef) return
     props.deletions.acknowledge(collaboratorScope, collab.name, collab.uid)
+    toast('info', `Collaborator update requested for ${props.name}.`)
     loadCollaborators()
   } catch (e) {
     collabDeleteError.value = errMessage(e)

--- a/providers/code/portal/src/views/RepositoriesView.vue
+++ b/providers/code/portal/src/views/RepositoriesView.vue
@@ -9,6 +9,7 @@ import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
 import StatusBadge from '../portalkit/StatusBadge.vue'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import { isCompleteFirstCursorPage, type ResourceTableChange } from '../portalkit/table'
 import {
   FAST_REFRESH_MS,
@@ -278,6 +279,7 @@ async function remove(row: Record<string, unknown>) {
     await api.deleteRepository(repository.name)
     if (!mounted) return
     props.deletions.acknowledge(deletionScope, repository.name, repository.uid)
+    toast('info', `Repository deletion requested for ${repository.name}.`)
     loadRepositories()
   } catch (e) {
     mutationError.value = errMessage(e)

--- a/providers/code/portal/src/views/RepositoryCreateView.vue
+++ b/providers/code/portal/src/views/RepositoryCreateView.vue
@@ -8,6 +8,7 @@ import type { ResourceDeletions } from '../refresh'
 import { createFullListReadCoordinator } from '../hybridPagination'
 import { createOperationLocks, operationKey } from '../refresh'
 import CreateGuidance from '../portalkit/CreateGuidance.vue'
+import { toast } from '../portalkit/toast'
 
 const props = defineProps<{ deletions: ResourceDeletions }>()
 const emit = defineEmits<{
@@ -238,6 +239,7 @@ async function submit(): Promise<void> {
     if (!isCurrentMutation(generation, expectedContext)) return
     const created = await api.createRepository(payload)
     if (!isCurrentMutation(generation, expectedContext)) return
+    toast('info', `Repository creation requested for ${created.name}.`)
     emit('created', created.name)
   } catch (e) {
     if (isCurrentMutation(generation, expectedContext)) formError.value = errMessage(e)

--- a/providers/databricks/portal/src/databricksPolish.source.test.mjs
+++ b/providers/databricks/portal/src/databricksPolish.source.test.mjs
@@ -308,3 +308,24 @@ test('prerequisite routes keep cancellation origin separate from success continu
   assert.match(wizard, /@click="complete">Done/)
   assert.match(wizard, /@click="cancel">Cancel/)
 })
+
+test('silent-success Databricks mutations use truthful Vue toasts', async () => {
+  const sources = await Promise.all([
+    read('./views/CreateConnectionView.vue'),
+    read('./views/CreateWarehouseView.vue'),
+    read('./views/CreateTableView.vue'),
+    read('./views/ConnectionDetailView.vue'),
+    read('./views/WarehouseDetailView.vue'),
+    read('./views/TableDetailView.vue'),
+    read('./views/ConnectionsView.vue'),
+    read('./views/WarehousesView.vue'),
+    read('./views/TablesView.vue'),
+  ])
+  const source = sources.join('\n')
+  assert.equal(source.match(/\btoast\(/g)?.length, 11)
+  assert.match(source, /toast\('ok', `Connection \$\{created\.name\} saved\.`/)
+  assert.match(source, /toast\('ok', `Warehouse \$\{created\.name\} registered\.`/)
+  assert.match(source, /editing\.value \? `Table \$\{created\.name\} updated\.` : `Table \$\{created\.name\} registered\.`/)
+  assert.equal(source.match(/deletion requested/g)?.length, 6)
+  assert.doesNotMatch(source, /toast\('error'/)
+})

--- a/providers/databricks/portal/src/resourceTable.ssr.test.mjs
+++ b/providers/databricks/portal/src/resourceTable.ssr.test.mjs
@@ -26,6 +26,7 @@ const canonicalTableHelpers = resolve(repositoryRoot, 'provider-sdk/portalkit-vu
 // so provide inert constructors that keep that browser-only branch false.
 if (typeof globalThis.Document === 'undefined') globalThis.Document = class {}
 if (typeof globalThis.ShadowRoot === 'undefined') globalThis.ShadowRoot = class {}
+if (typeof globalThis.HTMLElement === 'undefined') globalThis.HTMLElement = class {}
 
 test.before(async () => {
   vite = await createServer({
@@ -324,6 +325,7 @@ function mountDetailView(Component, props, components, provides = {}) {
     head: { appendChild() {} },
     addEventListener() {},
     removeEventListener() {},
+    dispatchEvent() { return true },
   }
   globalThis.window = {
     addEventListener() {},
@@ -3895,6 +3897,7 @@ function mountNavigationApp(App, ctx, storage) {
     head: { appendChild() {} },
     addEventListener() {},
     removeEventListener() {},
+    dispatchEvent() { return true },
   }
   globalThis.window = {
     sessionStorage: storage,

--- a/providers/databricks/portal/src/views/ConnectionDetailView.vue
+++ b/providers/databricks/portal/src/views/ConnectionDetailView.vue
@@ -10,6 +10,7 @@ import ResourceSectionCard from '../portalkit/ResourceSectionCard.vue'
 import ResourceStatCards, { type ResourceStatCard } from '../portalkit/ResourceStatCards.vue'
 import StatusBadge from '../portalkit/StatusBadge.vue'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import { formatDatabricksError, isTenantMissingError } from '../errors'
 import type { Connection } from '../types'
 import {
@@ -43,6 +44,7 @@ const editHostInput = ref<HTMLInputElement | null>(null)
 const saveErrorRef = ref<HTMLElement | null>(null)
 let poll!: AdaptiveRefreshTimer
 let refresh!: LatestRefreshController
+let mounted = false
 const operations = createOperationLocks()
 
 const validated = computed(() => conn.value?.conditions.find(c => c.type === 'Validated'))
@@ -196,18 +198,21 @@ async function saveEdit() {
   saveError.value = null
   mutationError.value = null
   try {
+    const current = conn.value
     await api.saveConnection({
-      name: conn.value.name,
+      name: current.name,
       host,
-      secretName: conn.value.secretName,
-      secretNamespace: conn.value.secretNamespace,
-      secretKey: conn.value.secretKey,
+      secretName: current.secretName,
+      secretNamespace: current.secretNamespace,
+      secretKey: current.secretKey,
       // An empty token intentionally preserves the existing Secret. Enter a
       // new token here only when rotating the credential.
       token: editToken.value || undefined,
     })
+    if (!mounted || props.name !== current.name) return
     editing.value = false
     editToken.value = ''
+    toast('ok', `Connection ${current.name} saved.`)
     load()
   } catch (e) {
     await focusSaveError(formatDatabricksError(e))
@@ -236,7 +241,9 @@ async function remove() {
   mutationError.value = null
   try {
     await api.deleteConnection(current)
+    if (!mounted || props.name !== current.name) return
     operations.tombstone(lock, current.uid)
+    toast('info', `Connection deletion requested for ${current.name}.`)
     emit('back')
   } catch (e) {
     mutationError.value = formatDatabricksError(e)
@@ -279,9 +286,11 @@ watch(() => props.name, () => {
 })
 
 onMounted(() => {
+  mounted = true
   load()
 })
 onUnmounted(() => {
+  mounted = false
   poll.stop()
   refresh.stop()
 })

--- a/providers/databricks/portal/src/views/ConnectionsView.vue
+++ b/providers/databricks/portal/src/views/ConnectionsView.vue
@@ -9,6 +9,7 @@ import StatusBadge from '../portalkit/StatusBadge.vue'
 import { api } from '../api'
 import { formatDatabricksError, isTenantMissingError } from '../errors'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import { isCompleteFirstCursorPage, type ResourceTableChange } from '../portalkit/table'
 import type { Connection } from '../types'
 import {
@@ -241,11 +242,13 @@ async function remove(row: Record<string, unknown>) {
   mutationError.value = null
   try {
     await api.deleteConnection(conn)
+    if (!mounted) return
     invalidateCompleteAuthority()
     firstPageSettled.value = false
     pendingDeletions.set(conn.name, conn.uid)
     operations.tombstone(lock, conn.uid)
     connections.value = connections.value.filter(item => item.name !== conn.name)
+    toast('info', `Connection deletion requested for ${conn.name}.`)
     load()
   } catch (e) {
     mutationError.value = formatDatabricksError(e)

--- a/providers/databricks/portal/src/views/CreateConnectionView.vue
+++ b/providers/databricks/portal/src/views/CreateConnectionView.vue
@@ -10,6 +10,7 @@ import {
 } from '../refresh'
 import { resourceNameError } from '../resourceName'
 import ManualCreateGuidance from '../components/ManualCreateGuidance.vue'
+import { toast } from '../portalkit/toast'
 
 const emit = defineEmits<{
   (event: 'cancel'): void
@@ -125,6 +126,7 @@ async function submit(): Promise<void> {
     }
     const created = await api.saveConnection(payload)
     if (!isCurrentMutation(generation, expectedContext)) return
+    toast('ok', `Connection ${created.name} saved.`)
     emit('created', created.name)
   } catch (error) {
     await focusFormError(formatDatabricksError(error), generation, expectedContext)

--- a/providers/databricks/portal/src/views/CreateTableView.vue
+++ b/providers/databricks/portal/src/views/CreateTableView.vue
@@ -14,6 +14,7 @@ import type { DatabricksPrerequisiteKind } from '../journey'
 import type { Connection, Table, Warehouse } from '../types'
 import FormSelect from '../portalkit/FormSelect.vue'
 import ManualCreateGuidance from '../components/ManualCreateGuidance.vue'
+import { toast } from '../portalkit/toast'
 
 const props = defineProps<{
   /** When set, this route edits the named table instead of creating one. */
@@ -216,6 +217,7 @@ async function submit(): Promise<void> {
     }
     const created = await api.saveTable(payload)
     if (!isCurrentMutation(generation, expectedContext)) return
+    toast('ok', editing.value ? `Table ${created.name} updated.` : `Table ${created.name} registered.`)
     emit('created', created.name)
   } catch (error) {
     await focusFormError(formatDatabricksError(error), generation, expectedContext)

--- a/providers/databricks/portal/src/views/CreateWarehouseView.vue
+++ b/providers/databricks/portal/src/views/CreateWarehouseView.vue
@@ -13,6 +13,7 @@ import type { DatabricksPrerequisiteKind } from '../journey'
 import type { Connection } from '../types'
 import FormSelect from '../portalkit/FormSelect.vue'
 import ManualCreateGuidance from '../components/ManualCreateGuidance.vue'
+import { toast } from '../portalkit/toast'
 
 const emit = defineEmits<{
   (event: 'cancel'): void
@@ -144,6 +145,7 @@ async function submit(): Promise<void> {
     }
     const created = await api.saveWarehouse(payload)
     if (!isCurrentMutation(generation, expectedContext)) return
+    toast('ok', `Warehouse ${created.name} registered.`)
     emit('created', created.name)
   } catch (error) {
     await focusFormError(formatDatabricksError(error), generation, expectedContext)

--- a/providers/databricks/portal/src/views/TableDetailView.vue
+++ b/providers/databricks/portal/src/views/TableDetailView.vue
@@ -11,6 +11,7 @@ import ResourceBackLink from '../portalkit/ResourceBackLink.vue'
 import ResourceSectionCard from '../portalkit/ResourceSectionCard.vue'
 import ResourceStatCards, { type ResourceStatCard } from '../portalkit/ResourceStatCards.vue'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import { formatDatabricksError, isTenantMissingError } from '../errors'
 import type { Table, TableColumn } from '../types'
 import {
@@ -38,6 +39,7 @@ const deleting = ref(false)
 const schemaCache = ref<{ uid?: string; generation?: number; refreshedAt?: string; columns: TableColumn[] } | null>(null)
 let poll!: AdaptiveRefreshTimer
 let refresh!: LatestRefreshController
+let mounted = false
 const operations = createOperationLocks()
 
 const ready = computed(() => table.value?.conditions.find(c => c.type === 'Ready'))
@@ -219,7 +221,9 @@ async function remove() {
   mutationError.value = null
   try {
     await api.deleteTable(current.name)
+    if (!mounted || props.name !== current.name) return
     operations.tombstone(lock, current.uid)
+    toast('info', `Table deletion requested for ${current.name}.`)
     emit('back')
   } catch (e) {
     mutationError.value = formatDatabricksError(e)
@@ -262,9 +266,11 @@ watch(() => props.name, () => {
 })
 
 onMounted(() => {
+  mounted = true
   load()
 })
 onUnmounted(() => {
+  mounted = false
   poll.stop()
   refresh.stop()
 })

--- a/providers/databricks/portal/src/views/TablesView.vue
+++ b/providers/databricks/portal/src/views/TablesView.vue
@@ -11,6 +11,7 @@ import StatusBadge from '../portalkit/StatusBadge.vue'
 import { api } from '../api'
 import { formatDatabricksError, isTenantMissingError } from '../errors'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import { isCompleteFirstCursorPage, type ResourceTableChange } from '../portalkit/table'
 import type { Connection, Table, Warehouse } from '../types'
 import {
@@ -246,11 +247,13 @@ async function remove(row: Record<string, unknown>) {
   mutationError.value = null
   try {
     await api.deleteTable(table.name)
+    if (!mounted) return
     invalidateCompleteAuthority()
     firstPageSettled.value = false
     pendingDeletions.set(table.name, table.uid)
     operations.tombstone(lock, table.uid)
     tables.value = tables.value.filter(item => item.name !== table.name)
+    toast('info', `Table deletion requested for ${table.name}.`)
     load()
   } catch (e) {
     mutationError.value = formatDatabricksError(e)

--- a/providers/databricks/portal/src/views/WarehouseDetailView.vue
+++ b/providers/databricks/portal/src/views/WarehouseDetailView.vue
@@ -10,6 +10,7 @@ import ResourceSectionCard from '../portalkit/ResourceSectionCard.vue'
 import ResourceStatCards, { type ResourceStatCard } from '../portalkit/ResourceStatCards.vue'
 import StatusBadge from '../portalkit/StatusBadge.vue'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import { formatDatabricksError, isTenantMissingError } from '../errors'
 import type { Warehouse } from '../types'
 import {
@@ -42,6 +43,7 @@ const editIDInput = ref<HTMLInputElement | null>(null)
 const saveErrorRef = ref<HTMLElement | null>(null)
 let poll!: AdaptiveRefreshTimer
 let refresh!: LatestRefreshController
+let mounted = false
 const operations = createOperationLocks()
 
 const ready = computed(() => warehouse.value?.conditions.find(c => c.type === 'Ready'))
@@ -203,12 +205,15 @@ async function saveEdit() {
   saveError.value = null
   mutationError.value = null
   try {
+    const current = warehouse.value
     await api.saveWarehouse({
-      name: warehouse.value.name,
-      connectionRef: warehouse.value.connectionRef,
+      name: current.name,
+      connectionRef: current.connectionRef,
       warehouseID: nextID,
     })
+    if (!mounted || props.name !== current.name) return
     editing.value = false
+    toast('ok', `Warehouse ${current.name} updated.`)
     load()
   } catch (e) {
     await focusSaveError(formatDatabricksError(e))
@@ -237,7 +242,9 @@ async function remove() {
   mutationError.value = null
   try {
     await api.deleteWarehouse(current.name)
+    if (!mounted || props.name !== current.name) return
     operations.tombstone(lock, current.uid)
+    toast('info', `Warehouse deletion requested for ${current.name}.`)
     emit('back')
   } catch (e) {
     mutationError.value = formatDatabricksError(e)
@@ -280,9 +287,11 @@ watch(() => props.name, () => {
 })
 
 onMounted(() => {
+  mounted = true
   load()
 })
 onUnmounted(() => {
+  mounted = false
   poll.stop()
   refresh.stop()
 })

--- a/providers/databricks/portal/src/views/WarehousesView.vue
+++ b/providers/databricks/portal/src/views/WarehousesView.vue
@@ -9,6 +9,7 @@ import StatusBadge from '../portalkit/StatusBadge.vue'
 import { api } from '../api'
 import { formatDatabricksError, isTenantMissingError } from '../errors'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import { isCompleteFirstCursorPage, type ResourceTableChange } from '../portalkit/table'
 import type { Connection, Warehouse } from '../types'
 import {
@@ -266,11 +267,13 @@ async function remove(row: Record<string, unknown>) {
   mutationError.value = null
   try {
     await api.deleteWarehouse(wh.name)
+    if (!mounted) return
     invalidateCompleteAuthority()
     firstPageSettled.value = false
     pendingDeletions.set(wh.name, wh.uid)
     operations.tombstone(lock, wh.uid)
     warehouses.value = warehouses.value.filter(item => item.name !== wh.name)
+    toast('info', `Warehouse deletion requested for ${wh.name}.`)
     load()
   } catch (e) {
     mutationError.value = formatDatabricksError(e)

--- a/providers/edges/portal/src/App.vue
+++ b/providers/edges/portal/src/App.vue
@@ -12,6 +12,7 @@ import WorkloadCreate from './WorkloadCreate.vue'
 import ConfirmDialog from './portalkit/ConfirmDialog.vue'
 import Tabs from './portalkit/Tabs.vue'
 import { confirmDialog } from './portalkit/confirm'
+import { toast } from './portalkit/toast'
 import {
   FAST_REFRESH_MS,
   STABLE_REFRESH_MS,
@@ -168,8 +169,11 @@ function onEdgeCollectionActivated(): void {
 
 async function onDelete(edge: Edge) {
   if (!(await confirmDialog({ title: `Delete ${edge.type === 'server' ? 'server' : 'cluster'} "${edge.name}"?`, danger: true, confirmLabel: 'Delete' }))) return
+  const expectedContextGeneration = contextGeneration.value
   try {
     await deleteEdge(edge)
+    if (contextGeneration.value !== expectedContextGeneration) return
+    toast('info', `${edge.type === 'server' ? 'Server' : 'Cluster'} deletion requested for ${edge.name}.`)
     await refresh()
   } catch (e) {
     error.value = (e as ErrorResponse)?.message ?? 'Delete failed'

--- a/providers/edges/portal/src/Detail.vue
+++ b/providers/edges/portal/src/Detail.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, onUnmounted } from 'vue'
 import { ArrowUpCircle, Boxes, Cable, Check, ChevronDown, ChevronUp, Cloud, Copy, Cpu, Globe2, Home, Plug, Plus, RefreshCw, Server, TerminalSquare, Trash2 } from 'lucide-vue-next'
 import { getEdge, deleteEdge, listEdgeServices, connectEdgeService, deleteEdgeService } from './api'
 import { confirmDialog } from './portalkit/confirm'
+import { toast } from './portalkit/toast'
 import ConditionsPanel from './portalkit/ConditionsPanel.vue'
 import ActionMenu, { type ActionMenuItem } from './portalkit/ActionMenu.vue'
 import ResourcePage from './portalkit/ResourcePage.vue'
@@ -22,6 +23,7 @@ import type { EdgeDetail, EdgeService, EdgeType, ErrorResponse } from './types'
 
 const props = defineProps<{ name: string; type: EdgeType; cluster: string | null; token: string | null }>()
 const emit = defineEmits<{ back: []; deleted: []; addService: [] }>()
+let stopped = false
 
 // SSH terminals dock at the bottom of the host portal (survives page
 // navigation) rather than rendering inline here. The provider is an isolated
@@ -96,12 +98,15 @@ async function refreshDetail() {
 }
 
 async function onDelete() {
-  if (!edge.value || deleting.value) return
+  const current = edge.value
+  if (!current || deleting.value) return
   if (!(await confirmDialog({ title: `Delete ${props.type === 'server' ? 'server' : 'cluster'} "${props.name}"?`, danger: true, confirmLabel: 'Delete' }))) return
   deleting.value = true
   mutationError.value = null
   try {
-    await deleteEdge(edge.value)
+    await deleteEdge(current)
+    if (stopped || props.name !== current.name) return
+    toast('info', `${props.type === 'server' ? 'Server' : 'Cluster'} deletion requested for ${current.name}.`)
     emit('deleted')
   } catch (e) {
     mutationError.value = (e as ErrorResponse)?.message ?? 'Delete failed'
@@ -340,6 +345,8 @@ async function removeService(name: string) {
   if (!(await confirmDialog({ title: `Delete service "${name}"?`, danger: true, confirmLabel: 'Delete' }))) return
   try {
     await deleteEdgeService(name)
+    if (stopped || props.name !== edge.value?.name) return
+    toast('info', `Service deletion requested for ${name}.`)
     await loadServices()
   } catch (e) {
     svcError.value = (e as ErrorResponse)?.message ?? 'Delete failed'
@@ -353,12 +360,15 @@ function startConnect(name: string) {
 
 async function submitConnect() {
   if (!connectFor.value || !tokenInput.value.trim()) return
+  const name = connectFor.value
   connecting.value = true
   svcError.value = null
   try {
-    await connectEdgeService(connectFor.value, tokenInput.value.trim())
+    await connectEdgeService(name, tokenInput.value.trim())
+    if (stopped || connectFor.value !== name) return
     connectFor.value = null
     tokenInput.value = ''
+    toast('ok', `Service credentials saved for ${name}.`)
     await loadServices()
   } catch (e) {
     svcError.value = (e as ErrorResponse)?.message ?? 'Connect failed'
@@ -404,6 +414,7 @@ watch(() => [props.name, props.type], () => {
   void load('foreground')
 }, { immediate: true })
 onUnmounted(() => {
+  stopped = true
   detailRefresh.stop()
   poller.stop()
   if (copyTimer) clearTimeout(copyTimer)

--- a/providers/edges/portal/src/ServiceCreate.vue
+++ b/providers/edges/portal/src/ServiceCreate.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { ArrowLeft, Globe2, Loader2, Plus, Server } from 'lucide-vue-next'
 import { createKubeEdgeService, fetchServiceCatalog, listEdges } from './api'
 import type { CatalogEntry } from './api'
 import type { Edge, EdgeServiceDraft, EdgeType, ErrorResponse } from './types'
 import CreateGuidance, { type CreateGuidanceValue } from './portalkit/CreateGuidance.vue'
 import FirstRunGuide from './portalkit/FirstRunGuide.vue'
+import { toast } from './portalkit/toast'
 
 const props = withDefaults(defineProps<{
   initialEdgeType?: EdgeType | null
@@ -26,6 +27,7 @@ const loading = ref(true)
 const busy = ref(false)
 const error = ref<string | null>(null)
 const selectedEdgeKey = ref('')
+let active = true
 
 function catalogFor(type?: string): CatalogEntry | undefined {
   return catalog.value.find((entry) => entry.type === type)
@@ -201,6 +203,8 @@ async function onCreate(): Promise<void> {
       port: Number(draft.value.port) || 8123,
       instructions: draft.value.instructions?.trim() || undefined,
     })
+    if (!active) return
+    toast('info', `Service creation requested for ${name}.`)
     emit('created', name)
   } catch (e) {
     error.value = (e as ErrorResponse)?.message ?? 'Create failed'
@@ -226,6 +230,9 @@ onMounted(async () => {
     error.value = (edgesResult.reason as ErrorResponse)?.message ?? 'Failed to load edges'
   }
   loading.value = false
+})
+onUnmounted(() => {
+  active = false
 })
 </script>
 

--- a/providers/edges/portal/src/ServiceEdit.vue
+++ b/providers/edges/portal/src/ServiceEdit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, onUnmounted, watch } from 'vue'
 import { Globe2, KeyRound, Plug, RefreshCw, Save, Server } from 'lucide-vue-next'
 import { confirmDialog } from './portalkit/confirm'
 import { connectEdgeService, deleteEdgeService, getService, updateEdgeService } from './api'
@@ -12,6 +12,7 @@ import ResourceBackLink from './portalkit/ResourceBackLink.vue'
 import ResourceSectionCard from './portalkit/ResourceSectionCard.vue'
 import ResourceStatCards, { type ResourceStatCard, type ResourceStatTone } from './portalkit/ResourceStatCards.vue'
 import StatusBadge from './portalkit/StatusBadge.vue'
+import { toast } from './portalkit/toast'
 
 // The route owns the resource identity. A list-row snapshot is optional and is
 // used only as a seed; every instance page performs an exact getService read so
@@ -36,6 +37,7 @@ const busy = ref(false)
 const deleting = ref(false)
 let selectionGeneration = 0
 let selectedName = ''
+let active = true
 
 const currentName = computed(() => service.value?.name || props.serviceName || props.service?.name || '')
 const title = computed(() => currentName.value || 'Service')
@@ -264,6 +266,7 @@ async function refreshDetail(): Promise<void> {
 async function onSaveConfig(): Promise<void> {
   const name = currentName.value
   if (!name || !service.value) return
+  const generation = selectionGeneration
   busy.value = true
   mutationError.value = null
   try {
@@ -278,6 +281,8 @@ async function onSaveConfig(): Promise<void> {
       instructions: instructions.value,
       targetMode: targetMode.value,
     })
+    if (!active || generation !== selectionGeneration || currentName.value !== name) return
+    toast('ok', `Service configuration saved for ${name}.`)
     await load()
     emit('saved')
   } catch (error) {
@@ -314,11 +319,14 @@ async function onSaveCreds(): Promise<void> {
   const name = currentName.value
   const token = packedCredential()
   if (!credentialsSupported.value || !name || !service.value || !token) return
+  const generation = selectionGeneration
   busy.value = true
   mutationError.value = null
   try {
     await connectEdgeService(name, token)
+    if (!active || generation !== selectionGeneration || currentName.value !== name) return
     credInputs.value = {}
+    toast('ok', `Service credentials saved for ${name}.`)
     await load()
     emit('saved')
   } catch (error) {
@@ -340,8 +348,11 @@ async function onDelete(): Promise<void> {
   deleting.value = true
   busy.value = true
   mutationError.value = null
+  const generation = selectionGeneration
   try {
     await deleteEdgeService(name)
+    if (!active || generation !== selectionGeneration || currentName.value !== name) return
+    toast('info', `Service deletion requested for ${name}.`)
     emit('deleted')
   } catch (error) {
     mutationError.value = errorMessage(error, 'Delete failed')
@@ -350,6 +361,11 @@ async function onDelete(): Promise<void> {
     busy.value = false
   }
 }
+
+onUnmounted(() => {
+  active = false
+  selectionGeneration += 1
+})
 </script>
 
 <template>

--- a/providers/edges/portal/src/Services.vue
+++ b/providers/edges/portal/src/Services.vue
@@ -8,6 +8,7 @@ import {
 import type { CatalogEntry } from './api'
 import type { EdgeService, Edge, ErrorResponse } from './types'
 import { confirmDialog } from './portalkit/confirm'
+import { toast } from './portalkit/toast'
 import ResourceTable from './portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from './portalkit/ResourceTableDeleteButton.vue'
 import ResourceTableEditButton from './portalkit/ResourceTableEditButton.vue'
@@ -403,6 +404,8 @@ async function onDelete(s: EdgeService) {
   if (!(await confirmDialog({ title: `Delete service "${s.name}"?`, message: 'Its MCP tools stop being exposed.', danger: true, confirmLabel: 'Delete' }))) return
   try {
     await deleteEdgeService(s.name)
+    if (stopped) return
+    toast('info', `Service deletion requested for ${s.name}.`)
     await refresh('foreground', true)
   } catch (e) {
     error.value = (e as ErrorResponse)?.message ?? 'Delete failed'

--- a/providers/edges/portal/src/Workloads.vue
+++ b/providers/edges/portal/src/Workloads.vue
@@ -4,6 +4,7 @@ import { RefreshCw, Plus, ChevronRight, ChevronDown, Store, Rocket, Boxes, Serve
 import { listWorkloads, listWorkloadsPage, deleteWorkload, listEdges } from './api'
 import type { Workload, Edge, ErrorResponse } from './types'
 import { confirmDialog } from './portalkit/confirm'
+import { toast } from './portalkit/toast'
 import ResourceTable from './portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from './portalkit/ResourceTableDeleteButton.vue'
 import StatusBadge from './portalkit/StatusBadge.vue'
@@ -337,6 +338,8 @@ async function onDelete(w: Workload) {
   if (!(await confirmDialog({ title: `Delete workload "${w.name}"?`, message: 'Its Deployments on every edge are removed.', danger: true, confirmLabel: 'Delete' }))) return
   try {
     await deleteWorkload(w.name)
+    if (stopped) return
+    toast('info', `Workload deletion requested for ${w.name}.`)
     await refresh('foreground', true)
   } catch (e) {
     error.value = (e as ErrorResponse)?.message ?? 'Delete failed'

--- a/providers/edges/portal/src/toast-adoption.test.ts
+++ b/providers/edges/portal/src/toast-adoption.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import app from './App.vue?raw'
+import detail from './Detail.vue?raw'
+import serviceCreate from './ServiceCreate.vue?raw'
+import serviceEdit from './ServiceEdit.vue?raw'
+import services from './Services.vue?raw'
+import workloads from './Workloads.vue?raw'
+
+const sources = [app, detail, serviceCreate, serviceEdit, services, workloads]
+
+describe('Edges toast adoption', () => {
+  it('covers every silent-success mutation entry point', () => {
+    expect(sources.join('\n').match(/\btoast\(/g)).toHaveLength(10)
+    expect(app).toContain("toast('info', `${edge.type === 'server' ? 'Server' : 'Cluster'} deletion requested for ${edge.name}.`)")
+    expect(detail).toContain("toast('ok', `Service credentials saved for ${name}.`)")
+    expect(serviceCreate).toContain("toast('info', `Service creation requested for ${name}.`)")
+    expect(serviceEdit).toContain("toast('ok', `Service configuration saved for ${name}.`)")
+    expect(serviceEdit).toContain("toast('ok', `Service credentials saved for ${name}.`)")
+    expect(sources.join('\n').match(/Service deletion requested/g)).toHaveLength(3)
+    expect(workloads).toContain("toast('info', `Workload deletion requested for ${w.name}.`)")
+  })
+
+  it('keeps contextual failures inline instead of producing error toasts', () => {
+    expect(sources.join('\n')).not.toContain("toast('error'")
+  })
+})

--- a/providers/edges/portal/src/views.behavior.test.ts
+++ b/providers/edges/portal/src/views.behavior.test.ts
@@ -28,9 +28,11 @@ const api = vi.hoisted(() => ({
 const confirm = vi.hoisted(() => ({
   confirmDialog: vi.fn(),
 }))
+const toastMock = vi.hoisted(() => vi.fn())
 
 vi.mock('./api', () => api)
 vi.mock('./portalkit/confirm', () => confirm)
+vi.mock('./portalkit/toast', () => ({ toast: toastMock }))
 
 import Services from './Services.vue'
 import App from './App.vue'
@@ -857,6 +859,7 @@ describe('edge list views', () => {
       expect(state.canCreate).toBe(false)
       await state.onCreate()
       expect(api.createKubeEdgeService).not.toHaveBeenCalled()
+      expect(toastMock).not.toHaveBeenCalled()
 
       state.draft.host = '  https://192.168.1.1:443/  '
       expect(state.canCreate).toBe(true)
@@ -866,6 +869,8 @@ describe('edge list views', () => {
         targetName: '',
         edgeKind: 'KubernetesCluster',
       }))
+      expect(toastMock).toHaveBeenCalledTimes(1)
+      expect(toastMock).toHaveBeenCalledWith('info', 'Service creation requested for unifi.')
     } finally {
       mounted.unmount()
     }
@@ -1061,6 +1066,7 @@ describe('edge list views', () => {
       expect(state.deleting).toBe(false)
       expect(state.busy).toBe(false)
       expect(state.mutationError).toBe('delete failed')
+      expect(toastMock).not.toHaveBeenCalled()
     } finally {
       mounted.unmount()
     }
@@ -1092,6 +1098,7 @@ describe('edge detail actions', () => {
         confirmLabel: 'Delete',
       }))
       expect(api.deleteEdge).not.toHaveBeenCalled()
+      expect(toastMock).not.toHaveBeenCalled()
       expect(state.edge).toEqual(edgeDetail)
 
       const pendingDelete = deferred<void>()
@@ -1110,6 +1117,32 @@ describe('edge detail actions', () => {
       expect(state.edge).toEqual(edgeDetail)
       expect(state.mutationError).toBe('delete failed')
       expect(state.actionItems[0].disabled).toBe(false)
+      expect(toastMock).not.toHaveBeenCalled()
+    } finally {
+      mounted.unmount()
+    }
+  })
+
+  it('emits one informational toast before leaving a successfully deleted edge', async () => {
+    api.getEdge.mockResolvedValue(edgeDetail)
+    api.listEdgeServices.mockResolvedValue([])
+    confirm.confirmDialog.mockResolvedValue(true)
+    const deleted = vi.fn()
+    const mounted = await mount(Detail, {
+      name: edgeDetail.name,
+      type: edgeDetail.type,
+      cluster: null,
+      token: null,
+      onDeleted: deleted,
+    })
+    try {
+      await flush()
+      await flush()
+      await mounted.instance.setupState.onDelete()
+
+      expect(toastMock).toHaveBeenCalledTimes(1)
+      expect(toastMock).toHaveBeenCalledWith('info', 'Cluster deletion requested for edge-a.')
+      expect(deleted).toHaveBeenCalledTimes(1)
     } finally {
       mounted.unmount()
     }

--- a/providers/infrastructure/portal/src/instanceDetailMounted.test.ts
+++ b/providers/infrastructure/portal/src/instanceDetailMounted.test.ts
@@ -8,6 +8,8 @@ import type { Instance } from './types'
 import { api } from './api'
 import { confirmDialog } from './portalkit/confirm'
 
+const toastMock = vi.hoisted(() => vi.fn())
+
 vi.mock('./api', () => ({
   api: {
     getInstance: vi.fn(),
@@ -20,6 +22,7 @@ vi.mock('./api', () => ({
 vi.mock('./portalkit/confirm', () => ({
   confirmDialog: vi.fn(),
 }))
+vi.mock('./portalkit/toast', () => ({ toast: toastMock }))
 
 const instance: Instance = {
   uid: 'uid-instance-1',
@@ -70,6 +73,7 @@ describe('mounted Infrastructure instance detail deletion behavior', () => {
   beforeEach(() => {
     vi.mocked(api.getInstance).mockResolvedValue({ ...instance })
     vi.mocked(api.getTemplate).mockResolvedValue({ template: { view: null } as never })
+    vi.mocked(api.deleteInstance).mockResolvedValue(undefined)
     vi.mocked(confirmDialog).mockResolvedValue(true)
     host = document.createElement('div')
     document.body.appendChild(host)
@@ -196,12 +200,33 @@ describe('mounted Infrastructure instance detail deletion behavior', () => {
 
     expect(host.querySelector('[role="alert"][aria-live="assertive"]')?.textContent)
       .toContain('HTTPError: delete failed')
+    expect(toastMock).not.toHaveBeenCalled()
     expect(host.querySelector('[role="status"][aria-live="polite"].instance-message')).toBeNull()
     expect(text('.k-resource-page__status .k-badge')).toContain('Ready')
     expect(host.textContent).toContain('retained-value')
     expect(refresh!.disabled).toBe(false)
     expect(back!.getAttribute('aria-disabled')).toBeNull()
     back!.click()
+    expect(navigate).toHaveBeenCalledWith('instances')
+  })
+
+  it('emits one informational toast before navigating after an accepted deletion', async () => {
+    const navigate = vi.fn()
+    app = createApp(InstanceDetailPage, {
+      instanceName: instance.name,
+      tombstones: createResourceTombstones(),
+      onNavigate: navigate,
+    })
+    app.mount(host)
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('.k-action-menu__trigger')!.click()
+    await flush()
+    host.querySelector<HTMLButtonElement>('.k-action-menu__item')!.click()
+    await flush()
+
+    expect(toastMock).toHaveBeenCalledTimes(1)
+    expect(toastMock).toHaveBeenCalledWith('info', 'Instance deletion requested for demo-instance.')
     expect(navigate).toHaveBeenCalledWith('instances')
   })
 })

--- a/providers/infrastructure/portal/src/provisionPageMounted.test.ts
+++ b/providers/infrastructure/portal/src/provisionPageMounted.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ProvisionPage from './views/ProvisionPage.vue'
 import { api } from './api'
 
+const toastMock = vi.hoisted(() => vi.fn())
+
 vi.mock('./api', () => ({
   api: {
     getTemplate: vi.fn(),
@@ -12,6 +14,7 @@ vi.mock('./api', () => ({
   },
   isContextChangedError: vi.fn(() => false),
 }))
+vi.mock('./portalkit/toast', () => ({ toast: toastMock }))
 
 async function flush(): Promise<void> {
   await Promise.resolve()
@@ -95,5 +98,23 @@ describe('mounted Infrastructure provisioning workflow', () => {
       values: { enabled: true, database: { size: 'large' } },
     })
     expect(provisioned).toHaveBeenCalledWith('demo-instance')
+    expect(toastMock).toHaveBeenCalledTimes(1)
+    expect(toastMock).toHaveBeenCalledWith('info', 'Provisioning started for demo-instance.')
+  })
+
+  it('keeps a failed provision contextual and does not toast', async () => {
+    vi.mocked(api.createInstance).mockRejectedValueOnce({ message: 'quota exceeded' })
+    app = createApp(ProvisionPage, { templateName: 'demo-template' })
+    app.mount(host)
+    await flush()
+
+    const name = host.querySelector<HTMLInputElement>('#infrastructure-instance-name')!
+    name.value = 'demo-instance'
+    name.dispatchEvent(new Event('input', { bubbles: true }))
+    host.querySelector('form')!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    await flush()
+
+    expect(host.querySelector('[role="alert"]')?.textContent).toContain('quota exceeded')
+    expect(toastMock).not.toHaveBeenCalled()
   })
 })

--- a/providers/infrastructure/portal/src/toastAdoption.test.ts
+++ b/providers/infrastructure/portal/src/toastAdoption.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import detail from './views/InstanceDetailPage.vue?raw'
+import list from './views/InstanceListPage.vue?raw'
+import provision from './views/ProvisionPage.vue?raw'
+
+describe('Infrastructure toast adoption', () => {
+  it('covers provisioning and both deletion entry points', () => {
+    expect(provision).toContain("toast('info', `Provisioning started for ${inst.name}.`)")
+    expect(detail).toContain("toast('info', `Instance deletion requested for ${deletingInstance.name}.`)")
+    expect(list).toContain("toast('info', `Instance deletion requested for ${currentInstance.name}.`)")
+    expect([provision, detail, list].join('\n').match(/\btoast\(/g)).toHaveLength(3)
+  })
+
+  it('does not duplicate contextual failures with error toasts', () => {
+    expect([provision, detail, list].join('\n')).not.toContain("toast('error'")
+  })
+})

--- a/providers/infrastructure/portal/src/views/InstanceDetailPage.vue
+++ b/providers/infrastructure/portal/src/views/InstanceDetailPage.vue
@@ -12,6 +12,7 @@ import ResourceSectionCard from '../portalkit/ResourceSectionCard.vue'
 import ResourceStatCards, { type ResourceStatCard } from '../portalkit/ResourceStatCards.vue'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import {
   createAdaptiveRefreshTimer,
   createLatestRefreshController,
@@ -231,6 +232,7 @@ async function executeDelete() {
     await api.deleteInstance(props.instanceName)
     if (active) {
       props.tombstones.add(deletingInstance.name, deletingInstance.uid)
+      toast('info', `Instance deletion requested for ${deletingInstance.name}.`)
       navigatingAway = true
       emit('navigate', 'instances')
     }

--- a/providers/infrastructure/portal/src/views/InstanceListPage.vue
+++ b/providers/infrastructure/portal/src/views/InstanceListPage.vue
@@ -6,6 +6,7 @@ import { api, isContextChangedError } from '../api'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
 import { confirmDialog } from '../portalkit/confirm'
+import { toast } from '../portalkit/toast'
 import {
   createAdaptiveRefreshTimer,
   createLatestRefreshController,
@@ -377,6 +378,7 @@ async function deleteInstance(instance: Instance) {
     await api.deleteInstance(currentInstance.name)
     if (active) {
       tombstones.add(instanceKey(currentInstance), currentInstance.uid)
+      toast('info', `Instance deletion requested for ${currentInstance.name}.`)
       reconcileAfterNextServerRead = true
       // The complete source is stale until the post-delete read proves the
       // tombstone's absence/presence, so query edits during that read must

--- a/providers/infrastructure/portal/src/views/ProvisionPage.vue
+++ b/providers/infrastructure/portal/src/views/ProvisionPage.vue
@@ -6,6 +6,7 @@ import { api, isContextChangedError } from '../api'
 import { createWritableValues } from '../createValues'
 import type { Template, ErrorResponse } from '../types'
 import { useDelayedLoading } from '../portalkit/useDelayedLoading'
+import { toast } from '../portalkit/toast'
 import { REASON_CLOUD_CREDENTIALS_MISSING, REASON_API_BINDING_MISSING, REASON_TENANT_MISSING } from '../types'
 
 const props = defineProps<{ templateName: string }>()
@@ -103,7 +104,10 @@ async function submit() {
       name: instanceName.value.trim(),
       values: writableValues,
     })
-    if (active) emit('provisioned', inst.name)
+    if (active) {
+      toast('info', `Provisioning started for ${inst.name}.`)
+      emit('provisioned', inst.name)
+    }
   } catch (e: unknown) {
     if (!active || isContextChangedError(e)) return
     const err = e as ErrorResponse


### PR DESCRIPTION
## Summary

- add shell-hosted success and accepted/requested toasts to Code connection, repository, deploy-key, and collaborator mutations
- add completed-save and asynchronous-deletion toasts to Databricks connections, warehouses, and tables
- add service lifecycle/configuration, Edge deletion, and Workload deletion toasts to Edges
- add provisioning and deletion-request toasts to Infrastructure list and detail flows
- preserve existing inline errors, status feedback, navigation, and stale-context guards

## Toast policy

- `ok` only when the returned state confirms completion
- `info` when a controller-backed request was accepted and reconciliation continues
- emit once after success and any current-context guard
- no toast for cancellation, validation failure, request failure, stale response, or reads

## Verification

- complete `npm test`, `npm run typecheck`, and `npm run build` for Code, Databricks, Edges, and Infrastructure portals
- `make verify-portalkit`
- `make verify-ui-conformance`
- `git diff --check`
- live Tilt smoke coverage for Code connection create/delete, Databricks connection create/delete, Edges service create/configuration/delete, and Infrastructure provision/delete

Temporary smoke-test resources received deletion requests after verification.
