### PR TITLE
Provider conformance 1/9: shared foundations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,7 @@ sync-portalkit: ## Vendor the shared portalkit UI kits into provider portals
 
 verify-portalkit: ## Verify vendored portalkit copies are in sync with the canonical source
 	@hack/sync-portalkit.sh --verify
+	@node --test provider-sdk/portalkit/dashboardtile.conformance.test.mjs
 
 test-portal-settings-conformance: ## Verify portal shell and organization/workspace source contracts
 	@node --test portal/src/theme-bootstrap.test.mjs portal/src/pages/OrganizationsWorkspace.conformance.test.mjs

--- a/docs/design/components/portalkit-support.md
+++ b/docs/design/components/portalkit-support.md
@@ -24,7 +24,13 @@ not render a standalone component:
   not replace content or disable actions.
 - `dashboardtile.ts` supplies the framework-neutral dashboard resource summary
   contract. It follows the same stale/read-state and semantic-token rules as
-  resource pages; provider facts remain provider-owned.
+  resource pages; provider facts remain provider-owned. Tailwind consumers use
+  `tileClass`, while plain-DOM consumers use the matching
+  `dashboardTileSemanticClass` hooks implemented in `faros-ui.css`. Both maps
+  describe the same slots; the semantic map is names only and therefore
+  requires the canonical stylesheet. Neither authorizes provider-local visual
+  variants. A change to either map or its CSS increments the matching
+  `FAROS_UI_VERSION` style-handoff contract before the assets are synced.
 
 See the [resource reads pattern](../patterns/resource-reads.md) and
 [provider integration foundation](../foundations/provider-integration.md) for

--- a/docs/design/content/ui-copy.md
+++ b/docs/design/content/ui-copy.md
@@ -41,7 +41,7 @@ in the [component entries](../components/); page composition stays in the
   state. Explain whether a credential is needed and how to supply or rotate it;
   expose a safe reference or non-secret status instead. The sole setup-handoff
   exception is a newly generated, one-time secret that the user must transfer:
-  keep it masked, reveal or copy it only through an explicit action, and clear
+  keep it masked, copy it only through an explicit action, and clear
   it on dismissal, navigation, context change, or unmount. It never enters a
   table, toast, error, log, or persisted browser state. Internal workloads may
   be described by name precisely because their setup does not need a URL or

--- a/docs/design/content/ui-copy.md
+++ b/docs/design/content/ui-copy.md
@@ -37,10 +37,14 @@ in the [component entries](../components/); page composition stays in the
   marks technical values explicitly. Technical detail is useful for operators,
   but it must not make a user-facing action unreadable.
 - **Keep details secret-safe.** Never render credential, token, password, or
-  secret values in page content, state copy, errors, summaries, or clipboard
-  helpers. Explain whether a credential is needed and how to supply or rotate
-  it; expose a safe reference or non-secret status instead. Internal workloads
-  may be described by name precisely because their setup does not need a URL or
+  secret values in tables, toasts, errors, logs, summaries, or persistent UI
+  state. Explain whether a credential is needed and how to supply or rotate it;
+  expose a safe reference or non-secret status instead. The sole setup-handoff
+  exception is a newly generated, one-time secret that the user must transfer:
+  keep it masked, reveal or copy it only through an explicit action, and clear
+  it on dismissal, navigation, context change, or unmount. It never enters a
+  table, toast, error, log, or persisted browser state. Internal workloads may
+  be described by name precisely because their setup does not need a URL or
   token.
 
 ## Informative examples

--- a/docs/design/foundations/recipes.md
+++ b/docs/design/foundations/recipes.md
@@ -16,7 +16,9 @@ before writing local CSS.
 | `.k-table` | 6px table wrapper; mono 9–10px uppercase headers, 13px rows, accent-tint hover through `.is-interactive` |
 | `.k-cell-mono` | Data-like names, IDs, and timestamps |
 | `.k-badge` (`--success/--warning/--danger/--muted`, `__dot`) | Square 3px mono tag, 10px/600 uppercase, `0.06em`, subtle semantic background and `color-mix` hairline |
-| `.k-btn` (`--primary/--ghost/--text/--danger`) | 4px control; primary is solid accent plus glow, ghost overlay plus hairline, text transparent, danger tinted and never glowing |
+| `.k-btn` (`--primary/--ghost/--text/--danger`) | 4px control; primary is solid accent plus glow, ghost overlay plus hairline, text transparent, danger tinted and never glowing; all variants reach 44×44px for coarse and hybrid pointers |
+| `.k-dashboard-action` | Compact text action inside a dashboard tile; remains visually quiet while reaching 44×44px for coarse and hybrid pointers |
+| `.k-spin` | Canonical 0.8s linear loading rotation; becomes static under reduced motion and never replaces status text or the affected region's busy state |
 | `.k-back-action` | Intrinsic-width, start-aligned borderless link; 12px/500 accent, 6px icon gap, hover underline, no control surface |
 | `.k-input` | 4px overlay input; focus is accent border, 3px subtle ring, and glow |
 | `.k-form-select` (`__trigger`, `__panel`, `__option`) | Accessible PortalKit single-select combobox using input/menu recipes |

