### PR TITLE
Provider conformance 9/9: Kuery shared semantics

### DIFF
--- a/providers/kuery/portal/browser/kuery.spec.ts
+++ b/providers/kuery/portal/browser/kuery.spec.ts
@@ -154,6 +154,10 @@ test('dashboard tile uses shared semantics while preserving escaping and navigat
   await expect(page.locator('.k-dashboard-tile')).toHaveCount(1)
   await expect(row).toHaveClass(/k-dashboard-tile__row/)
   await expect(row).toHaveAttribute('data-edge', 'edge-<one>&')
+  expect(await page.locator('.k-dashboard-tile__list').evaluate(element => {
+    const style = getComputedStyle(element)
+    return { listStyle: style.listStyleType, margin: style.margin, padding: style.padding }
+  })).toEqual({ listStyle: 'none', margin: '0px', padding: '0px' })
   await row.click()
   expect(await page.evaluate(() => (window as typeof window & { tileNavigation?: unknown }).tileNavigation)).toEqual({ path: '' })
 })

--- a/providers/kuery/portal/browser/kuery.spec.ts
+++ b/providers/kuery/portal/browser/kuery.spec.ts
@@ -112,3 +112,48 @@ test('narrow inventory filters reflow without clipping', async ({ page }, testIn
   await expect(page.locator('.CodeMirror')).toBeVisible()
   expect(await page.locator('.CodeMirror').evaluate(element => getComputedStyle(element).backgroundColor)).toBe('rgb(241, 241, 246)')
 })
+
+for (const viewport of [
+  { name: 'mobile', width: 390, height: 844 },
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: '4k', width: 3840, height: 2160 },
+] as const) {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`${viewport.name} ${theme} tabs retain labels, icons, and viewport bounds`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height })
+      await mountKuery(page, theme)
+
+      const tabs = page.getByRole('navigation', { name: 'Kuery views' })
+      await expect(tabs.getByRole('button')).toHaveCount(3)
+      await expect(tabs.locator('.k-tab__icon svg')).toHaveCount(3)
+      expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true)
+    })
+  }
+}
+
+test('dashboard tile uses shared semantics while preserving escaping and navigation', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.route('**/api/edges', route => route.fulfill({ json: { edges: ['edge-<one>&'] } }))
+  await page.setContent(`<!doctype html><html class="light"><head><base href="https://kuery.test/"></head><body>
+    <faros-dashboard-tile-kuery id="tile"></faros-dashboard-tile-kuery>
+  </body></html>`)
+  await page.addScriptTag({ path: asset('main.js') })
+  await page.locator('#tile').evaluate(element => {
+    const target = element as HTMLElement & { farosContext: unknown }
+    ;(window as typeof window & { tileNavigation?: unknown }).tileNavigation = null
+    target.addEventListener('faros-navigate', event => {
+      ;(window as typeof window & { tileNavigation?: unknown }).tileNavigation = (event as CustomEvent).detail
+    })
+    target.farosContext = {
+      basePath: '/ui/providers/kuery/', token: 'test-token', tenant: 'root:faros:tenant', orgUUID: 'org', workspaceUUID: 'workspace', theme: 'light',
+    }
+  })
+
+  const row = page.getByRole('button', { name: 'edge-<one>&' })
+  await expect(row).toBeVisible()
+  await expect(page.locator('.k-dashboard-tile')).toHaveCount(1)
+  await expect(row).toHaveClass(/k-dashboard-tile__row/)
+  await expect(row).toHaveAttribute('data-edge', 'edge-<one>&')
+  await row.click()
+  expect(await page.evaluate(() => (window as typeof window & { tileNavigation?: unknown }).tileNavigation)).toEqual({ path: '' })
+})

