### PR TITLE
Provider conformance 2/9: Agents safety

### DIFF
--- a/providers/agents/api/agents.go
+++ b/providers/agents/api/agents.go
@@ -13,7 +13,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -114,6 +116,51 @@ type createAgentRequest struct {
 	// stays undiscovered. Unknown names are dropped; core is always granted.
 	InteractiveFamilies []string `json:"interactiveFamilies,omitempty"`
 	BackgroundFamilies  []string `json:"backgroundFamilies,omitempty"`
+}
+
+var budgetDecimalPattern = regexp.MustCompile(`^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?$`)
+
+// normalizeAgentBudget applies the requested budget fields to the current
+// budget, validates the effective limits, and removes zero-valued caps. The
+// same boundary serves REST and MCP mutations through applyAgentCreate and
+// applyAgentUpdate. Existing stored values keep their historical runtime
+// behavior; this validator governs new writes without acting as a migration.
+func normalizeAgentBudget(current *agentsv1alpha1.AgentBudget, tokenLimit *int64, usdLimit *string) (*agentsv1alpha1.AgentBudget, error) {
+	budget := agentsv1alpha1.AgentBudget{Window: "month"}
+	if current != nil {
+		budget = *current
+		if budget.Window == "" {
+			budget.Window = "month"
+		}
+	}
+	if tokenLimit != nil {
+		budget.TokenLimit = *tokenLimit
+	}
+	if usdLimit != nil {
+		budget.USDLimit = strings.TrimSpace(*usdLimit)
+	} else {
+		budget.USDLimit = strings.TrimSpace(budget.USDLimit)
+	}
+
+	if budget.TokenLimit < 0 {
+		return nil, errors.New("budgetTokens must be zero or greater")
+	}
+	if budget.USDLimit != "" {
+		limit, err := strconv.ParseFloat(budget.USDLimit, 64)
+		if !budgetDecimalPattern.MatchString(budget.USDLimit) || err != nil || math.IsNaN(limit) || math.IsInf(limit, 0) {
+			return nil, errors.New("budgetUSD must be a finite number zero or greater")
+		}
+		if limit < 0 {
+			return nil, errors.New("budgetUSD must be zero or greater")
+		}
+		if limit == 0 {
+			budget.USDLimit = ""
+		}
+	}
+	if budget.TokenLimit == 0 && budget.USDLimit == "" {
+		return nil, nil
+	}
+	return &budget, nil
 }
 
 // channelInput is the REST shape of an agent channel binding.