--- a/docs/design/patterns/navigation-and-feedback.md
+++ b/docs/design/patterns/navigation-and-feedback.md
@@ -25,6 +25,12 @@ use `surface-overlay`, user bubbles `accent-subtle`, and neither glows. Empty
 states use restrained contour-grid texture, an eyebrow, one-line explanation,
 and one primary action.
 
+A settings page may contain one primary action for each independently
+persisted, visibly named form region. Each such region owns its own dirty,
+busy, success, and error state, so saving one region cannot imply that another
+region was saved. This is a persistence boundary, not permission to place
+multiple competing primary actions in one form or task.
+
 Native checkboxes and radios inherit `accent-color: var(--color-accent)` from
 `body`; do not restyle them with raw blue. Custom toggles use a sharp 3px track
 (`bg-accent` on, `bg-border-default` off) and 2px `bg-text-primary` knob, never

--- a/hack/sync-portalkit.sh
+++ b/hack/sync-portalkit.sh
@@ -58,7 +58,7 @@ HOST_UI="$ROOT/portal/src/assets/faros-ui.css"
 # README.md documents the canonical kit but is not a distributable vendored
 # asset. Every other direct file in the canonical directories must be listed
 # above so adding a new source file cannot silently skip every portal.
-TS_CANONICAL_ONLY=(README.md page-state.ts)
+TS_CANONICAL_ONLY=(README.md dashboardtile.conformance.test.mjs page-state.ts)
 VUE_CANONICAL_ONLY=(ActionMenu.conformance.test.mjs Toast.behavior.test.mjs Toast.conformance.test.mjs)
 
 # Vue migrations no longer need the vanilla confirm/alert implementation;

--- a/portal/src/assets/faros-ui.css
+++ b/portal/src/assets/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/portal/src/assets/faros-ui.css
+++ b/portal/src/assets/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/portal/src/portalkit/dashboardtile.ts
+++ b/portal/src/portalkit/dashboardtile.ts
@@ -66,6 +66,34 @@ export const tileClass = {
   error: 'text-[11px] text-danger',
 } as const
 