--- a/providers/kuery/portal/element.contract.test.mjs
+++ b/providers/kuery/portal/element.contract.test.mjs
@@ -21,7 +21,11 @@ test('the provider contract is a thin reactive light-DOM Vue mount', () => {
 })
 
 test('top-level navigation and inventory use PortalKit contracts', () => {
+  assert.match(app, /import \{ Braces, Network, TableProperties \} from 'lucide-vue-next'/u)
   assert.match(app, /import Tabs from '\.\/portalkit\/Tabs\.vue'/u)
+  assert.match(app, /\{ id: 'topology', label: 'Topology', icon: Network \}/u)
+  assert.match(app, /\{ id: 'inventory', label: 'Inventory', icon: TableProperties \}/u)
+  assert.match(app, /\{ id: 'playground', label: 'Playground', icon: Braces \}/u)
   assert.match(app, /<Tabs[^>]*:active="active"/u)
   assert.match(inventory, /import ResourceTable from '\.\.\/portalkit\/ResourceTable\.vue'/u)
   assert.match(inventory, /pageSize: request\.pageSize, cursor: request\.cursor, count: true, filters: request\.filters/u)
@@ -107,6 +111,7 @@ test('Kuery requests share one context-derived transport contract', () => {
 })
 
 test('dashboard tile fences post-await writes to mounted context and request', () => {
+  assert.match(tile, /dashboardTileSemanticClass/u)
   assert.match(tile, /private _contextGeneration = 0/u)
   assert.match(tile, /private _connected = false/u)
   assert.match(tile, /const generation = this\._contextGeneration/u)
@@ -117,5 +122,13 @@ test('dashboard tile fences post-await writes to mounted context and request', (
   assert.match(tile, /if \(!isCurrent\(\)\) return[\s\S]*this\._loading = false/u)
   assert.match(tile, /this\._contextGeneration \+= 1[\s\S]*this\._poller\?\.stop\(\)/u)
   assert.match(tile, /class="kuery-tile-live" role="status" aria-live="polite" aria-atomic="true"/u)
+  assert.match(tile, /dashboardTileSemanticClass\.root/u)
+  assert.match(tile, /dashboardTileSemanticClass\.row/u)
+  assert.match(tile, /dashboardTileSemanticClass\.empty/u)
+  assert.match(styles, /faros-dashboard-tile-kuery \{ display: block; font-size: 13px; \}/u)
+  assert.match(styles, /\.kuery-tile-dot--success \{ background: var\(--color-success\); \}/u)
+  assert.doesNotMatch(styles, /\.kuery-tile-(?:stats|stat|label|rows|name|chev|more|empty|msg|err)\b/u)
+  assert.match(tile, /data-edge="\$\{escapeHTML\(name\)\}"/u)
+  assert.match(tile, /el\.addEventListener\('click', \(\) => this\._navigate\(''\)\)/u)
   assert.match(tile, /if \(html === this\._lastHTML\) return false/u)
 })

--- a/providers/kuery/portal/src/App.vue
+++ b/providers/kuery/portal/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { Braces, Network, TableProperties } from 'lucide-vue-next'
 
 import type { ObjectResult } from './api'
 import type { FarosContext } from './element'
@@ -27,9 +28,9 @@ let edgesController: AbortController | null = null
 let edgesRequestID = 0
 
 const tabs = [
-  { id: 'topology', label: 'Topology' },
-  { id: 'inventory', label: 'Inventory' },
-  { id: 'playground', label: 'Playground' },
+  { id: 'topology', label: 'Topology', icon: Network },
+  { id: 'inventory', label: 'Inventory', icon: TableProperties },
+  { id: 'playground', label: 'Playground', icon: Braces },
 ]
 
 function selectTab(id: string): void {

--- a/providers/kuery/portal/src/dashboard-tile.ts
+++ b/providers/kuery/portal/src/dashboard-tile.ts
@@ -8,13 +8,13 @@
 // returns nothing) and it is honest about scope: the edge lifecycle belongs to
 // the edges provider's tile, not this one.
 //
-// Plain DOM, mirroring portalkit/dashboardtile's tileClass — this portal ships
-// no renderer and no Tailwind build.
+// Plain DOM using portalkit's framework-neutral dashboard tile semantics.
 
 import { ic } from './portalkit/icons'
 import {
   TILE_ROWS,
   createTilePoller,
+  dashboardTileSemanticClass,
   hasWorkspaceContext,
   isBenignTileError,
   tileErrorText,
@@ -106,38 +106,38 @@ export class KueryDashboardTile extends HTMLElement {
 
   private _render(): void {
     if (this._loading) {
-      this._commit('<div class="kuery-tile-msg" role="status" aria-live="polite" aria-atomic="true">Loading edges…</div>')
+      this._commit(`<div class="${dashboardTileSemanticClass.message}" role="status" aria-live="polite" aria-atomic="true">Loading edges…</div>`)
       return
     }
     if (this._error) {
-      this._commit(`<div class="kuery-tile-err" role="alert">Failed to load: ${escapeHTML(this._error)}</div>`)
+      this._commit(`<div class="${dashboardTileSemanticClass.error}" role="alert">Failed to load: ${escapeHTML(this._error)}</div>`)
       return
     }
 
     const rows = this._edges.slice(0, TILE_ROWS)
     const more = this._edges.length - rows.length
-    const stats = `<span class="kuery-tile-stat">${ic('search')}<strong>${this._edges.length}</strong> ${
+    const stats = `<span class="${dashboardTileSemanticClass.stat} ${dashboardTileSemanticClass.statTotal}">${ic('search', dashboardTileSemanticClass.statIcon)}<strong class="${dashboardTileSemanticClass.statNum}">${this._edges.length}</strong> <span class="${dashboardTileSemanticClass.statLabel}">${
       this._edges.length === 1 ? 'edge queryable' : 'edges queryable'
-    }</span>`
+    }</span></span>`
 
     const body = rows.length
       ? `<div>
-           <div class="kuery-tile-label">Edges</div>
-           <ul class="kuery-tile-rows">${rows
+           <div class="${dashboardTileSemanticClass.sectionLabel}">Edges</div>
+           <ul class="${dashboardTileSemanticClass.list}">${rows
              .map(
-               (name) => `<li><button type="button" data-edge="${escapeHTML(name)}">
-                 <span class="kuery-tile-dot"></span>
-                 <span class="kuery-tile-name">${escapeHTML(name)}</span>
+               (name) => `<li><button type="button" class="${dashboardTileSemanticClass.row}" data-edge="${escapeHTML(name)}">
+                 <span class="${dashboardTileSemanticClass.rowDot} kuery-tile-dot--success"></span>
+                 <span class="${dashboardTileSemanticClass.rowPrimary}">${escapeHTML(name)}</span>
                  ${chevron()}
                </button></li>`,
              )
              .join('')}</ul>
-           ${more > 0 ? `<div class="kuery-tile-more">+${more} more</div>` : ''}
+           ${more > 0 ? `<div class="${dashboardTileSemanticClass.rowSecondary}">+${more} more</div>` : ''}
          </div>`
-      : `<p class="kuery-tile-empty">No edges to query yet — enroll one in Edges first.</p>`
+      : `<p class="${dashboardTileSemanticClass.empty}">No edges to query yet — enroll one in Edges first.</p>`
 
     const liveText = `${this._edges.length} ${this._edges.length === 1 ? 'edge is' : 'edges are'} queryable.`
-    const html = `<span class="kuery-tile-live" role="status" aria-live="polite" aria-atomic="true">${liveText}</span><div class="kuery-tile"><div class="kuery-tile-stats">${stats}</div>${body}</div>`
+    const html = `<span class="kuery-tile-live" role="status" aria-live="polite" aria-atomic="true">${liveText}</span><div class="${dashboardTileSemanticClass.root}"><div class="${dashboardTileSemanticClass.stats}">${stats}</div>${body}</div>`
     if (!this._commit(html)) return
 
     for (const el of Array.from(this.querySelectorAll<HTMLButtonElement>('button[data-edge]'))) {
@@ -156,7 +156,7 @@ export class KueryDashboardTile extends HTMLElement {
 }
 
 function chevron(): string {
-  return `<svg class="kuery-tile-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>`
+  return `<svg class="${dashboardTileSemanticClass.chevron}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>`
 }
 
 // Edge names come from the API and land in an HTML string, so escape them.

--- a/providers/kuery/portal/src/style.css
+++ b/providers/kuery/portal/src/style.css
@@ -544,61 +544,10 @@ faros-provider-kuery .legend-swatch {
   flex: none;
 }
 
-/* --- dashboard tile (console dashboard card) ------------------------------
-   Mirrors portalkit/dashboardtile.ts `tileClass`; this portal has no Tailwind
-   build, so the shared vocabulary is restated. Keep the two in step. */
+/* --- dashboard tile (console dashboard card) --------------------------- */
 faros-dashboard-tile-kuery { display: block; font-size: 13px; }
 faros-dashboard-tile-kuery .kuery-tile-live {
   position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
   overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
 }
-faros-dashboard-tile-kuery .kuery-tile { display: flex; flex-direction: column; gap: 12px; }
-faros-dashboard-tile-kuery .kuery-tile-stats {
-  display: flex; flex-wrap: wrap; align-items: center; gap: 4px 12px; font-size: 11px;
-  color: var(--color-text-muted, #5d5f78);
-}
-faros-dashboard-tile-kuery .kuery-tile-stat { display: inline-flex; align-items: center; gap: 4px; }
-/* `ic()` supplies the canonical k-icon class; the attribute selector scopes
-   this tile's size without redeclaring the shared .k-icon recipe. */
-faros-dashboard-tile-kuery .kuery-tile-stat [class~="k-icon"] { width: 12px; height: 12px; flex: none; }
-faros-dashboard-tile-kuery .kuery-tile-stat strong {
-  font-weight: 620; font-variant-numeric: tabular-nums; color: var(--color-text-primary);
-}
-faros-dashboard-tile-kuery .kuery-tile-label {
-  margin-bottom: 8px; font-size: 10px; font-weight: 600; text-transform: uppercase;
-  letter-spacing: 0.12em; color: var(--color-text-muted, #5d5f78);
-}
-faros-dashboard-tile-kuery .kuery-tile-rows { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
-faros-dashboard-tile-kuery .kuery-tile-rows button {
-  display: flex; width: 100%; align-items: center; gap: 8px; padding: 6px 10px;
-  border-radius: 4px; text-align: left; cursor: pointer; font: inherit; color: inherit;
-  border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
-  background: color-mix(in srgb, var(--color-surface-overlay, #171927) 40%, transparent);
-  transition: background-color 0.12s;
-}
-faros-dashboard-tile-kuery .kuery-tile-rows button:hover {
-  background: color-mix(in srgb, var(--color-accent, #8b6bff) 4%, transparent);
-}
-faros-dashboard-tile-kuery .kuery-tile-dot {
-  width: 6px; height: 6px; flex: none; border-radius: 9999px;
-  background: var(--color-success);
-}
-faros-dashboard-tile-kuery .kuery-tile-name {
-  min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  font-size: 12px; color: var(--color-text-primary);
-}
-faros-dashboard-tile-kuery .kuery-tile-chev {
-  width: 12px; height: 12px; flex: none; color: var(--color-text-muted, #5d5f78); opacity: 0.3;
-  transition: transform 0.12s, opacity 0.12s, color 0.12s;
-}
-faros-dashboard-tile-kuery .kuery-tile-rows button:hover .kuery-tile-chev {
-  transform: translateX(2px); opacity: 0.6; color: var(--color-accent, #8b6bff);
-}
-faros-dashboard-tile-kuery .kuery-tile-more { margin-top: 6px; font-size: 10px; color: var(--color-text-muted, #5d5f78); }
-faros-dashboard-tile-kuery .kuery-tile-empty {
-  padding: 12px; border-radius: 6px; text-align: center; font-size: 11px;
-  border: 1px dashed var(--color-border-subtle, rgba(255, 255, 255, 0.07));
-  color: var(--color-text-muted, #5d5f78);
-}
-faros-dashboard-tile-kuery .kuery-tile-msg { font-size: 11px; color: var(--color-text-muted, #5d5f78); }
-faros-dashboard-tile-kuery .kuery-tile-err { font-size: 11px; color: var(--color-danger); }
+faros-dashboard-tile-kuery .kuery-tile-dot--success { background: var(--color-success); }


### PR DESCRIPTION
## Summary
- add icon-plus-label Topology, Inventory, and Playground tabs
- migrate dashboard markup to framework-neutral PortalKit semantic classes
- preserve graph, fonts, inventory width, polling, escaping, and navigation

## Verification
- 39 portal tests, typecheck, and Makefile build
- 9 Playwright checks across 390, 1440, and 3840 widths in light/dark, including tile escaping/navigation/computed list reset
- design/PortalKit/UI conformance gates
- independent whole-stack review

Stack 9 of 9.