### PR TITLE
Provider conformance 5/9: Infrastructure navigation authority

### DIFF
--- a/providers/infrastructure/portal/src/App.vue
+++ b/providers/infrastructure/portal/src/App.vue
@@ -5,11 +5,11 @@ import ProvisionPage from './views/ProvisionPage.vue'
 import InstanceListPage from './views/InstanceListPage.vue'
 import InstanceDetailPage from './views/InstanceDetailPage.vue'
 import MissingCredentialsPage from './views/MissingCredentialsPage.vue'
-import Tabs from './portalkit/Tabs.vue'
 import ConfirmDialog from './portalkit/ConfirmDialog.vue'
 import { resolveConfirm } from './portalkit/confirm'
 import { setBasePath, setTenant, setToken } from './api'
 import { createResourceTombstones } from './refresh'
+import { legacyInfrastructurePath, parseInfrastructureSubPath } from './routes'
 import type { FarosContext } from './types'
 import { useDelayedLoading } from './portalkit/useDelayedLoading'
 
@@ -32,38 +32,7 @@ import { useDelayedLoading } from './portalkit/useDelayedLoading'
 
 const props = defineProps<{ ctx: FarosContext | null }>()
 
-interface Route {
-  page: 'templates' | 'instances' | 'missing-credentials'
-  id?: string
-}
-
-function decodeSegment(value: string): string {
-  try {
-    return decodeURIComponent(value)
-  } catch {
-    return value
-  }
-}
-
-function parseSubPath(sub: string | null | undefined): Route {
-  const s = (sub ?? '').replace(/^\/+|\/+$/g, '')
-  if (s === '' || s === 'templates') return { page: 'templates' }
-  if (s === 'instances') return { page: 'instances' }
-  if (s === 'missing-credentials') return { page: 'missing-credentials' }
-  const [head, ...rest] = s.split('/')
-  if (head === 'templates' && rest.length) return { page: 'templates', id: decodeSegment(rest.join('/')) }
-  if (head === 'instances' && rest.length) return { page: 'instances', id: decodeSegment(rest.join('/')) }
-  // Unknown sub-path: fall back to templates rather than 404'ing —
-  // the shell's URL might have stale segments from a prior provider.
-  return { page: 'templates' }
-}
-
-const route = computed<Route>(() => parseSubPath(props.ctx?.subPath))
-const sectionTabs = [
-  { id: 'templates', label: 'Templates' },
-  { id: 'instances', label: 'Instances' },
-] as const
-const activeSection = computed(() => route.value.page === 'instances' ? 'instances' : 'templates')
+const route = computed(() => parseInfrastructureSubPath(props.ctx?.subPath))
 const tenantPath = computed(() => props.ctx?.tenant ?? null)
 const contextInitialized = computed(() => props.ctx !== null)
 const contextPending = computed(() => !contextInitialized.value)
@@ -110,31 +79,12 @@ function navigate(path: string) {
   el.dispatchEvent(new CustomEvent('faros-navigate', { detail: { path }, bubbles: true }))
 }
 
