### PR TITLE
Provider conformance 4/9: Databricks read resilience

### DIFF
--- a/providers/databricks/portal/src/DashboardTile.vue
+++ b/providers/databricks/portal/src/DashboardTile.vue
@@ -29,8 +29,14 @@ const rootRef = ref<HTMLElement | null>(null)
 const warehouses = ref<Warehouse[]>([])
 const connections = ref<Connection[]>([])
 const loading = ref(true)
+const loaded = ref(false)
 const error = ref<string | null>(null)
 let poller: TilePoller | null = null
+let requestGeneration = 0
+
+function contextIdentity(ctx: TileContext | null): string {
+  return JSON.stringify([ctx?.tenant ?? '', ctx?.orgUUID ?? '', ctx?.workspaceUUID ?? ''])
+}
 
 // Databricks reports warehouse state in its own vocabulary; treat anything
 // that is not explicitly RUNNING/STARTING as stopped rather than guessing at
@@ -49,45 +55,85 @@ const stats = computed(() => {
 const rows = computed(() => mostRecent(warehouses.value, (w) => w.creationTimestamp))
 
 async function load() {
+  const generation = ++requestGeneration
   const ctx = props.context
   if (!hasWorkspaceContext(ctx)) {
+    if (generation !== requestGeneration) return
     warehouses.value = []
     connections.value = []
     error.value = null
     loading.value = false
+    loaded.value = true
     return
   }
+  loading.value = true
   setToken(ctx?.token ?? null)
   setTenant(ctx?.tenant ?? null)
   setTenantSelection(ctx?.orgUUID ?? null, ctx?.workspaceUUID ?? null)
   try {
     const [w, c] = await Promise.all([api.listWarehouses(), api.listConnections()])
+    if (generation !== requestGeneration) return
     warehouses.value = w
     connections.value = c
     error.value = null
+    loaded.value = true
   } catch (e) {
-    warehouses.value = []
-    connections.value = []
-    error.value = isBenignTileError(e) ? null : formatDatabricksError(e)
+    if (generation !== requestGeneration || (e as { reason?: string })?.reason === 'ContextChanged') return
+    if (isBenignTileError(e)) {
+      warehouses.value = []
+      connections.value = []
+      error.value = null
+      loaded.value = true
+    } else {
+      error.value = formatDatabricksError(e)
+    }
   } finally {
-    loading.value = false
+    if (generation === requestGeneration) loading.value = false
   }
+}
+
+function retry() {
+  poller?.refresh()
 }
 
 onMounted(() => {
   poller = createTilePoller(load)
   poller.start()
 })
-onUnmounted(() => poller?.stop())
-watch(() => props.context, () => poller?.refresh())
+onUnmounted(() => {
+  requestGeneration += 1
+  poller?.stop()
+})
+watch(
+  () => [props.context?.tenant, props.context?.orgUUID, props.context?.workspaceUUID, props.context?.token, props.context?.basePath] as const,
+  (_next, previous) => {
+    requestGeneration += 1
+    if (contextIdentity(props.context) !== JSON.stringify([previous?.[0] ?? '', previous?.[1] ?? '', previous?.[2] ?? ''])) {
+      warehouses.value = []
+      connections.value = []
+      error.value = null
+      loaded.value = false
+      loading.value = true
+    }
+    poller?.refresh()
+  },
+)
 </script>
 
 <template>
-  <div ref="rootRef" :class="tileClass.root">
-    <div v-if="loading" :class="tileClass.message">Loading warehouses&hellip;</div>
-    <div v-else-if="error" :class="tileClass.error">Failed to load: {{ error }}</div>
+  <div ref="rootRef" :class="tileClass.root" :aria-busy="loading">
+    <div v-if="!loaded && loading" :class="tileClass.message" role="status" aria-live="polite">Loading warehouses&hellip;</div>
+    <div v-else-if="!loaded && error" :class="tileClass.error" role="alert" aria-live="assertive">
+      Failed to load: {{ error }}
+      <button type="button" class="k-dashboard-action" @click="retry">Retry</button>
+    </div>
 
     <template v-else>
+      <span v-if="loading" class="sr-only" role="status" aria-live="polite">Updating Databricks warehouses…</span>
+      <div v-if="error" :class="tileClass.error" role="status" aria-live="polite">
+        Showing the last successful result. {{ error }}
+        <button type="button" class="k-dashboard-action" @click="retry">Retry</button>
+      </div>
       <div :class="tileClass.stats">
         <span :class="[tileClass.stat, tileClass.statTotal]">
           <Package :class="tileClass.statIcon" :stroke-width="1.75" aria-hidden="true" />

--- a/providers/databricks/portal/src/databricksPolish.source.test.mjs
+++ b/providers/databricks/portal/src/databricksPolish.source.test.mjs
@@ -247,7 +247,7 @@ test('wide provider surfaces stay readable at 4K and in detail/import views', as
   assert.match(sharedStyles, /\.k-create-guidance\s*\{[\s\S]*max-inline-size: 75ch/)
   assert.match(styles, /@container k-create-surface \(min-width: 1800px\)[\s\S]*\.manual-create-body-guided[\s\S]*minmax\(17\.5rem, min\(32rem, 40%\)\)/)
   assert.match(styles, /@container k-create-surface \(min-width: 1800px\)[\s\S]*\.manual-create-fields-grid--connection[\s\S]*repeat\(3, minmax\(0, 1fr\)/)
-  assert.match(styles, /@container k-create-surface \(min-width: 3000px\)[\s\S]*\.manual-create-form-fields--table \.form-grid[\s\S]*repeat\(4, minmax\(0, 1fr\)/)
+  assert.doesNotMatch(styles, /\.manual-create-fields-grid--(?:connection|warehouse),?[\s\S]{0,500}repeat\(4, minmax\(0, 1fr\)/)
   assert.match(styles, /@media \(max-width: 620px\)[\s\S]*\.manual-create-form input:not\(\[type='hidden'\]\)[\s\S]*min-height: 44px/)
   assert.match(styles, /@media \(max-width: 620px\)[\s\S]*\.manual-create-form > \.manual-create-body-guided \+ div\s*\{[\s\S]*position: static[\s\S]*z-index: auto/)
   assert.match(warehouseCreate, /manual-create-support-note/)

--- a/providers/databricks/portal/src/lazyCheckboxTree.source.test.mjs
+++ b/providers/databricks/portal/src/lazyCheckboxTree.source.test.mjs
@@ -70,8 +70,10 @@ test('wizard focus trap follows the natural tab sequence', async () => {
 
 test('split create uses canonical buttons and menu items', async () => {
   const source = await readFile(new URL('./components/SplitCreateButton.vue', import.meta.url), 'utf8')
+  const styles = await readFile(new URL('./style.css', import.meta.url), 'utf8')
   assert.match(source, /class="k-btn k-btn--primary split-create-main"/)
   assert.match(source, /class="k-btn k-btn--primary split-create-toggle"/)
+  assert.doesNotMatch(styles, /\.split-create-toggle\s*\{[^}]*min-width:\s*30px/)
   assert.match(source, /class="split-create-menu k-menu" role="menu"/)
   assert.match(source, /class="k-menu-item split-create-menu-item" type="button" role="menuitem" tabindex="-1"/)
   assert.doesNotMatch(source, /class="(?:secondary|icon-button)[^"]*"/)

--- a/providers/databricks/portal/src/resourceTable.ssr.test.mjs
+++ b/providers/databricks/portal/src/resourceTable.ssr.test.mjs
@@ -356,12 +356,214 @@ function mountDetailView(Component, props, components, provides = {}) {
   }
 }
 
+function mountDashboardTile(Component, initialContext) {
+  const previousDocument = globalThis.document
+  const previousWindow = globalThis.window
+  globalThis.document = {
+    documentElement: { style: { getPropertyValue: () => '' } },
+    getElementById: () => null,
+    createElement: () => ({ id: '', textContent: '', setAttribute() {} }),
+    head: { appendChild() {} },
+  }
+  globalThis.window = {
+    addEventListener() {},
+    removeEventListener() {},
+    setInterval: () => 1,
+    clearInterval() {},
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+  }
+  const context = reactive({ ...initialContext })
+  const { renderer, root } = createHostRenderer()
+  const app = renderer.createApp({
+    render: () => h(Component, { context }),
+  })
+  const IconStub = { setup: () => () => h('svg', { 'aria-hidden': 'true' }) }
+  for (const name of ['Package', 'Check', 'Link2', 'ChevronRight']) app.component(name, IconStub)
+  app._context.provides[Symbol.for('v-scx')] = { modules: new Set() }
+  app.mount(root)
+  return {
+    context,
+    root,
+    get instance() {
+      return app._instance?.subTree?.component
+    },
+    find: predicate => findHostNode(root, predicate),
+    unmount() {
+      app.unmount()
+      if (previousDocument === undefined) delete globalThis.document
+      else globalThis.document = previousDocument
+      if (previousWindow === undefined) delete globalThis.window
+      else globalThis.window = previousWindow
+    },
+  }
+}
+
 async function flushVue() {
   for (let i = 0; i < 6; i += 1) {
     await Promise.resolve()
     await nextTick()
   }
 }
+
+function pendingDashboardRead(pendingReads, kind, tenant) {
+  const index = pendingReads.findIndex(read => read.kind === kind && read.tenant === tenant)
+  assert.ok(index >= 0, `the dashboard tile started a ${kind} read for ${tenant}`)
+  return pendingReads.splice(index, 1)[0]
+}
+
+test('dashboard tile fences prior-tenant results before committing a refreshed snapshot', async () => {
+  const [DashboardTile, apiModule] = await Promise.all([
+    loadMountedSFC('/src/DashboardTile.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+  ])
+  const original = {
+    listWarehouses: apiModule.api.listWarehouses,
+    listConnections: apiModule.api.listConnections,
+  }
+  const pendingReads = []
+  let activeTenant = 'tenant-a'
+  const queue = kind => new Promise((resolve, reject) => pendingReads.push({ kind, tenant: activeTenant, resolve, reject }))
+  apiModule.api.listWarehouses = () => queue('warehouses')
+  apiModule.api.listConnections = () => queue('connections')
+
+  const mounted = mountDashboardTile(DashboardTile, {
+    tenant: 'tenant-a',
+    orgUUID: 'org-a',
+    workspaceUUID: 'workspace-a',
+    token: 'token-a',
+  })
+  try {
+    await nextTick()
+    assert.equal(pendingReads.length, 2, 'the first tenant load is pending')
+
+    activeTenant = 'tenant-b'
+    Object.assign(mounted.context, {
+      tenant: 'tenant-b',
+      orgUUID: 'org-b',
+      workspaceUUID: 'workspace-b',
+      token: 'token-b',
+    })
+    await nextTick()
+    pendingDashboardRead(pendingReads, 'warehouses', 'tenant-a').resolve([{
+      name: 'tenant-a-warehouse',
+      state: 'RUNNING',
+      creationTimestamp: '2026-09-04T10:00:00Z',
+    }])
+    pendingDashboardRead(pendingReads, 'connections', 'tenant-a').resolve([{
+      name: 'tenant-a-connection',
+      host: 'https://tenant-a.example.com',
+      authType: 'pat',
+      status: 'Ready',
+    }])
+    await flushVue()
+
+    assert.doesNotMatch(hostText(mounted.root), /tenant-a-warehouse/, 'the late prior-tenant row is never rendered')
+    assert.equal(mounted.instance.setupState.loaded, false, 'the late prior-tenant response does not establish snapshot authority')
+    assert.equal(pendingReads.filter(read => read.tenant === 'tenant-b').length, 2, 'the queued refresh starts for the current tenant')
+
+    pendingDashboardRead(pendingReads, 'warehouses', 'tenant-b').resolve([{
+      name: 'tenant-b-warehouse',
+      state: 'STOPPED',
+      creationTimestamp: '2026-09-04T11:00:00Z',
+    }])
+    pendingDashboardRead(pendingReads, 'connections', 'tenant-b').resolve([{
+      name: 'tenant-b-connection',
+      host: 'https://tenant-b.example.com',
+      authType: 'pat',
+      status: 'Ready',
+    }])
+    await flushVue()
+
+    assert.match(hostText(mounted.root), /tenant-b-warehouse/, 'the current tenant result becomes the authoritative snapshot')
+    assert.equal(mounted.instance.setupState.loaded, true)
+  } finally {
+    mounted.unmount()
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.listConnections = original.listConnections
+  }
+})
+
+test('dashboard tile distinguishes initial failure from stale failure, retains its snapshot, and retries', async () => {
+  const [DashboardTile, apiModule] = await Promise.all([
+    loadMountedSFC('/src/DashboardTile.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+  ])
+  const original = {
+    listWarehouses: apiModule.api.listWarehouses,
+    listConnections: apiModule.api.listConnections,
+  }
+  const pendingReads = []
+  const queue = kind => new Promise((resolve, reject) => pendingReads.push({ kind, tenant: 'tenant-a', resolve, reject }))
+  apiModule.api.listWarehouses = () => queue('warehouses')
+  apiModule.api.listConnections = () => queue('connections')
+
+  const mounted = mountDashboardTile(DashboardTile, {
+    tenant: 'tenant-a',
+    orgUUID: 'org-a',
+    workspaceUUID: 'workspace-a',
+    token: 'token-a',
+  })
+  try {
+    await nextTick()
+    pendingDashboardRead(pendingReads, 'warehouses', 'tenant-a').reject(new Error('initial read unavailable'))
+    pendingDashboardRead(pendingReads, 'connections', 'tenant-a').resolve([])
+    await flushVue()
+
+    const initialAlert = mounted.find(node => node.props?.role === 'alert')
+    assert.ok(initialAlert, 'an initial failure is assertive because there is no useful snapshot')
+    assert.match(hostText(initialAlert), /Failed to load: Databricks request failed/, 'the initial failure uses the provider error boundary')
+    const initialRetry = mounted.find(node => node.type === 'button' && hostText(node).trim() === 'Retry')
+    assert.ok(initialRetry, 'initial failure exposes Retry')
+    assert.equal(initialRetry.props.class, 'k-dashboard-action', 'initial Retry uses the canonical dashboard action recipe')
+
+    initialRetry.props.onClick()
+    await flushVue()
+    pendingDashboardRead(pendingReads, 'warehouses', 'tenant-a').resolve([{
+      name: 'orders-warehouse',
+      state: 'RUNNING',
+      creationTimestamp: '2026-09-04T12:00:00Z',
+    }])
+    pendingDashboardRead(pendingReads, 'connections', 'tenant-a').resolve([{
+      name: 'analytics',
+      host: 'https://dbc.example.com',
+      authType: 'pat',
+      status: 'Ready',
+    }])
+    await flushVue()
+    assert.match(hostText(mounted.root), /orders-warehouse/, 'Retry can establish the first successful snapshot')
+
+    mounted.instance.setupState.load()
+    await nextTick()
+    pendingDashboardRead(pendingReads, 'warehouses', 'tenant-a').reject(new Error('background refresh unavailable'))
+    pendingDashboardRead(pendingReads, 'connections', 'tenant-a').resolve([])
+    await flushVue()
+
+    assert.match(hostText(mounted.root), /orders-warehouse/, 'a background failure retains the last successful row')
+    assert.equal(mounted.find(node => node.props?.role === 'alert'), null, 'a stale-result failure does not interrupt with an assertive alert')
+    const staleStatus = mounted.find(node => node.props?.role === 'status' && /last successful result/i.test(hostText(node)))
+    assert.ok(staleStatus, 'a stale-result failure labels the retained snapshot politely')
+    const staleRetry = mounted.find(node => node.type === 'button' && hostText(node).trim() === 'Retry')
+    assert.ok(staleRetry, 'stale-result failure exposes Retry')
+    assert.equal(staleRetry.props.class, 'k-dashboard-action', 'stale Retry uses the canonical dashboard action recipe')
+
+    staleRetry.props.onClick()
+    await flushVue()
+    pendingDashboardRead(pendingReads, 'warehouses', 'tenant-a').resolve([{
+      name: 'fresh-warehouse',
+      state: 'RUNNING',
+      creationTimestamp: '2026-09-04T13:00:00Z',
+    }])
+    pendingDashboardRead(pendingReads, 'connections', 'tenant-a').resolve([])
+    await flushVue()
+    assert.match(hostText(mounted.root), /fresh-warehouse/, 'Retry replaces the stale snapshot with fresh data')
+    assert.doesNotMatch(hostText(mounted.root), /orders-warehouse/)
+    assert.equal(mounted.find(node => node.props?.role === 'status' && /last successful result/i.test(hostText(node))), null)
+  } finally {
+    mounted.unmount()
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.listConnections = original.listConnections
+  }
+})
 
 test('ResourceBackLink keeps the href fallback and emits only for active clicks', async () => {
   const ResourceBackLink = await loadMountedSFC(canonicalResourceBackLink)
@@ -2038,6 +2240,13 @@ async function settleResourceListPage(pendingReads, pageKind, result) {
   await flushVue()
 }
 
+async function rejectResourceListPage(pendingReads, pageKind, error) {
+  const index = pendingReads.findIndex(read => read.kind === pageKind)
+  assert.ok(index >= 0, `the view started a ${pageKind} read`)
+  pendingReads.splice(index, 1)[0].reject(error)
+  await flushVue()
+}
+
 function resourceListCreateControl(mounted, kind) {
   return mounted.find(node => kind === 'connections'
     ? node.type === 'button' && hostText(node).includes('Add connection')
@@ -2140,6 +2349,132 @@ test('collection create controls wait for authority and known-empty surfaces sta
     apiModule.api.listWarehousesPage = original.listWarehousesPage
     apiModule.api.listTablesPage = original.listTablesPage
     apiModule.api.deleteConnection = original.deleteConnection
+  }
+})
+
+test('collection reads reject results settled after the tenant context changes', async () => {
+  const [ConnectionsView, WarehousesView, TablesView, apiModule, contextModule] = await Promise.all([
+    loadMountedSFC('/src/views/ConnectionsView.vue'),
+    loadMountedSFC('/src/views/WarehousesView.vue'),
+    loadMountedSFC('/src/views/TablesView.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+    vite.ssrLoadModule('/src/context.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+    listConnectionsPage: apiModule.api.listConnectionsPage,
+    listWarehousesPage: apiModule.api.listWarehousesPage,
+    listTablesPage: apiModule.api.listTablesPage,
+  }
+  const cases = [
+    {
+      kind: 'connections', Component: ConnectionsView, pageKind: 'connections-page', supportKinds: [],
+      rows: [{ name: 'tenant-a-connection', uid: 'connection-a', host: 'https://dbc.example.com', authType: 'pat', status: 'Ready' }],
+    },
+    {
+      kind: 'warehouses', Component: WarehousesView, pageKind: 'warehouses-page', supportKinds: ['connections'],
+      rows: [{ name: 'tenant-a-warehouse', uid: 'warehouse-a', connectionRef: 'tenant-a-connection', warehouseID: 'warehouse-a', status: 'Ready' }],
+    },
+    {
+      kind: 'tables', Component: TablesView, pageKind: 'tables-page', supportKinds: ['connections', 'warehouses'],
+      rows: [{ name: 'tenant-a-table', uid: 'table-a', connectionRef: 'tenant-a-connection', warehouseRef: 'tenant-a-warehouse', catalog: 'main', schema: 'sales', table: 'orders', fullName: 'main.sales.orders', columns: [], status: 'Ready' }],
+    },
+  ]
+
+  try {
+    for (const testCase of cases) {
+      const pendingReads = []
+      const queue = kind => new Promise((resolve, reject) => pendingReads.push({ kind, resolve, reject }))
+      apiModule.api.listConnections = () => queue('connections')
+      apiModule.api.listWarehouses = () => queue('warehouses')
+      apiModule.api.listConnectionsPage = () => queue('connections-page')
+      apiModule.api.listWarehousesPage = () => queue('warehouses-page')
+      apiModule.api.listTablesPage = () => queue('tables-page')
+      const contextGeneration = ref(1)
+      const mounted = mountDetailView(
+        testCase.Component,
+        {},
+        resourceListStubComponents(),
+        { [contextModule.contextGenerationKey]: contextGeneration },
+      )
+      try {
+        await nextTick()
+        await settleResourceListSupport(pendingReads, testCase.supportKinds)
+        assert.equal(pendingReads.filter(read => read.kind === testCase.pageKind).length, 1, `${testCase.kind} page read is pending before context rotation`)
+
+        contextGeneration.value += 1
+        resourceListPendingRead(pendingReads, testCase.pageKind)({ items: testCase.rows, continue: null })
+        await flushVue()
+
+        assert.equal(
+          mounted.find(node => className(node).includes('k-table'))?.props?.['data-row-count'],
+          '0',
+          `${testCase.kind} did not commit the prior tenant's late page`,
+        )
+        assert.equal(mounted.instance.setupState.loaded, false, `${testCase.kind} did not mark the prior tenant's late page loaded`)
+      } finally {
+        mounted.unmount()
+      }
+    }
+  } finally {
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.listConnectionsPage = original.listConnectionsPage
+    apiModule.api.listWarehousesPage = original.listWarehousesPage
+    apiModule.api.listTablesPage = original.listTablesPage
+  }
+})
+
+test('background failures preserve authoritative empty collection snapshots and expose Retry', async () => {
+  const [ConnectionsView, WarehousesView, apiModule] = await Promise.all([
+    loadMountedSFC('/src/views/ConnectionsView.vue'),
+    loadMountedSFC('/src/views/WarehousesView.vue'),
+    vite.ssrLoadModule('/src/api.ts'),
+  ])
+  const original = {
+    listConnections: apiModule.api.listConnections,
+    listWarehouses: apiModule.api.listWarehouses,
+    listConnectionsPage: apiModule.api.listConnectionsPage,
+    listWarehousesPage: apiModule.api.listWarehousesPage,
+  }
+  const cases = [
+    { kind: 'connections', Component: ConnectionsView, pageKind: 'connections-page', supportKinds: [] },
+    { kind: 'warehouses', Component: WarehousesView, pageKind: 'warehouses-page', supportKinds: ['connections'] },
+  ]
+
+  try {
+    for (const testCase of cases) {
+      const pendingReads = []
+      const queue = kind => new Promise((resolve, reject) => pendingReads.push({ kind, resolve, reject }))
+      apiModule.api.listConnections = () => queue('connections')
+      apiModule.api.listWarehouses = () => queue('warehouses')
+      apiModule.api.listConnectionsPage = () => queue('connections-page')
+      apiModule.api.listWarehousesPage = () => queue('warehouses-page')
+      const mounted = mountDetailView(testCase.Component, {}, resourceListStubComponents())
+      try {
+        await nextTick()
+        await settleResourceListSupport(pendingReads, testCase.supportKinds)
+        await settleResourceListPage(pendingReads, testCase.pageKind, { items: [], continue: null })
+        assert.ok(mounted.find(node => className(node).includes('databricks-first-run')), `${testCase.kind} starts from an authoritative empty snapshot`)
+
+        mounted.instance.setupState.load('background')
+        await nextTick()
+        await settleResourceListSupport(pendingReads, testCase.supportKinds)
+        await rejectResourceListPage(pendingReads, testCase.pageKind, new Error('background refresh unavailable'))
+
+        assert.ok(mounted.find(node => className(node).includes('databricks-first-run')), `${testCase.kind} keeps its authoritative empty snapshot after a background failure`)
+        assert.ok(mounted.find(node => node.props?.role === 'status' && /last successful result/i.test(hostText(node))), `${testCase.kind} labels the retained snapshot as stale without an assertive interruption`)
+        assert.ok(mounted.find(node => node.type === 'button' && hostText(node).trim() === 'Retry'), `${testCase.kind} exposes Retry after a background failure`)
+      } finally {
+        mounted.unmount()
+      }
+    }
+  } finally {
+    apiModule.api.listConnections = original.listConnections
+    apiModule.api.listWarehouses = original.listWarehouses
+    apiModule.api.listConnectionsPage = original.listConnectionsPage
+    apiModule.api.listWarehousesPage = original.listWarehousesPage
   }
 })
 

--- a/providers/databricks/portal/src/style.css
+++ b/providers/databricks/portal/src/style.css
@@ -288,7 +288,6 @@ faros-provider-databricks .split-create-toggle {
   border-bottom-left-radius: 0 !important;
   border-left-color: var(--color-accent-hover, #a18aff) !important;
   border-top-left-radius: 0 !important;
-  min-width: 30px;
   padding-left: 8px !important;
   padding-right: 8px !important;
 }
@@ -830,15 +829,6 @@ faros-provider-databricks .import-primary > :is(.import-actions, footer) :where(
   faros-provider-databricks .manual-create-fields-grid--warehouse,
   faros-provider-databricks .manual-create-form-fields--table .form-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@container k-create-surface (min-width: 3000px) {
-  /* At 4K, keep each control below a comfortable reading width. */
-  faros-provider-databricks .manual-create-fields-grid--connection,
-  faros-provider-databricks .manual-create-fields-grid--warehouse,
-  faros-provider-databricks .manual-create-form-fields--table .form-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
 

--- a/providers/databricks/portal/src/views/ConnectionsView.vue
+++ b/providers/databricks/portal/src/views/ConnectionsView.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ExternalLink } from 'lucide-vue-next'
-import { computed, onActivated, onMounted, onUnmounted, ref } from 'vue'
+import { computed, inject, onActivated, onMounted, onUnmounted, ref } from 'vue'
 import DatabricksEmptyState from '../components/DatabricksEmptyState.vue'
+import { contextGenerationKey } from '../context'
 import type { DatabricksJourneyAction } from '../journey'
 import ResourceTable from '../portalkit/ResourceTable.vue'
 import ResourceTableDeleteButton from '../portalkit/ResourceTableDeleteButton.vue'
@@ -39,6 +40,7 @@ import {
 } from '../databricksPagination'
 
 const emit = defineEmits<{ (e: 'open', name: string): void; (e: 'create'): void }>()
+const contextGeneration = inject(contextGenerationKey, ref(0))
 
 const connections = ref<Connection[]>([])
 const loading = ref(false)
@@ -67,7 +69,6 @@ const rows = computed<Array<Record<string, unknown>>>(() => connections.value
 const firstPageSettled = ref(false)
 const pendingDeletions = new Map<string, string | undefined>()
 const showFirstRun = computed(() => firstPageSettled.value
-  && !error.value
   && rows.value.length === 0
   && connectionPage.value === 1
   && !hasActiveFilters(connectionQuery.value, connectionFilters.value))
@@ -258,6 +259,7 @@ async function remove(row: Record<string, unknown>) {
 }
 
 refresh = createLatestRefreshController(async (requestID, mode) => {
+  const expectedContext = contextGeneration.value
   const request = currentConnectionRequest()
   let walkGeneration: number | undefined
   let serverPageGeneration: number | undefined
@@ -274,7 +276,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
       fullWalkPending = true
       walkGeneration = authorityGeneration
       const next = await completeRead.request()
-      if (!mounted) return
+      if (!mounted || contextGeneration.value !== expectedContext) return
       if (walkGeneration !== authorityGeneration) return
       const current = currentConnectionRequest()
       if (!current.active && current.mode === 'server') return
@@ -295,7 +297,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
       serverPageGeneration = authorityGeneration
       const next = await serverPageRead.request()
       serverPageReadPending = false
-      if (!mounted || serverPageGeneration !== authorityGeneration) return
+      if (!mounted || contextGeneration.value !== expectedContext || serverPageGeneration !== authorityGeneration) return
       const currentAfterPage = currentConnectionRequest()
       const currentIsActive = currentAfterPage.active || currentAfterPage.mode === 'client'
       const nextPageInfo = toPageInfo(next.continue)
@@ -311,7 +313,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
         fullWalkPending = true
         walkGeneration = authorityGeneration
         const connectionList = await completeRead.request()
-        if (!mounted) return
+        if (!mounted || contextGeneration.value !== expectedContext) return
         if (walkGeneration !== authorityGeneration) return
         const current = currentConnectionRequest()
         if (!current.active && current.mode === 'server') return
@@ -366,12 +368,12 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
     const staleWalk = walkGeneration !== undefined && walkGeneration !== authorityGeneration
     const staleServerPage = serverPageGeneration !== undefined && serverPageGeneration !== authorityGeneration
     const staleServerRequest = !(current.active || current.mode === 'client') && !connectionRequestIsCurrent(requestID, request)
-    if (!mounted || staleWalk || staleServerPage || staleServerRequest) return
+    if (!mounted || contextGeneration.value !== expectedContext || staleWalk || staleServerPage || staleServerRequest) return
     error.value = isTenantMissingError(e) ? null : formatDatabricksError(e)
   } finally {
     fullWalkPending = false
     serverPageReadPending = false
-    if (refresh.isCurrent(requestID)) {
+    if (contextGeneration.value === expectedContext && refresh.isCurrent(requestID)) {
       if (mode === 'foreground') loading.value = false
       poll.schedule()
     }
@@ -416,11 +418,13 @@ onUnmounted(() => {
       <button class="k-btn k-btn--ghost" type="button" @click="mutationError = null">Dismiss</button>
     </div>
 
-    <DatabricksEmptyState
-      v-if="showFirstRun"
-      kind="connection"
-      @action="handleFirstRunAction"
-    />
+    <template v-if="showFirstRun">
+      <div v-if="error" class="error" role="status" aria-live="polite">
+        Showing the last successful result. {{ error }}
+        <button class="k-btn k-btn--ghost" type="button" @click="load">Retry</button>
+      </div>
+      <DatabricksEmptyState kind="connection" @action="handleFirstRunAction" />
+    </template>
 
     <div v-else class="databricks-resource-table">
       <ResourceTable

--- a/providers/databricks/portal/src/views/TablesView.vue
+++ b/providers/databricks/portal/src/views/TablesView.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, onActivated, onMounted, onUnmounted, ref } from 'vue'
+import { computed, inject, onActivated, onMounted, onUnmounted, ref } from 'vue'
 import { RefreshCw } from 'lucide-vue-next'
 import DatabricksEmptyState from '../components/DatabricksEmptyState.vue'
+import { contextGenerationKey } from '../context'
 import SplitCreateButton from '../components/SplitCreateButton.vue'
 import type { DatabricksJourneyAction, DatabricksPrerequisiteKind } from '../journey'
 import ResourceTable from '../portalkit/ResourceTable.vue'
@@ -42,6 +43,7 @@ const emit = defineEmits<{
   (e: 'edit', name: string): void
   (e: 'prerequisite', kind: DatabricksPrerequisiteKind): void
 }>()
+const contextGeneration = inject(contextGenerationKey, ref(0))
 
 const connections = ref<Connection[]>([])
 const warehouses = ref<Warehouse[]>([])
@@ -99,7 +101,6 @@ const rows = computed<Array<Record<string, unknown>>>(() =>
   })),
 )
 const showFirstRun = computed(() => firstPageSettled.value
-  && !error.value
   && rows.value.length === 0
   && tablePage.value === 1
   && !hasActiveFilters(tableQuery.value, tableFiltersValue.value))
@@ -263,6 +264,7 @@ async function remove(row: Record<string, unknown>) {
 }
 
 refresh = createLatestRefreshController(async (requestID, mode) => {
+  const expectedContext = contextGeneration.value
   const request = currentTableRequest()
   let walkGeneration: number | undefined
   let supportGeneration: number | undefined
@@ -278,7 +280,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
     supportGeneration = authorityGeneration
     const [availableConnections, availableWarehouses] = await supportRead.request()
     supportReadPending = false
-    if (!mounted || supportGeneration !== authorityGeneration) return
+    if (!mounted || contextGeneration.value !== expectedContext || supportGeneration !== authorityGeneration) return
     connections.value = availableConnections
     warehouses.value = availableWarehouses
 
@@ -287,7 +289,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
       fullWalkPending = true
       walkGeneration = authorityGeneration
       const tableList = await completeRead.request()
-      if (!mounted) return
+      if (!mounted || contextGeneration.value !== expectedContext) return
       if (walkGeneration !== authorityGeneration) return
       const current = currentTableRequest()
       if (!current.active && current.mode === 'server') return
@@ -308,7 +310,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
       serverPageGeneration = authorityGeneration
       const tablePageResult = await serverPageRead.request()
       serverPageReadPending = false
-      if (!mounted || serverPageGeneration !== authorityGeneration) return
+      if (!mounted || contextGeneration.value !== expectedContext || serverPageGeneration !== authorityGeneration) return
       const currentAfterPage = currentTableRequest()
       const currentIsActive = currentAfterPage.active || currentAfterPage.mode === 'client'
       const nextPageInfo = toPageInfo(tablePageResult.continue)
@@ -324,7 +326,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
         fullWalkPending = true
         walkGeneration = authorityGeneration
         const tableList = await completeRead.request()
-        if (!mounted) return
+        if (!mounted || contextGeneration.value !== expectedContext) return
         if (walkGeneration !== authorityGeneration) return
         const current = currentTableRequest()
         if (!current.active && current.mode === 'server') return
@@ -381,13 +383,13 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
     const staleSupport = supportGeneration !== undefined && supportGeneration !== authorityGeneration
     const staleServerPage = serverPageGeneration !== undefined && serverPageGeneration !== authorityGeneration
     const staleServerRequest = !(current.active || current.mode === 'client') && !tableRequestIsCurrent(requestID, request)
-    if (!mounted || staleWalk || staleSupport || staleServerPage || staleServerRequest) return
+    if (!mounted || contextGeneration.value !== expectedContext || staleWalk || staleSupport || staleServerPage || staleServerRequest) return
     error.value = isTenantMissingError(e) ? null : formatDatabricksError(e)
   } finally {
     fullWalkPending = false
     supportReadPending = false
     serverPageReadPending = false
-    if (refresh.isCurrent(requestID) && mode === 'foreground') loading.value = false
+    if (contextGeneration.value === expectedContext && refresh.isCurrent(requestID) && mode === 'foreground') loading.value = false
   }
 })
 onMounted(() => {
@@ -432,13 +434,18 @@ onUnmounted(() => {
       <button class="k-btn k-btn--ghost" type="button" @click="mutationError = null">Dismiss</button>
     </div>
 
-    <DatabricksEmptyState
-      v-if="showFirstRun"
-      kind="table"
-      :has-connections="connections.length > 0"
-      :has-warehouses="warehouses.length > 0"
-      @action="handleFirstRunAction"
-    />
+    <template v-if="showFirstRun">
+      <div v-if="error" class="error" role="status" aria-live="polite">
+        Showing the last successful result. {{ error }}
+        <button class="k-btn k-btn--ghost" type="button" @click="load">Retry</button>
+      </div>
+      <DatabricksEmptyState
+        kind="table"
+        :has-connections="connections.length > 0"
+        :has-warehouses="warehouses.length > 0"
+        @action="handleFirstRunAction"
+      />
+    </template>
 
     <div v-else class="databricks-resource-table">
       <ResourceTable

--- a/providers/databricks/portal/src/views/WarehousesView.vue
+++ b/providers/databricks/portal/src/views/WarehousesView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, onActivated, onMounted, onUnmounted, ref } from 'vue'
+import { computed, inject, onActivated, onMounted, onUnmounted, ref } from 'vue'
 import DatabricksEmptyState from '../components/DatabricksEmptyState.vue'
+import { contextGenerationKey } from '../context'
 import SplitCreateButton from '../components/SplitCreateButton.vue'
 import type { DatabricksJourneyAction, DatabricksPrerequisiteKind } from '../journey'
 import ResourceTable from '../portalkit/ResourceTable.vue'
@@ -43,6 +44,7 @@ const emit = defineEmits<{
   (e: 'create', mode: 'manual' | 'browse'): void
   (e: 'prerequisite', kind: DatabricksPrerequisiteKind): void
 }>()
+const contextGeneration = inject(contextGenerationKey, ref(0))
 
 const connections = ref<Connection[]>([])
 const warehouses = ref<Warehouse[]>([])
@@ -91,7 +93,6 @@ const rows = computed<Array<Record<string, unknown>>>(() => warehouses.value
 const firstPageSettled = ref(false)
 const pendingDeletions = new Map<string, string | undefined>()
 const showFirstRun = computed(() => firstPageSettled.value
-  && !error.value
   && rows.value.length === 0
   && warehousePage.value === 1
   && !hasActiveFilters(warehouseQuery.value, warehouseFiltersValue.value))
@@ -283,6 +284,7 @@ async function remove(row: Record<string, unknown>) {
 }
 
 refresh = createLatestRefreshController(async (requestID, mode) => {
+  const expectedContext = contextGeneration.value
   const request = currentWarehouseRequest()
   let walkGeneration: number | undefined
   let supportGeneration: number | undefined
@@ -298,7 +300,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
     supportGeneration = authorityGeneration
     const availableConnections = await supportRead.request()
     supportReadPending = false
-    if (!mounted || supportGeneration !== authorityGeneration) return
+    if (!mounted || contextGeneration.value !== expectedContext || supportGeneration !== authorityGeneration) return
     connections.value = availableConnections
 
     const currentAfterSupport = currentWarehouseRequest()
@@ -306,7 +308,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
       fullWalkPending = true
       walkGeneration = authorityGeneration
       const warehouseList = await completeRead.request()
-      if (!mounted) return
+      if (!mounted || contextGeneration.value !== expectedContext) return
       if (walkGeneration !== authorityGeneration) return
       const current = currentWarehouseRequest()
       if (!current.active && current.mode === 'server') return
@@ -327,7 +329,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
       serverPageGeneration = authorityGeneration
       const warehousePageResult = await serverPageRead.request()
       serverPageReadPending = false
-      if (!mounted || serverPageGeneration !== authorityGeneration) return
+      if (!mounted || contextGeneration.value !== expectedContext || serverPageGeneration !== authorityGeneration) return
       const currentAfterPage = currentWarehouseRequest()
       const currentIsActive = currentAfterPage.active || currentAfterPage.mode === 'client'
       const nextPageInfo = toPageInfo(warehousePageResult.continue)
@@ -343,7 +345,7 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
         fullWalkPending = true
         walkGeneration = authorityGeneration
         const warehouseList = await completeRead.request()
-        if (!mounted) return
+        if (!mounted || contextGeneration.value !== expectedContext) return
         if (walkGeneration !== authorityGeneration) return
         const current = currentWarehouseRequest()
         if (!current.active && current.mode === 'server') return
@@ -400,13 +402,13 @@ refresh = createLatestRefreshController(async (requestID, mode) => {
     const staleSupport = supportGeneration !== undefined && supportGeneration !== authorityGeneration
     const staleServerPage = serverPageGeneration !== undefined && serverPageGeneration !== authorityGeneration
     const staleServerRequest = !(current.active || current.mode === 'client') && !warehouseRequestIsCurrent(requestID, request)
-    if (!mounted || staleWalk || staleSupport || staleServerPage || staleServerRequest) return
+    if (!mounted || contextGeneration.value !== expectedContext || staleWalk || staleSupport || staleServerPage || staleServerRequest) return
     error.value = isTenantMissingError(e) ? null : formatDatabricksError(e)
   } finally {
     fullWalkPending = false
     supportReadPending = false
     serverPageReadPending = false
-    if (refresh.isCurrent(requestID)) {
+    if (contextGeneration.value === expectedContext && refresh.isCurrent(requestID)) {
       if (mode === 'foreground') loading.value = false
       poll.schedule()
     }
@@ -451,12 +453,17 @@ onUnmounted(() => {
       <button class="k-btn k-btn--ghost" type="button" @click="mutationError = null">Dismiss</button>
     </div>
 
-    <DatabricksEmptyState
-      v-if="showFirstRun"
-      kind="warehouse"
-      :has-connections="connections.length > 0"
-      @action="handleFirstRunAction"
-    />
+    <template v-if="showFirstRun">
+      <div v-if="error" class="error" role="status" aria-live="polite">
+        Showing the last successful result. {{ error }}
+        <button class="k-btn k-btn--ghost" type="button" @click="load">Retry</button>
+      </div>
+      <DatabricksEmptyState
+        kind="warehouse"
+        :has-connections="connections.length > 0"
+        @action="handleFirstRunAction"
+      />
+    </template>
 
     <div v-else class="databricks-resource-table">
       <ResourceTable


### PR DESCRIPTION
## Summary
- add request-generation fencing for stale contexts
- retain useful snapshots through background failures with distinct initial/stale error states and Retry
- cap dashboard geometry at three columns and use shared touch/action recipes

## Verification
- red-first stale request and snapshot tests
- 139 portal tests, typecheck, and Makefile build
- design/PortalKit/UI conformance gates
- independent review

Stack 4 of 9.