@@ -222,6 +269,10 @@ func (s *Server) applyAgentCreate(ctx context.Context, c *agentsclient.Client, r
 	if req.Name == "" {
 		return nil, errBadRequest("name is required")
 	}
+	budget, err := normalizeAgentBudget(nil, &req.BudgetTokens, &req.BudgetUSD)
+	if err != nil {
+		return nil, errBadRequest(err.Error())
+	}
 	if strings.TrimSpace(req.DisplayName) == "" {
 		req.DisplayName = req.Name
 	}
@@ -240,9 +291,7 @@ func (s *Server) applyAgentCreate(ctx context.Context, c *agentsclient.Client, r
 	if fb := trimmedList(req.ModelFallbacks); len(fb) > 0 {
 		a.Spec.ModelFallbacks = fb
 	}
-	if req.BudgetTokens > 0 || strings.TrimSpace(req.BudgetUSD) != "" {
-		a.Spec.Budget = &agentsv1alpha1.AgentBudget{Window: "month", TokenLimit: req.BudgetTokens, USDLimit: strings.TrimSpace(req.BudgetUSD)}
-	}
+	a.Spec.Budget = budget
 	if len(req.InteractiveFamilies) > 0 {
 		a.Spec.Tools.Interactive.Families = normalizeFamilies(req.InteractiveFamilies)
 	}
@@ -374,9 +423,24 @@ func (s *Server) updateAgent(w http.ResponseWriter, r *http.Request) {
 // so both surfaces have identical semantics: absent fields are untouched, list
 // fields replace wholesale, and core is always re-added to family grants.
 func (s *Server) applyAgentUpdate(ctx context.Context, c *agentsclient.Client, name string, req *updateAgentRequest) (*agentsv1alpha1.Agent, error) {
+	if req.BudgetTokens != nil || req.BudgetUSD != nil {
+		// Validate caller-supplied values before reading or mutating the resource.
+		// The second normalization below combines a valid partial patch with the
+		// stored counterpart.
+		if _, err := normalizeAgentBudget(nil, req.BudgetTokens, req.BudgetUSD); err != nil {
+			return nil, errBadRequest(err.Error())
+		}
+	}
 	agent, err := c.Agents().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
+	}
+	var budget *agentsv1alpha1.AgentBudget
+	if req.BudgetTokens != nil || req.BudgetUSD != nil {
+		budget, err = normalizeAgentBudget(agent.Spec.Budget, req.BudgetTokens, req.BudgetUSD)
+		if err != nil {
+			return nil, errBadRequest(err.Error())
+		}
 	}
 	if req.ModelCredential != nil {
 		cred := strings.TrimSpace(*req.ModelCredential)
@@ -448,19 +512,7 @@ func (s *Server) applyAgentUpdate(ctx context.Context, c *agentsclient.Client, n
 		agent.Spec.Tools.Background.Connections = *req.BackgroundConnections
 	}
 	if req.BudgetTokens != nil || req.BudgetUSD != nil {
-		if agent.Spec.Budget == nil {
-			agent.Spec.Budget = &agentsv1alpha1.AgentBudget{Window: "month"}
-		}
-		if req.BudgetTokens != nil {
-			agent.Spec.Budget.TokenLimit = *req.BudgetTokens
-		}
-		if req.BudgetUSD != nil {
-			agent.Spec.Budget.USDLimit = strings.TrimSpace(*req.BudgetUSD)
-		}
-		// A fully-zeroed budget means "remove the cap".
-		if agent.Spec.Budget.TokenLimit == 0 && agent.Spec.Budget.USDLimit == "" {
-			agent.Spec.Budget = nil
-		}
+		agent.Spec.Budget = budget
 	}
 	return c.Agents().Update(ctx, agent, metav1.UpdateOptions{})
 }

--- a/providers/agents/api/agents_budget_test.go
+++ b/providers/agents/api/agents_budget_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	agentsv1alpha1 "github.com/faroshq/provider-agents/apis/v1alpha1"
+)
+
+func TestNormalizeAgentBudget(t *testing.T) {
+	int64Ptr := func(value int64) *int64 { return &value }
+	stringPtr := func(value string) *string { return &value }
+
+	tests := []struct {
+		name       string
+		current    *agentsv1alpha1.AgentBudget
+		tokenLimit *int64
+		usdLimit   *string
+		want       *agentsv1alpha1.AgentBudget
+		wantErr    bool
+	}{
+		{name: "absent budget stays unlimited"},
+		{name: "zero and blank are unlimited", tokenLimit: int64Ptr(0), usdLimit: stringPtr("  ")},
+		{name: "zero decimal is unlimited", usdLimit: stringPtr(" 0.00 ")},
+		{
+			name:       "positive limits use monthly default",
+			tokenLimit: int64Ptr(100),
+			usdLimit:   stringPtr(" 1.25 "),
+			want:       &agentsv1alpha1.AgentBudget{Window: "month", TokenLimit: 100, USDLimit: "1.25"},
+		},
+		{
+			name:       "partial token update preserves usd and window",
+			current:    &agentsv1alpha1.AgentBudget{Window: "day", TokenLimit: 100, USDLimit: "2.50"},
+			tokenLimit: int64Ptr(0),
+			want:       &agentsv1alpha1.AgentBudget{Window: "day", USDLimit: "2.50"},
+		},
+		{
+			name:     "partial blank usd removes only usd cap",
+			current:  &agentsv1alpha1.AgentBudget{Window: "day", TokenLimit: 100, USDLimit: "2.50"},
+			usdLimit: stringPtr(""),
+			want:     &agentsv1alpha1.AgentBudget{Window: "day", TokenLimit: 100},
+		},
+		{
+			name:       "clearing both caps removes budget",
+			current:    &agentsv1alpha1.AgentBudget{Window: "day", TokenLimit: 100, USDLimit: "2.50"},
+			tokenLimit: int64Ptr(0),
+			usdLimit:   stringPtr("0"),
+		},
+		{name: "negative tokens rejected", tokenLimit: int64Ptr(-1), wantErr: true},
+		{name: "malformed usd rejected", usdLimit: stringPtr("twelve"), wantErr: true},
+		{name: "hex usd rejected", usdLimit: stringPtr("0x10"), wantErr: true},
+		{name: "negative usd rejected", usdLimit: stringPtr("-0.01"), wantErr: true},
+		{name: "nan usd rejected", usdLimit: stringPtr("NaN"), wantErr: true},
+		{name: "positive infinity rejected", usdLimit: stringPtr("+Inf"), wantErr: true},
+		{name: "negative infinity rejected", usdLimit: stringPtr("-Inf"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeAgentBudget(tt.current, tt.tokenLimit, tt.usdLimit)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("normalizeAgentBudget() error = nil, want validation error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeAgentBudget() unexpected error: %v", err)
+			}
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("normalizeAgentBudget() = %#v, want nil", got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.want {
+				t.Fatalf("normalizeAgentBudget() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentBudgetMutationValidationPrecedesClientAccess(t *testing.T) {
+	server := &Server{}
+	negative := int64(-1)
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "create",
+			call: func() error {
+				_, err := server.applyAgentCreate(context.Background(), nil, &createAgentRequest{
+					Name:      "test-agent",
+					BudgetUSD: "NaN",
+				})
+				return err
+			},
+		},
+		{
+			name: "update",
+			call: func() error {
+				_, err := server.applyAgentUpdate(context.Background(), nil, "test-agent", &updateAgentRequest{
+					BudgetTokens: &negative,
+				})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			requestErr, ok := err.(*requestError)
+			if !ok {
+				t.Fatalf("error = %T %v, want *requestError", err, err)
+			}
+			if requestErr.code != http.StatusBadRequest || requestErr.reason != "BadRequest" {
+				t.Fatalf("request error = %#v, want HTTP 400 BadRequest", requestErr)
+			}
+
+			recorder := httptest.NewRecorder()
+			writeUpdateError(recorder, err)
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("HTTP status = %d, want %d", recorder.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}

--- a/providers/agents/api/approval_test.go
+++ b/providers/agents/api/approval_test.go
@@ -10,8 +10,12 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -163,6 +167,118 @@ func TestApprovalGrantAuthorizesExactCall(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("unapproved calls executed (calls=%d)", calls)
+	}
+}
+
+func TestResolveInboxDecisionRequiresDisclosedObjectBeforeApproval(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     store.InboxItemKind
+		payload  map[string]any
+		state    store.InboxItemState
+		wantCode int
+	}{
+		{name: "missing tool", payload: map[string]any{"args": `{}`}, state: store.InboxStateApproved, wantCode: http.StatusConflict},
+		{name: "missing arguments", payload: map[string]any{"tool": "notify"}, state: store.InboxStateApproved, wantCode: http.StatusConflict},
+		{name: "malformed arguments", payload: map[string]any{"tool": "notify", "args": `{`}, state: store.InboxStateApproved, wantCode: http.StatusConflict},
+		{name: "null arguments", payload: map[string]any{"tool": "notify", "args": `null`}, state: store.InboxStateApproved, wantCode: http.StatusConflict},
+		{name: "array arguments", payload: map[string]any{"tool": "notify", "args": `[]`}, state: store.InboxStateApproved, wantCode: http.StatusConflict},
+		{name: "scalar arguments", payload: map[string]any{"tool": "notify", "args": `true`}, state: store.InboxStateApproved, wantCode: http.StatusConflict},
+		{name: "empty object is valid", payload: map[string]any{"tool": "notify", "args": `{}`}, state: store.InboxStateApproved},
+		{name: "denial remains available", payload: map[string]any{}, state: store.InboxStateDenied},
+		{name: "non-approval kind keeps existing decision behavior", kind: store.InboxKindQuestion, payload: map[string]any{}, state: store.InboxStateApproved},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := store.NewMemoryStore()
+			s := &Server{store: st}
+			scope := store.Scope{OrgUUID: "org", WorkspaceUUID: "ws"}
+			now := time.Now().UTC()
+			kind := tc.kind
+			if kind == "" {
+				kind = store.InboxKindApproval
+			}
+			if err := st.AddInboxItem(ctx, scope, store.InboxItem{
+				ID: "i1", Kind: kind, State: store.InboxStatePending,
+				Payload: tc.payload, CreatedAt: now, UpdatedAt: now,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := s.resolveInboxDecision(ctx, scope, "i1", tc.state, "", now.Add(time.Second))
+			if tc.wantCode == 0 {
+				if err != nil {
+					t.Fatalf("resolve: %v", err)
+				}
+				got, getErr := st.GetInboxItem(ctx, scope, "i1")
+				if getErr != nil || got.State != tc.state {
+					t.Fatalf("state = %q (err %v), want %q", got.State, getErr, tc.state)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("approval unexpectedly resolved without a complete disclosure")
+			}
+			got, getErr := st.GetInboxItem(ctx, scope, "i1")
+			if getErr != nil || got.State != store.InboxStatePending {
+				t.Fatalf("invalid approval mutated inbox state to %q (err %v)", got.State, getErr)
+			}
+			w := httptest.NewRecorder()
+			writeUpdateError(w, err)
+			if w.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d: %s", w.Code, tc.wantCode, w.Body.String())
+			}
+			var body map[string]any
+			if decodeErr := json.Unmarshal(w.Body.Bytes(), &body); decodeErr != nil {
+				t.Fatal(decodeErr)
+			}
+			if body["reason"] != "ApprovalDisclosureUnavailable" {
+				t.Fatalf("reason = %#v, want ApprovalDisclosureUnavailable", body["reason"])
+			}
+		})
+	}
+}
+
+func TestChannelApprovalReportsUnavailableDisclosureWithoutMutating(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	s := &Server{store: st}
+	scope := store.Scope{OrgUUID: "org", WorkspaceUUID: "ws", AgentName: "ada"}
+	now := time.Now().UTC()
+	if err := st.AddInboxItem(ctx, scope, store.InboxItem{
+		ID: "i1", AgentName: "ada", Kind: store.InboxKindApproval, State: store.InboxStatePending,
+		Prompt: "Allow the tool?", Payload: map[string]any{"tool": "notify", "args": `not-json secret-value`},
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	listed, handled := s.channelCommand(req, scope, nil, "", mkAgent(agentsv1alpha1.AutonomyAsk), "", "/inbox")
+	if !handled || !strings.Contains(listed, "Allow the tool?") {
+		t.Fatalf("inbox disclosure = %q", listed)
+	}
+	if strings.Contains(listed, "secret-value") {
+		t.Fatalf("malformed arguments were rendered back to the channel: %q", listed)
+	}
+
+	reply, handled := s.channelCommand(req, scope, nil, "", mkAgent(agentsv1alpha1.AutonomyAsk), "", "/approve 1")
+	if !handled || !strings.Contains(reply, approvalDisclosureUnavailableMessage) {
+		t.Fatalf("approve reply = %q", reply)
+	}
+	item, err := st.GetInboxItem(ctx, scope, "i1")
+	if err != nil || item.State != store.InboxStatePending {
+		t.Fatalf("invalid channel approval mutated inbox state to %q (err %v)", item.State, err)
+	}
+
+	if reply, handled = s.channelCommand(req, scope, nil, "", mkAgent(agentsv1alpha1.AutonomyAsk), "", "/deny 1"); !handled || !strings.Contains(reply, "Denied") {
+		t.Fatalf("deny reply = %q", reply)
+	}
+	item, err = st.GetInboxItem(ctx, scope, "i1")
+	if err != nil || item.State != store.InboxStateDenied {
+		t.Fatalf("denial state = %q (err %v), want denied", item.State, err)
 	}
 }
 

--- a/providers/agents/api/channels_inbound.go
+++ b/providers/agents/api/channels_inbound.go
@@ -207,7 +207,7 @@ func (s *Server) channelCommand(r *http.Request, scope store.Scope, dyn dynamic.
 			state = store.InboxStateDenied
 			verb = "🚫 Denied"
 		}
-		resolved, err := s.store.ResolveInboxItem(ctx, wsScope, item.ID, state, "via channel", time.Now().UTC())
+		resolved, err := s.resolveInboxDecision(ctx, wsScope, item.ID, state, "via channel", time.Now().UTC())
 		if err != nil {
 			return "Failed: " + err.Error(), true
 		}

--- a/providers/agents/api/inbox.go
+++ b/providers/agents/api/inbox.go
@@ -9,7 +9,9 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -39,6 +41,43 @@ type resolveInboxRequest struct {
 	Response string `json:"response,omitempty"`
 }
 
+const approvalDisclosureUnavailableMessage = "Approval details are unavailable or malformed. Deny this request or inspect the run."
+
+func approvalDisclosureAvailable(item store.InboxItem) bool {
+	tool, ok := item.Payload["tool"].(string)
+	if !ok || strings.TrimSpace(tool) == "" {
+		return false
+	}
+	args, ok := item.Payload["args"].(string)
+	if !ok || strings.TrimSpace(args) == "" {
+		return false
+	}
+	var disclosed map[string]json.RawMessage
+	return json.Unmarshal([]byte(args), &disclosed) == nil && disclosed != nil
+}
+
+// resolveInboxDecision keeps approval validation next to the persisted inbox
+// disclosure and, critically, completes it before any inbox mutation. Denials
+// remain available when the disclosure is unavailable so the user can stop the
+// requested action safely.
+func (s *Server) resolveInboxDecision(ctx context.Context, scope store.Scope, id string, state store.InboxItemState, response string, now time.Time) (store.InboxItem, error) {
+	if state != store.InboxStateApproved {
+		return s.store.ResolveInboxItem(ctx, scope, id, state, response, now)
+	}
+	item, err := s.store.GetInboxItem(ctx, scope, id)
+	if err != nil {
+		return store.InboxItem{}, err
+	}
+	if item.Kind == store.InboxKindApproval && !approvalDisclosureAvailable(item) {
+		return store.InboxItem{}, &requestError{
+			code:   http.StatusConflict,
+			reason: "ApprovalDisclosureUnavailable",
+			msg:    approvalDisclosureUnavailableMessage,
+		}
+	}
+	return s.store.ResolveInboxItem(ctx, scope, id, state, response, now)
+}
+
 // resolveInboxItem records the user's decision on an approval or question.
 // Resolving an approval bound to a paused run resumes it in place: approve
 // executes the gated call with the exact requested arguments, deny feeds the
@@ -66,9 +105,11 @@ func (s *Server) resolveInboxItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	wsScope := store.Scope{OrgUUID: id.orgUUID, WorkspaceUUID: id.workspaceUUID}
-	item, err := s.store.ResolveInboxItem(r.Context(), wsScope, r.PathValue("id"), state, req.Response, time.Now().UTC())
+	item, err := s.resolveInboxDecision(r.Context(), wsScope, r.PathValue("id"), state, req.Response, time.Now().UTC())
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if _, ok := errors.AsType[*requestError](err); ok {
+			writeUpdateError(w, err)
+		} else if strings.Contains(err.Error(), "not found") {
 			writeStatus(w, http.StatusNotFound, "NotFound", err.Error())
 		} else {
 			writeStatus(w, http.StatusInternalServerError, "InternalError", err.Error())

--- a/providers/agents/portal/src/approval-disclosure.ts
+++ b/providers/agents/portal/src/approval-disclosure.ts
@@ -1,0 +1,37 @@
+export const APPROVAL_DISCLOSURE_ERROR = 'Approval details are unavailable or malformed. Deny this request or inspect the run.'
+
+export interface ApprovalDisclosure {
+  tool: string
+  formattedArgs: string
+  argsAvailable: boolean
+  valid: boolean
+}
+
+// Approval cards may only enable approval when the server-provided, redacted
+// disclosure names a tool and contains a JSON object. An empty object is a
+// complete disclosure for a no-argument tool; arrays, scalars, null, missing,
+// and malformed JSON are not.
+export function approvalDisclosure(tool: unknown, args: unknown): ApprovalDisclosure {
+  const normalizedTool = typeof tool === 'string' ? tool.trim() : ''
+  if (typeof args !== 'string' || !args.trim()) {
+    return { tool: normalizedTool, formattedArgs: '', argsAvailable: false, valid: false }
+  }
+  try {
+    const parsed: unknown = JSON.parse(args)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return { tool: normalizedTool, formattedArgs: '', argsAvailable: false, valid: false }
+    }
+    return {
+      tool: normalizedTool,
+      formattedArgs: JSON.stringify(parsed, null, 2),
+      argsAvailable: true,
+      valid: normalizedTool !== '',
+    }
+  } catch {
+    return { tool: normalizedTool, formattedArgs: '', argsAvailable: false, valid: false }
+  }
+}
+
+export function approvalDisclosureAvailable(tool: unknown, args: unknown): boolean {
+  return approvalDisclosure(tool, args).valid
+}

--- a/providers/agents/portal/src/budget-validation.ts
+++ b/providers/agents/portal/src/budget-validation.ts
@@ -1,0 +1,45 @@
+export interface BudgetValidationResult {
+  budgetUSD: string
+  budgetTokens: number
+  usdError: string
+  tokenError: string
+}
+
+// The portal mirrors the provider's write contract so invalid drafts never
+// become requests. The server remains authoritative and applies the same rules
+// to REST and MCP callers.
+export function validateBudgetInputs(usdInput: string, tokenInput: string): BudgetValidationResult {
+  const usd = usdInput.trim()
+  const tokens = tokenInput.trim()
+  let usdError = ''
+  let tokenError = ''
+  let budgetUSD = ''
+  let budgetTokens = 0
+
+  if (usd) {
+    // Match strconv.ParseFloat's decimal/exponent forms without accepting
+    // JavaScript-only numeric syntax such as hexadecimal literals.
+    const decimal = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
+    const parsed = Number(usd)
+    if (!decimal.test(usd) || !Number.isFinite(parsed) || parsed < 0) {
+      usdError = 'Enter a finite amount of zero or more, or leave this blank for unlimited.'
+    } else if (parsed > 0) {
+      budgetUSD = usd
+    }
+  }
+
+  if (tokens) {
+    if (!/^\d+$/.test(tokens)) {
+      tokenError = 'Enter a whole number of zero or more, or leave this blank for unlimited.'
+    } else {
+      const parsed = Number(tokens)
+      if (!Number.isSafeInteger(parsed)) {
+        tokenError = 'Enter a whole number within the supported range.'
+      } else {
+        budgetTokens = parsed
+      }
+    }
+  }
+
+  return { budgetUSD, budgetTokens, usdError, tokenError }
+}

--- a/providers/agents/portal/src/components/ApprovalDisclosure.vue
+++ b/providers/agents/portal/src/components/ApprovalDisclosure.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { KeyRound } from 'lucide-vue-next'
+import { APPROVAL_DISCLOSURE_ERROR, approvalDisclosure } from '../approval-disclosure'
+
+const props = withDefaults(defineProps<{
+  tool?: unknown
+  args?: unknown
+  paused?: boolean
+}>(), { tool: undefined, args: undefined, paused: false })
+
+const disclosure = computed(() => approvalDisclosure(props.tool, props.args))
+</script>
+
+<template>
+  <div class="agents-approval-disclosure">
+    <div class="agents-approval-head">
+      <KeyRound :stroke-width="1.75" aria-hidden="true" />
+      {{ paused ? 'Paused — approval required for' : 'Approval required —' }}
+      <span v-if="disclosure.tool" class="mono">{{ disclosure.tool }}</span>
+      <span v-else>tool unavailable</span>
+    </div>
+    <pre v-if="disclosure.argsAvailable" class="agents-approval-args">{{ disclosure.formattedArgs }}</pre>
+    <div v-if="!disclosure.valid" class="agents-err agents-approval-disclosure-error" role="alert">
+      {{ APPROVAL_DISCLOSURE_ERROR }}
+    </div>
+  </div>
+</template>

--- a/providers/agents/portal/src/components/SecretHandoff.vue
+++ b/providers/agents/portal/src/components/SecretHandoff.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { onBeforeUnmount, ref } from 'vue'
+import { Check, Copy, X } from 'lucide-vue-next'
+
+withDefaults(defineProps<{ value: string; label?: string; copyLabel?: string }>(), {
+  label: 'One-time setup value',
+  copyLabel: 'Copy setup value',
+})
+const emit = defineEmits<{ cleared: [] }>()
+const copied = ref(false)
+const copyError = ref('')
+
+async function copy(value: string): Promise<void> {
+  copyError.value = ''
+  try {
+    await navigator.clipboard.writeText(value)
+    copied.value = true
+  } catch {
+    copyError.value = 'Could not copy. Check clipboard permission and try again.'
+  }
+}
+
+function clear(): void {
+  copied.value = false
+  copyError.value = ''
+  emit('cleared')
+}
+
+onBeforeUnmount(() => {
+  copied.value = false
+  copyError.value = ''
+})
+</script>
+
+<template>
+  <section class="k-card agents-secret-handoff" aria-label="One-time setup handoff">
+    <div>
+      <strong>{{ label }}</strong>
+      <code aria-label="Masked one-time setup value">••••••••••••••••••••••••</code>
+    </div>
+    <div class="agents-secret-handoff-actions">
+      <button type="button" class="k-btn k-btn--ghost" @click="copy(value)"><Check v-if="copied" aria-hidden="true" /><Copy v-else aria-hidden="true" /> {{ copied ? 'Copied' : copyLabel }}</button>
+      <button type="button" class="k-icon-action" :aria-label="`Dismiss ${label}`" @click="clear"><X aria-hidden="true" /></button>
+    </div>
+    <span class="sr-only" role="status" aria-live="polite">{{ copied ? `${label} copied.` : '' }}</span>
+    <p v-if="copyError" class="agents-fielderr" role="alert">{{ copyError }}</p>
+  </section>
+</template>

--- a/providers/agents/portal/src/conn-defs.ts
+++ b/providers/agents/portal/src/conn-defs.ts
@@ -91,6 +91,12 @@ export function connShape(c: Pick<Connection, 'spec'>): ConnShape {
   }
 }
 
+/** Webhook URLs are credentials: show their configured state, never the value. */
+export function isSecretBearingWebhook(c: Pick<Connection, 'spec'>): boolean {
+  const channel = (c.spec.channel || '').trim().toLowerCase()
+  return (c.spec.type === 'slack' && channel.startsWith('https://hooks.slack.com/')) || connShape(c).discordWebhook
+}
+
 export interface InboundState {
   on: boolean
   canEnable: boolean

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -127,6 +127,16 @@ faros-provider-agents .agents-checkrow { display: flex; flex-wrap: wrap; gap: 8p
 faros-provider-agents .agents-form-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 faros-provider-agents .agents-hint { font-size: 12px; color: var(--color-text-muted, inherit); font-weight: 400; }
 faros-provider-agents .agents-fielderr { font-size: 12px; color: var(--color-danger, #ff5d5d); font-weight: 500; }
+faros-provider-agents .agents-secret-handoff {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+}
+faros-provider-agents .agents-secret-handoff > div { display: flex; align-items: center; gap: 10px; min-width: 0; }
+faros-provider-agents .agents-secret-handoff code { color: var(--color-text-muted); letter-spacing: 0.08em; }
+faros-provider-agents .agents-secret-handoff-actions { flex-wrap: wrap; justify-content: flex-end; }
 
 /* Routed Agents panels own their interior spacing. The canonical k-card recipe
  * supplies the surface and border, while this provider wrapper keeps Activity,

--- a/providers/agents/portal/src/test/activity.test.ts
+++ b/providers/agents/portal/src/test/activity.test.ts
@@ -202,7 +202,7 @@ describe('Activity.vue', () => {
     const store = makeStore(api)
     const item: InboxItem = {
       id: 'i1', agentName: 'scout', runID: 'r9', kind: 'approval', state: 'pending',
-      prompt: 'scout wants to run edges__pods_delete', payload: { tool: 'edges__pods_delete' }, createdAt: new Date().toISOString(),
+      prompt: 'scout wants to run edges__pods_delete', payload: { tool: 'edges__pods_delete', args: '{}' }, createdAt: new Date().toISOString(),
     }
     store.inbox.data = [item]
     store.inbox.loaded = true
@@ -213,6 +213,8 @@ describe('Activity.vue', () => {
       ['H3', 'Activity'],
       ['H4', 'Needs your attention (1)'],
     ])
+    expect(text(view.element.querySelector('.agents-approval-disclosure'))).toContain('edges__pods_delete')
+    expect(text(view.element.querySelector('.agents-approval-args'))).toBe('{}')
 
     const actions = view.element.querySelector('.agents-approval-actions')!
     buttonWithText(actions, 'Approve').click()
@@ -226,6 +228,30 @@ describe('Activity.vue', () => {
     resolution.resolve({})
     await settleVue()
     expect(view.element.querySelector('.agents-approvals')).toBeNull()
+  })
+
+  it('blocks approval without a valid disclosed argument object but leaves denial available', async () => {
+    const resolveInbox = vi.fn().mockResolvedValue({})
+    const api = stubApi({ listRuns: vi.fn().mockResolvedValue({ items: [], nextCursor: '' }), resolveInbox })
+    const store = makeStore(api)
+    store.inbox.data = [{
+      id: 'i1', agentName: 'scout', runID: 'r9', kind: 'approval', state: 'pending',
+      prompt: 'scout wants to run edges__pods_delete', payload: { tool: 'edges__pods_delete', args: 'not-json' }, createdAt: new Date().toISOString(),
+    }]
+    store.inbox.loaded = true
+    store.inbox.hasSnapshot = true
+    const view = await mount(Activity, { store, api })
+
+    const actions = view.element.querySelector('.agents-approval-actions')!
+    const approve = buttonWithText(actions, 'Approve')
+    const deny = buttonWithText(actions, 'Deny')
+    expect(approve.disabled).toBe(true)
+    expect(deny.disabled).toBe(false)
+    expect(text(view.element.querySelector('[role="alert"]'))).toContain('Approval details are unavailable or malformed')
+
+    deny.click()
+    await settleVue()
+    expect(resolveInbox).toHaveBeenCalledWith('i1', 'deny')
   })
 })
 
@@ -370,6 +396,28 @@ describe('RunDetail.vue', () => {
 
     resolution.resolve({})
     await settleVue()
+  })
+
+  it('blocks a run approval with missing disclosure while leaving denial available', async () => {
+    const resolveInbox = vi.fn().mockResolvedValue({})
+    const api = stubApi({
+      getRun: vi.fn().mockResolvedValue(detail({
+        phase: 'PendingApproval',
+        pending: { inboxID: 'i7', tool: '', args: '{}' },
+      })),
+      resolveInbox,
+    })
+    const view = await mount(RunDetail, { store: makeStore(api), api, runId: 'r5' })
+    const actions = view.element.querySelector('.agents-approval-actions')!
+    const approve = buttonWithText(actions, 'Approve & resume')
+    const deny = buttonWithText(actions, 'Deny')
+
+    expect(approve.disabled).toBe(true)
+    expect(deny.disabled).toBe(false)
+    expect(text(view.element.querySelector('.agents-approval-disclosure-error'))).toContain('Deny this request or inspect the run')
+    deny.click()
+    await settleVue()
+    expect(resolveInbox).toHaveBeenCalledWith('i7', 'deny')
   })
 
   it('ignores server events for unrelated runs', async () => {

--- a/providers/agents/portal/src/test/approval-disclosure.test.ts
+++ b/providers/agents/portal/src/test/approval-disclosure.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { approvalDisclosure } from '../approval-disclosure'
+
+describe('approval disclosure', () => {
+  it('accepts an empty object for a no-argument tool', () => {
+    expect(approvalDisclosure('notify', '{}')).toEqual({
+      tool: 'notify',
+      formattedArgs: '{}',
+      argsAvailable: true,
+      valid: true,
+    })
+  })
+
+  it.each([
+    ['missing tool', '', '{}'],
+    ['missing arguments', 'notify', ''],
+    ['malformed arguments', 'notify', '{'],
+    ['null arguments', 'notify', 'null'],
+    ['array arguments', 'notify', '[]'],
+    ['scalar arguments', 'notify', 'true'],
+  ])('rejects %s', (_name, tool, args) => {
+    expect(approvalDisclosure(tool, args).valid).toBe(false)
+  })
+
+  it('formats a disclosed object without changing its values', () => {
+    const disclosure = approvalDisclosure(' edges__pods_delete ', '{"namespace":"prod","name":"api"}')
+    expect(disclosure.tool).toBe('edges__pods_delete')
+    expect(disclosure.formattedArgs).toBe('{\n  "namespace": "prod",\n  "name": "api"\n}')
+    expect(disclosure.valid).toBe(true)
+  })
+})

--- a/providers/agents/portal/src/test/budget-validation.test.ts
+++ b/providers/agents/portal/src/test/budget-validation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { validateBudgetInputs } from '../budget-validation'
+
+describe('budget validation', () => {
+  it.each(['', '0', '000', '42'])('accepts whole token limits (%s)', value => {
+    const result = validateBudgetInputs('', value)
+    expect(result.tokenError).toBe('')
+    expect(result.budgetTokens).toBe(value ? Number(value) : 0)
+  })
+
+  it.each(['-1', '1.5', 'NaN', 'Infinity', 'tokens'])('rejects malformed token limits (%s)', value => {
+    expect(validateBudgetInputs('', value).tokenError).not.toBe('')
+  })
+
+  it.each(['', '0', '0.00'])('normalizes zero-dollar or blank budgets to unlimited (%s)', value => {
+    const result = validateBudgetInputs(value, '')
+    expect(result.usdError).toBe('')
+    expect(result.budgetUSD).toBe('')
+  })
+
+  it.each(['-1', 'NaN', 'Infinity', '-Infinity', 'USD', '0x10'])('rejects invalid dollar budgets (%s)', value => {
+    expect(validateBudgetInputs(value, '').usdError).not.toBe('')
+  })
+})

--- a/providers/agents/portal/src/test/chat.test.ts
+++ b/providers/agents/portal/src/test/chat.test.ts
@@ -282,6 +282,29 @@ describe('chat streaming', () => {
     expect(text(el.querySelector('.agents-approval-done'))).toContain('resuming')
   })
 
+  it('blocks malformed approval disclosure while leaving denial available', async () => {
+    const resolveInbox = vi.fn().mockResolvedValue({ id: 'i1', state: 'denied' })
+    const { el } = await mountChat(
+      scripted([
+        { event: 'start', data: { runID: 'r1', sessionID: 's1' } },
+        {
+          event: 'approval_required',
+          data: { runID: 'r1', inboxID: 'i1', tool: 'edges__pods_delete', args: 'not-json', content: 'Approve?' },
+        },
+      ]),
+      { resolveInbox },
+    )
+    await send(el, 'delete it')
+
+    const [approve, deny] = [...el.querySelectorAll<HTMLButtonElement>('.agents-approval-actions button')]
+    expect(approve.disabled).toBe(true)
+    expect(deny.disabled).toBe(false)
+    expect(text(el.querySelector('.agents-approval-disclosure-error'))).toContain('Approval details are unavailable or malformed')
+    deny.click()
+    await settle(4)
+    expect(resolveInbox).toHaveBeenCalledWith('i1', 'deny')
+  })
+
   it('does not show a failed approval after the user leaves its session', async () => {
     const resolution = deferred<{ id: string; state: string }>()
     const { el } = await mountChat(

--- a/providers/agents/portal/src/test/config.test.ts
+++ b/providers/agents/portal/src/test/config.test.ts
@@ -4,7 +4,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import AgentConfig from '../views/AgentConfig.vue'
 import AgentCreate from '../views/AgentCreate.vue'
-import type { AgentPatch } from '../types'
+import type { AgentPatch, Connection } from '../types'
 import { familiesForConns } from '../conn-defs'
 import { clearToasts, subscribeToasts } from '../ui/toast'
 import { agentFixture, makeStore, stubApi } from './helpers'
@@ -130,6 +130,46 @@ describe('agent config', () => {
     sectionButton(el, 'Save policy').click()
     await settle(4)
     expect(patchAgent.mock.calls[0][1]).toMatchObject({ maxToolTurns: 0, timeoutSeconds: 0, budgetTokens: 0 })
+  })
+
+  it.each([
+    ['not-a-number', '', 'Enter a finite amount'],
+    ['-1', '', 'Enter a finite amount'],
+    ['NaN', '', 'Enter a finite amount'],
+    ['Infinity', '', 'Enter a finite amount'],
+    ['', '-1', 'Enter a whole number'],
+    ['', '1.5', 'Enter a whole number'],
+  ])('rejects an invalid budget draft without patching (%s, %s)', async (usd, tokens, message) => {
+    const { el, patchAgent } = await mountConfig()
+    const inputs = [...el.querySelectorAll<HTMLInputElement>('input')]
+    const usdInput = inputs.find(input => input.placeholder === 'blank = unlimited')!
+    const tokenInput = inputs.filter(input => input.placeholder === 'blank = unlimited')[1]!
+    usdInput.value = usd
+    usdInput.dispatchEvent(new Event('input'))
+    tokenInput.value = tokens
+    tokenInput.dispatchEvent(new Event('input'))
+    sectionButton(el, 'Save policy').click()
+    await settle()
+
+    expect(patchAgent).not.toHaveBeenCalled()
+    expect(text(el)).toContain(message)
+    const invalid = usd ? usdInput : tokenInput
+    expect(invalid.getAttribute('aria-invalid')).toBe('true')
+    expect(invalid.getAttribute('aria-describedby')).toBeTruthy()
+  })
+
+  it('normalizes explicit zero budgets to unlimited values', async () => {
+    const { el, patchAgent } = await mountConfig()
+    const [usdInput, tokenInput] = [...el.querySelectorAll<HTMLInputElement>('input')]
+      .filter(input => input.placeholder === 'blank = unlimited')
+    usdInput.value = '0.00'
+    usdInput.dispatchEvent(new Event('input'))
+    tokenInput.value = '0'
+    tokenInput.dispatchEvent(new Event('input'))
+    sectionButton(el, 'Save policy').click()
+    await settle(4)
+
+    expect(patchAgent).toHaveBeenCalledWith('scout', expect.objectContaining({ budgetUSD: '', budgetTokens: 0 }))
   })
 
   it('rolls the optimistic edit back when the save fails', async () => {
@@ -631,6 +671,63 @@ describe('agent config', () => {
 })
 
 describe('connection test feedback', () => {
+  it('keeps the Slack inbound request URL out of ordinary feedback and exposes only explicit masked copy', async () => {
+    const requestURL = 'https://faros.example.test/services/providers/agents/inbound/slack/secret'
+    const enableInbound = vi.fn().mockResolvedValue({ registered: false, note: 'Paste this request URL into Slack.', webhookURL: requestURL })
+    const connection = { metadata: { name: 'slack' }, spec: { type: 'slack', channel: 'C012345' } } satisfies Connection
+    const api = stubApi({ enableInbound, listConnections: () => Promise.resolve([connection]) })
+    const store = makeStore(api)
+    store.agents.data = [agentFixture('scout', { channels: [{ name: 'primary', connectionRef: 'slack', primary: true }] })]
+    store.connections.data = [connection]
+    Object.assign(store.connections, { loaded: true, hasSnapshot: true })
+    store.agents.loaded = true
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined)
+    const view = await mountVue(AgentConfig, { store, api, name: 'scout' })
+    mounted.push(view)
+    await settle()
+    clearToasts()
+
+    const enable = [...view.element.querySelectorAll<HTMLButtonElement>('.agents-inbound-actions button')]
+      .find(button => text(button).includes('Enable inbound'))!
+    enable.click()
+    await settle(6)
+
+    expect(view.element.innerHTML).not.toContain(requestURL)
+    expect(document.body.innerHTML).not.toContain(requestURL)
+    const copy = [...view.element.querySelectorAll<HTMLButtonElement>('button')]
+      .find(button => text(button) === 'Copy Slack request URL')!
+    expect(copy).toBeTruthy()
+    copy.click()
+    await settle()
+    expect(writeText).toHaveBeenCalledWith(requestURL)
+  })
+
+  it('reports Telegram registration success without presenting its callback URL', async () => {
+    const callbackURL = 'https://faros.example.test/services/providers/agents/inbound/telegram/secret'
+    const enableInbound = vi.fn().mockResolvedValue({ registered: true, note: 'Telegram webhook registered.', webhookURL: callbackURL })
+    const connection = { metadata: { name: 'tg' }, spec: { type: 'telegram', channel: '123' } } satisfies Connection
+    const api = stubApi({ enableInbound, listConnections: () => Promise.resolve([connection]) })
+    const store = makeStore(api)
+    store.agents.data = [agentFixture('scout', { channels: [{ name: 'primary', connectionRef: 'tg', primary: true }] })]
+    store.connections.data = [connection]
+    Object.assign(store.connections, { loaded: true, hasSnapshot: true })
+    store.agents.loaded = true
+    const view = await mountVue(AgentConfig, { store, api, name: 'scout' })
+    mounted.push(view)
+    await settle()
+    clearToasts()
+
+    const enable = [...view.element.querySelectorAll<HTMLButtonElement>('.agents-inbound-actions button')]
+      .find(button => text(button).includes('Enable inbound'))!
+    enable.click()
+    await settle(6)
+
+    expect(text(document.body)).toContain('Telegram webhook registered.')
+    expect(document.body.innerHTML).not.toContain(callbackURL)
+    expect(view.element.innerHTML).not.toContain(callbackURL)
+    expect(text(view.element)).not.toContain('Copy Slack request URL')
+  })
+
   it('surfaces the reason from a failed channel test (HTTP error convention)', async () => {
     const testConnection = vi.fn().mockRejectedValue(new Error('telegram: 403 bot was blocked by the user'))
     const api = stubApi({ testConnection })

--- a/providers/agents/portal/src/test/connections-resource-table.test.ts
+++ b/providers/agents/portal/src/test/connections-resource-table.test.ts
@@ -40,6 +40,25 @@ function toolset(name: string, connections: string[] = []): Toolset {
 }
 
 describe('Connections resource tables', () => {
+  it('shows secret-bearing webhook destinations as configured without putting their URLs in the table', async () => {
+    const secrets = [
+      { metadata: { name: 'slack-hook' }, spec: { type: 'slack', displayName: 'Slack hook', channel: 'https://hooks.slack.com/services/T/B/secret' } },
+      { metadata: { name: 'discord-hook' }, spec: { type: 'discord', displayName: 'Discord hook', channel: 'https://discord.com/api/webhooks/1/secret' } },
+      { metadata: { name: 'slack-channel' }, spec: { type: 'slack', displayName: 'Slack channel', channel: 'C012345' } },
+    ] satisfies Connection[]
+    const api = stubApi()
+    const store = makeStore(api)
+    store.connections.data = secrets
+    Object.assign(store.connections, { loaded: true, hasSnapshot: true })
+
+    const el = await mount<Connections>('agents-connections', { store, api, routeOwned: true })
+
+    expect(el.innerHTML).not.toContain('hooks.slack.com')
+    expect(el.innerHTML).not.toContain('discord.com/api/webhooks')
+    expect(text(el)).toContain('Configured')
+    expect(text(el)).toContain('C012345')
+  })
+
   it.each([
     {
       label: 'initial load failure',
@@ -154,6 +173,76 @@ describe('Connections resource tables', () => {
     await settle(el, 6)
 
     expect(patchConnection).toHaveBeenCalledWith(original.metadata.name, expected)
+  })
+
+  it('keeps a stored webhook write-only and omits an unchanged destination from its patch', async () => {
+    const original = {
+      metadata: { name: 'slack-hook' },
+      spec: { type: 'slack', displayName: 'Slack hook', channel: 'https://hooks.slack.com/services/T/B/secret' },
+    } satisfies Connection
+    const patchConnection = vi.fn().mockResolvedValue(original)
+    const api = stubApi({ patchConnection, listConnections: () => Promise.resolve([original]) })
+    const store = makeStore(api)
+    store.connections.data = [original]
+    Object.assign(store.connections, { loaded: true, hasSnapshot: true })
+    const el = await mount<Connections>('agents-connections', { store, api, routeOwned: true, editRoute: true, editName: original.metadata.name })
+    const form = el.querySelector<HTMLFormElement>('form')!
+
+    expect(el.innerHTML).not.toContain('hooks.slack.com')
+    expect(text(form)).toContain('Replacement webhook URL')
+    expect(form.querySelector<HTMLInputElement>('input[name="endpoint"]')?.value).toBe('')
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await settle(el, 6)
+
+    expect(patchConnection).toHaveBeenCalledWith('slack-hook', { displayName: 'Slack hook' })
+  })
+
+  it('sends an explicitly entered webhook replacement', async () => {
+    const original = {
+      metadata: { name: 'slack-hook' },
+      spec: { type: 'slack', displayName: 'Slack hook', channel: 'https://hooks.slack.com/services/T/B/secret' },
+    } satisfies Connection
+    const patchConnection = vi.fn().mockResolvedValue(original)
+    const api = stubApi({ patchConnection, listConnections: () => Promise.resolve([original]) })
+    const store = makeStore(api)
+    store.connections.data = [original]
+    Object.assign(store.connections, { loaded: true, hasSnapshot: true })
+    const el = await mount<Connections>('agents-connections', { store, api, routeOwned: true, editRoute: true, editName: original.metadata.name })
+    const form = el.querySelector<HTMLFormElement>('form')!
+    const endpoint = form.querySelector<HTMLInputElement>('input[name="endpoint"]')!
+    endpoint.value = 'https://hooks.slack.com/services/new'
+    endpoint.dispatchEvent(new InputEvent('input', { bubbles: true }))
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+    await settle(el, 6)
+
+    expect(patchConnection).toHaveBeenCalledWith('slack-hook', {
+      displayName: 'Slack hook',
+      channel: 'https://hooks.slack.com/services/new',
+    })
+  })
+
+  it('keeps a Slack request URL masked and copies it only from the explicit handoff action', async () => {
+    const requestURL = 'https://faros.example.test/services/providers/agents/inbound/slack/secret'
+    const item = { metadata: { name: 'slack' }, spec: { type: 'slack', displayName: 'Slack', channel: 'C012345' } } satisfies Connection
+    const enableInbound = vi.fn().mockResolvedValue({ registered: false, note: 'Paste this request URL into Slack.', webhookURL: requestURL })
+    const api = stubApi({ enableInbound, listConnections: () => Promise.resolve([item]) })
+    const store = makeStore(api)
+    store.connections.data = [item]
+    Object.assign(store.connections, { loaded: true, hasSnapshot: true })
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined)
+    const el = await mount<Connections>('agents-connections', { store, api, routeOwned: true })
+
+    el.querySelector<HTMLButtonElement>('[aria-label="Enable inbound chat for slack"]')!.click()
+    await settle(el, 6)
+    expect(el.innerHTML).not.toContain(requestURL)
+    const copy = [...el.querySelectorAll<HTMLButtonElement>('button')].find(button => text(button) === 'Copy Slack request URL')!
+    expect(copy).toBeTruthy()
+    copy.click()
+    await settle(el)
+    expect(writeText).toHaveBeenCalledWith(requestURL)
+    el.querySelector<HTMLButtonElement>('[aria-label="Dismiss Slack request URL"]')!.click()
+    await settle(el)
+    expect(text(el)).not.toContain('Slack request URL')
   })
 
   it('keeps routed connection edits single-flight and preserves a failed draft', async () => {

--- a/providers/agents/portal/src/views/Activity.vue
+++ b/providers/agents/portal/src/views/Activity.vue
@@ -10,6 +10,8 @@ import StatusBadge from '../portalkit/StatusBadge.vue'
 import { toast } from '../ui/toast'
 import { useAuthorityGuard, useStoreRevision } from '../vue/runtime'
 import type { Route } from '../router'
+import { approvalDisclosureAvailable } from '../approval-disclosure'
+import ApprovalDisclosure from '../components/ApprovalDisclosure.vue'
 
 const props = withDefaults(defineProps<{
   store: AppStore
@@ -224,16 +226,16 @@ onBeforeUnmount(() => {
         <div v-for="item in pending" :key="item.id" class="agents-approval-row">
           <div class="agents-approval-body">
             <div class="agents-approval-prompt">{{ item.prompt }}</div>
+            <ApprovalDisclosure v-if="item.kind === 'approval'" :tool="item.payload?.tool" :args="item.payload?.args" />
             <div class="agents-approval-meta">
               <span class="k-badge agents-badge">{{ item.agentName }}</span>
-              <span v-if="item.payload?.tool" class="k-badge agents-badge mono">{{ item.payload.tool }}</span>
               <span class="muted">{{ fmtTime(item.createdAt) }}</span>
               <button v-if="item.runID" class="k-btn k-btn--ghost agents-linkbtn" type="button" @click="emit('navigate', { kind: 'run', id: item.runID! })">view run</button>
             </div>
           </div>
           <div class="agents-approval-actions">
             <template v-if="item.kind === 'approval'">
-              <button class="k-btn k-btn--primary" type="button" :disabled="resolvingInbox.has(item.id)" :aria-busy="resolvingInbox.has(item.id) || undefined" @click="resolve(item, 'approve')"><Check :stroke-width="1.75" aria-hidden="true" /> {{ resolvingInbox.has(item.id) ? 'Resolving…' : 'Approve' }}</button>
+              <button class="k-btn k-btn--primary" type="button" :disabled="resolvingInbox.has(item.id) || !approvalDisclosureAvailable(item.payload?.tool, item.payload?.args)" :aria-busy="resolvingInbox.has(item.id) || undefined" @click="resolve(item, 'approve')"><Check :stroke-width="1.75" aria-hidden="true" /> {{ resolvingInbox.has(item.id) ? 'Resolving…' : 'Approve' }}</button>
               <button class="k-btn k-btn--ghost secondary" type="button" :disabled="resolvingInbox.has(item.id)" @click="resolve(item, 'deny')"><X :stroke-width="1.75" aria-hidden="true" /> Deny</button>
             </template>
             <span v-else class="agents-hint">Answer from the agent's channel or chat.</span>

--- a/providers/agents/portal/src/views/AgentConfig.vue
+++ b/providers/agents/portal/src/views/AgentConfig.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watchEffect } from 'vue'
+import { computed, onBeforeUnmount, ref, watch, watchEffect } from 'vue'
 import {
   ArrowLeftRight,
   Check,
@@ -15,6 +15,8 @@ import {
   X,
 } from 'lucide-vue-next'
 import type { ApiClient } from '../api'
+import { validateBudgetInputs } from '../budget-validation'
+import SecretHandoff from '../components/SecretHandoff.vue'
 import { channelInbound } from '../conn-defs'
 import { mutate } from '../mutate'
 import FormSelect, { type FormSelectOption } from '../portalkit/FormSelect.vue'
@@ -53,11 +55,14 @@ const fallbacks = ref<string[]>([])
 const autonomy = ref<Autonomy>('ask')
 const budgetUSD = ref('')
 const budgetTokens = ref('')
+const budgetUSDError = ref('')
+const budgetTokensError = ref('')
 const maxToolTurns = ref('')
 const timeoutSeconds = ref('')
 const channels = ref<ChannelRow[]>([])
 const channelError = ref('')
 const channelErrorTarget = ref<{ key: number; field: 'name' | 'connection' } | null>(null)
+const slackRequestURL = ref('')
 
 let hydratedStore: AppStore | null = null
 let hydratedName = ''
@@ -130,6 +135,8 @@ function hydrate(source: Agent): void {
   autonomy.value = (source.spec?.autonomy as Autonomy) || 'ask'
   budgetUSD.value = source.spec?.budget?.usdLimit || ''
   budgetTokens.value = source.spec?.budget?.tokenLimit ? String(source.spec.budget.tokenLimit) : ''
+  budgetUSDError.value = ''
+  budgetTokensError.value = ''
   maxToolTurns.value = source.spec?.limits?.maxToolTurns ? String(source.spec.limits.maxToolTurns) : ''
   timeoutSeconds.value = source.spec?.limits?.timeoutSeconds ? String(source.spec.limits.timeoutSeconds) : ''
   channels.value = (source.spec?.channels || []).map(channel => ({ ...channel, key: ++rowKey }))
@@ -197,10 +204,14 @@ function saveModel(): void {
 }
 
 function savePolicy(): void {
-  const tokens = intOrZero(budgetTokens.value)
+  const budget = validateBudgetInputs(budgetUSD.value, budgetTokens.value)
+  budgetUSDError.value = budget.usdError
+  budgetTokensError.value = budget.tokenError
+  if (budget.usdError || budget.tokenError) return
+  const tokens = budget.budgetTokens
   const turns = intOrZero(maxToolTurns.value)
   const timeout = intOrZero(timeoutSeconds.value)
-  const usd = budgetUSD.value.trim()
+  const usd = budget.budgetUSD
   const mode = autonomy.value
   void save(
     { autonomy: mode, budgetUSD: usd, budgetTokens: tokens, maxToolTurns: turns, timeoutSeconds: timeout },
@@ -376,15 +387,21 @@ async function saveChannels(): Promise<void> {
 async function enableInbound(name: string): Promise<void> {
   const authority = captureAuthority()
   const agentName = props.name
+  slackRequestURL.value = ''
   const result = await mutate(authority.store, {
     run: () => authority.api.enableInbound(name),
     failure: 'Enable inbound failed',
     reload: ['connections'],
   })
   if (result && authorityIsCurrent(authority) && props.name === agentName) {
-    toast(result.registered ? 'ok' : 'info', `${result.note} ${result.webhookURL}`)
+    const connection = channelConnections.value.find(item => item.metadata.name === name)
+    if (connection?.spec.type === 'slack' && result.webhookURL) slackRequestURL.value = result.webhookURL
+    toast(result.registered ? 'ok' : 'info', result.note)
   }
 }
+
+watch(() => [props.store, props.authorityEpoch, props.name], () => { slackRequestURL.value = '' })
+onBeforeUnmount(() => { slackRequestURL.value = '' })
 
 async function testChannel(name: string): Promise<void> {
   const authority = captureAuthority()
@@ -472,8 +489,8 @@ function setGrants(spec: Agent['spec'], patch: AgentPatch): void {
       <div class="agents-fieldset">
         <span class="agents-fieldset-legend">Budget</span>
         <div class="agents-grid2">
-          <label>Monthly budget (USD)<input v-model="budgetUSD" class="k-input" inputmode="decimal" placeholder="blank = unlimited" /></label>
-          <label>Monthly token cap<input v-model="budgetTokens" class="k-input" inputmode="numeric" placeholder="blank = unlimited" /></label>
+          <label>Monthly budget (USD)<input v-model="budgetUSD" class="k-input" inputmode="decimal" placeholder="blank = unlimited" :aria-invalid="budgetUSDError ? 'true' : undefined" :aria-describedby="budgetUSDError ? 'agent-budget-usd-error' : undefined" /><span v-if="budgetUSDError" id="agent-budget-usd-error" class="agents-fielderr" role="alert">{{ budgetUSDError }}</span></label>
+          <label>Monthly token cap<input v-model="budgetTokens" class="k-input" inputmode="numeric" placeholder="blank = unlimited" :aria-invalid="budgetTokensError ? 'true' : undefined" :aria-describedby="budgetTokensError ? 'agent-budget-tokens-error' : undefined" /><span v-if="budgetTokensError" id="agent-budget-tokens-error" class="agents-fielderr" role="alert">{{ budgetTokensError }}</span></label>
         </div>
       </div>
       <div class="agents-fieldset">
@@ -544,6 +561,7 @@ function setGrants(spec: Agent['spec'], patch: AgentPatch): void {
     </ResourceSectionCard>
 
     <ResourceSectionCard class="agents-config-sec" heading-id="agent-channels-heading" title="Channels" description="Where this agent messages you — and, for chat channels, where you message it. Bind a primary channel plus named secondaries; schedules and triggers can route to any of them by name.">
+      <SecretHandoff v-if="slackRequestURL" :value="slackRequestURL" label="Slack request URL" copy-label="Copy Slack request URL" @cleared="slackRequestURL = ''" />
       <div v-if="connectionSlice.error && !connectionSlice.hasSnapshot" class="agents-state agents-state-error" role="alert">
         <span>Could not load channel connections. {{ connectionSlice.error }}</span>
         <button class="k-btn k-btn--ghost secondary" type="button" :disabled="connectionSlice.loading" @click="store.load('connections')">{{ connectionSlice.loading ? 'Retrying…' : 'Retry' }}</button>

--- a/providers/agents/portal/src/views/ChatMessage.vue
+++ b/providers/agents/portal/src/views/ChatMessage.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, onUpdated, ref } from 'vue'
-import { Check, ChevronRight, KeyRound, LoaderCircle, X } from 'lucide-vue-next'
+import { Check, ChevronRight, LoaderCircle, X } from 'lucide-vue-next'
 import { attachCodeCopy, sanitizedMarkdown } from '../vue/chat'
 import { fmtDuration, fmtTokens, fmtUSD, prettyJSON, type ChatMessage, type ToolCall } from '../types'
+import { approvalDisclosureAvailable } from '../approval-disclosure'
+import ApprovalDisclosure from '../components/ApprovalDisclosure.vue'
 
 const props = withDefaults(defineProps<{
   message: ChatMessage
@@ -92,10 +94,7 @@ onBeforeUnmount(() => { mounted = false })
     <div v-else class="agents-body agents-thinking"><span class="agents-dots" aria-hidden="true"></span> thinking…</div>
 
     <div v-if="message.approval" class="agents-approval" role="group" aria-label="Tool approval required">
-      <div class="agents-approval-head">
-        <KeyRound aria-hidden="true" /> Approval required — <span class="mono">{{ message.approval.tool }}</span>
-      </div>
-      <pre v-if="message.approval.args" class="agents-approval-args">{{ prettyJSON(message.approval.args) }}</pre>
+      <ApprovalDisclosure :tool="message.approval.tool" :args="message.approval.args" />
       <div v-if="message.approval.resolved" class="agents-approval-done">
         {{ message.approval.resolved === 'approve' ? 'Approved — the run is resuming.' : 'Denied — the agent was told no.' }}
       </div>
@@ -103,7 +102,7 @@ onBeforeUnmount(() => { mounted = false })
         <button
           class="k-btn k-btn--primary"
           type="button"
-          :disabled="!!approvalBusy"
+          :disabled="!!approvalBusy || !approvalDisclosureAvailable(message.approval.tool, message.approval.args)"
           :aria-busy="approvalBusy ? 'true' : undefined"
           @click="emit('approval', { inboxID: message.approval!.inboxID, decision: 'approve' })"
         >

--- a/providers/agents/portal/src/views/Connections.vue
+++ b/providers/agents/portal/src/views/Connections.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { AlertCircle, ArrowLeft, Check, Link, Megaphone, Plug, Plus, Send, Shuffle, Wrench } from 'lucide-vue-next'
-import { computed, ref, watch, type Component } from 'vue'
+import { computed, onBeforeUnmount, ref, watch, type Component } from 'vue'
 import type { ApiClient } from '../api'
-import { CATEGORY_META, CONN_DEFS, connCategory, connShape, type ConnCategory, type ConnField, type ConnTypeDef } from '../conn-defs'
+import SecretHandoff from '../components/SecretHandoff.vue'
+import { CATEGORY_META, CONN_DEFS, connCategory, connShape, isSecretBearingWebhook, type ConnCategory, type ConnField, type ConnTypeDef } from '../conn-defs'
 import { mutate } from '../mutate'
 import { confirmDialog } from '../portalkit/confirm'
 import CreateGuidance from '../portalkit/CreateGuidance.vue'
@@ -46,6 +47,7 @@ const deletingName = ref('')
 const createValues = ref<Record<string, string>>({})
 const editValues = ref<Record<string, string>>({})
 const editValuesFor = ref('')
+const slackRequestURL = ref('')
 const fence = (): Fence => ({ store: props.store, authorityEpoch: props.authorityEpoch, createSession: props.createSession })
 
 const connections = computed(() => { revision.value; return { ...props.store.connections } })
@@ -65,7 +67,10 @@ const filters: TableFilterDefinition[] = [
 ]
 const categoryIcons: Record<ConnCategory, Component> = { tool: Wrench, channel: Megaphone, connection: Plug }
 
-function endpoint(item: Connection): string { return item.spec.config?.instance || item.spec.baseURL || item.spec.channel || '' }
+function endpoint(item: Connection): string {
+  if (isSecretBearingWebhook(item)) return 'Configured'
+  return item.spec.config?.instance || item.spec.baseURL || item.spec.channel || ''
+}
 function selfHostedSearch(item: Connection): boolean { return item.spec.type === 'websearch' && item.spec.config?.provider === 'searxng' }
 function instanceBacked(item: Connection): boolean { return selfHostedSearch(item) || (item.spec.type === 'mcp' && !!item.spec.config?.instance) }
 function needsInstance(item: Connection): boolean { return selfHostedSearch(item) && !item.spec.config?.instance }
@@ -141,7 +146,7 @@ async function create(def: ConnTypeDef): Promise<void> {
 function hydrateEdit(item: Connection): void {
   const usesChannel = connCategory(item.spec.type) === 'channel' || Boolean(item.spec.channel)
   editValuesFor.value = item.metadata.name
-  editValues.value = { displayName: item.spec.displayName || '', endpoint: (usesChannel ? item.spec.channel : item.spec.baseURL) || '', instance: item.spec.config?.instance || '', secret: '' }
+  editValues.value = { displayName: item.spec.displayName || '', endpoint: isSecretBearingWebhook(item) ? '' : (usesChannel ? item.spec.channel : item.spec.baseURL) || '', instance: item.spec.config?.instance || '', secret: '' }
 }
 async function saveEdit(item: Connection): Promise<void> {
   if (editBusy.value) return
@@ -150,8 +155,9 @@ async function saveEdit(item: Connection): Promise<void> {
   const get = (key: string) => (editValues.value[key] || '').trim()
   const patch: ConnectionWrite = { displayName: get('displayName') }
   if (instanceBacked(item)) patch.config = { ...item.spec.config, instance: get('instance') }
-  else if (usesChannel) patch.channel = get('endpoint')
-  else patch.baseURL = get('endpoint')
+  else if (usesChannel) {
+    if (get('endpoint')) patch.channel = get('endpoint')
+  } else patch.baseURL = get('endpoint')
   if (get('secret')) patch.secret = get('secret')
   editBusy.value = true
   try {
@@ -193,11 +199,17 @@ async function enableInbound(name: string): Promise<void> {
   actionBusy.value = operation
   try {
     const result = await mutate(authority.store, { run: () => authority.api.enableInbound(name), failure: 'Enable inbound failed', reload: ['connections'] })
-    if (result && authorityIsCurrent(authority)) toast(result.registered ? 'ok' : 'info', `${result.note} ${result.webhookURL}`)
+    if (result && authorityIsCurrent(authority)) {
+      const connection = connections.value.data.find(item => item.metadata.name === name)
+      if (connection?.spec.type === 'slack' && result.webhookURL) slackRequestURL.value = result.webhookURL
+      toast(result.registered ? 'ok' : 'info', result.note)
+    }
   } finally {
     if (actionBusy.value === operation) actionBusy.value = ''
   }
 }
+watch(() => [props.store, props.authorityEpoch], () => { slackRequestURL.value = '' })
+onBeforeUnmount(() => { slackRequestURL.value = '' })
 async function oauth(name: string): Promise<void> {
   if (actionBusy.value || deletePendingName.value || deletingName.value) return
   const authority = captureAuthority()
@@ -285,7 +297,7 @@ function forwardCreate(detail: CreateSuccessDetail & Partial<Fence>): void { emi
             <div class="k-create-body k-create-fields">
               <label>Display name<input v-model="editValues.displayName" class="k-input" name="displayName" :placeholder="currentEdit.metadata.name" :disabled="editBusy" /></label>
               <label v-if="instanceBacked(currentEdit)">Instance name *<input v-model="editValues.instance" class="k-input" name="instance" placeholder="search" required autocomplete="off" :disabled="editBusy" /><span class="agents-hint">The instance under Infrastructure. Agents reach it over the platform's internal path — there is no URL and no token.</span></label>
-              <label v-else>{{ endpointLabel(currentEdit) }}<input v-model="editValues.endpoint" class="k-input" name="endpoint" :disabled="editBusy" /></label>
+              <label v-else>{{ isSecretBearingWebhook(currentEdit) ? 'Replacement webhook URL' : endpointLabel(currentEdit) }}<input v-model="editValues.endpoint" class="k-input" name="endpoint" :placeholder="isSecretBearingWebhook(currentEdit) ? 'Configured — leave blank to keep it' : ''" :disabled="editBusy" /><span v-if="isSecretBearingWebhook(currentEdit)" class="agents-hint">Configured; leave blank to keep the current destination.</span></label>
               <p v-if="!instanceBacked(currentEdit) && !connShape(currentEdit).discordWebhook && currentEdit.spec.auth === 'oauth'" class="agents-hint">This is an OAuth connection — use the <Link :stroke-width="1.75" /> button in the table to re-authorize. Client credentials aren't edited here.</p>
               <label v-else-if="!instanceBacked(currentEdit) && !connShape(currentEdit).discordWebhook">New {{ connShape(currentEdit).discordBot ? 'bot token' : 'secret / token' }}<input v-model="editValues.secret" class="k-input" name="secret" type="password" placeholder="leave blank to keep the current one" autocomplete="off" :disabled="editBusy" /><span class="agents-hint">Only set this to rotate the credential.</span></label>
             </div>
@@ -298,6 +310,7 @@ function forwardCreate(detail: CreateSuccessDetail & Partial<Fence>): void { emi
   <div v-else class="agents-menu">
     <div class="agents-panel k-card agents-route-panel">
       <div class="agents-panel-head"><h3 tabindex="-1" data-connections-heading>Connections</h3><button v-if="!showFirstRun" class="k-btn k-btn--primary" @click="emit('navigate', { kind: 'create', resource: 'connection' })"><Plus :stroke-width="1.75" /> New connection</button></div>
+      <SecretHandoff v-if="slackRequestURL" :value="slackRequestURL" label="Slack request URL" copy-label="Copy Slack request URL" @cleared="slackRequestURL = ''" />
       <p class="muted agents-connections-copy">Shared credentials for external systems. Each is a <Wrench :stroke-width="1.75" /> <strong>Tool</strong> agents call, a <Megaphone :stroke-width="1.75" /> <strong>Channel</strong> they message you on, or a <Plug :stroke-width="1.75" /> generic <strong>Connection</strong>. Stored as Secrets in your workspace.</p>
       <template v-if="showFirstRun">
         <div v-if="connections.error" class="agents-stale" role="status">

--- a/providers/agents/portal/src/views/RunDetail.vue
+++ b/providers/agents/portal/src/views/RunDetail.vue
@@ -4,7 +4,6 @@ import {
   Check,
   ChevronRight,
   Circle,
-  KeyRound,
   RefreshCw,
   Wrench,
   X,
@@ -33,6 +32,8 @@ import StatusBadge from '../portalkit/StatusBadge.vue'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import { toast } from '../ui/toast'
 import { useAuthorityGuard, useStoreRevision } from '../vue/runtime'
+import { approvalDisclosureAvailable } from '../approval-disclosure'
+import ApprovalDisclosure from '../components/ApprovalDisclosure.vue'
 
 const props = withDefaults(defineProps<{
   store: AppStore
@@ -320,10 +321,9 @@ onBeforeUnmount(() => {
 
       <ResourceSectionCard v-if="run.phase === 'PendingApproval' && run.pending" title="Approval required">
         <div class="agents-approval" role="group" aria-label="Tool approval required">
-          <div class="agents-approval-head"><KeyRound :stroke-width="1.75" aria-hidden="true" /> Paused — approval required for <span class="mono">{{ run.pending.tool }}</span></div>
-          <pre v-if="run.pending.args" class="agents-approval-args">{{ prettyJSON(run.pending.args) }}</pre>
+          <ApprovalDisclosure :tool="run.pending.tool" :args="run.pending.args" paused />
           <div class="agents-approval-actions">
-            <button class="k-btn k-btn--primary" type="button" :disabled="!!resolvingInboxID" :aria-busy="resolvingInboxID === run.pending.inboxID || undefined" @click="resolve(run.pending.inboxID, 'approve')"><Check :stroke-width="1.75" aria-hidden="true" /> {{ resolvingInboxID === run.pending.inboxID ? 'Resolving…' : 'Approve & resume' }}</button>
+            <button class="k-btn k-btn--primary" type="button" :disabled="!!resolvingInboxID || !approvalDisclosureAvailable(run.pending.tool, run.pending.args)" :aria-busy="resolvingInboxID === run.pending.inboxID || undefined" @click="resolve(run.pending.inboxID, 'approve')"><Check :stroke-width="1.75" aria-hidden="true" /> {{ resolvingInboxID === run.pending.inboxID ? 'Resolving…' : 'Approve & resume' }}</button>
             <button class="k-btn k-btn--ghost secondary" type="button" :disabled="!!resolvingInboxID" @click="resolve(run.pending.inboxID, 'deny')"><X :stroke-width="1.75" aria-hidden="true" /> Deny</button>
           </div>
         </div>

--- a/providers/agents/store/memory.go
+++ b/providers/agents/store/memory.go
@@ -486,6 +486,19 @@ func (m *MemoryStore) AddInboxItem(_ context.Context, scope Scope, item InboxIte
 	return nil
 }
 
+func (m *MemoryStore) GetInboxItem(_ context.Context, scope Scope, id string) (InboxItem, error) {
+	if err := scope.validate(); err != nil {
+		return InboxItem{}, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	it, ok := m.inbox[tenantKey(scope)+"|"+id]
+	if !ok {
+		return InboxItem{}, fmt.Errorf("inbox item %q not found", id)
+	}
+	return it, nil
+}
+
 func (m *MemoryStore) ListInbox(_ context.Context, scope Scope, state InboxItemState) ([]InboxItem, error) {
 	if err := scope.validate(); err != nil {
 		return nil, err

--- a/providers/agents/store/memory_test.go
+++ b/providers/agents/store/memory_test.go
@@ -120,6 +120,10 @@ func TestMemoryStore_InboxResolve(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("add inbox: %v", err)
 	}
+	got, err := s.GetInboxItem(ctx, sc, "i1")
+	if err != nil || got.RunID != "r1" {
+		t.Fatalf("get inbox: %v %+v", err, got)
+	}
 	pending, err := s.ListInbox(ctx, sc, InboxStatePending)
 	if err != nil || len(pending) != 1 {
 		t.Fatalf("list pending: %v n=%d", err, len(pending))

--- a/providers/agents/store/postgres.go
+++ b/providers/agents/store/postgres.go
@@ -703,6 +703,32 @@ func (p *PostgresStore) AddInboxItem(ctx context.Context, scope Scope, item Inbo
 	return err
 }
 
+func (p *PostgresStore) GetInboxItem(ctx context.Context, scope Scope, id string) (InboxItem, error) {
+	if err := scope.validate(); err != nil {
+		return InboxItem{}, err
+	}
+	var it InboxItem
+	var kind, state string
+	var payload []byte
+	err := p.db.QueryRowContext(ctx, `
+		SELECT id, agent_name, run_id, kind, state, prompt, payload, response, created_at, updated_at
+		FROM agents_inbox WHERE org_uuid=$1 AND workspace_uuid=$2 AND id=$3`,
+		scope.OrgUUID, scope.WorkspaceUUID, id,
+	).Scan(&it.ID, &it.AgentName, &it.RunID, &kind, &state, &it.Prompt, &payload, &it.Response, &it.CreatedAt, &it.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return InboxItem{}, fmt.Errorf("inbox item %q not found", id)
+	}
+	if err != nil {
+		return InboxItem{}, err
+	}
+	it.Kind, it.State = InboxItemKind(kind), InboxItemState(state)
+	if len(payload) > 0 {
+		_ = json.Unmarshal(payload, &it.Payload)
+	}
+	it.CreatedAt, it.UpdatedAt = it.CreatedAt.UTC(), it.UpdatedAt.UTC()
+	return it, nil
+}
+
 func (p *PostgresStore) ListInbox(ctx context.Context, scope Scope, state InboxItemState) ([]InboxItem, error) {
 	if err := scope.validate(); err != nil {
 		return nil, err

--- a/providers/agents/store/postgres_test.go
+++ b/providers/agents/store/postgres_test.go
@@ -183,6 +183,10 @@ func TestPostgres_InboxMemoryTenantRefTeardown(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("inbox add: %v", err)
 	}
+	gotItem, err := ps.GetInboxItem(ctx, sc, itemID)
+	if err != nil || gotItem.Payload["tool"] != "github__merge" {
+		t.Fatalf("inbox get: %v %+v", err, gotItem)
+	}
 	pending, err := ps.ListInbox(ctx, Scope{OrgUUID: sc.OrgUUID, WorkspaceUUID: sc.WorkspaceUUID}, InboxStatePending)
 	if err != nil || len(pending) != 1 || pending[0].Payload["tool"] != "github__merge" {
 		t.Fatalf("inbox list: %v %+v", err, pending)

--- a/providers/agents/store/store.go
+++ b/providers/agents/store/store.go
@@ -334,6 +334,7 @@ type Store interface {
 
 	// Approvals inbox.
 	AddInboxItem(ctx context.Context, scope Scope, item InboxItem) error
+	GetInboxItem(ctx context.Context, scope Scope, id string) (InboxItem, error)
 	ListInbox(ctx context.Context, scope Scope, state InboxItemState) ([]InboxItem, error)
 	ResolveInboxItem(ctx context.Context, scope Scope, id string, state InboxItemState, response string, now time.Time) (InboxItem, error)
 


### PR DESCRIPTION
## Summary
- centralize redacted approval disclosure and reject unsafe approval before inbox mutation
- unify budget validation across portal, REST, and MCP
- remove callback/webhook secrets from ordinary presentation while preserving compatible storage and APIs

## Verification
- Agents portal tests/typecheck/build
- `go test -count=1 ./...` in `providers/agents`
- design/PortalKit/UI conformance gates
- independent security review

Stack 2 of 9. Depends on #1 foundation branch.