### PR TITLE
Add App Studio access and archive toasts

### DIFF
--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -51,6 +51,12 @@ import { confirmDialog, confirmState } from './portalkit/confirm'
 import { readLayoutPreference, writeLayoutPreference, type LayoutMode } from './portalkit/layoutPreference'
 import { toast } from './portalkit/toast'
 import {
+  accessMutationToast,
+  previewAccessUpdateToast,
+  productionAccessUpdateToast,
+  type AccessMutation,
+} from './toastPolicy'
+import {
   canSubmitCreatePrompt,
   createSetupItems,
   gitConnectionReady,
@@ -3999,6 +4005,8 @@ async function publishCurrentProject() {
     // publication immediately; the background refresh intentionally does not
     // overwrite a live Share draft while the dialog is open.
     shareMode.value = state.publication?.mode === 'public' ? 'public' : mode
+    const notice = productionAccessUpdateToast()
+    toast(notice.kind, notice.message)
     await loadPublishing()
   } catch (err) {
     if (selected.value?.name === name) {
@@ -4022,6 +4030,8 @@ async function savePreviewAccess() {
     if (selected.value?.name !== name) return
     previewAccess.value = state
     previewMode.value = state.mode === 'public' ? 'public' : 'restricted'
+    const notice = previewAccessUpdateToast(state.converged)
+    toast(notice.kind, notice.message)
   } catch (err) {
     if (selected.value?.name === name) {
       publishingActionError.value = err instanceof Error ? err.message : String(err)
@@ -4035,30 +4045,49 @@ async function savePreviewAccess() {
 // instance, so the two grant lists are independent — revoking preview access
 // leaves production access untouched.
 async function grantCurrentProjectPreviewAccess(user: string) {
-  await mutatePreviewGrants((name) => api.createPreviewGrant(props.ctx, name, user, false))
+  await mutatePreviewGrants({
+    mutation: 'grant',
+    subject: user,
+    run: (name) => api.createPreviewGrant(props.ctx, name, user, false),
+  })
 }
 
 async function inviteCurrentProjectPreviewAccess(email: string) {
-  await mutatePreviewGrants((name) => api.createPreviewGrant(props.ctx, name, email, true))
+  await mutatePreviewGrants({
+    mutation: 'invite',
+    subject: email,
+    run: (name) => api.createPreviewGrant(props.ctx, name, email, true),
+  })
 }
 
 async function revokeCurrentProjectPreviewAccess(grant: string) {
-  await mutatePreviewGrants((name) => api.revokePreviewGrant(props.ctx, name, grant))
+  await mutatePreviewGrants({
+    mutation: 'revoke',
+    run: (name) => api.revokePreviewGrant(props.ctx, name, grant),
+  })
 }
 
-async function mutatePreviewGrants(run: (name: string) => Promise<ProjectPublishingGrant[]>) {
+interface PreviewGrantMutation {
+  mutation: AccessMutation
+  subject?: string
+  run: (name: string) => Promise<ProjectPublishingGrant[]>
+}
+
+async function mutatePreviewGrants(operation: PreviewGrantMutation) {
   const name = selected.value?.name
   if (!name || publishingActionBusy.value) return
   publishingActionBusy.value = true
   publishingActionError.value = null
   try {
-    const grants = await run(name)
+    const grants = await operation.run(name)
     if (selected.value?.name !== name) return
     // Keep the visibility fields and swap only the grant list, so the toggle's
     // converged/pending state is not reset by a grant mutation.
     previewAccess.value = previewAccess.value
       ? { ...previewAccess.value, grants }
       : previewAccess.value
+    const notice = accessMutationToast('preview', operation.mutation, operation.subject)
+    toast(notice.kind, notice.message)
   } catch (err) {
     if (selected.value?.name === name) {
       publishingActionError.value = err instanceof Error ? err.message : String(err)
@@ -4091,6 +4120,7 @@ async function unpublishCurrentProject() {
     const state = await api.unpublishProject(props.ctx, name)
     if (selected.value?.name !== name) return
     publishing.value = state
+    toast('ok', 'Production access disabled.')
     await loadPublishing()
     disableSucceeded = true
   } catch (err) {
@@ -4124,6 +4154,8 @@ async function grantOrInviteProjectAccess(user: string, invite: boolean) {
   try {
     await api.grantPublishingAccess(props.ctx, name, selectedUser, invite)
     if (selected.value?.name !== name) return
+    const notice = accessMutationToast('production', invite ? 'invite' : 'grant', selectedUser)
+    toast(notice.kind, notice.message)
     await loadPublishing()
   } catch (err) {
     if (selected.value?.name === name) {
@@ -4142,6 +4174,8 @@ async function revokeCurrentProjectAccess(grant: string) {
   try {
     await api.revokePublishingAccess(props.ctx, name, grant)
     if (selected.value?.name !== name) return
+    const notice = accessMutationToast('production', 'revoke')
+    toast(notice.kind, notice.message)
     await loadPublishing()
   } catch (err) {
     if (selected.value?.name === name) {
@@ -5832,6 +5866,7 @@ async function archiveAssistantThread(threadID: string) {
     unreadAssistantThreadIDs.value = unreadAssistantThreadIDs.value.filter((candidate) => candidate !== threadID)
     const remaining = assistantThreads.value.filter((thread) => thread.id !== threadID)
     assistantThreads.value = remaining
+    toast('ok', 'Conversation archived.')
     if (!wasActive) {
       threadRailRef.value?.focusThread?.(activeAssistantThreadID.value)
       return

--- a/providers/app-studio/portal/src/publishingControls.test.mjs
+++ b/providers/app-studio/portal/src/publishingControls.test.mjs
@@ -8,6 +8,35 @@ const releasePipeline = await readFile(new URL('./ReleasePipeline.vue', import.m
 const promotionState = await readFile(new URL('./promotionState.ts', import.meta.url), 'utf8')
 const productionSettings = await readFile(new URL('./useProductionSettings.ts', import.meta.url), 'utf8')
 
+function functionSource(start, end) {
+  const startIndex = app.indexOf(start)
+  const endIndex = app.indexOf(end, startIndex)
+  assert.ok(startIndex >= 0 && endIndex > startIndex)
+  return app.slice(startIndex, endIndex)
+}
+
+test('emits truthful publishing and access toasts only after current responses', () => {
+  const publish = functionSource('async function publishCurrentProject', '\n\n// savePreviewAccess')
+  assert.match(publish, /if \(selected\.value\?\.name !== name\) return[\s\S]*productionAccessUpdateToast\(\)[\s\S]*toast\(notice\.kind, notice\.message\)/)
+
+  const preview = functionSource('async function savePreviewAccess', '\n\n// Preview grants')
+  assert.match(preview, /if \(selected\.value\?\.name !== name\) return[\s\S]*previewAccessUpdateToast\(state\.converged\)[\s\S]*toast\(notice\.kind, notice\.message\)/)
+
+  const previewGrantCalls = functionSource('async function grantCurrentProjectPreviewAccess', '\n\ninterface PreviewGrantMutation')
+  assert.match(previewGrantCalls, /mutation: 'grant'[\s\S]*mutation: 'invite'[\s\S]*mutation: 'revoke'/)
+  const previewGrants = functionSource('interface PreviewGrantMutation', '\n\nasync function unpublishCurrentProject')
+  assert.match(previewGrants, /if \(selected\.value\?\.name !== name\) return[\s\S]*accessMutationToast\('preview', operation\.mutation, operation\.subject\)[\s\S]*toast\(notice\.kind, notice\.message\)/)
+
+  const unpublish = functionSource('async function unpublishCurrentProject', '\n\nasync function grantCurrentProjectAccess')
+  assert.match(unpublish, /if \(selected\.value\?\.name !== name\) return[\s\S]*toast\('ok', 'Production access disabled\.'\)/)
+
+  const productionGrants = functionSource('async function grantCurrentProjectAccess', '\n\nasync function promoteToProd')
+  assert.equal((productionGrants.match(/accessMutationToast\('production'/g) ?? []).length, 2)
+  assert.equal((productionGrants.match(/toast\(notice\.kind, notice\.message\)/g) ?? []).length, 2)
+  assert.equal((productionGrants.match(/if \(selected\.value\?\.name !== name\) return/g) ?? []).length, 2)
+  assert.doesNotMatch([publish, preview, previewGrants, unpublish, productionGrants].join('\n'), /toast\('error'/)
+})
+
 test('exposes Publishing separately and keeps workspace model config out of Project Settings', () => {
   assert.doesNotMatch(app, /type ProjectSettingsPane/)
   assert.doesNotMatch(app, /projectSettingsPanes/)

--- a/providers/app-studio/portal/src/threadRailIntegration.test.mjs
+++ b/providers/app-studio/portal/src/threadRailIntegration.test.mjs
@@ -36,6 +36,8 @@ test('keeps pin and manual read state project scoped and archives through the ca
   assert.match(archiveSource, /archiveFailed = true/)
   assert.match(archiveSource, /finally \{[\s\S]*releaseThreadMutationLatch\(threadMutationLatchOwner\)[\s\S]*if \(archiveFailed\) threadRailRef\.value\?\.focusThread\?\.\(threadID\)/)
   assert.match(archiveSource, /activeAssistantThreadID\.value = ''[\s\S]*messages\.value = \[\]/)
+  assert.match(archiveSource, /assistantThreads\.value = remaining[\s\S]*toast\('ok', 'Conversation archived\.'\)[\s\S]*if \(!wasActive\)/)
+  assert.equal((archiveSource.match(/Conversation archived\./g) ?? []).length, 1)
   assert.match(archiveSource, /if \(!wasActive\) \{[\s\S]*focusThread\?\.\(activeAssistantThreadID\.value\)/)
   assert.match(archiveSource, /if \(requestIsCurrent\(\)\) \{[\s\S]*threadError\.value = e instanceof Error \? e\.message : String\(e\)[\s\S]*archiveFailed = true[\s\S]*\}\n    return[\s\S]*finally/)
   assert.match(archiveSource, /if \(!requestIsCurrent\(\) \|\| !contextIsCurrent\(\)\) return/)

--- a/providers/app-studio/portal/src/toastPolicy.test.mjs
+++ b/providers/app-studio/portal/src/toastPolicy.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createServer } from 'vite'
+
+const server = await createServer({
+  appType: 'custom',
+  cacheDir: '/tmp/faros-vite-toast-policy',
+  configFile: false,
+  server: { middlewareMode: true },
+})
+
+const policy = await server.ssrLoadModule('/src/toastPolicy.ts')
+
+test.after(async () => {
+  await server.close()
+})
+
+test('reports production and pending preview policy changes as accepted', () => {
+  assert.deepEqual(policy.productionAccessUpdateToast(), {
+    kind: 'info',
+    message: 'Production access update accepted. Status will update here.',
+  })
+  assert.deepEqual(policy.previewAccessUpdateToast(false), {
+    kind: 'info',
+    message: 'Preview access update accepted. Status will update here.',
+  })
+})
+
+test('reports converged preview policy changes as complete', () => {
+  assert.deepEqual(policy.previewAccessUpdateToast(true), {
+    kind: 'ok',
+    message: 'Preview access updated.',
+  })
+})
+
+test('uses operation-specific access grant, invite, and revoke confirmations', () => {
+  assert.deepEqual(policy.accessMutationToast('production', 'grant', 'Ada'), {
+    kind: 'ok',
+    message: 'Production access granted to Ada.',
+  })
+  assert.deepEqual(policy.accessMutationToast('production', 'invite', 'ada@example.com'), {
+    kind: 'ok',
+    message: 'Production invitation created for ada@example.com.',
+  })
+  assert.deepEqual(policy.accessMutationToast('production', 'revoke'), {
+    kind: 'ok',
+    message: 'Production access revoked.',
+  })
+  assert.deepEqual(policy.accessMutationToast('preview', 'grant', 'Grace'), {
+    kind: 'ok',
+    message: 'Preview access granted to Grace.',
+  })
+  assert.deepEqual(policy.accessMutationToast('preview', 'invite', 'grace@example.com'), {
+    kind: 'ok',
+    message: 'Preview invitation created for grace@example.com.',
+  })
+  assert.deepEqual(policy.accessMutationToast('preview', 'revoke'), {
+    kind: 'ok',
+    message: 'Preview access revoked.',
+  })
+})

--- a/providers/app-studio/portal/src/toastPolicy.ts
+++ b/providers/app-studio/portal/src/toastPolicy.ts
@@ -1,0 +1,46 @@
+import type { ToastKind } from './portalkit/toast'
+
+export interface ToastNotice {
+  kind: ToastKind
+  message: string
+}
+
+export type AccessSurface = 'production' | 'preview'
+export type AccessMutation = 'grant' | 'invite' | 'revoke'
+
+export function productionAccessUpdateToast(): ToastNotice {
+  return {
+    kind: 'info',
+    message: 'Production access update accepted. Status will update here.',
+  }
+}
+
+export function previewAccessUpdateToast(converged: boolean): ToastNotice {
+  return converged
+    ? { kind: 'ok', message: 'Preview access updated.' }
+    : { kind: 'info', message: 'Preview access update accepted. Status will update here.' }
+}
+
+export function accessMutationToast(
+  surface: AccessSurface,
+  mutation: AccessMutation,
+  subject = '',
+): ToastNotice {
+  const label = surface === 'production' ? 'Production' : 'Preview'
+  const normalizedSubject = subject.trim()
+  if (mutation === 'revoke') return { kind: 'ok', message: `${label} access revoked.` }
+  if (mutation === 'invite') {
+    return {
+      kind: 'ok',
+      message: normalizedSubject
+        ? `${label} invitation created for ${normalizedSubject}.`
+        : `${label} invitation created.`,
+    }
+  }
+  return {
+    kind: 'ok',
+    message: normalizedSubject
+      ? `${label} access granted to ${normalizedSubject}.`
+      : `${label} access granted.`,
+  }
+}


### PR DESCRIPTION
## Summary

- add accepted/pending confirmations for production publishing and access-policy mutations
- add converged versus pending preview-access confirmations
- distinguish preview grant, invite, and revoke messages with explicit operation metadata
- confirm production grant, invite, and revoke mutations without duplicating durable feedback
- emit `Conversation archived.` after the active projection removes an archived thread
- keep the existing project-deletion toast and existing durable settings/model/integration feedback unchanged

## Toast policy

- `ok` only when the returned state confirms completion
- `info` when publication or access-policy reconciliation remains pending
- emit once after success and current-project guards
- no toast for cancellation, failure, stale responses, or read-only flows

## Verification

- complete App Studio portal `npm test`, `npm run typecheck`, and `npm run build`
- focused converged/pending preview, grant/invite/revoke, production-policy, and active/non-active archival cases
- `make verify-portalkit`
- `make verify-ui-conformance`
- `git diff --check`
- live Tilt smoke coverage for conversation archival through the Console shell toast host

The temporary smoke-test thread was removed after verification.
