### PR TITLE
feat(hub): delegated tokens for platform providers behind a flag

### DIFF
--- a/cmd/faros-hub/main.go
+++ b/cmd/faros-hub/main.go
@@ -76,6 +76,13 @@ func main() {
 	cmd.Flags().StringSliceVar(&opts.Providers, "providers", providers.BuiltinNames(),
 		"First-party providers to enable as CatalogEntries (comma-separated or repeat). "+
 			"Defaults to all known builtins. Dependencies are enforced — e.g. mcp requires server-edges.")
+	cmd.Flags().StringVar(&opts.ProviderDelegatedTokens, "provider-delegated-tokens", opts.ProviderDelegatedTokens,
+		"Which providers receive a short-lived workspace-scoped ServiceAccount token instead of the caller's own bearer on /services/providers/*: "+
+			"off (platform providers get the caller's bearer; org-owned providers are always delegated), "+
+			"platform (also platform providers, except --provider-delegated-tokens-exclude), or all (every platform provider). "+
+			"Default off for this release; the next release defaults to platform.")
+	cmd.Flags().StringSliceVar(&opts.ProviderDelegatedTokensExclude, "provider-delegated-tokens-exclude", opts.ProviderDelegatedTokensExclude,
+		"Platform providers that keep receiving the caller's bearer under --provider-delegated-tokens=platform (comma-separated or repeat).")
 
 	cmd.Flags().StringVar(&opts.ProviderHeartbeatAuth, "provider-heartbeat-auth", opts.ProviderHeartbeatAuth, "What to do with a provider heartbeat whose bearer token does not verify as that provider's own service account: warn (log and accept) or enforce (reject). Default warn for this release; the next release defaults to enforce.")
 	cmd.Flags().BoolVar(&opts.ProviderWorkspaceClusterAdmin, "provider-workspace-cluster-admin", opts.ProviderWorkspaceClusterAdmin,

--- a/docs/hub-proxy-workspace-access.md
+++ b/docs/hub-proxy-workspace-access.md
@@ -293,6 +293,40 @@ the hub REST handlers.
   faros terms as `{id}:{edgeName}`, authorized by the parent workspace's
   membership (A-3).
 
+## Delegated tokens on the provider backend proxy
+
+**Implemented**, and worth reading alongside A-6 because it is the same
+mechanism pointed the other way.
+
+A-6 says a ServiceAccount token is authorized only in the cluster its own claim
+names — the token *is* the scope. The provider backend proxy now uses that
+property deliberately: instead of forwarding the caller's hub bearer (which A-1
+lets reach *every* workspace they are a member of), it mints a ServiceAccount in
+the caller's **current** workspace and sends that
+(`pkg/hub/serviceaccounts/delegated_user_token.go`,
+`pkg/hub/providers/proxy.go`, `proxy_edge.go`). A provider that calls back into
+the hub with it lands on the SA path in A-6, pinned to that one workspace, and
+the tenant resolver maps the account back to the human for `X-Faros-User`
+(`pkg/hub/provider_tenant_resolver.go`).
+
+So the two halves compose: A-1 widens what a **user's own** token may address to
+the workspaces they belong to; delegation narrows what a **provider acting for
+them** may address to the one workspace the request was made in. The blast radius
+of a compromised or buggy provider stops being "everything this user can reach".
+
+- Org-owned providers always receive the delegated token.
+- Platform providers follow `--provider-delegated-tokens=off|platform|all`
+  (default `off` this release, `platform` next), with
+  `--provider-delegated-tokens-exclude` for backends that cannot use one.
+- Every failure is closed — no path falls back to forwarding the bearer.
+- A request with no workspace selection (`X-Faros-Workspace`) cannot be
+  delegated and is refused. This follows A-1's "no bare-path default": with no
+  workspace selector there is nothing to authorize against, so the answer is a
+  refusal rather than a guess.
+
+Per-provider verdicts and the flag's semantics are in
+[provider-scoping.md](./provider-scoping.md#delegated-tokens--what-credential-a-provider-receives).
+
 ## Open questions
 
 None outstanding — the design decisions above cover the proposal. Remaining work

--- a/docs/provider-scoping.md
+++ b/docs/provider-scoping.md
@@ -245,6 +245,86 @@ no permission-claim dialog, one-click — but never an auto-bind.
 
 ---
 
+## Delegated tokens — what credential a provider receives
+
+**Implemented.** Separate from *which* copy of a provider a request reaches
+(above), there is the question of *what credential* crosses when it gets there.
+
+The backend proxy used to forward the caller's own `Authorization` header to
+every provider. That header is a full hub credential: it reaches every workspace
+the user is a member of and every REST endpoint they can call. A provider needs
+far less — it acts in one workspace, on the caller's behalf.
+
+A **delegated user token** replaces it: a ServiceAccount token minted by the hub
+in the caller's *current* workspace (`faros-du-<hash>` in `default`,
+`pkg/hub/serviceaccounts/delegated_user_token.go`), audience-bound, ten minutes
+long, bound to the same role the caller holds there, and annotated with the human
+it stands in for. `X-Faros-User` / `X-Faros-Tenant` / `X-Faros-Cluster` are
+unchanged, so a provider still attributes work to the person. A provider calling
+back into the hub with it resolves to that person
+(`pkg/hub/provider_tenant_resolver.go`).
+
+Who gets one:
+
+| Provider scope | Credential |
+|---|---|
+| Org-owned (`root:faros:tenants:{org}:providers:{name}`) | **Always** the delegated token. Its backend runs in a tenant's own cluster; the caller's hub bearer must never cross that line. |
+| Platform (`root:faros:providers`) | Per `--provider-delegated-tokens`. |
+
+`--provider-delegated-tokens=off|platform|all` (hub flag, `pkg/hub/options.go`):
+
+- `off` — platform providers receive the caller's bearer, as they always have.
+  **The default for this release.**
+- `platform` — platform providers receive the delegated token, except those
+  named in `--provider-delegated-tokens-exclude` (default: `edges`). **The
+  default from the next release**; run it now to confirm your providers need
+  nothing beyond `/clusters/{id}` access.
+- `all` — every platform provider, exclusion list ignored.
+
+Fail-closed on every path, same as the org-owned one: an unresolvable caller or
+a caller with no workspace selection is refused (403), a missing issuer or a mint
+error is a 503. Nothing falls back to forwarding the bearer. Anonymous requests
+(health probes) carry no credential and are forwarded as-is.
+
+**Requests need a workspace.** The delegated account lives in a team workspace,
+so a request made in the portal's organization-only mode (no `X-Faros-Workspace`)
+has nowhere to mint one and is refused. Org workspaces are hub-mediated only
+(P-2 / O-10) and kcp will not honour an SA token bound there, so minting in the
+org workspace is not an option. In practice the portal's provider frames require
+a selected workspace before they mount, and `portalkit`'s `tenantHeaders()` sends
+both headers.
+
+### Per-provider audit
+
+Every consumer of the forwarded bearer, and whether a workspace-scoped SA token
+serves it. The recurring answer is yes, because no provider parses the bearer as
+a JWT — a repo-wide search for `ParseUnverified` / `jwt.Parse` / `ParseSigned`
+under `providers/` and `provider-sdk/` finds nothing that inspects the *caller's*
+token — and every provider takes identity from `X-Faros-User` / `X-Faros-Tenant`
+instead.
+
+| Consumer | What it does with the bearer | Verdict |
+|---|---|---|
+| `provider-sdk/tenantaccess` `NewClient` | `rest.Config{Host: {hub}/clusters/{id}, BearerToken: …}` | **Works.** Also never fed a caller bearer today — its four callers pass a reconciler-minted SA token. |
+| `providers/infrastructure/dataplane/identity.go`, `authorizer.go` | `SelfSubjectAccessReview` on `<resource>/exec`, plus a caller-scoped instance GET | **Works.** SSAR asks "what can *this* credential do", so the delegated SA's workspace role is evaluated, matching the user's. No username or groups are supplied. |
+| `providers/infrastructure/tenant/`, `providers/code/tenant/` | `{hub}/clusters/{X-Faros-Cluster}` dynamic + authorization clients | **Works.** Opaque credential; the provider's own kubeconfig credentials are deliberately dropped from the config. |
+| `providers/edges` — tunnel, k8s subresource, `services/{name}/proxy` | TokenReview then SAR (`verb: proxy`) through the APIExport VW for the addressed cluster | **Works.** A delegated token authenticates in the workspace that minted it — the same one being addressed — keeps its groups, and its `cluster-admin` binding passes the SAR. Already exercised: the org-provider tunnel carries delegated tokens today. |
+| `providers/edges` — SSH with `spec.sshUserMapping: identity` | TokenReview'd username becomes the **Linux login name** | **Breaks.** Resolves to `system:serviceaccount:default:faros-du-<hash>`, which is not the human's account. `edges` is therefore in the default exclusion list. Lifting it means taking that identity from `X-Faros-User`. |
+| `providers/app-studio` | GraphQL as the caller; one raw `{hub}/clusters/{id}` DELETE; forwards the bearer to the hub MCP aggregate, to provider action routes, and to the infrastructure data plane | **Works.** All hops are hub surfaces that accept an SA token; each re-forwards `X-Faros-*` alongside. |
+| `providers/agents` (`tenant/graphql.go`) | `{hub}/graphql/{cluster}` as the caller; forwards it to the edges MCP endpoint and the infrastructure data plane | **Works.** Its own TokenReview/SAR path is the *s2s* endpoint, which is not hub-proxied and is unaffected. |
+| `providers/databricks` | `{hub}/clusters/{id}` client + SSAR per action | **Works.** The Databricks-facing PAT is a workspace Secret, unrelated to the caller's bearer. |
+| `providers/kuery`, `providers/quickstart` | Echo the token's length/fingerprint only | **Works.** Neither uses it as a credential. |
+| Hub GraphQL gateway (`/graphql/{cluster}`, `pkg/hub/graphql.go`) | Passes the token to the gateway, which dials `{front-proxy}/clusters/{cluster}` as the caller | **Works.** kcp pins an SA token to its own cluster claim, which is the workspace the delegated account was minted in. |
+
+Two consequences worth stating. First, a delegated token is **pinned to one
+workspace** by kcp, so a provider that (today) could follow the caller's bearer
+into another of their workspaces no longer can — that is the point of the change,
+but it will surface as a 403 in any provider that was relying on it. Second,
+several providers hold the caller's credential past the request (`agents` for the
+lifetime of a detached run, `app-studio` for a sandbox's lifetime, `databricks`
+in a 10-minute client cache); with delegation on, what they hold expires in ten
+minutes and is scoped to one workspace instead of being a live hub credential.
+
 ## Proxy gating
 
 `/services/providers/{slug}` and `/ui/providers/{slug}` need the active