-function selectSection(section: string) {
-  if (section === 'templates' || section === 'instances') navigate(section)
-}
-
 // Bridge legacy navigate('catalog' | 'provision' | 'instances' | 'detail' | 'missing-credentials')
 // emits from the existing view components — they were written before URL
 // routing existed. Maps each legacy verb to the new path scheme so we
 // don't have to edit every child to know about the new contract.
 function legacyNavigate(view: string) {
-  switch (view) {
-    case 'catalog':
-    case 'templates':
-      navigate('templates')
-      break
-    case 'instances':
-      navigate('instances')
-      break
-    case 'missing-credentials':
-      navigate('missing-credentials')
-      break
-    // 'provision' / 'detail' are reached by selectTemplate / selectInstance below
-    // — they always come with an ID, never as a bare view name.
-    default:
-      navigate(view)
-  }
+  navigate(legacyInfrastructurePath(view))
 }
 
 function selectTemplate(name: string) {
@@ -150,14 +100,6 @@ function provisioned(name: string) {
 
 <template>
   <div ref="rootRef" class="app">
-    <Tabs
-      v-if="contextInitialized && tenantPath"
-      class="infra-tabs"
-      :tabs="sectionTabs"
-      :active="activeSection"
-      aria-label="Infrastructure sections"
-      @select="selectSection"
-    />
     <!--
       Every routed page calls into api.ts on mount, which queries the
       /graphql/<tenant> gateway. Without a tenant the call

--- a/providers/infrastructure/portal/src/compositionConformance.test.mjs
+++ b/providers/infrastructure/portal/src/compositionConformance.test.mjs
@@ -9,9 +9,9 @@ const viewValue = readFileSync(new URL('./components/ViewValue.vue', import.meta
 const templateCard = readFileSync(new URL('./components/TemplateCard.vue', import.meta.url), 'utf8')
 
 describe('Infrastructure composition contracts', () => {
-  it('separates provider tabs from routed page content', () => {
-    expect(app).toContain('class="infra-tabs"')
-    expect(styles).toMatch(/\.infra-tabs \{[\s\S]*margin-bottom: 16px;/)
+  it('does not recreate manifest-owned navigation inside the provider', () => {
+    expect(app).not.toContain('class="infra-tabs"')
+    expect(styles).not.toContain('.infra-tabs')
   })
 
   it('adds deliberate columns for wide template catalogs', () => {

--- a/providers/infrastructure/portal/src/provisionWorkflowConformance.test.ts
+++ b/providers/infrastructure/portal/src/provisionWorkflowConformance.test.ts
@@ -6,10 +6,12 @@ const provision = readFileSync(new URL('./views/ProvisionPage.vue', import.meta.
 const detail = readFileSync(new URL('./views/InstanceDetailPage.vue', import.meta.url), 'utf8')
 
 describe('Infrastructure primary provisioning workflow', () => {
-  it('keeps Templates and Instances navigation present across routed pages', () => {
-    expect(app).toContain("{ id: 'templates', label: 'Templates' }")
-    expect(app).toContain("{ id: 'instances', label: 'Instances' }")
-    expect(app).toMatch(/<Tabs[\s\S]*:active="activeSection"[\s\S]*@select="selectSection"/)
+  it('leaves primary section navigation to the manifest-owned shell', () => {
+    expect(app).not.toContain("import Tabs from './portalkit/Tabs.vue'")
+    expect(app).not.toContain('sectionTabs')
+    expect(app).not.toContain('activeSection')
+    expect(app).toContain("new CustomEvent('faros-navigate'")
+    expect(app).toContain('parseInfrastructureSubPath(props.ctx?.subPath)')
   })
 
   it('uses one bounded, authoritative instance name', () => {

--- a/providers/infrastructure/portal/src/routes.test.ts
+++ b/providers/infrastructure/portal/src/routes.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { legacyInfrastructurePath, parseInfrastructureSubPath } from './routes'
+
+describe('Infrastructure provider routes', () => {
+  it('preserves list, direct detail, and browser-history paths from the shell', () => {
+    expect(parseInfrastructureSubPath('')).toEqual({ page: 'templates' })
+    expect(parseInfrastructureSubPath('/templates/')).toEqual({ page: 'templates' })
+    expect(parseInfrastructureSubPath('instances')).toEqual({ page: 'instances' })
+    expect(parseInfrastructureSubPath('templates/postgres%2Fha')).toEqual({ page: 'templates', id: 'postgres/ha' })
+    expect(parseInfrastructureSubPath('instances/demo%20instance')).toEqual({ page: 'instances', id: 'demo instance' })
+    expect(parseInfrastructureSubPath('missing-credentials')).toEqual({ page: 'missing-credentials' })
+  })
+
+  it('keeps malformed and stale shell paths safe', () => {
+    expect(parseInfrastructureSubPath('templates/bad%2')).toEqual({ page: 'templates', id: 'bad%2' })
+    expect(parseInfrastructureSubPath('retired-section')).toEqual({ page: 'templates' })
+  })
+
+  it('translates legacy child events without taking navigation authority', () => {
+    expect(legacyInfrastructurePath('catalog')).toBe('templates')
+    expect(legacyInfrastructurePath('templates')).toBe('templates')
+    expect(legacyInfrastructurePath('instances')).toBe('instances')
+    expect(legacyInfrastructurePath('missing-credentials')).toBe('missing-credentials')
+    expect(legacyInfrastructurePath('instances/demo')).toBe('instances/demo')
+  })
+})

--- a/providers/infrastructure/portal/src/routes.ts
+++ b/providers/infrastructure/portal/src/routes.ts
@@ -1,0 +1,37 @@
+export interface InfrastructureRoute {
+  page: 'templates' | 'instances' | 'missing-credentials'
+  id?: string
+}
+
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+export function parseInfrastructureSubPath(sub: string | null | undefined): InfrastructureRoute {
+  const path = (sub ?? '').replace(/^\/+|\/+$/g, '')
+  if (path === '' || path === 'templates') return { page: 'templates' }
+  if (path === 'instances') return { page: 'instances' }
+  if (path === 'missing-credentials') return { page: 'missing-credentials' }
+  const [head, ...rest] = path.split('/')
+  if (head === 'templates' && rest.length) return { page: 'templates', id: decodeSegment(rest.join('/')) }
+  if (head === 'instances' && rest.length) return { page: 'instances', id: decodeSegment(rest.join('/')) }
+  return { page: 'templates' }
+}
+
+export function legacyInfrastructurePath(view: string): string {
+  switch (view) {
+    case 'catalog':
+    case 'templates':
+      return 'templates'
+    case 'instances':
+      return 'instances'
+    case 'missing-credentials':
+      return 'missing-credentials'
+    default:
+      return view
+  }
+}

--- a/providers/infrastructure/portal/src/style.css
+++ b/providers/infrastructure/portal/src/style.css
@@ -20,12 +20,6 @@ faros-provider-infrastructure .page {
   gap: 16px;
 }
 
-/* Separate provider navigation from the routed page using the same major
- * rhythm as the page's own content groups. */
-faros-provider-infrastructure .infra-tabs {
-  margin-bottom: 16px;
-}
-
 faros-provider-infrastructure .page-head {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## Summary
- remove duplicate Templates/Instances local tabs
- keep manifest-owned shell navigation authoritative
- preserve direct links, history, detail routes, and legacy route translation

## Verification
- Infrastructure navigation authority tests
- portal full suite/typecheck/build
- design/PortalKit/UI conformance gates
- independent review

Stack 5 of 9.