+// Plain-DOM portals cannot rely on Tailwind's generated utilities. This map
+// exposes the same semantic slots as tileClass while keeping the visual recipe
+// in faros-ui.css. Existing Tailwind consumers remain on tileClass; string-
+// building portals use these names instead of maintaining a local facsimile.
+export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = {
+  root: 'k-dashboard-tile',
+  stats: 'k-dashboard-tile__stats',
+  stat: 'k-dashboard-tile__stat',
+  statIcon: 'k-dashboard-tile__stat-icon',
+  statTotal: 'k-dashboard-tile__stat--total',
+  statOk: 'k-dashboard-tile__stat--ok',
+  statWarn: 'k-dashboard-tile__stat--warning',
+  statBad: 'k-dashboard-tile__stat--danger',
+  statMuted: 'k-dashboard-tile__stat--muted',
+  statNum: 'k-dashboard-tile__stat-number',
+  statLabel: 'k-dashboard-tile__stat-label',
+  sectionLabel: 'k-dashboard-tile__section-label',
+  list: 'k-dashboard-tile__list',
+  row: 'k-dashboard-tile__row',
+  rowPrimary: 'k-dashboard-tile__row-primary',
+  rowSecondary: 'k-dashboard-tile__row-secondary',
+  rowDot: 'k-dashboard-tile__row-dot',
+  chevron: 'k-dashboard-tile__chevron',
+  empty: 'k-dashboard-tile__empty',
+  message: 'k-dashboard-tile__message',
+  error: 'k-dashboard-tile__error',
+}
+
 // TileContext is the subset of farosContext a tile needs. The console pushes
 // the full object; tiles only ever read these.
 export interface TileContext {

--- a/portal/src/portalkit/faros-ui.css
+++ b/portal/src/portalkit/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/portal/src/portalkit/faros-ui.css
+++ b/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/portal/src/portalkit/styles.ts
+++ b/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 5
+export const FAROS_UI_VERSION = 6
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/provider-sdk/portalkit/dashboardtile.conformance.test.mjs
+++ b/provider-sdk/portalkit/dashboardtile.conformance.test.mjs
@@ -18,6 +18,7 @@ test('dashboard tiles expose matching Tailwind and plain-DOM semantic slots', ()
   for (const className of classNames) {
     assert.ok(styles.includes(`.${className}`), `missing canonical CSS for ${className}`)
   }
+  assert.match(styles, /\.k-dashboard-tile__list\s*\{[^}]*margin: 0;[^}]*padding: 0;[^}]*list-style: none;/s)
 })
 
 test('stylesheet marker and runtime handoff require the same version', () => {

--- a/provider-sdk/portalkit/dashboardtile.conformance.test.mjs
+++ b/provider-sdk/portalkit/dashboardtile.conformance.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('./dashboardtile.ts', import.meta.url), 'utf8')
+const styles = readFileSync(new URL('./faros-ui.css', import.meta.url), 'utf8')
+const styleHandoff = readFileSync(new URL('./styles.ts', import.meta.url), 'utf8')
+
+test('dashboard tiles expose matching Tailwind and plain-DOM semantic slots', () => {
+  assert.match(source, /export const tileClass = \{[\s\S]*?error:/)
+  assert.match(source, /export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = \{[\s\S]*?error:/)
+  const semanticMap = source.slice(
+    source.indexOf('export const dashboardTileSemanticClass'),
+    source.indexOf('\n}', source.indexOf('export const dashboardTileSemanticClass')) + 2,
+  )
+  const classNames = [...semanticMap.matchAll(/^\s+\w+: '([^']+)'/gm)].map(match => match[1])
+  assert.equal(classNames.length, 21)
+  for (const className of classNames) {
+    assert.ok(styles.includes(`.${className}`), `missing canonical CSS for ${className}`)
+  }
+})
+
+test('stylesheet marker and runtime handoff require the same version', () => {
+  const cssVersion = styles.match(/--faros-ui-version:\s*(\d+);/)?.[1]
+  const runtimeVersion = styleHandoff.match(/FAROS_UI_VERSION = (\d+)/)?.[1]
+  assert.ok(cssVersion)
+  assert.equal(runtimeVersion, cssVersion)
+})
+
+test('shared loading and dashboard actions respect input and motion preferences', () => {
+  assert.match(styles, /\.k-spin\s*\{\s*animation: k-spin 0\.8s linear infinite;/)
+  assert.match(styles, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.k-spin\s*\{\s*animation: none;/)
+  assert.match(styles, /@media \(pointer: coarse\), \(any-pointer: coarse\)[\s\S]*?\.k-btn,[\s\S]*?\.k-dashboard-action,[\s\S]*?\.k-dashboard-tile__row\s*\{[\s\S]*?min-height: 44px;[\s\S]*?min-width: 44px;/)
+})

--- a/provider-sdk/portalkit/dashboardtile.ts
+++ b/provider-sdk/portalkit/dashboardtile.ts
@@ -66,6 +66,34 @@ export const tileClass = {
   error: 'text-[11px] text-danger',
 } as const
 
+// Plain-DOM portals cannot rely on Tailwind's generated utilities. This map
+// exposes the same semantic slots as tileClass while keeping the visual recipe
+// in faros-ui.css. Existing Tailwind consumers remain on tileClass; string-
+// building portals use these names instead of maintaining a local facsimile.
+export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = {
+  root: 'k-dashboard-tile',
+  stats: 'k-dashboard-tile__stats',
+  stat: 'k-dashboard-tile__stat',
+  statIcon: 'k-dashboard-tile__stat-icon',
+  statTotal: 'k-dashboard-tile__stat--total',
+  statOk: 'k-dashboard-tile__stat--ok',
+  statWarn: 'k-dashboard-tile__stat--warning',
+  statBad: 'k-dashboard-tile__stat--danger',
+  statMuted: 'k-dashboard-tile__stat--muted',
+  statNum: 'k-dashboard-tile__stat-number',
+  statLabel: 'k-dashboard-tile__stat-label',
+  sectionLabel: 'k-dashboard-tile__section-label',
+  list: 'k-dashboard-tile__list',
+  row: 'k-dashboard-tile__row',
+  rowPrimary: 'k-dashboard-tile__row-primary',
+  rowSecondary: 'k-dashboard-tile__row-secondary',
+  rowDot: 'k-dashboard-tile__row-dot',
+  chevron: 'k-dashboard-tile__chevron',
+  empty: 'k-dashboard-tile__empty',
+  message: 'k-dashboard-tile__message',
+  error: 'k-dashboard-tile__error',
+}
+
 // TileContext is the subset of farosContext a tile needs. The console pushes
 // the full object; tiles only ever read these.
 export interface TileContext {

--- a/provider-sdk/portalkit/faros-ui.css
+++ b/provider-sdk/portalkit/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/provider-sdk/portalkit/faros-ui.css
+++ b/provider-sdk/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/provider-sdk/portalkit/styles.ts
+++ b/provider-sdk/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 5
+export const FAROS_UI_VERSION = 6
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/agents/portal/src/portalkit/dashboardtile.ts
+++ b/providers/agents/portal/src/portalkit/dashboardtile.ts
@@ -66,6 +66,34 @@ export const tileClass = {
   error: 'text-[11px] text-danger',
 } as const
 
+// Plain-DOM portals cannot rely on Tailwind's generated utilities. This map
+// exposes the same semantic slots as tileClass while keeping the visual recipe
+// in faros-ui.css. Existing Tailwind consumers remain on tileClass; string-
+// building portals use these names instead of maintaining a local facsimile.
+export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = {
+  root: 'k-dashboard-tile',
+  stats: 'k-dashboard-tile__stats',
+  stat: 'k-dashboard-tile__stat',
+  statIcon: 'k-dashboard-tile__stat-icon',
+  statTotal: 'k-dashboard-tile__stat--total',
+  statOk: 'k-dashboard-tile__stat--ok',
+  statWarn: 'k-dashboard-tile__stat--warning',
+  statBad: 'k-dashboard-tile__stat--danger',
+  statMuted: 'k-dashboard-tile__stat--muted',
+  statNum: 'k-dashboard-tile__stat-number',
+  statLabel: 'k-dashboard-tile__stat-label',
+  sectionLabel: 'k-dashboard-tile__section-label',
+  list: 'k-dashboard-tile__list',
+  row: 'k-dashboard-tile__row',
+  rowPrimary: 'k-dashboard-tile__row-primary',
+  rowSecondary: 'k-dashboard-tile__row-secondary',
+  rowDot: 'k-dashboard-tile__row-dot',
+  chevron: 'k-dashboard-tile__chevron',
+  empty: 'k-dashboard-tile__empty',
+  message: 'k-dashboard-tile__message',
+  error: 'k-dashboard-tile__error',
+}
+
 // TileContext is the subset of farosContext a tile needs. The console pushes
 // the full object; tiles only ever read these.
 export interface TileContext {

--- a/providers/agents/portal/src/portalkit/faros-ui.css
+++ b/providers/agents/portal/src/portalkit/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/providers/agents/portal/src/portalkit/faros-ui.css
+++ b/providers/agents/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/providers/agents/portal/src/portalkit/styles.ts
+++ b/providers/agents/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 5
+export const FAROS_UI_VERSION = 6
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/app-studio/portal/src/portalkit/dashboardtile.ts
+++ b/providers/app-studio/portal/src/portalkit/dashboardtile.ts
@@ -66,6 +66,34 @@ export const tileClass = {
   error: 'text-[11px] text-danger',
 } as const
 
+// Plain-DOM portals cannot rely on Tailwind's generated utilities. This map
+// exposes the same semantic slots as tileClass while keeping the visual recipe
+// in faros-ui.css. Existing Tailwind consumers remain on tileClass; string-
+// building portals use these names instead of maintaining a local facsimile.
+export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = {
+  root: 'k-dashboard-tile',
+  stats: 'k-dashboard-tile__stats',
+  stat: 'k-dashboard-tile__stat',
+  statIcon: 'k-dashboard-tile__stat-icon',
+  statTotal: 'k-dashboard-tile__stat--total',
+  statOk: 'k-dashboard-tile__stat--ok',
+  statWarn: 'k-dashboard-tile__stat--warning',
+  statBad: 'k-dashboard-tile__stat--danger',
+  statMuted: 'k-dashboard-tile__stat--muted',
+  statNum: 'k-dashboard-tile__stat-number',
+  statLabel: 'k-dashboard-tile__stat-label',
+  sectionLabel: 'k-dashboard-tile__section-label',
+  list: 'k-dashboard-tile__list',
+  row: 'k-dashboard-tile__row',
+  rowPrimary: 'k-dashboard-tile__row-primary',
+  rowSecondary: 'k-dashboard-tile__row-secondary',
+  rowDot: 'k-dashboard-tile__row-dot',
+  chevron: 'k-dashboard-tile__chevron',
+  empty: 'k-dashboard-tile__empty',
+  message: 'k-dashboard-tile__message',
+  error: 'k-dashboard-tile__error',
+}
+
 // TileContext is the subset of farosContext a tile needs. The console pushes
 // the full object; tiles only ever read these.
 export interface TileContext {

--- a/providers/app-studio/portal/src/portalkit/faros-ui.css
+++ b/providers/app-studio/portal/src/portalkit/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/providers/app-studio/portal/src/portalkit/faros-ui.css
+++ b/providers/app-studio/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/providers/app-studio/portal/src/portalkit/styles.ts
+++ b/providers/app-studio/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 5
+export const FAROS_UI_VERSION = 6
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/code/portal/src/portalkit/dashboardtile.ts
+++ b/providers/code/portal/src/portalkit/dashboardtile.ts
@@ -66,6 +66,34 @@ export const tileClass = {
   error: 'text-[11px] text-danger',
 } as const
 
+// Plain-DOM portals cannot rely on Tailwind's generated utilities. This map
+// exposes the same semantic slots as tileClass while keeping the visual recipe
+// in faros-ui.css. Existing Tailwind consumers remain on tileClass; string-
+// building portals use these names instead of maintaining a local facsimile.
+export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = {
+  root: 'k-dashboard-tile',
+  stats: 'k-dashboard-tile__stats',
+  stat: 'k-dashboard-tile__stat',
+  statIcon: 'k-dashboard-tile__stat-icon',
+  statTotal: 'k-dashboard-tile__stat--total',
+  statOk: 'k-dashboard-tile__stat--ok',
+  statWarn: 'k-dashboard-tile__stat--warning',
+  statBad: 'k-dashboard-tile__stat--danger',
+  statMuted: 'k-dashboard-tile__stat--muted',
+  statNum: 'k-dashboard-tile__stat-number',
+  statLabel: 'k-dashboard-tile__stat-label',
+  sectionLabel: 'k-dashboard-tile__section-label',
+  list: 'k-dashboard-tile__list',
+  row: 'k-dashboard-tile__row',
+  rowPrimary: 'k-dashboard-tile__row-primary',
+  rowSecondary: 'k-dashboard-tile__row-secondary',
+  rowDot: 'k-dashboard-tile__row-dot',
+  chevron: 'k-dashboard-tile__chevron',
+  empty: 'k-dashboard-tile__empty',
+  message: 'k-dashboard-tile__message',
+  error: 'k-dashboard-tile__error',
+}
+
 // TileContext is the subset of farosContext a tile needs. The console pushes
 // the full object; tiles only ever read these.
 export interface TileContext {

--- a/providers/code/portal/src/portalkit/faros-ui.css
+++ b/providers/code/portal/src/portalkit/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/providers/code/portal/src/portalkit/faros-ui.css
+++ b/providers/code/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/providers/code/portal/src/portalkit/styles.ts
+++ b/providers/code/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 5
+export const FAROS_UI_VERSION = 6
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/databricks/portal/src/portalkit/dashboardtile.ts
+++ b/providers/databricks/portal/src/portalkit/dashboardtile.ts
@@ -66,6 +66,34 @@ export const tileClass = {
   error: 'text-[11px] text-danger',
 } as const
 
+// Plain-DOM portals cannot rely on Tailwind's generated utilities. This map
+// exposes the same semantic slots as tileClass while keeping the visual recipe
+// in faros-ui.css. Existing Tailwind consumers remain on tileClass; string-
+// building portals use these names instead of maintaining a local facsimile.
+export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = {
+  root: 'k-dashboard-tile',
+  stats: 'k-dashboard-tile__stats',
+  stat: 'k-dashboard-tile__stat',
+  statIcon: 'k-dashboard-tile__stat-icon',
+  statTotal: 'k-dashboard-tile__stat--total',
+  statOk: 'k-dashboard-tile__stat--ok',
+  statWarn: 'k-dashboard-tile__stat--warning',
+  statBad: 'k-dashboard-tile__stat--danger',
+  statMuted: 'k-dashboard-tile__stat--muted',
+  statNum: 'k-dashboard-tile__stat-number',
+  statLabel: 'k-dashboard-tile__stat-label',
+  sectionLabel: 'k-dashboard-tile__section-label',
+  list: 'k-dashboard-tile__list',
+  row: 'k-dashboard-tile__row',
+  rowPrimary: 'k-dashboard-tile__row-primary',
+  rowSecondary: 'k-dashboard-tile__row-secondary',
+  rowDot: 'k-dashboard-tile__row-dot',
+  chevron: 'k-dashboard-tile__chevron',
+  empty: 'k-dashboard-tile__empty',
+  message: 'k-dashboard-tile__message',
+  error: 'k-dashboard-tile__error',
+}
+
 // TileContext is the subset of farosContext a tile needs. The console pushes
 // the full object; tiles only ever read these.
 export interface TileContext {

--- a/providers/databricks/portal/src/portalkit/faros-ui.css
+++ b/providers/databricks/portal/src/portalkit/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/providers/databricks/portal/src/portalkit/faros-ui.css
+++ b/providers/databricks/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/providers/databricks/portal/src/portalkit/styles.ts
+++ b/providers/databricks/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 5
+export const FAROS_UI_VERSION = 6
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/edges/portal/src/portalkit/dashboardtile.ts
+++ b/providers/edges/portal/src/portalkit/dashboardtile.ts
@@ -66,6 +66,34 @@ export const tileClass = {
   error: 'text-[11px] text-danger',
 } as const
 
+// Plain-DOM portals cannot rely on Tailwind's generated utilities. This map
+// exposes the same semantic slots as tileClass while keeping the visual recipe
+// in faros-ui.css. Existing Tailwind consumers remain on tileClass; string-
+// building portals use these names instead of maintaining a local facsimile.
+export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = {
+  root: 'k-dashboard-tile',
+  stats: 'k-dashboard-tile__stats',
+  stat: 'k-dashboard-tile__stat',
+  statIcon: 'k-dashboard-tile__stat-icon',
+  statTotal: 'k-dashboard-tile__stat--total',
+  statOk: 'k-dashboard-tile__stat--ok',
+  statWarn: 'k-dashboard-tile__stat--warning',
+  statBad: 'k-dashboard-tile__stat--danger',
+  statMuted: 'k-dashboard-tile__stat--muted',
+  statNum: 'k-dashboard-tile__stat-number',
+  statLabel: 'k-dashboard-tile__stat-label',
+  sectionLabel: 'k-dashboard-tile__section-label',
+  list: 'k-dashboard-tile__list',
+  row: 'k-dashboard-tile__row',
+  rowPrimary: 'k-dashboard-tile__row-primary',
+  rowSecondary: 'k-dashboard-tile__row-secondary',
+  rowDot: 'k-dashboard-tile__row-dot',
+  chevron: 'k-dashboard-tile__chevron',
+  empty: 'k-dashboard-tile__empty',
+  message: 'k-dashboard-tile__message',
+  error: 'k-dashboard-tile__error',
+}
+
 // TileContext is the subset of farosContext a tile needs. The console pushes
 // the full object; tiles only ever read these.
 export interface TileContext {

--- a/providers/edges/portal/src/portalkit/faros-ui.css
+++ b/providers/edges/portal/src/portalkit/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/providers/edges/portal/src/portalkit/faros-ui.css
+++ b/providers/edges/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/providers/edges/portal/src/portalkit/styles.ts
+++ b/providers/edges/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 5
+export const FAROS_UI_VERSION = 6
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/infrastructure/portal/src/portalkit/dashboardtile.ts
+++ b/providers/infrastructure/portal/src/portalkit/dashboardtile.ts
@@ -66,6 +66,34 @@ export const tileClass = {
   error: 'text-[11px] text-danger',
 } as const
 
+// Plain-DOM portals cannot rely on Tailwind's generated utilities. This map
+// exposes the same semantic slots as tileClass while keeping the visual recipe
+// in faros-ui.css. Existing Tailwind consumers remain on tileClass; string-
+// building portals use these names instead of maintaining a local facsimile.
+export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = {
+  root: 'k-dashboard-tile',
+  stats: 'k-dashboard-tile__stats',
+  stat: 'k-dashboard-tile__stat',
+  statIcon: 'k-dashboard-tile__stat-icon',
+  statTotal: 'k-dashboard-tile__stat--total',
+  statOk: 'k-dashboard-tile__stat--ok',
+  statWarn: 'k-dashboard-tile__stat--warning',
+  statBad: 'k-dashboard-tile__stat--danger',
+  statMuted: 'k-dashboard-tile__stat--muted',
+  statNum: 'k-dashboard-tile__stat-number',
+  statLabel: 'k-dashboard-tile__stat-label',
+  sectionLabel: 'k-dashboard-tile__section-label',
+  list: 'k-dashboard-tile__list',
+  row: 'k-dashboard-tile__row',
+  rowPrimary: 'k-dashboard-tile__row-primary',
+  rowSecondary: 'k-dashboard-tile__row-secondary',
+  rowDot: 'k-dashboard-tile__row-dot',
+  chevron: 'k-dashboard-tile__chevron',
+  empty: 'k-dashboard-tile__empty',
+  message: 'k-dashboard-tile__message',
+  error: 'k-dashboard-tile__error',
+}
+
 // TileContext is the subset of farosContext a tile needs. The console pushes
 // the full object; tiles only ever read these.
 export interface TileContext {

--- a/providers/infrastructure/portal/src/portalkit/faros-ui.css
+++ b/providers/infrastructure/portal/src/portalkit/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/providers/infrastructure/portal/src/portalkit/faros-ui.css
+++ b/providers/infrastructure/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/providers/infrastructure/portal/src/portalkit/styles.ts
+++ b/providers/infrastructure/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 5
+export const FAROS_UI_VERSION = 6
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/kuery/portal/src/portalkit/dashboardtile.ts
+++ b/providers/kuery/portal/src/portalkit/dashboardtile.ts
@@ -66,6 +66,34 @@ export const tileClass = {
   error: 'text-[11px] text-danger',
 } as const
 
+// Plain-DOM portals cannot rely on Tailwind's generated utilities. This map
+// exposes the same semantic slots as tileClass while keeping the visual recipe
+// in faros-ui.css. Existing Tailwind consumers remain on tileClass; string-
+// building portals use these names instead of maintaining a local facsimile.
+export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = {
+  root: 'k-dashboard-tile',
+  stats: 'k-dashboard-tile__stats',
+  stat: 'k-dashboard-tile__stat',
+  statIcon: 'k-dashboard-tile__stat-icon',
+  statTotal: 'k-dashboard-tile__stat--total',
+  statOk: 'k-dashboard-tile__stat--ok',
+  statWarn: 'k-dashboard-tile__stat--warning',
+  statBad: 'k-dashboard-tile__stat--danger',
+  statMuted: 'k-dashboard-tile__stat--muted',
+  statNum: 'k-dashboard-tile__stat-number',
+  statLabel: 'k-dashboard-tile__stat-label',
+  sectionLabel: 'k-dashboard-tile__section-label',
+  list: 'k-dashboard-tile__list',
+  row: 'k-dashboard-tile__row',
+  rowPrimary: 'k-dashboard-tile__row-primary',
+  rowSecondary: 'k-dashboard-tile__row-secondary',
+  rowDot: 'k-dashboard-tile__row-dot',
+  chevron: 'k-dashboard-tile__chevron',
+  empty: 'k-dashboard-tile__empty',
+  message: 'k-dashboard-tile__message',
+  error: 'k-dashboard-tile__error',
+}
+
 // TileContext is the subset of farosContext a tile needs. The console pushes
 // the full object; tiles only ever read these.
 export interface TileContext {

--- a/providers/kuery/portal/src/portalkit/faros-ui.css
+++ b/providers/kuery/portal/src/portalkit/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/providers/kuery/portal/src/portalkit/faros-ui.css
+++ b/providers/kuery/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/providers/kuery/portal/src/portalkit/styles.ts
+++ b/providers/kuery/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 5
+export const FAROS_UI_VERSION = 6
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())

--- a/providers/quickstart/portal/src/portalkit/dashboardtile.ts
+++ b/providers/quickstart/portal/src/portalkit/dashboardtile.ts
@@ -66,6 +66,34 @@ export const tileClass = {
   error: 'text-[11px] text-danger',
 } as const
 
+// Plain-DOM portals cannot rely on Tailwind's generated utilities. This map
+// exposes the same semantic slots as tileClass while keeping the visual recipe
+// in faros-ui.css. Existing Tailwind consumers remain on tileClass; string-
+// building portals use these names instead of maintaining a local facsimile.
+export const dashboardTileSemanticClass: Record<keyof typeof tileClass, string> = {
+  root: 'k-dashboard-tile',
+  stats: 'k-dashboard-tile__stats',
+  stat: 'k-dashboard-tile__stat',
+  statIcon: 'k-dashboard-tile__stat-icon',
+  statTotal: 'k-dashboard-tile__stat--total',
+  statOk: 'k-dashboard-tile__stat--ok',
+  statWarn: 'k-dashboard-tile__stat--warning',
+  statBad: 'k-dashboard-tile__stat--danger',
+  statMuted: 'k-dashboard-tile__stat--muted',
+  statNum: 'k-dashboard-tile__stat-number',
+  statLabel: 'k-dashboard-tile__stat-label',
+  sectionLabel: 'k-dashboard-tile__section-label',
+  list: 'k-dashboard-tile__list',
+  row: 'k-dashboard-tile__row',
+  rowPrimary: 'k-dashboard-tile__row-primary',
+  rowSecondary: 'k-dashboard-tile__row-secondary',
+  rowDot: 'k-dashboard-tile__row-dot',
+  chevron: 'k-dashboard-tile__chevron',
+  empty: 'k-dashboard-tile__empty',
+  message: 'k-dashboard-tile__message',
+  error: 'k-dashboard-tile__error',
+}
+
 // TileContext is the subset of farosContext a tile needs. The console pushes
 // the full object; tiles only ever read these.
 export interface TileContext {

--- a/providers/quickstart/portal/src/portalkit/faros-ui.css
+++ b/providers/quickstart/portal/src/portalkit/faros-ui.css
@@ -190,7 +190,14 @@ html.light .k-card {
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
-.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .k-dashboard-tile__row {
   display: flex;
   width: 100%;

--- a/providers/quickstart/portal/src/portalkit/faros-ui.css
+++ b/providers/quickstart/portal/src/portalkit/faros-ui.css
@@ -29,7 +29,7 @@
   /* Bump this when a standalone primitive requires a newer stylesheet than
    * the generic canonical marker can describe. Provider bundles use it to
    * recover from a host stylesheet served from an older deployment. */
-  --faros-ui-version: 5;
+  --faros-ui-version: 6;
   --k-toast-bottom-offset: 16px;
   /* Shared stacking contract: menus sit above page content, fullscreen
    * surfaces above menus, and global modal/toast layers remain topmost. */
@@ -161,6 +161,123 @@ html.light .k-card {
   background: currentColor;
 }
 
+/* ── Dashboard tile semantics ────────────────────────────────────────────
+ * Framework-neutral mirror of dashboardtile.ts's Tailwind vocabulary. Plain
+ * DOM providers use these hooks instead of carrying a provider-local copy. */
+.k-dashboard-tile > :not([hidden]) ~ :not([hidden]) { margin-block-start: 12px; }
+.k-dashboard-tile__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 11px;
+}
+.k-dashboard-tile__stat { display: inline-flex; align-items: center; gap: 4px; }
+.k-dashboard-tile__stat-icon { width: 12px; height: 12px; flex: none; }
+.k-dashboard-tile__stat--total { color: var(--color-text-primary, #e9e9f2); }
+.k-dashboard-tile__stat--ok { color: var(--color-success, #2fd6a0); }
+.k-dashboard-tile__stat--warning { color: var(--color-warning, #f0a63a); }
+.k-dashboard-tile__stat--danger { color: var(--color-danger, #ff5d5d); }
+.k-dashboard-tile__stat--muted { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__stat-number { font-weight: 600; font-variant-numeric: tabular-nums; }
+.k-dashboard-tile__stat-label { color: var(--color-text-muted, #8587a1); }
+.k-dashboard-tile__section-label {
+  margin-block-end: 8px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.k-dashboard-tile__list { display: flex; flex-direction: column; gap: 4px; }
+.k-dashboard-tile__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.k-dashboard-tile__row:hover {
+  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
+}
+.k-dashboard-tile__row-primary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-primary, #e9e9f2);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-secondary {
+  flex: none;
+  max-width: 50%;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 70%, transparent);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.k-dashboard-tile__row-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 9999px;
+}
+.k-dashboard-tile__chevron {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  color: color-mix(in srgb, var(--color-text-muted, #8587a1) 30%, transparent);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+.k-dashboard-tile__row:hover .k-dashboard-tile__chevron {
+  color: color-mix(in srgb, var(--color-accent, #8b6bff) 60%, transparent);
+  transform: translateX(2px);
+}
+.k-dashboard-tile__empty {
+  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
+  border-radius: 6px;
+  padding: 12px;
+  color: var(--color-text-muted, #8587a1);
+  font-size: 11px;
+  text-align: center;
+}
+.k-dashboard-tile__message { color: var(--color-text-muted, #8587a1); font-size: 11px; }
+.k-dashboard-tile__error { color: var(--color-danger, #ff5d5d); font-size: 11px; }
+
+/* Canonical compact action used inside dashboard state copy. */
+.k-dashboard-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 2px 4px;
+  background: transparent;
+  color: var(--color-accent, #8b6bff);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.k-dashboard-action:hover { color: var(--color-accent-hover, #a18aff); }
+.k-dashboard-action:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-accent, #8b6bff);
+  outline-offset: 2px;
+}
+.k-dashboard-action:disabled { cursor: not-allowed; opacity: 0.4; }
+
 /* ── Buttons ──────────────────────────────────────────────────────────────*/
 .k-btn {
   display: inline-flex;
@@ -175,6 +292,12 @@ html.light .k-card {
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
+
+/* A single loading glyph recipe prevents each provider from inventing its own
+ * duration. It is decorative: callers still provide status text and mark the
+ * affected region busy, because a spinner alone never communicates progress. */
+.k-spin { animation: k-spin 0.8s linear infinite; }
+@keyframes k-spin { to { transform: rotate(360deg); } }
 .k-btn:disabled {
   pointer-events: none;
   opacity: 0.4;
@@ -2617,6 +2740,7 @@ faros-resource-table-filter { display: contents; }
 
 @media (prefers-reduced-motion: reduce) {
   .live-dot { animation: none; }
+  .k-spin { animation: none; }
   .k-resource-technical__chevron { transition: none; }
   .k-action-menu__busy { animation: none; }
   .k-toast__action-spinner { animation: none; }
@@ -2648,6 +2772,12 @@ faros-resource-table-filter { display: contents; }
   .k-inline-notification__action { max-inline-size: 38%; overflow-wrap: anywhere; }
 }
 @media (pointer: coarse), (any-pointer: coarse) {
+  .k-btn,
+  .k-dashboard-action,
+  .k-dashboard-tile__row {
+    min-height: 44px;
+    min-width: 44px;
+  }
   .k-toast__action,
   .k-toast-host .k-toast__action,
   .k-toast-host .k-toast__dismiss,

--- a/providers/quickstart/portal/src/portalkit/styles.ts
+++ b/providers/quickstart/portal/src/portalkit/styles.ts
@@ -14,7 +14,7 @@ export const FAROS_UI_STYLE_ID = 'k-faros-ui'
 export const FAROS_UI_CANONICAL_MARKER = '--faros-ui-canonical'
 export const FAROS_UI_CANONICAL_VALUE = '1'
 export const FAROS_UI_VERSION_MARKER = '--faros-ui-version'
-export const FAROS_UI_VERSION = 5
+export const FAROS_UI_VERSION = 6
 
 function hasRequiredVersion(value: string): boolean {
   const version = Number(value.trim())


### PR DESCRIPTION
## Summary
- add canonical coarse-pointer sizing, dashboard actions, spinner, and plain-DOM dashboard tile semantics
- document copy-only setup-secret handoff and independent settings-region persistence
- sync PortalKit to every portal, retaining `tileClass`

## Verification
- all provider portal builds and focused tests
- `make verify-design-docs`
- `make verify-portalkit`
- `make verify-ui-conformance`
- independent review

Stack 1 of 9. Base: `main`.