--- a/pkg/hub/options.go
+++ b/pkg/hub/options.go
@@ -75,6 +75,28 @@ type Options struct {
 	DevMode          bool
 	StaticAuthTokens []string
 
+	// ProviderDelegatedTokens selects which providers receive a short-lived,
+	// workspace-scoped ServiceAccount token in place of the caller's own hub
+	// bearer on the backend proxy (/services/providers/{name}/*). Org-owned
+	// providers always receive the delegated token regardless of this
+	// setting; it governs platform providers only:
+	//
+	//   off      — platform providers receive the caller's bearer as-is
+	//              (the historical behaviour).
+	//   platform — platform providers receive the delegated token, except
+	//              the names in ProviderDelegatedTokensExclude.
+	//   all      — every platform provider receives the delegated token;
+	//              the exclusion list is ignored.
+	//
+	// Default "off" for this release. The next release defaults to
+	// "platform"; deployments should run "platform" ahead of that to
+	// confirm their providers need nothing beyond /clusters/{id} access.
+	ProviderDelegatedTokens string
+	// ProviderDelegatedTokensExclude names platform providers that keep
+	// receiving the caller's bearer under ProviderDelegatedTokens=platform.
+	// Defaults to providers.DefaultDelegationExclude.
+	ProviderDelegatedTokensExclude []string
+
 	// AdminUsers is the allowlist of platform-admin identities permitted to
 	// reach the /api/admin/* surface and the portal's /bonkers area. Each entry
 	// matches a User CR by name, email, or rbacIdentity (case-insensitive).
@@ -173,7 +195,9 @@ func NewOptions() *Options {
 
 		ProviderHeartbeatAuth: string(providers.HeartbeatAuthWarn),
 		// Wide for this release; the next one defaults to false. See the field.
-		ProviderWorkspaceClusterAdmin: true,
+		ProviderWorkspaceClusterAdmin:  true,
+		ProviderDelegatedTokens:        string(providers.DelegationOff),
+		ProviderDelegatedTokensExclude: append([]string(nil), providers.DefaultDelegationExclude...),
 
 		GraphQLAPIExportSliceName:      "core.faros.sh",
 		GraphQLAPIExportLogicalCluster: kcppaths.SystemControllers,

--- a/pkg/hub/providers/proxy.go
+++ b/pkg/hub/providers/proxy.go
@@ -89,10 +89,12 @@ func (f TenantResolverFunc) Resolve(r *http.Request) (string, string, error) {
 }
 
 // NewBackendProxy returns an http.Handler serving /services/providers/{name}/*
-// by reverse proxying to the provider's spec.backend.url. For a platform
-// provider the user's Authorization header is forwarded as-is; for an
-// org-owned provider it is replaced with a short-lived delegated token (see
-// serveOverEdge and SetDelegatedTokenIssuer). If a TenantResolver is
+// by reverse proxying to the provider's spec.backend.url. An org-owned
+// provider always has the user's Authorization header replaced with a
+// short-lived delegated token (see serveOverEdge and SetDelegatedTokenIssuer);
+// a platform provider gets the same treatment when the DelegationPolicy
+// selects it (SetDelegationPolicy) and the caller's bearer as-is otherwise.
+// If a TenantResolver is
 // installed via SetTenantResolver, the proxy resolves the caller's
 // identity and injects X-Faros-User + X-Faros-Tenant so the provider can
 // scope work without re-parsing the bearer token. Incoming
@@ -258,10 +260,16 @@ type ProviderProxy struct {
 	clusterResolver func(ctx context.Context, tenantPath string) (string, error)
 
 	// delegatedIssuer mints the token that replaces the caller's bearer on
-	// requests to org-owned providers. Nil means the org-provider path fails
-	// closed: the hub never forwards a user's hub token into a tenant's
-	// cluster. See SetDelegatedTokenIssuer and serveOverEdge.
+	// requests to org-owned providers, and to platform providers when
+	// delegation selects them. Nil means those paths fail closed: the hub
+	// never forwards a user's hub token where a delegated one was required.
+	// See SetDelegatedTokenIssuer, serveOverEdge, and delegatedAuthorization.
 	delegatedIssuer DelegatedTokenIssuer
+
+	// delegation decides which platform providers have the caller's bearer
+	// swapped for a delegated token. Zero value is DelegationOff. See
+	// SetDelegationPolicy.
+	delegation DelegationPolicy
 
 	// denyHubOnlyEndpoints reserves the hub-only path prefixes on a
 	// provider's backend origin. Provider action routes (/actions/*) are a
@@ -363,6 +371,22 @@ func (p *ProviderProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A platform provider is dialled directly, and historically received the
+	// caller's own bearer. Under a delegating policy it gets the same
+	// workspace-scoped token an org-owned provider does; the decision to
+	// substitute is made here, before the proxy is built, so every failure
+	// refuses the request rather than falling back to the bearer. The UI
+	// proxy never enters this branch: it serves assets, and its requests
+	// carry no credential to protect.
+	substitute := !p.fallbackForSPA && p.delegation.DelegatesPlatform(prov.Name)
+	delegated := ""
+	if substitute {
+		var ok bool
+		if delegated, ok = p.delegatedAuthorization(w, r, prov); !ok {
+			return
+		}
+	}
+
 	basePath := p.pathPrefix + "/" + name
 
 	rp := &httputil.ReverseProxy{
@@ -384,6 +408,15 @@ func (p *ProviderProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			req.URL.RawPath = "" // let net/url re-encode from Path
 			req.Host = target.Host
 			p.setHeaders(req, name, basePath)
+			if substitute {
+				// Same boundary as serveOverEdge: the caller's hub token
+				// stops here. The provider receives the delegated token,
+				// or nothing for an anonymous probe.
+				req.Header.Del("Authorization")
+				if delegated != "" {
+					req.Header.Set("Authorization", "Bearer "+delegated)
+				}
+			}
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			p.log.Error(err, "upstream error", "provider", name, "target", target.String())

--- a/pkg/hub/providers/proxy_delegation.go
+++ b/pkg/hub/providers/proxy_delegation.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DelegationMode selects which providers receive a delegated ServiceAccount
+// token in place of the caller's own hub bearer on the backend proxy.
+//
+// Org-owned providers are never a question of mode: they always receive the
+// delegated token (see serveOverEdge). The mode decides what a PLATFORM
+// provider — one in root:faros:providers, dialled directly by the hub — gets.
+type DelegationMode string
+
+const (
+	// DelegationOff forwards the caller's hub bearer to platform providers
+	// as-is. This is the historical behaviour and the default for this
+	// release.
+	DelegationOff DelegationMode = "off"
+	// DelegationPlatform swaps the bearer for a delegated token on every
+	// platform provider except those listed in DelegationPolicy.Exclude.
+	DelegationPlatform DelegationMode = "platform"
+	// DelegationAll swaps the bearer on every platform provider and ignores
+	// the exclusion list. For deployments that have verified — or do not
+	// run — the providers the default exclusion covers.
+	DelegationAll DelegationMode = "all"
+)
+
+// ParseDelegationMode accepts the flag spelling of a DelegationMode. An empty
+// string is DelegationOff so an unset option behaves like the default.
+func ParseDelegationMode(s string) (DelegationMode, error) {
+	switch m := DelegationMode(strings.ToLower(strings.TrimSpace(s))); m {
+	case "":
+		return DelegationOff, nil
+	case DelegationOff, DelegationPlatform, DelegationAll:
+		return m, nil
+	default:
+		return "", fmt.Errorf("unknown provider delegated-tokens mode %q (want off, platform, or all)", s)
+	}
+}
+
+// DefaultDelegationExclude is the built-in exclusion list for
+// DelegationPlatform: platform providers whose backend cannot act on a
+// workspace-scoped ServiceAccount token. See docs/provider-scoping.md
+// "Delegated tokens" for the per-provider verdicts behind this list.
+//
+// edges: its SSH data plane resolves the caller's identity with a TokenReview
+// and, for an edge with spec.sshUserMapping=identity, uses the resulting
+// username as the Linux user to log in as
+// (providers/edges/internal/tunnel/edges_proxy_builder.go fetchSSHCredentials).
+// A delegated token resolves to system:serviceaccount:default:faros-du-<hash>,
+// which is not the human's account and is not a login name on any host, so the
+// session would be refused or land on the wrong user. Everything else in edges
+// — the tunnel, the k8s subresource, the Service proxy — works with a
+// delegated token and already receives one on the org-owned provider path
+// (serveOverEdge). Lifting this needs the SSH path to take its identity from
+// X-Faros-User (which the hub still sends) rather than from the bearer.
+var DefaultDelegationExclude = []string{EdgesProviderName}
+
+// DelegationPolicy is the backend proxy's answer to "does this platform
+// provider get the caller's bearer or a delegated token?".
+type DelegationPolicy struct {
+	Mode DelegationMode
+	// Exclude names platform providers that keep receiving the caller's
+	// bearer under DelegationPlatform. Ignored under DelegationAll. Matching
+	// is exact on the provider name.
+	Exclude []string
+}
+
+// DelegatesPlatform reports whether the platform provider name should have the
+// caller's bearer replaced with a delegated token.
+func (pol DelegationPolicy) DelegatesPlatform(name string) bool {
+	switch pol.Mode {
+	case DelegationAll:
+		return true
+	case DelegationPlatform:
+		for _, excluded := range pol.Exclude {
+			if strings.TrimSpace(excluded) == name {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// SetDelegationPolicy installs the platform-provider delegation policy. Wire
+// alongside SetDelegatedTokenIssuer; without a call the proxy stays at
+// DelegationOff. Only the backend proxy consults it — the UI proxy carries no
+// credential to substitute.
+func (p *ProviderProxy) SetDelegationPolicy(pol DelegationPolicy) {
+	p.delegation = pol
+}

--- a/pkg/hub/providers/proxy_delegation_test.go
+++ b/pkg/hub/providers/proxy_delegation_test.go
@@ -1,0 +1,343 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package providers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// platformUpstream stands in for a platform provider's backend and records the
+// credential and identity headers the hub sent it.
+type platformUpstream struct {
+	hit           bool
+	authorization string
+	user          string
+	tenant        string
+}
+
+// newPlatformProxy builds a backend proxy in front of one platform provider,
+// resolving the caller to root:faros:tenants:{org}[:{ws}].
+func newPlatformProxy(t *testing.T, name, wsOfCaller string) (*ProviderProxy, *platformUpstream) {
+	t.Helper()
+	rec := &platformUpstream{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.hit = true
+		rec.authorization = r.Header.Get("Authorization")
+		rec.user = r.Header.Get("X-Faros-User")
+		rec.tenant = r.Header.Get("X-Faros-Tenant")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	backendURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: name, BackendURL: backendURL, EndpointsValid: true})
+
+	proxy := NewBackendProxy(reg, logr.Discard())
+	proxy.SetTenantResolver(TenantResolverFunc(func(*http.Request) (string, string, error) {
+		path := "root:faros:tenants:" + testOrg
+		if wsOfCaller != "" {
+			path += ":" + wsOfCaller
+		}
+		return "alice", path, nil
+	}))
+	return proxy, rec
+}
+
+// off is the default and the behaviour every deployment has today: the caller's
+// own hub bearer reaches a platform provider untouched. Changing that silently
+// would break any provider that has not been confirmed to work with an SA
+// token, so the flag has to be opt-in for this release.
+func TestPlatformDelegationOffForwardsTheCallerBearer(t *testing.T) {
+	for _, pol := range []struct {
+		name   string
+		policy *DelegationPolicy
+	}{
+		{"unset policy", nil},
+		{"explicit off", &DelegationPolicy{Mode: DelegationOff}},
+		{"off ignores the exclude list", &DelegationPolicy{Mode: DelegationOff, Exclude: []string{"other"}}},
+	} {
+		t.Run(pol.name, func(t *testing.T) {
+			proxy, rec := newPlatformProxy(t, "infrastructure", testWS)
+			issuer := &recordingIssuer{}
+			proxy.SetDelegatedTokenIssuer(issuer)
+			if pol.policy != nil {
+				proxy.SetDelegationPolicy(*pol.policy)
+			}
+
+			serveProxy(proxy, "/services/providers/infrastructure/x")
+
+			if rec.authorization != "Bearer "+callerBearer {
+				t.Errorf("Authorization = %q, want the caller's bearer", rec.authorization)
+			}
+			if issuer.calls != 0 {
+				t.Error("a delegated token was minted with delegation off")
+			}
+		})
+	}
+}
+
+// The change this PR exists for: under platform mode a platform provider gets
+// the same workspace-scoped token an org-owned one does, and the caller's hub
+// bearer — good for every workspace and REST endpoint they can reach — stops at
+// the hub. The identity headers are unchanged, because that is what providers
+// attribute work with.
+func TestPlatformDelegationSwapsTheBearer(t *testing.T) {
+	for _, mode := range []DelegationMode{DelegationPlatform, DelegationAll} {
+		t.Run(string(mode), func(t *testing.T) {
+			proxy, rec := newPlatformProxy(t, "infrastructure", testWS)
+			issuer := &recordingIssuer{}
+			proxy.SetDelegatedTokenIssuer(issuer)
+			proxy.SetDelegationPolicy(DelegationPolicy{Mode: mode})
+
+			w := serveProxy(proxy, "/services/providers/infrastructure/dataplane/x")
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (body %q)", w.Code, w.Body.String())
+			}
+			if rec.authorization != "Bearer "+delegatedToken {
+				t.Errorf("Authorization = %q, want the delegated token", rec.authorization)
+			}
+			if strings.Contains(rec.authorization, callerBearer) {
+				t.Error("the caller's hub bearer reached a platform provider")
+			}
+			if rec.user != "alice" || rec.tenant != "root:faros:tenants:"+testOrg+":"+testWS {
+				t.Errorf("identity headers = (%q, %q), want the caller's — providers attribute work with them", rec.user, rec.tenant)
+			}
+			if issuer.calls != 1 || issuer.org != testOrg || issuer.ws != testWS || issuer.user != "alice" || issuer.provider != "infrastructure" {
+				t.Errorf("issuer asked for %+v, want (org=%s, ws=%s, user=alice, provider=infrastructure) once", issuer, testOrg, testWS)
+			}
+		})
+	}
+}
+
+// A provider that cannot act on an SA token is named in the exclusion list
+// rather than left half-working. edges is there by default: its SSH data plane
+// maps the Linux login name from the TokenReview'd caller identity.
+func TestPlatformDelegationHonoursTheExclusionList(t *testing.T) {
+	t.Run("excluded provider keeps the caller bearer", func(t *testing.T) {
+		proxy, rec := newPlatformProxy(t, EdgesProviderName, testWS)
+		issuer := &recordingIssuer{}
+		proxy.SetDelegatedTokenIssuer(issuer)
+		proxy.SetDelegationPolicy(DelegationPolicy{Mode: DelegationPlatform, Exclude: DefaultDelegationExclude})
+
+		serveProxy(proxy, "/services/providers/edges/edgeproxy/x")
+
+		if rec.authorization != "Bearer "+callerBearer {
+			t.Errorf("Authorization = %q, want the caller's bearer for an excluded provider", rec.authorization)
+		}
+		if issuer.calls != 0 {
+			t.Error("a delegated token was minted for an excluded provider")
+		}
+	})
+
+	t.Run("all ignores the exclusion list", func(t *testing.T) {
+		proxy, rec := newPlatformProxy(t, EdgesProviderName, testWS)
+		proxy.SetDelegatedTokenIssuer(&recordingIssuer{})
+		proxy.SetDelegationPolicy(DelegationPolicy{Mode: DelegationAll, Exclude: DefaultDelegationExclude})
+
+		serveProxy(proxy, "/services/providers/edges/edgeproxy/x")
+
+		if rec.authorization != "Bearer "+delegatedToken {
+			t.Errorf("Authorization = %q, want the delegated token under mode=all", rec.authorization)
+		}
+	})
+
+	t.Run("a non-excluded provider is unaffected", func(t *testing.T) {
+		proxy, rec := newPlatformProxy(t, "infrastructure", testWS)
+		proxy.SetDelegatedTokenIssuer(&recordingIssuer{})
+		proxy.SetDelegationPolicy(DelegationPolicy{Mode: DelegationPlatform, Exclude: DefaultDelegationExclude})
+
+		serveProxy(proxy, "/services/providers/infrastructure/x")
+
+		if rec.authorization != "Bearer "+delegatedToken {
+			t.Errorf("Authorization = %q, want the delegated token", rec.authorization)
+		}
+	})
+}
+
+// Same property as the org path, now for platform providers: whatever goes
+// wrong on the hub, the caller's hub token is not what gets forwarded. Each
+// failure refuses outright rather than falling back to the bearer.
+func TestPlatformDelegationFailsClosed(t *testing.T) {
+	const path = "/services/providers/infrastructure/dataplane/x"
+
+	t.Run("no issuer wired", func(t *testing.T) {
+		proxy, rec := newPlatformProxy(t, "infrastructure", testWS)
+		proxy.SetDelegationPolicy(DelegationPolicy{Mode: DelegationPlatform})
+		if w := serveProxy(proxy, path); w.Code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", w.Code)
+		}
+		if rec.hit {
+			t.Fatalf("request forwarded with Authorization %q despite no issuer", rec.authorization)
+		}
+	})
+
+	t.Run("issuer fails", func(t *testing.T) {
+		proxy, rec := newPlatformProxy(t, "infrastructure", testWS)
+		proxy.SetDelegatedTokenIssuer(&recordingIssuer{err: errors.New("kcp unavailable")})
+		proxy.SetDelegationPolicy(DelegationPolicy{Mode: DelegationPlatform})
+		if w := serveProxy(proxy, path); w.Code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", w.Code)
+		}
+		if rec.hit {
+			t.Fatalf("request forwarded with Authorization %q despite mint failure", rec.authorization)
+		}
+	})
+
+	t.Run("org-scope caller with no workspace", func(t *testing.T) {
+		// The delegated account lives in a team workspace; an org-scope
+		// selection has nowhere to mint it, and kcp seals Org workspaces
+		// anyway (O-10). Refuse rather than proceed with the bearer.
+		proxy, rec := newPlatformProxy(t, "infrastructure", "")
+		proxy.SetDelegatedTokenIssuer(&recordingIssuer{})
+		proxy.SetDelegationPolicy(DelegationPolicy{Mode: DelegationPlatform})
+		if w := serveProxy(proxy, path); w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", w.Code)
+		}
+		if rec.hit {
+			t.Fatalf("request forwarded with Authorization %q despite no workspace", rec.authorization)
+		}
+	})
+
+	t.Run("caller identity unresolved", func(t *testing.T) {
+		proxy, rec := newPlatformProxy(t, "infrastructure", testWS)
+		proxy.SetDelegatedTokenIssuer(&recordingIssuer{})
+		proxy.SetDelegationPolicy(DelegationPolicy{Mode: DelegationPlatform})
+		proxy.SetTenantResolver(TenantResolverFunc(func(*http.Request) (string, string, error) {
+			return "", "", errors.New("token verify failed")
+		}))
+		if w := serveProxy(proxy, path); w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", w.Code)
+		}
+		if rec.hit {
+			t.Fatalf("request forwarded with Authorization %q despite unresolved identity", rec.authorization)
+		}
+	})
+}
+
+// Health probes carry no credential to protect, and refusing them would take
+// every platform provider's /healthz down the moment the flag is turned on.
+func TestPlatformDelegationLetsAnonymousProbesThrough(t *testing.T) {
+	proxy, rec := newPlatformProxy(t, "infrastructure", testWS)
+	issuer := &recordingIssuer{}
+	proxy.SetDelegatedTokenIssuer(issuer)
+	proxy.SetDelegationPolicy(DelegationPolicy{Mode: DelegationPlatform})
+
+	w := httptest.NewRecorder()
+	proxy.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/services/providers/infrastructure/healthz", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", w.Code, w.Body.String())
+	}
+	if !rec.hit || rec.authorization != "" {
+		t.Errorf("anonymous probe forwarded with Authorization %q (hit=%v)", rec.authorization, rec.hit)
+	}
+	if issuer.calls != 0 {
+		t.Error("a delegated token was minted for an anonymous request")
+	}
+}
+
+// The UI proxy serves static assets and has no credential to substitute. It
+// must not start refusing asset loads (403/503) when the flag is on — the
+// portal would render provider cards without icons.
+func TestUIProxyIgnoresTheDelegationPolicy(t *testing.T) {
+	var gotAuthorization string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+	uiURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse UI URL: %v", err)
+	}
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "infrastructure", UIURL: uiURL, EndpointsValid: true})
+	proxy := NewUIProxy(reg, logr.Discard())
+	proxy.SetDelegationPolicy(DelegationPolicy{Mode: DelegationAll})
+
+	w := serveProxy(proxy, "/ui/providers/infrastructure/main.js")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", w.Code, w.Body.String())
+	}
+	if gotAuthorization != "Bearer "+callerBearer {
+		t.Errorf("Authorization = %q, want the request untouched by the delegation policy", gotAuthorization)
+	}
+}
+
+func TestParseDelegationMode(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		want    DelegationMode
+		wantErr bool
+	}{
+		{"", DelegationOff, false},
+		{"off", DelegationOff, false},
+		{"platform", DelegationPlatform, false},
+		{"all", DelegationAll, false},
+		{"  Platform  ", DelegationPlatform, false},
+		{"ALL", DelegationAll, false},
+		{"on", "", true},
+		{"true", "", true},
+		{"org", "", true},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseDelegationMode(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseDelegationMode(%q) = %q, want an error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseDelegationMode(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("ParseDelegationMode(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDelegationPolicyDelegatesPlatform(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		policy DelegationPolicy
+		who    string
+		want   bool
+	}{
+		{"zero value delegates nothing", DelegationPolicy{}, "infrastructure", false},
+		{"off", DelegationPolicy{Mode: DelegationOff}, "infrastructure", false},
+		{"platform", DelegationPolicy{Mode: DelegationPlatform}, "infrastructure", true},
+		{"platform, excluded", DelegationPolicy{Mode: DelegationPlatform, Exclude: []string{"edges"}}, "edges", false},
+		{"platform, exclusion is exact", DelegationPolicy{Mode: DelegationPlatform, Exclude: []string{"edge"}}, "edges", true},
+		{"platform, exclusion is trimmed", DelegationPolicy{Mode: DelegationPlatform, Exclude: []string{" edges "}}, "edges", false},
+		{"all overrides the exclusion", DelegationPolicy{Mode: DelegationAll, Exclude: []string{"edges"}}, "edges", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.policy.DelegatesPlatform(tc.who); got != tc.want {
+				t.Errorf("DelegatesPlatform(%q) = %v, want %v", tc.who, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/hub/providers/proxy_edge.go
+++ b/pkg/hub/providers/proxy_edge.go
@@ -98,20 +98,30 @@ func splitTenantPath(tenantPath string) (orgUUID, wsUUID string) {
 	return orgUUID, wsUUID
 }
 
-// delegatedAuthorization decides what Authorization an org-owned provider
-// receives for r, writing the response itself when the request must not go
-// on. It returns the delegated bearer, or "" for an anonymous caller (whose
-// request carried nothing to substitute), and whether to proceed.
+// delegatedAuthorization decides what Authorization a provider receives for r
+// when the caller's bearer must not reach it, writing the response itself when
+// the request must not go on. It returns the delegated bearer, or "" for an
+// anonymous caller (whose request carried nothing to substitute), and whether
+// to proceed.
 //
-// This is the boundary the whole file exists to hold: the far end of the
-// tunnel is a workload in a tenant's cluster, installed by whichever member
-// registered it, so the caller's own hub token — good for every workspace and
-// every REST endpoint they can reach — must never cross it. What crosses
-// instead is a ServiceAccount token scoped by kcp to the caller's current
-// workspace, carrying the caller's name in annotations for the provider to
-// attribute the call. Every failure here is closed: no identity, no
-// workspace, no issuer, or a mint error all refuse rather than fall back to
-// forwarding the bearer.
+// For an org-owned provider this is the boundary the whole file exists to
+// hold: the far end of the tunnel is a workload in a tenant's cluster,
+// installed by whichever member registered it, so the caller's own hub token —
+// good for every workspace and every REST endpoint they can reach — must never
+// cross it. A platform provider under a delegating policy (proxy_delegation.go)
+// gets the same treatment for the same reason in weaker form: it is trusted
+// code, but a bug in it should be able to act in one workspace, not as the
+// user everywhere. What crosses instead is a ServiceAccount token scoped by
+// kcp to the caller's current workspace, carrying the caller's name in
+// annotations for the provider to attribute the call. Every failure here is
+// closed: no identity, no workspace, no issuer, or a mint error all refuse
+// rather than fall back to forwarding the bearer.
+//
+// The delegated account is minted in the workspace the caller selected
+// (X-Faros-Workspace, verified against their membership by the resolver). An
+// org-scope selection has nowhere to mint it — org workspaces are sealed
+// (O-10) and the hub's SA proxy path refuses tokens bound there — so it is
+// refused for platform providers exactly as for org-owned ones.
 func (p *ProviderProxy) delegatedAuthorization(w http.ResponseWriter, r *http.Request, prov Provider) (string, bool) {
 	if strings.TrimSpace(r.Header.Get("Authorization")) == "" {
 		// Anonymous probe (health checks). There is no credential to
@@ -120,27 +130,34 @@ func (p *ProviderProxy) delegatedAuthorization(w http.ResponseWriter, r *http.Re
 	}
 	user, tenantPath, err := p.resolveCaller(r)
 	if err != nil || user == "" {
-		p.log.Info("refusing org-owned provider request: caller identity unresolved",
+		p.log.Info("refusing provider request: caller identity unresolved",
 			"provider", prov.Name, "org", prov.OrgUUID, "err", errString(err))
 		http.Error(w, "caller identity could not be established for provider: "+prov.Name, http.StatusForbidden)
 		return "", false
 	}
 	orgUUID, wsUUID := splitTenantPath(tenantPath)
-	if orgUUID == "" || orgUUID != prov.OrgUUID {
+	if orgUUID == "" {
+		http.Error(w, "caller has no tenant workspace to act from for provider: "+prov.Name, http.StatusForbidden)
+		return "", false
+	}
+	if prov.OrgUUID != "" && orgUUID != prov.OrgUUID {
 		// resolveProvider picked this provider from the same resolution, so a
-		// mismatch means the memo is not what routed us. Refuse.
+		// mismatch means the memo is not what routed us. Refuse. A platform
+		// provider has no owning org; the caller's own is where the token
+		// is minted.
 		http.Error(w, "caller is not in the organization that owns provider: "+prov.Name, http.StatusForbidden)
 		return "", false
 	}
 	if wsUUID == "" {
 		// The delegated account lives in a team workspace; an org-scope
 		// resolution (no X-Faros-Workspace) has nowhere to mint it. The portal
-		// always sends the workspace header on provider calls.
+		// sends the workspace header on provider calls whenever a workspace
+		// is selected.
 		http.Error(w, "a workspace selection (X-Faros-Workspace) is required to reach provider: "+prov.Name, http.StatusForbidden)
 		return "", false
 	}
 	if p.delegatedIssuer == nil {
-		p.log.Info("refusing org-owned provider request: no delegated token issuer wired",
+		p.log.Info("refusing provider request: no delegated token issuer wired",
 			"provider", prov.Name, "org", prov.OrgUUID)
 		http.Error(w, "delegated identity unavailable for provider: "+prov.Name, http.StatusServiceUnavailable)
 		return "", false

--- a/pkg/hub/providers/proxy_edge_test.go
+++ b/pkg/hub/providers/proxy_edge_test.go
@@ -267,9 +267,11 @@ func TestBackendProxyOrgProviderNeverSeesUserBearer(t *testing.T) {
 	})
 }
 
-// Step C of the remediation plan is deliberate future work: a platform
-// provider still receives the caller's own bearer. Pinning it keeps the
-// change to org-owned providers from silently widening.
+// A platform provider receives the caller's own bearer unless the delegation
+// policy says otherwise, which it does not by default (step C ships behind
+// --provider-delegated-tokens, default off; see proxy_delegation_test.go).
+// Pinning it here keeps an issuer being wired from silently widening what the
+// default configuration does.
 func TestBackendProxyPlatformProviderStillReceivesCallerBearer(t *testing.T) {
 	var gotAuthorization string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -119,6 +119,10 @@ func (s *Server) Run(ctx context.Context) error {
 	if err := kcp.ValidateProviders(s.opts.Providers); err != nil {
 		return err
 	}
+	delegationMode, err := providers.ParseDelegationMode(s.opts.ProviderDelegatedTokens)
+	if err != nil {
+		return err
+	}
 
 	var kcpConfig *rest.Config
 	var bootstrapper *kcp.Bootstrapper
@@ -744,6 +748,14 @@ func (s *Server) Run(ctx context.Context) error {
 			// the caller's workspace (pkg/hub/serviceaccounts
 			// delegated_user_token.go). Without this the org path refuses.
 			backendProxy.SetDelegatedTokenIssuer(serviceaccounts.NewManager(bootstrapper, delegatedProofKeys))
+			// Platform providers follow --provider-delegated-tokens: off keeps
+			// forwarding the caller's bearer, platform/all swap it for the
+			// same delegated token (pkg/hub/providers/proxy_delegation.go).
+			backendProxy.SetDelegationPolicy(providers.DelegationPolicy{
+				Mode:    delegationMode,
+				Exclude: s.opts.ProviderDelegatedTokensExclude,
+			})
+			logger.Info("provider delegated tokens", "mode", delegationMode, "exclude", s.opts.ProviderDelegatedTokensExclude)
 
 			// Step 10: Org / Workspace / Membership / User REST
 			apiMgr := restapi.NewManager(userClient, bootstrapper)

--- a/providers/edges/internal/tunnel/auth_test.go
+++ b/providers/edges/internal/tunnel/auth_test.go
@@ -1,0 +1,320 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/client-go/rest"
+)
+
+// The hub replaces a caller's own bearer with a delegated ServiceAccount token
+// before a request reaches a provider through the backend proxy — always for an
+// org-owned provider (which rides this provider's tunnel), and for platform
+// providers when --provider-delegated-tokens selects them. These tests pin what
+// authorize() does with such a token: it must resolve to a usable identity in
+// the workspace that minted it and pass the `proxy` SAR the tenant's RBAC
+// grants that account.
+
+// delegatedSAToken builds a token shaped like the one
+// pkg/hub/serviceaccounts.IssueDelegatedUserToken mints: a bound (TokenRequest)
+// ServiceAccount JWT, whose cluster lives in the NESTED kubernetes.io
+// claim and whose issuer is the kcp API server, not "kubernetes/serviceaccount".
+func delegatedSAToken(t *testing.T, cluster, name string) string {
+	t.Helper()
+	claims := map[string]any{
+		"iss": "https://kcp.default.svc",
+		"sub": "system:serviceaccount:default:" + name,
+		"kubernetes.io": map[string]any{
+			"clusterName":    cluster,
+			"namespace":      "default",
+			"serviceaccount": map[string]any{"name": name},
+		},
+	}
+	return encodeJWT(t, claims)
+}
+
+// legacySAToken builds the older, secret-backed kcp SA token shape: flat
+// clusterName claim and the "kubernetes/serviceaccount" issuer.
+func legacySAToken(t *testing.T, cluster, name string) string {
+	t.Helper()
+	return encodeJWT(t, map[string]any{
+		"iss": "kubernetes/serviceaccount",
+		"kubernetes.io/serviceaccount/clusterName":          cluster,
+		"kubernetes.io/serviceaccount/service-account.name": name,
+	})
+}
+
+func encodeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}
+
+// authRecorder is a fake kcp endpoint that answers TokenReview and
+// SubjectAccessReview, recording what it was asked. authorize() builds its own
+// clients from *rest.Config, so the only seam is the Host.
+type authRecorder struct {
+	// username / groups are what TokenReview reports back.
+	username string
+	groups   []string
+	// authenticated and allowed drive the two answers.
+	authenticated bool
+	allowed       bool
+
+	tokenReviewPaths []string
+	reviewedTokens   []string
+	sarPaths         []string
+	sarUsers         []string
+	sarGroups        [][]string
+	sarAttributes    []authorizationv1.ResourceAttributes
+}
+
+func (a *authRecorder) start(t *testing.T) *rest.Config {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/tokenreviews"):
+			var in authenticationv1.TokenReview
+			if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+				t.Errorf("decode TokenReview: %v", err)
+			}
+			a.tokenReviewPaths = append(a.tokenReviewPaths, r.URL.Path)
+			a.reviewedTokens = append(a.reviewedTokens, in.Spec.Token)
+			in.Status = authenticationv1.TokenReviewStatus{
+				Authenticated: a.authenticated,
+				User:          authenticationv1.UserInfo{Username: a.username, Groups: a.groups},
+			}
+			writeJSON(t, w, &in)
+		case strings.HasSuffix(r.URL.Path, "/subjectaccessreviews"):
+			var in authorizationv1.SubjectAccessReview
+			if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+				t.Errorf("decode SubjectAccessReview: %v", err)
+			}
+			a.sarPaths = append(a.sarPaths, r.URL.Path)
+			a.sarUsers = append(a.sarUsers, in.Spec.User)
+			a.sarGroups = append(a.sarGroups, in.Spec.Groups)
+			if in.Spec.ResourceAttributes != nil {
+				a.sarAttributes = append(a.sarAttributes, *in.Spec.ResourceAttributes)
+			}
+			in.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: a.allowed, Reason: "test"}
+			writeJSON(t, w, &in)
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return &rest.Config{Host: srv.URL}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, obj any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(obj); err != nil {
+		t.Errorf("encode response: %v", err)
+	}
+}
+
+// The delegated account lives in the caller's own team workspace, which is the
+// same workspace the request addresses. So the token is not "foreign": it
+// authenticates natively through the APIExport virtual workspace scoped to that
+// cluster, keeps its real groups, and is authorized under its plain
+// system:serviceaccount: name — the subject the hub's cluster-admin binding for
+// faros-du-* names.
+func TestAuthorizeAcceptsADelegatedUserToken(t *testing.T) {
+	const cluster = "260dym853j73uupr"
+	const sa = "faros-du-9f2c1a7b5e4d3c2b1a09"
+
+	rec := &authRecorder{
+		username:      "system:serviceaccount:default:" + sa,
+		groups:        []string{"system:serviceaccounts", "system:serviceaccounts:default", "system:authenticated"},
+		authenticated: true,
+		allowed:       true,
+	}
+	tenantCfg := rec.start(t)
+	// A distinct kcpConfig, so a test that wrongly took the foreign-SA branch
+	// would review against a server that is not running.
+	kcpCfg := &rest.Config{Host: "https://provider-workspace.invalid"}
+
+	token := delegatedSAToken(t, cluster, sa)
+	err := authorize(context.Background(), tenantCfg, kcpCfg, token, cluster,
+		"proxy", "edges.faros.sh", "services", "provider-infrastructure")
+	if err != nil {
+		t.Fatalf("authorize() = %v, want nil — a delegated token must reach an edge the caller may use", err)
+	}
+
+	if len(rec.tokenReviewPaths) != 1 || len(rec.sarPaths) != 1 {
+		t.Fatalf("got %d TokenReviews and %d SARs, want 1 each", len(rec.tokenReviewPaths), len(rec.sarPaths))
+	}
+	if rec.reviewedTokens[0] != token {
+		t.Error("TokenReview did not carry the delegated token")
+	}
+	// Both reviews go to the tenant config (the APIExport VW for the addressed
+	// cluster), never to the provider's own workspace.
+	if strings.Contains(rec.tokenReviewPaths[0], "provider-workspace") {
+		t.Errorf("TokenReview path %q, want the tenant VW", rec.tokenReviewPaths[0])
+	}
+	if got := rec.sarUsers[0]; got != "system:serviceaccount:default:"+sa {
+		t.Errorf("SAR user = %q, want the plain SA subject the workspace binding names", got)
+	}
+	if len(rec.sarGroups[0]) != len(rec.groups) {
+		t.Errorf("SAR groups = %v, want the reviewed groups kept for a workspace-local SA", rec.sarGroups[0])
+	}
+	want := authorizationv1.ResourceAttributes{
+		Verb: "proxy", Group: "edges.faros.sh", Version: "v1alpha1",
+		Resource: "services", Name: "provider-infrastructure",
+	}
+	if rec.sarAttributes[0] != want {
+		t.Errorf("SAR attributes = %+v, want %+v", rec.sarAttributes[0], want)
+	}
+}
+
+// The tenant's RBAC is the whole gate. A delegated token whose account has no
+// proxy grant on the named edge is refused, not waved through because the
+// credential authenticated.
+func TestAuthorizeRefusesADelegatedTokenWithoutTheProxyGrant(t *testing.T) {
+	const cluster = "260dym853j73uupr"
+	rec := &authRecorder{
+		username:      "system:serviceaccount:default:faros-du-9f2c1a7b5e4d3c2b1a09",
+		authenticated: true,
+		allowed:       false,
+	}
+	cfg := rec.start(t)
+
+	err := authorize(context.Background(), cfg, cfg, delegatedSAToken(t, cluster, "faros-du-9f2c1a7b5e4d3c2b1a09"), cluster,
+		"proxy", "edges.faros.sh", "linuxservers", "prod-eu")
+	if err == nil {
+		t.Fatal("authorize() = nil, want a denial when the SAR says no")
+	}
+	if !strings.Contains(err.Error(), "access denied") {
+		t.Errorf("err = %v, want an access-denied error", err)
+	}
+}
+
+func TestAuthorizeRefusesAnUnauthenticatedToken(t *testing.T) {
+	rec := &authRecorder{authenticated: false, allowed: true}
+	cfg := rec.start(t)
+
+	err := authorize(context.Background(), cfg, cfg, delegatedSAToken(t, "260dym853j73uupr", "faros-du-dead"), "260dym853j73uupr",
+		"proxy", "edges.faros.sh", "services", "svc")
+	if err == nil {
+		t.Fatal("authorize() = nil, want a refusal for an unauthenticated token")
+	}
+	if len(rec.sarPaths) != 0 {
+		t.Error("a SAR was issued for a token that did not authenticate")
+	}
+}
+
+// parseServiceAccountToken decides which workspace a token is reviewed in, so
+// the shapes it recognizes are load-bearing. A bound token — the shape
+// TokenRequest mints, and the shape every delegated token has — carries its
+// cluster in a nested claim under a different issuer, so it is deliberately NOT
+// treated as a foreign SA: it authenticates in the workspace being addressed,
+// which is where it was minted.
+func TestParseServiceAccountTokenShapes(t *testing.T) {
+	const cluster = "260dym853j73uupr"
+
+	t.Run("legacy secret-backed token is recognized", func(t *testing.T) {
+		claims, ok := parseServiceAccountToken(legacySAToken(t, cluster, "provider-edges"))
+		if !ok {
+			t.Fatal("legacy SA token not recognized")
+		}
+		if claims.ClusterName != cluster {
+			t.Errorf("ClusterName = %q, want %q", claims.ClusterName, cluster)
+		}
+	})
+
+	t.Run("bound delegated token is not a foreign SA", func(t *testing.T) {
+		if _, ok := parseServiceAccountToken(delegatedSAToken(t, cluster, "faros-du-abc")); ok {
+			t.Error("a bound delegated token was classed as a foreign SA; it would be reviewed in the wrong workspace")
+		}
+	})
+
+	t.Run("non-JWT credentials are not SA tokens", func(t *testing.T) {
+		for _, token := range []string{"", "opaque-static-token", "a.b", "not.base64!.sig"} {
+			if _, ok := parseServiceAccountToken(token); ok {
+				t.Errorf("parseServiceAccountToken(%q) reported an SA token", token)
+			}
+		}
+	})
+}
+
+// A legacy SA token minted somewhere else — the provider's own credential, say
+// — is reviewed in its home workspace and re-qualified before the SAR, so a
+// tenant's binding for their OWN "default" SA cannot be matched by a stranger's.
+func TestAuthorizeRequalifiesAForeignServiceAccount(t *testing.T) {
+	const consumer = "260dym853j73uupr"
+	const home = "1a2b3c4d5e6f7g8h"
+
+	rec := &authRecorder{
+		username:      "system:serviceaccount:default:provider-edges",
+		groups:        []string{"system:serviceaccounts"},
+		authenticated: true,
+		allowed:       true,
+	}
+	cfg := rec.start(t)
+
+	// Both configs point at the recorder so the foreign branch (which re-roots
+	// kcpConfig at the SA's home cluster) still reaches it.
+	if err := authorize(context.Background(), cfg, cfg, legacySAToken(t, home, "provider-edges"), consumer,
+		"proxy", "edges.faros.sh", "services", "svc"); err != nil {
+		t.Fatalf("authorize() = %v, want nil", err)
+	}
+
+	if got := rec.tokenReviewPaths[0]; !strings.Contains(got, "/clusters/"+home+"/") {
+		t.Errorf("TokenReview path = %q, want the SA's home cluster %q", got, home)
+	}
+	if got := rec.sarUsers[0]; got != "system:kcp:serviceaccount:"+home+":default:provider-edges" {
+		t.Errorf("SAR user = %q, want the cluster-qualified name", got)
+	}
+	if len(rec.sarGroups[0]) != 0 {
+		t.Errorf("SAR groups = %v, want none — a foreign SA must not match the tenant's own group bindings", rec.sarGroups[0])
+	}
+}
+
+// A foreign-looking token whose home workspace resolves it to a human is
+// refused rather than authorized under an identity that cannot be encoded
+// unambiguously.
+func TestAuthorizeRefusesAForeignTokenThatResolvesToANonServiceAccount(t *testing.T) {
+	rec := &authRecorder{username: "alice@example.com", authenticated: true, allowed: true}
+	cfg := rec.start(t)
+
+	err := authorize(context.Background(), cfg, cfg, legacySAToken(t, "1a2b3c4d5e6f7g8h", "x"), "260dym853j73uupr",
+		"proxy", "edges.faros.sh", "services", "svc")
+	if err == nil {
+		t.Fatal("authorize() = nil, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "expected ServiceAccount identity") {
+		t.Errorf("err = %v, want the identity-shape refusal", err)
+	}
+	if len(rec.sarPaths) != 0 {
+		t.Error("a SAR was issued for an identity that could not be qualified")
+	}
+}


### PR DESCRIPTION
**Stacked on #635 — must merge after it.** Base is `sec/1.2-delegated-tokens-for-org-providers`; the diff shown here is only step C on top of it.

Security remediation plan item 3.3 (step C of item 1.2, finding 2).

## Problem

#635 stopped forwarding the caller's hub bearer to **org-owned** providers, and pinned platform providers as unchanged (`TestBackendProxyPlatformProviderStillReceivesCallerBearer`). So `pkg/hub/providers/proxy.go` still hands a platform provider the caller's own `Authorization` header.

That header is a full hub credential. Under A-1 (`docs/hub-proxy-workspace-access.md`) it reaches every workspace the user is a member of, plus every hub REST endpoint they can call. A platform provider needs far less — it acts in one workspace, on the caller's behalf. The gap is not hypothetical retention-wise: `providers/agents` holds the caller's token for the lifetime of a detached run (`api/run.go` `HubToken`, resumed on `context.WithoutCancel`), `providers/app-studio` holds it for a sandbox's lifetime (`assistant_run_sandbox_core.go` `id identity`) and re-forwards it verbatim to the hub MCP aggregate and to other providers' action routes (`api/llm.go`, `api/integrations.go`), and `providers/databricks` caches clients built from it for 10 minutes (`tenant/client.go`). A bug or compromise in any of them acts as the user everywhere, not in the one workspace the request was made in.

## Change

**Flag.** `--provider-delegated-tokens=off|platform|all` plus `--provider-delegated-tokens-exclude` (`pkg/hub/options.go`, `cmd/faros-hub/main.go`). `off` is today's behaviour and this release's default; the doc comment and flag help both say the next release defaults to `platform`. Parsed once at startup before any expensive init, so a typo fails in milliseconds rather than after kcp boots.

**Policy type.** `pkg/hub/providers/proxy_delegation.go` — `DelegationMode`, `ParseDelegationMode`, `DelegationPolicy.DelegatesPlatform(name)`, and `DefaultDelegationExclude`. Kept separate from the proxy so the audit verdict behind the exclusion list lives next to the list itself. Zero value is `off`, so a proxy built without `SetDelegationPolicy` (every test, and any embedder) behaves exactly as before.

**Proxy.** The platform branch of `ServeHTTP` reuses step A's `delegatedAuthorization` before building the reverse proxy, and the Director deletes `Authorization` after `setHeaders` and sets the delegated bearer — the same two lines, in the same order, as `serveOverEdge`. `delegatedAuthorization` was generalised: the org-ownership check now only applies when `prov.OrgUUID != ""` (a platform provider has no owning org, so the token is minted in the *caller's* org), and a caller with no resolvable org is refused. Everything else is unchanged, including the 403/503 split. The UI proxy is excluded structurally (`!p.fallbackForSPA`), so asset loads cannot start 403ing when the flag is turned on.

**Workspace scope.** The delegated account is minted in the workspace the request targets (`X-Faros-Workspace`, verified against the caller's membership by the resolver before it becomes `X-Faros-Tenant`). Org-scope requests with no workspace header are refused with 403, as in step A. I checked whether platform providers legitimately receive org-scope requests today and concluded they do not: `portalkit`'s `tenantHeaders()` sends both headers, `stores/tenant.ts` normalises organization-only mode to `workspaceUUID = null`, and `ProviderFrame.vue` gates `accessAllowed` on a workspace being selected. Minting in the org workspace is not an option regardless — O-10 seals org workspaces and the hub's SA proxy path (`serveServiceAccount`) refuses a token whose cluster claim is one.

**Nothing under `providers/` or `provider-sdk/` changed** except a new test file.

## Compatibility

**Flag default is `off`** — no deployment changes behaviour on upgrade. Org-owned providers are unaffected either way: they always get the delegated token, as of #635.

**Rollout order.** Merge #635 → ship this with `off` → run `platform` in staging and confirm no provider 403s → flip production to `platform` → next release changes the default, at which point `off` remains available as an escape hatch.

**What each provider needs.** Per-consumer audit; the full table with file references is in `docs/provider-scoping.md`. The recurring answer is "nothing", because no provider parses the caller's bearer as a JWT (a repo-wide search for `ParseUnverified` / `jwt.Parse` / `ParseSigned` under `providers/` and `provider-sdk/` finds only tokens that are *not* the caller's) and every provider takes identity from `X-Faros-User`, which the hub still sends unchanged.

| Consumer | Bearer use | Verdict |
|---|---|---|
| `provider-sdk/tenantaccess` `NewClient` | `{hub}/clusters/{id}` client | **Works.** Also never fed a caller bearer today — its four callers pass a reconciler-minted SA token. |
| `providers/infrastructure/dataplane/identity.go` + `authorizer.go` | SSAR on `<resource>/exec`; caller-scoped instance GET as the access gate | **Works.** SSAR asks what *this* credential can do, so the delegated SA's workspace role is evaluated. No username/groups supplied; `X-Faros-User` is carried but ignored by the authorizer. |
| `providers/infrastructure/tenant/`, `providers/code/tenant/` | `{hub}/clusters/{X-Faros-Cluster}` dynamic + authorization clients, `BearerToken: token` | **Works.** Opaque credential; the provider's own kubeconfig credentials are deliberately dropped from the config. |
| `providers/edges` — tunnel, k8s subresource, `services/{name}/proxy` | TokenReview → SAR (`verb: proxy`) via the APIExport VW for the addressed cluster | **Works.** A delegated token authenticates in the workspace that minted it (= the one addressed), keeps its groups, and its binding passes the SAR. Already exercised in production shape: the org-provider tunnel carries delegated tokens as of #635. |
| `providers/edges` — SSH, `spec.sshUserMapping: identity` | TokenReview'd username becomes the **Linux login name** (`fetchSSHCredentials`) | **Breaks.** Would resolve to `system:serviceaccount:default:faros-du-<hash>`. **`edges` is in `DefaultDelegationExclude`** with a comment; fixing it means sourcing that identity from `X-Faros-User`. |
| `providers/app-studio` | GraphQL as caller; one raw `{hub}/clusters/{id}` DELETE; re-forwards the bearer to the hub MCP aggregate, provider action routes, infra data plane | **Works.** All hub surfaces that accept an SA token; each hop re-sends `X-Faros-*`. |
| `providers/agents` (`tenant/graphql.go`) | `{hub}/graphql/{cluster}`; forwards to edges MCP + infra data plane | **Works.** Its TokenReview/SAR path is the `/s2s` endpoint, which is not hub-proxied and is untouched. |
| `providers/databricks` | `{hub}/clusters/{id}` client + SSAR per action | **Works.** The Databricks PAT is a workspace Secret, unrelated to the caller's bearer. |
| `providers/kuery`, `providers/quickstart` | Echo token length / fingerprint only | **Works.** Neither uses it as a credential. |
| Hub GraphQL gateway `/graphql/{cluster}` (`pkg/hub/graphql.go`) | Token passed to the gateway, which dials `{front-proxy}/clusters/{cluster}` as the caller | **Works.** kcp pins an SA token to its own cluster claim — the workspace the account was minted in. |

**Two behaviour changes to expect under `platform`.** A delegated token is pinned by kcp to one workspace, so a provider that was following the caller's bearer into a *different* workspace of theirs now gets a 403 — that is the point, but it is the shape any breakage will take. And the credential those three providers retain past the request expires in ten minutes instead of being a live hub token.

## Tests

- `pkg/hub/providers/proxy_delegation_test.go` (new): `off` (unset policy, explicit off, off-with-exclusions) forwards the caller's bearer and mints nothing; `platform`/`all` swap it, never leak `callerBearer`, keep `X-Faros-User`/`X-Faros-Tenant`, and ask the issuer for exactly `(org, ws, user, provider)` once; the exclusion list is honoured under `platform`, ignored under `all`, matched exactly and trimmed; fail-closed for no issuer (503), mint error (503), org-scope caller with no workspace (403), unresolved caller (403), each asserting the upstream was never hit; anonymous probes still reach the provider with no credential; the UI proxy ignores the policy; plus table tests for `ParseDelegationMode` and `DelegatesPlatform`.
- `pkg/hub/providers/proxy_edge_test.go`: comment on `TestBackendProxyPlatformProviderStillReceivesCallerBearer` updated — it now pins the *default* configuration rather than "step C is future work". Assertions unchanged.
- `providers/edges/internal/tunnel/auth_test.go` (new — the package had no coverage of `auth.go`): a delegated SA token from the tenant workspace resolves to a usable identity and passes the `proxy` SAR on a Service the caller may reach, with both reviews going to the tenant VW rather than the provider's workspace and the SA's real groups kept; SAR denial and unauthenticated tokens are refused (no SAR issued in the latter); `parseServiceAccountToken` shape table showing a bound delegated token is deliberately *not* a foreign SA (so it is reviewed in the workspace that minted it) while the legacy secret-backed shape is; foreign-SA re-qualification to `system:kcp:serviceaccount:{home}:default:{name}` with groups dropped; and a foreign token resolving to a human is refused.

Commands, all green: `GOWORK=off go build ./...`, `GOWORK=off go vet ./pkg/...`, `GOWORK=off go test -count=1 ./pkg/hub/... ./pkg/server/...`, `cd providers/edges && GOWORK=off go build ./... && go vet ./... && go test -count=1 ./...`, `GOWORK=off make fix-lint && GOWORK=off make lint` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
