### PR TITLE
feat(hub): scope and rotate provider workspace credentials

### DIFF
--- a/apis/providers/v1alpha1/types_catalogentry.go
+++ b/apis/providers/v1alpha1/types_catalogentry.go
@@ -641,6 +641,20 @@ type CatalogEntryStatus struct {
 	// +optional
 	ReportedVersion string `json:"reportedVersion,omitempty"`
 
+	// CredentialsRotatedAt is when the hub last issued a NEW workspace
+	// credential for this provider's ServiceAccount
+	// (POST .../providers/{name}/credentials/rotate). Empty means the provider
+	// still holds the credential minted at registration.
+	//
+	// It is recorded here, on the object an operator already looks at, because
+	// the credential itself is returned once and never stored: without this
+	// there is nothing anywhere that says how old the token in a provider's
+	// Secret is. The previous credential keeps working for a grace period
+	// after this timestamp, so it also dates the window in which a rollout has
+	// to finish.
+	// +optional
+	CredentialsRotatedAt *metav1.Time `json:"credentialsRotatedAt,omitempty"`
+
 	// Conditions describe the current state of the provider.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/apis/providers/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/providers/v1alpha1/zz_generated.deepcopy.go
@@ -139,6 +139,10 @@ func (in *CatalogEntryStatus) DeepCopyInto(out *CatalogEntryStatus) {
 		in, out := &in.LastHeartbeat, &out.LastHeartbeat
 		*out = (*in).DeepCopy()
 	}
+	if in.CredentialsRotatedAt != nil {
+		in, out := &in.CredentialsRotatedAt, &out.CredentialsRotatedAt
+		*out = (*in).DeepCopy()
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/cmd/faros-hub/main.go
+++ b/cmd/faros-hub/main.go
@@ -78,6 +78,10 @@ func main() {
 			"Defaults to all known builtins. Dependencies are enforced — e.g. mcp requires server-edges.")
 
 	cmd.Flags().StringVar(&opts.ProviderHeartbeatAuth, "provider-heartbeat-auth", opts.ProviderHeartbeatAuth, "What to do with a provider heartbeat whose bearer token does not verify as that provider's own service account: warn (log and accept) or enforce (reject). Default warn for this release; the next release defaults to enforce.")
+	cmd.Flags().BoolVar(&opts.ProviderWorkspaceClusterAdmin, "provider-workspace-cluster-admin", opts.ProviderWorkspaceClusterAdmin,
+		"Bind each provider's ServiceAccount to cluster-admin inside its own provider workspace. "+
+			"False binds the narrower generated faros:provider ClusterRole instead. Default true for this release so "+
+			"operators can stage the change; the next release defaults to false. Changing it replaces the existing binding.")
 	cmd.Flags().StringVar(&opts.GraphQLAddr, "graphql-addr", opts.GraphQLAddr, "Address of an external GraphQL gateway to proxy /graphql/* requests to (empty to disable)")
 	cmd.Flags().BoolVar(&opts.EmbeddedGraphQL, "embedded-graphql", opts.EmbeddedGraphQL, "Run GraphQL listener+gateway in-process (requires embedded or external kcp; overrides --graphql-addr)")
 	cmd.Flags().StringVar(&opts.GraphQLAPIExportSliceName, "graphql-apiexport-slice-name", opts.GraphQLAPIExportSliceName, "APIExportEndpointSlice name to watch for GraphQL schema generation")

--- a/config/crds/providers.faros.sh_catalogentries.yaml
+++ b/config/crds/providers.faros.sh_catalogentries.yaml
@@ -730,6 +730,21 @@ spec:
                   - type
                   type: object
                 type: array
+              credentialsRotatedAt:
+                description: |-
+                  CredentialsRotatedAt is when the hub last issued a NEW workspace
+                  credential for this provider's ServiceAccount
+                  (POST .../providers/{name}/credentials/rotate). Empty means the provider
+                  still holds the credential minted at registration.
+
+                  It is recorded here, on the object an operator already looks at, because
+                  the credential itself is returned once and never stored: without this
+                  there is nothing anywhere that says how old the token in a provider's
+                  Secret is. The previous credential keeps working for a grace period
+                  after this timestamp, so it also dates the window in which a rollout has
+                  to finish.
+                format: date-time
+                type: string
               endpoints:
                 description: Endpoints echo the resolved URLs from spec, for debugging.
                 properties:

--- a/config/kcp/apiexport-providers.faros.sh.yaml
+++ b/config/kcp/apiexport-providers.faros.sh.yaml
@@ -6,7 +6,7 @@ spec:
   resources:
   - group: providers.faros.sh
     name: catalogentries
-    schema: v260819-ca930b58.catalogentries.providers.faros.sh
+    schema: v260905-a2d6321c.catalogentries.providers.faros.sh
     storage:
       crd: {}
 status: {}

--- a/config/kcp/apiresourceschema-catalogentries.providers.faros.sh.yaml
+++ b/config/kcp/apiresourceschema-catalogentries.providers.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260819-ca930b58.catalogentries.providers.faros.sh
+  name: v260905-a2d6321c.catalogentries.providers.faros.sh
 spec:
   group: providers.faros.sh
   names:
@@ -724,6 +724,21 @@ spec:
                 - type
                 type: object
               type: array
+            credentialsRotatedAt:
+              description: |-
+                CredentialsRotatedAt is when the hub last issued a NEW workspace
+                credential for this provider's ServiceAccount
+                (POST .../providers/{name}/credentials/rotate). Empty means the provider
+                still holds the credential minted at registration.
+
+                It is recorded here, on the object an operator already looks at, because
+                the credential itself is returned once and never stored: without this
+                there is nothing anywhere that says how old the token in a provider's
+                Secret is. The previous credential keeps working for a grace period
+                after this timestamp, so it also dates the window in which a rollout has
+                to finish.
+              format: date-time
+              type: string
             endpoints:
               description: Endpoints echo the resolved URLs from spec, for debugging.
               properties:

--- a/docs/byo-providers.md
+++ b/docs/byo-providers.md
@@ -363,10 +363,11 @@ multicluster managers for no behavioral gain.
 ## Endpoints
 
 ```
-POST   /api/orgs/{org}/providers                      register; returns the install kubeconfig
-GET    /api/orgs/{org}/providers                      list this Org's providers + registration state
-DELETE /api/orgs/{org}/providers/{name}               delete the provider workspace (cascades)
-GET    /api/orgs/{org}/providers/{name}/kubeconfig    re-fetch the install kubeconfig
+POST   /api/orgs/{org}/providers                              register; returns the install kubeconfig
+GET    /api/orgs/{org}/providers                              list this Org's providers + registration state
+DELETE /api/orgs/{org}/providers/{name}                       delete the provider workspace (cascades)
+GET    /api/orgs/{org}/providers/{name}/kubeconfig            re-fetch the install kubeconfig
+POST   /api/orgs/{org}/providers/{name}/credentials/rotate    issue a NEW credential (org admin only)
 ```
 
 Mutating calls honour `Organization.spec.catalogEntryCreation` (decision O-7):
@@ -393,13 +394,70 @@ only once the chart has actually run). The gap between them is the
 `registered: false` state — workspace exists, provider not installed yet — which
 is the state an operator is most likely to be debugging.
 
+## Credentials and rotation
+
+Registration mints one long-lived credential: a
+`kubernetes.io/service-account-token` Secret for the `provider` ServiceAccount
+in the provider's own workspace, wrapped in the kubeconfig the Org installs the
+chart with. It does not expire on its own — it is valid until the Secret or the
+ServiceAccount is deleted — which is exactly why there has to be a way to
+replace it.
+
+**Rotating.** An **Org admin** (always, regardless of
+`spec.catalogEntryCreation` — see the Endpoints note above) posts:
+
+```
+POST /api/orgs/{org}/providers/{name}/credentials/rotate
+```
+
+The response carries a `kubeconfig` in the same shape registration returns, a
+`rotatedAt`, and a `previousValidUntil`. Reinstall the chart with the new
+kubeconfig before `previousValidUntil`; that is the whole procedure.
+
+**What the hub does.** It issues a *second* token Secret for the same
+ServiceAccount, records which one is current on the ServiceAccount
+(`providers.faros.sh/active-token-secret`), and stamps the previous Secret with
+`providers.faros.sh/delete-after` — 24 hours out by default. The catalog
+controller deletes retired Secrets once that time passes.
+
+**Why both work in the meantime.** Both Secrets are tokens for the *same*
+ServiceAccount, so kcp authenticates either as
+`system:serviceaccount:default:provider`. Every hub-side check keys on that
+identity, not on which Secret a token came from — including the heartbeat's
+TokenReview — so a provider still running on the old kubeconfig keeps working,
+and keeps reporting alive, for the whole grace period. Rotation is a rolling
+change, not an outage.
+
+**What it does not do.** It does not revoke anything early: if a credential has
+leaked, delete the retired Secret in the provider workspace by hand, or delete
+and re-register the provider. It also does not restart anything — the hub has no
+write access into the Org's cluster.
+
+`status.credentialsRotatedAt` on the provider's `CatalogEntry` records the last
+rotation, because the credential itself is shown once and stored nowhere the
+hub can read back.
+
+Platform providers have the same endpoint behind the platform-admin gate:
+`POST /api/admin/providers/{name}/credentials/rotate`, which additionally
+rewrites the kubeconfig Secret in `root:faros:system:providers` so in-cluster
+readers move with it. There is no `faros` CLI subcommand for either; use curl:
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $FAROS_TOKEN" \
+  "$FAROS_HUB_URL/api/orgs/$ORG/providers/$NAME/credentials/rotate" \
+  | jq -r .kubeconfig > provider-kubeconfig.yaml
+```
+
 ## Isolation
 
 What an Org gets is deliberately narrow.
 
-- **The minted ServiceAccount is cluster-admin in its own provider workspace and
-  nowhere else.** It cannot read the Org workspace above it or any team
-  workspace beside it.
+- **The minted ServiceAccount holds rights only inside its own provider
+  workspace** — cluster-admin there today, and the narrower generated
+  `faros:provider` role on a hub started with
+  `--provider-workspace-cluster-admin=false` (see
+  [providers.md](./providers.md#credentials-and-rotation)). Either way it cannot
+  read the Org workspace above it or any team workspace beside it.
 - **Cross-workspace reach only ever comes from the APIExport's permission
   claims**, which each consuming Workspace accepts individually at Enable time —
   the same consent gate platform providers pass.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -997,6 +997,86 @@ A provider's UI MUST:
 
 ---
 
+## Credentials and rotation
+
+Every provider gets one credential from the hub: a kubeconfig for the `provider`
+ServiceAccount in its own workspace (`FAROS_PROVIDER_KUBECONFIG`). Its bearer is
+a legacy `kubernetes.io/service-account-token` Secret, so it does not expire —
+it is valid until the Secret or the ServiceAccount is deleted.
+
+### What the credential is allowed to do
+
+The ServiceAccount is bound to a role **inside its own provider workspace and
+nowhere else**; cross-workspace reach only ever comes from the APIExport's
+permission claims, which each consuming workspace accepts at Enable time.
+
+Which role is a hub flag:
+
+| `--provider-workspace-cluster-admin` | Bound to | |
+|---|---|---|
+| `true` (default this release) | `cluster-admin` | The historical behaviour. |
+| `false` (default next release) | generated `faros:provider` | Explicit allow-list. |
+
+`faros:provider` is generated from what providers actually do with this
+kubeconfig (`providerClusterRoleRules` in `pkg/hub/providers/provision.go`):
+`apis.kcp.io` APIResourceSchemas / APIExports / APIExportEndpointSlices /
+APIBindings, `apiexports/content` with all verbs (the APIExport
+virtual-workspace authorizer SARs the in-flight request's own verb, discovery
+included), `bind` on `apiexports` so `init` can write the tenant bind grant,
+`cache.kcp.io` CachedResources and their endpoint slices, `core.kcp.io`
+LogicalClusters (read), `providers.faros.sh` CatalogEntries and their status,
+ClusterRoles and ClusterRoleBindings, CustomResourceDefinitions, core
+ServiceAccounts / Secrets / ConfigMaps / Namespaces / Events,
+`coordination.k8s.io` Leases for leader election, `create` on TokenReviews and
+SubjectAccessReviews for providers that authenticate their own callers, and the
+discovery non-resource URLs.
+
+It deliberately withholds `escalate` on ClusterRoles (so RBAC's
+escalation-prevention holds the provider to rights it already has, and it cannot
+promote itself back), `impersonate`, and any write to `tenancy.kcp.io`.
+
+Stage the change rather than flipping it blind: a provider that defines its own
+CRDs in this workspace *and* writes objects of them — the `infrastructure`
+provider seeding Templates — needs more than the allow-list grants, and must
+stay on `true` until it declares what it needs. Flipping either way replaces the
+existing binding (RoleRef is immutable, so the hub deletes and recreates it).
+
+### Rotating
+
+```
+POST /api/admin/providers/{name}/credentials/rotate          platform admin
+POST /api/orgs/{org}/providers/{name}/credentials/rotate     org admin
+```
+
+Both return a fresh `kubeconfig` plus `rotatedAt` and `previousValidUntil`. The
+hub issues a **second** token Secret for the same ServiceAccount, points itself
+at it (`providers.faros.sh/active-token-secret` on the ServiceAccount), and
+stamps the previous Secret with `providers.faros.sh/delete-after` — 24 hours by
+default. The catalog controller deletes retired Secrets once that lapses. The
+platform endpoint additionally rewrites the kubeconfig Secret in
+`root:faros:system:providers`, so in-cluster readers move with it.
+
+During the grace period **both credentials work**: they are tokens for the same
+ServiceAccount, so kcp authenticates either as
+`system:serviceaccount:default:provider`, and every hub-side check — the
+heartbeat's TokenReview included — keys on that identity rather than on which
+Secret the token came from. Reinstall the chart with the new kubeconfig before
+`previousValidUntil`.
+
+`status.credentialsRotatedAt` on the `CatalogEntry` records the last rotation;
+the credential itself is shown once and stored nowhere the hub reads back. There
+is no `faros` CLI subcommand — use curl:
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $FAROS_TOKEN" \
+  "$FAROS_HUB_URL/api/admin/providers/$NAME/credentials/rotate" \
+  | jq -r .kubeconfig > provider-kubeconfig.yaml
+```
+
+Rotation is not revocation: it schedules the old credential's death, it does not
+hasten it. For a leaked credential, delete the retired Secret in the provider
+workspace by hand.
+
 ## Security considerations
 
 - **Auth token forwarding** (backend proxy): the user's bearer token is

--- a/pkg/hub/admin/handler.go
+++ b/pkg/hub/admin/handler.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	farosclient "github.com/faroshq/faros/pkg/client"
@@ -61,6 +62,11 @@ func (h *Handler) Register(r *mux.Router) {
 	r.HandleFunc("/providers", h.createProvider).Methods(http.MethodPost)
 	r.HandleFunc("/providers/{name}", h.deleteProvider).Methods(http.MethodDelete)
 	r.HandleFunc("/providers/{name}/kubeconfig", h.providerKubeconfig).Methods(http.MethodGet)
+	// Rotation is a POST, not another GET on the kubeconfig route: the
+	// kubeconfig endpoint deliberately returns the SAME credential every time
+	// (re-fetching must not multiply live tokens), so "give me a different one"
+	// has to be a separate, explicit, non-idempotent call.
+	r.HandleFunc("/providers/{name}/credentials/rotate", h.rotateProviderCredential).Methods(http.MethodPost)
 }
 
 type userDTO struct {
@@ -326,6 +332,59 @@ func (h *Handler) providerKubeconfig(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/yaml")
 	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
 	_, _ = w.Write(kc)
+}
+
+// rotateProviderCredentialDTO is the body of
+// POST /api/admin/providers/{name}/credentials/rotate.
+type rotateProviderCredentialDTO struct {
+	Name       string `json:"name"`
+	Kubeconfig string `json:"kubeconfig"`
+	// PreviousValidUntil is when the credential this call replaced stops
+	// working, RFC3339. Empty when there was nothing to retire. It is the
+	// deadline for rolling the provider onto the new kubeconfig — until then
+	// both authenticate as the same ServiceAccount, so the provider keeps
+	// working (its heartbeat included) on either.
+	PreviousValidUntil string `json:"previousValidUntil,omitempty"`
+	RotatedAt          string `json:"rotatedAt"`
+}
+
+// rotateProviderCredential mints a second ServiceAccount token for a platform
+// provider, makes it the credential the hub hands out, and puts the previous
+// one on a deletion clock. Returns the new kubeconfig in the response body —
+// the only time it is shown, exactly like registration.
+func (h *Handler) rotateProviderCredential(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "provider name is required")
+		return
+	}
+	mode, err := ParseKubeconfigServerMode(r.URL.Query().Get("server"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	kc, rotated, err := h.svc.RotateProviderCredential(r.Context(), name, mode)
+	if err != nil {
+		if errors.Is(err, ErrServerModeUnavailable) {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if apierrors.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	dto := rotateProviderCredentialDTO{
+		Name:       name,
+		Kubeconfig: string(kc),
+		RotatedAt:  rotated.RotatedAt.UTC().Format(time.RFC3339),
+	}
+	if !rotated.PreviousValidUntil.IsZero() {
+		dto.PreviousValidUntil = rotated.PreviousValidUntil.UTC().Format(time.RFC3339)
+	}
+	writeJSON(w, dto)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/pkg/hub/admin/handler_test.go
+++ b/pkg/hub/admin/handler_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+// adminGatedRouter mounts the admin routes behind the real gate, with the
+// caller's identity and admin verdict supplied by the test.
+func adminGatedRouter(user string, isAdmin bool) http.Handler {
+	r := mux.NewRouter()
+	sub := r.PathPrefix("/api/admin").Subrouter()
+	sub.Use(Middleware(
+		UserResolverFunc(func(*http.Request) (string, error) { return user, nil }),
+		AdminCheckerFunc(func(context.Context, string) bool { return isAdmin }),
+	))
+	// A nil Service is enough: every case here is refused by the gate or the
+	// handler's own validation before any kcp call, and a case that got past
+	// both would panic rather than silently pass.
+	NewHandler(nil, nil, nil).Register(sub)
+	return r
+}
+
+// Rotation mints a live cluster credential for a platform provider, so it sits
+// behind the same platform-admin gate as the rest of /api/admin — an
+// authenticated non-admin gets 403 and an unidentified caller 401, and neither
+// reaches the handler.
+func TestRotateProviderCredentialRequiresPlatformAdmin(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		user       string
+		isAdmin    bool
+		wantStatus int
+	}{
+		{"non-admin", "bob", false, http.StatusForbidden},
+		{"unidentified", "", false, http.StatusUnauthorized},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/api/admin/providers/code/credentials/rotate", nil)
+			adminGatedRouter(tc.user, tc.isAdmin).ServeHTTP(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// Rotation must be a POST to its own path. A GET on the kubeconfig route
+// deliberately returns the SAME credential every time, so if rotation were
+// reachable by any other method or path the "re-fetching does not multiply live
+// credentials" property would be quietly gone.
+func TestRotateProviderCredentialIsPOSTOnly(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(method, "/api/admin/providers/code/credentials/rotate", nil)
+		adminGatedRouter("alice", true).ServeHTTP(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s: status = %d, want 405", method, rec.Code)
+		}
+	}
+}
+
+// The server mode is parsed before anything is minted: an unknown value is the
+// caller's mistake, and rotating first and then failing to render would burn a
+// credential and start the previous one's deletion clock for nothing.
+func TestRotateProviderCredentialRejectsAnUnknownServerModeBeforeMinting(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/providers/code/credentials/rotate?server=sideways", nil)
+	adminGatedRouter("alice", true).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (a nil Service would have panicked had it minted)", rec.Code)
+	}
+}

--- a/pkg/hub/admin/service.go
+++ b/pkg/hub/admin/service.go
@@ -264,6 +264,72 @@ func (s *Service) GetProviderKubeconfig(ctx context.Context, name string, mode K
 	return rewriteKubeconfigServer(kc, base)
 }
 
+// RotateProviderCredential issues a NEW workspace credential for a platform
+// provider's ServiceAccount, rewrites the kubeconfig Secret the Provider
+// controller keeps in root:faros:system:providers, and returns the fresh
+// kubeconfig in the same shape the download endpoint serves.
+//
+// The Secret is rewritten rather than left alone because that Secret is where
+// in-cluster consumers read the credential from: a rotation the Secret did not
+// see would hand the operator a kubeconfig while every automated reader kept
+// the retired one, and the retired one is on a deletion clock.
+//
+// mode re-points the server URL on the way out, exactly as GetProviderKubeconfig
+// does; the stored Secret always keeps the address the hub minted.
+func (s *Service) RotateProviderCredential(ctx context.Context, name string, mode KubeconfigServerMode) ([]byte, *providers.RotatedCredential, error) {
+	cfg := rest.CopyConfig(s.kcpConfig)
+	cfg.Host = apiurl.KCPClusterURL(cfg.Host, kcppaths.SystemProviders)
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dynamic client for %s: %w", kcppaths.SystemProviders, err)
+	}
+	prov, err := dyn.Resource(providerGVR).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting Provider %q: %w", name, err)
+	}
+
+	serverURL := s.hubInternalURL
+	if serverURL == "" {
+		serverURL = s.hubExternalURL
+	}
+	if override, _, _ := unstructured.NestedString(prov.Object, "spec", "serverURLOverride"); override != "" {
+		serverURL = override
+	}
+	rotated, err := s.prov.RotateProviderCredential(ctx, name, serverURL)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	secretNS, _, _ := unstructured.NestedString(prov.Object, "status", "secretRef", "namespace")
+	secretName, _, _ := unstructured.NestedString(prov.Object, "status", "secretRef", "name")
+	secretKey, _, _ := unstructured.NestedString(prov.Object, "status", "secretRef", "key")
+	if secretNS == "" {
+		secretNS = "default"
+	}
+	if secretName == "" {
+		secretName = name + "-kubeconfig"
+	}
+	if secretKey == "" {
+		secretKey = providers.ProviderKubeconfigSecretKey
+	}
+	if err := s.prov.WriteKubeconfigSecret(ctx, secretNS, secretName, secretKey, rotated.Kubeconfig, name); err != nil {
+		return nil, nil, fmt.Errorf("writing rotated kubeconfig Secret %s/%s: %w", secretNS, secretName, err)
+	}
+
+	if mode == ServerModeAsMinted {
+		return rotated.Kubeconfig, rotated, nil
+	}
+	base, err := s.serverBaseFor(mode)
+	if err != nil {
+		return nil, nil, err
+	}
+	out, err := rewriteKubeconfigServer(rotated.Kubeconfig, base)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, rotated, nil
+}
+
 // DeleteProvider removes a Provider object from root:faros:system:providers.
 // The reconciler's finalizer then tears down the sub-workspace. Idempotent.
 func (s *Service) DeleteProvider(ctx context.Context, name string) error {
@@ -302,9 +368,9 @@ type Service struct {
 // kubeconfig download offer either address regardless of which one the Provider
 // reconciler baked into the Secret. hubInternalURL may be empty, in which
 // case only the external mode is offered.
-func NewService(kcpConfig *rest.Config, hubExternalURL, hubInternalURL string) *Service {
+func NewService(kcpConfig *rest.Config, hubExternalURL, hubInternalURL string, provOpts ...providers.ProvisionerOption) *Service {
 	return &Service{
-		prov:           providers.NewProvisioner(kcpConfig),
+		prov:           providers.NewProvisioner(kcpConfig, provOpts...),
 		kcpConfig:      kcpConfig,
 		bootstrapper:   kcp.NewBootstrapper(kcpConfig),
 		hubExternalURL: hubExternalURL,

--- a/pkg/hub/bootstrap/crds/providers.faros.sh_catalogentries.yaml
+++ b/pkg/hub/bootstrap/crds/providers.faros.sh_catalogentries.yaml
@@ -730,6 +730,21 @@ spec:
                   - type
                   type: object
                 type: array
+              credentialsRotatedAt:
+                description: |-
+                  CredentialsRotatedAt is when the hub last issued a NEW workspace
+                  credential for this provider's ServiceAccount
+                  (POST .../providers/{name}/credentials/rotate). Empty means the provider
+                  still holds the credential minted at registration.
+
+                  It is recorded here, on the object an operator already looks at, because
+                  the credential itself is returned once and never stored: without this
+                  there is nothing anywhere that says how old the token in a provider's
+                  Secret is. The previous credential keeps working for a grace period
+                  after this timestamp, so it also dates the window in which a rollout has
+                  to finish.
+                format: date-time
+                type: string
               endpoints:
                 description: Endpoints echo the resolved URLs from spec, for debugging.
                 properties:

--- a/pkg/hub/options.go
+++ b/pkg/hub/options.go
@@ -97,6 +97,18 @@ type Options struct {
 	// they are rolled forward; the next release flips the default to
 	// "enforce". See providers.HeartbeatAuthMode.
 	ProviderHeartbeatAuth string
+	// ProviderWorkspaceClusterAdmin selects the role the provider ServiceAccount
+	// is bound to inside its own provider workspace: true (the default this
+	// release) keeps cluster-admin, false binds the generated, narrower
+	// faros:provider ClusterRole.
+	//
+	// The default is the wide one for one release so an operator can stage the
+	// change — flip it, watch their providers, flip back if one of them needed
+	// a right the narrow role does not grant (the infrastructure provider, which
+	// serves its own CRDs from this workspace, is the known case). The NEXT
+	// release defaults this to false. Flipping either way replaces the existing
+	// binding: RoleRef is immutable, so the hub deletes and recreates it.
+	ProviderWorkspaceClusterAdmin bool
 
 	// GraphQLAddr is the address of an external GraphQL gateway to proxy /graphql/ requests to.
 	// If empty and EmbeddedGraphQL is false, the graphql proxy is disabled.
@@ -160,6 +172,8 @@ func NewOptions() *Options {
 		KCPBatteriesInclude: "admin,user",
 
 		ProviderHeartbeatAuth: string(providers.HeartbeatAuthWarn),
+		// Wide for this release; the next one defaults to false. See the field.
+		ProviderWorkspaceClusterAdmin: true,
 
 		GraphQLAPIExportSliceName:      "core.faros.sh",
 		GraphQLAPIExportLogicalCluster: kcppaths.SystemControllers,

--- a/pkg/hub/providers/controller.go
+++ b/pkg/hub/providers/controller.go
@@ -88,6 +88,24 @@ type CatalogReconciler struct {
 	// by the number of provider workspaces the hub has observed.
 	clusterPathsMu sync.RWMutex
 	clusterPaths   map[string]string
+
+	// sweepCredentials deletes rotated-out provider token Secrets whose grace
+	// period lapsed, reporting how many went and when the next one lapses. Nil
+	// means "use the Provisioner"; it is a field so tests can observe the call
+	// without a live kcp.
+	sweepCredentials func(ctx context.Context, cluster string) (int, time.Time, error)
+}
+
+// credentialSweeper returns the sweep to run for this reconcile, or nil when
+// there is nothing to sweep with (registry-only mode).
+func (r *CatalogReconciler) credentialSweeper() func(context.Context, string) (int, time.Time, error) {
+	if r.sweepCredentials != nil {
+		return r.sweepCredentials
+	}
+	if r.prov == nil {
+		return nil
+	}
+	return r.prov.SweepExpiredProviderTokens
 }
 
 type httpDoer interface {
@@ -118,6 +136,13 @@ type CatalogReconcilerOptions struct {
 	// the hub-owned Service in front of it. Nil leaves org-owned providers on
 	// their declared backend URL, which is the pre-edge-transport behaviour.
 	EdgeRoutes EdgeRouteResolver
+
+	// Provisioner configures the Provisioner these controllers build — notably
+	// WithWorkspaceClusterAdmin, which decides the role a provider's
+	// ServiceAccount is bound to in its own workspace. Nil means the
+	// Provisioner defaults, so a caller that forgets it gets the wide,
+	// backwards-compatible binding rather than silently narrowing one.
+	Provisioner []ProvisionerOption
 }
 
 // SetupCatalogWithManager wires the reconciler into a multicluster manager.
@@ -137,7 +162,7 @@ func SetupCatalogWithManager(mgr mcmanager.Manager, reg *Registry, kcpConfig *re
 		clusterPaths:   map[string]string{},
 	}
 	if kcpConfig != nil {
-		r.prov = NewProvisioner(kcpConfig)
+		r.prov = NewProvisioner(kcpConfig, opts.Provisioner...)
 	}
 	return mcbuilder.ControllerManagedBy(mgr).
 		Named("provider-catalog").
@@ -571,6 +596,29 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 		}
 	}
 
+	// Rotated-out provider credentials die here. Rotation only writes an expiry
+	// onto the retired token Secret; something has to come back later and
+	// delete it, and this reconciler is the one loop that runs for every
+	// provider workspace the hub knows — platform and org-owned alike, without
+	// the hub having to enumerate every Org's tree. The CatalogEntry lives in
+	// the provider's own workspace, so the cluster it was observed in IS the
+	// workspace holding the Secrets; a cluster with no provider ServiceAccount
+	// (a builtin entry seeded into system:providers) sweeps to a no-op.
+	var credentialExpiryPending bool
+	if sweep := r.credentialSweeper(); sweep != nil {
+		deleted, next, err := sweep(ctx, string(req.ClusterName))
+		switch {
+		case err != nil:
+			// Never fatal to the reconcile: a provider whose old credential
+			// outlives its grace period by one interval is a smaller problem
+			// than a registry that stops tracking the provider at all.
+			logger.Info("WARNING could not sweep expired provider token Secrets", "err", err.Error())
+		case deleted > 0:
+			logger.Info("Deleted expired provider token Secrets", "count", deleted)
+		}
+		credentialExpiryPending = !next.IsZero()
+	}
+
 	// Update status.
 	now := metav1.NewTime(time.Now())
 	entry.Status.Endpoints = &providersv1alpha1.ProviderEndpoints{}
@@ -639,7 +687,7 @@ func (r *CatalogReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 	} else if requeue {
 		return ctrl.Result{Requeue: true}, nil
 	}
-	if prov.BackendHealthRequired || prov.HeartbeatRequired || edgeRouteErr != nil {
+	if prov.BackendHealthRequired || prov.HeartbeatRequired || edgeRouteErr != nil || credentialExpiryPending {
 		return ctrl.Result{RequeueAfter: SweepInterval}, nil
 	}
 	return ctrl.Result{}, nil

--- a/pkg/hub/providers/controller_test.go
+++ b/pkg/hub/providers/controller_test.go
@@ -525,3 +525,76 @@ func conditionByType(conditions []metav1.Condition, conditionType string) *metav
 	}
 	return nil
 }
+
+// Rotation only writes an expiry onto the retired credential; the catalog
+// reconciler is what actually deletes it, in whichever workspace the provider's
+// CatalogEntry lives — which is the same workspace holding its Secrets. A
+// pending expiry has to bring the reconciler back, or the credential outlives
+// its grace period until something unrelated happens to requeue the entry.
+func TestCatalogReconcilerSweepsRotatedProviderCredentials(t *testing.T) {
+	reg := NewRegistry()
+	scheme := newProviderTestScheme(t)
+	entry := &providersv1alpha1.CatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost"},
+		Spec: providersv1alpha1.CatalogEntrySpec{
+			APIExport: &providersv1alpha1.ProviderAPIExport{Name: "cost.providers.faros.sh"},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&providersv1alpha1.CatalogEntry{}).
+		WithObjects(entry).
+		Build()
+
+	var swept []string
+	next := time.Now().Add(time.Hour)
+	r := &CatalogReconciler{
+		mgr: testfakes.NewManager(c), reg: reg, noKCP: true,
+		sweepCredentials: func(_ context.Context, cluster string) (int, time.Time, error) {
+			swept = append(swept, cluster)
+			return 1, next, nil
+		},
+	}
+	res, err := r.Reconcile(context.Background(), testfakes.NewRequest("cost-cluster", "", "cost"))
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(swept) != 1 || swept[0] != "cost-cluster" {
+		t.Fatalf("swept %v, want the provider's own workspace cluster", swept)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatal("a pending credential expiry did not schedule a requeue; the retired token would outlive its grace period")
+	}
+}
+
+// A sweep that cannot run must not take the provider out of the registry with
+// it: routing is the reconciler's real job, and an un-deleted Secret is the
+// lesser failure.
+func TestCatalogReconcilerSurvivesASweepFailure(t *testing.T) {
+	reg := NewRegistry()
+	scheme := newProviderTestScheme(t)
+	entry := &providersv1alpha1.CatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "cost"},
+		Spec: providersv1alpha1.CatalogEntrySpec{
+			APIExport: &providersv1alpha1.ProviderAPIExport{Name: "cost.providers.faros.sh"},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&providersv1alpha1.CatalogEntry{}).
+		WithObjects(entry).
+		Build()
+
+	r := &CatalogReconciler{
+		mgr: testfakes.NewManager(c), reg: reg, noKCP: true,
+		sweepCredentials: func(context.Context, string) (int, time.Time, error) {
+			return 0, time.Time{}, fmt.Errorf("kcp unavailable")
+		},
+	}
+	if _, err := r.Reconcile(context.Background(), testfakes.NewRequest("cost-cluster", "", "cost")); err != nil {
+		t.Fatalf("reconcile failed on a sweep error: %v", err)
+	}
+	if _, ok := reg.Get("cost"); !ok {
+		t.Fatal("provider dropped out of the registry because a credential sweep failed")
+	}
+}

--- a/pkg/hub/providers/provider_controller.go
+++ b/pkg/hub/providers/provider_controller.go
@@ -75,7 +75,7 @@ func SetupProviderWithManager(mgr mcmanager.Manager, kcpConfig *rest.Config, opt
 	}
 	r := &ProviderReconciler{
 		mgr:               mgr,
-		prov:              NewProvisioner(kcpConfig),
+		prov:              NewProvisioner(kcpConfig, opts.Provisioner...),
 		providerServerURL: serverURL,
 	}
 	return mcbuilder.ControllerManagedBy(mgr).

--- a/pkg/hub/providers/provision.go
+++ b/pkg/hub/providers/provision.go
@@ -28,10 +28,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 
 	"github.com/faroshq/faros/pkg/apiurl"
 	"github.com/faroshq/faros/pkg/kcppaths"
@@ -44,14 +46,78 @@ import (
 // `init`.
 type Provisioner struct {
 	kcpConfig *rest.Config
+
+	// workspaceClusterAdmin binds the provider ServiceAccount to cluster-admin
+	// in its own workspace instead of the generated faros:provider role. See
+	// WithWorkspaceClusterAdmin.
+	workspaceClusterAdmin bool
+	// credentialGracePeriod is how long a rotated-out token Secret stays valid
+	// before the sweeper deletes it. Zero means DefaultCredentialGracePeriod.
+	credentialGracePeriod time.Duration
+	// clock is overridable in tests. Read it through now(), which tolerates a
+	// zero-value Provisioner — several tests build one directly.
+	clock func() time.Time
+}
+
+// now is the Provisioner's clock, defaulting to the real one.
+func (p *Provisioner) now() time.Time {
+	if p.clock == nil {
+		return time.Now()
+	}
+	return p.clock()
+}
+
+// gracePeriod is how long a retired credential stays valid, defaulting to
+// DefaultCredentialGracePeriod.
+func (p *Provisioner) gracePeriod() time.Duration {
+	if p.credentialGracePeriod <= 0 {
+		return DefaultCredentialGracePeriod
+	}
+	return p.credentialGracePeriod
+}
+
+// ProvisionerOption configures a Provisioner.
+type ProvisionerOption func(*Provisioner)
+
+// WithWorkspaceClusterAdmin selects the role the provider's ServiceAccount is
+// bound to inside its own provider workspace: true keeps the historical
+// cluster-admin binding, false binds the generated, narrower faros:provider
+// ClusterRole (see providerClusterRoleRules).
+//
+// It is a Provisioner-level option rather than a per-call argument because
+// every caller that creates a provider SA — admin onboarding, the Provider
+// reconciler, org-owned registration — must agree: a hub that narrowed the
+// role in one path and not another would leave the wider binding in place for
+// whichever path ran last.
+func WithWorkspaceClusterAdmin(clusterAdmin bool) ProvisionerOption {
+	return func(p *Provisioner) { p.workspaceClusterAdmin = clusterAdmin }
+}
+
+// WithCredentialGracePeriod overrides how long a rotated-out provider token
+// Secret stays usable before it is swept. Zero or negative restores the
+// default.
+func WithCredentialGracePeriod(d time.Duration) ProvisionerOption {
+	return func(p *Provisioner) { p.credentialGracePeriod = d }
 }
 
 // NewProvisioner returns a Provisioner that performs provider-workspace
 // side-effects (workspace, ServiceAccount, minted kubeconfig) against kcp using
 // the given admin config. Used by the admin onboarding API
 // (pkg/hub/admin); the catalog controller no longer provisions.
-func NewProvisioner(kcpConfig *rest.Config) *Provisioner {
-	return &Provisioner{kcpConfig: kcpConfig}
+//
+// The default is the historical behaviour — cluster-admin in the provider's own
+// workspace. Pass WithWorkspaceClusterAdmin(false) to bind the narrower
+// generated role instead.
+func NewProvisioner(kcpConfig *rest.Config, opts ...ProvisionerOption) *Provisioner {
+	p := &Provisioner{
+		kcpConfig:             kcpConfig,
+		workspaceClusterAdmin: true,
+		credentialGracePeriod: DefaultCredentialGracePeriod,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // providersParentWorkspace is the parent of per-provider sub-workspaces
@@ -66,6 +132,9 @@ var (
 	}
 	clusterRoleBindingGVR = schema.GroupVersionResource{
 		Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings",
+	}
+	clusterRoleGVR = schema.GroupVersionResource{
+		Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles",
 	}
 	serviceAccountGVR = schema.GroupVersionResource{
 		Group: "", Version: "v1", Resource: "serviceaccounts",
@@ -98,6 +167,151 @@ const ProviderSANamespace = "default"
 // the provider pod — and any downstream consumer such as the kro cluster —
 // never needs a rotation loop.
 const ProviderTokenSecretSuffix = "-token"
+
+// ProviderTokenSecretName is the Secret every provider workspace starts with.
+// Rotation mints differently-named Secrets beside it and records which one is
+// current on the ServiceAccount, so this stays the name of the *first*
+// credential rather than always the live one — read the live one with
+// activeTokenSecretName.
+const ProviderTokenSecretName = ProviderSAName + ProviderTokenSecretSuffix
+
+const (
+	// AnnotationActiveTokenSecret names, on the provider ServiceAccount, the
+	// token Secret the hub currently mints kubeconfigs from. Its absence means
+	// ProviderTokenSecretName, which is what every workspace provisioned
+	// before rotation existed carries.
+	//
+	// The pointer lives on the ServiceAccount rather than being derived from
+	// Secret names so that "which credential is current" has exactly one
+	// answer, and so a half-finished rotation (new Secret created, pointer not
+	// yet moved) keeps handing out the old, still-valid credential rather than
+	// an unpopulated one.
+	AnnotationActiveTokenSecret = "providers.faros.sh/active-token-secret"
+
+	// AnnotationTokenSecretExpiry is stamped on a rotated-out token Secret with
+	// the RFC3339 time after which it may be deleted. Until then both tokens
+	// authenticate as the same ServiceAccount, which is what lets a provider be
+	// rolled onto the new credential without a gap.
+	AnnotationTokenSecretExpiry = "providers.faros.sh/delete-after"
+)
+
+// DefaultCredentialGracePeriod is how long a rotated-out provider token stays
+// valid. It has to outlast a leisurely rollout of the provider's chart — the
+// operator has to take the new kubeconfig, put it in a Secret, and restart the
+// workload — so a day rather than an hour, and short enough that a leaked
+// credential is not indefinitely live.
+const DefaultCredentialGracePeriod = 24 * time.Hour
+
+// ProviderClusterRoleName is the generated, narrower role bound to the provider
+// ServiceAccount in its own workspace when the hub runs with
+// --provider-workspace-cluster-admin=false.
+const ProviderClusterRoleName = "faros:provider"
+
+// providerSABindingName is the ClusterRoleBinding tying the provider SA to
+// whichever role the hub selected. The name is historical and stable across the
+// role switch: a rename would leave the old (cluster-admin) binding behind.
+const providerSABindingName = "faros:providers:sa:" + ProviderSAName
+
+// providerClusterRoleRules is what a provider actually needs inside its own
+// workspace, derived from what runs against the minted kubeconfig:
+// `provider-sdk/install` (every provider's `init`), the APIExport
+// virtual-workspace clients, the SDK's leader election, and the runtime
+// bootstrap the infrastructure provider performs.
+//
+// Everything a provider does OUTSIDE this workspace still comes from its
+// APIExport's permission claims, which each consuming workspace accepts at
+// Enable time; nothing here widens that.
+//
+// What it deliberately does NOT grant, and cluster-admin did:
+//   - escalate on ClusterRoles. The provider may create RBAC (the bind grant
+//     `init` writes), but RBAC's escalation-prevention then holds it to rights
+//     it already has, so it cannot promote itself back to cluster-admin.
+//   - impersonate, on any subject.
+//   - the workspace's own tenancy objects (Workspace, WorkspaceType) — the
+//     `provider` WorkspaceType does not extend universal, so a provider could
+//     not create sub-workspaces anyway, and this stops it deleting its own.
+//
+// A provider that defines its own CRDs in this workspace AND writes objects of
+// those CRDs (today: infrastructure, which seeds Templates) needs more than
+// this: escalation prevention stops it granting itself access to a resource it
+// has no rule for. That is the case --provider-workspace-cluster-admin=true
+// exists to keep working while providers declare what they need.
+func providerClusterRoleRules() []any {
+	rule := func(groups, resources, verbs []string) map[string]any {
+		return map[string]any{
+			"apiGroups": toAnySlice(groups),
+			"resources": toAnySlice(resources),
+			"verbs":     toAnySlice(verbs),
+		}
+	}
+	readWrite := []string{"get", "list", "watch", "create", "update", "patch", "delete"}
+	return []any{
+		// `init` applies schemas, the APIExport, and the endpoint slice; the
+		// multicluster provider lists APIBindings and watches the slice to
+		// discover which logical clusters bound the export.
+		rule([]string{"apis.kcp.io"},
+			[]string{"apiresourceschemas", "apiexports", "apiexportendpointslices", "apibindings"},
+			readWrite),
+		// The APIExport virtual workspace gates EVERY call through a SAR for
+		// apiexports/content with the verb of the in-flight request — discovery
+		// included — so the verb set has to be open. Scope comes from the
+		// workspace: only this provider's exports live here.
+		rule([]string{"apis.kcp.io"}, []string{"apiexports/content"}, []string{"*"}),
+		// `bind` is what lets ApplyBindGrant create the tenant-facing bind
+		// ClusterRole without `escalate`: RBAC only permits granting rights the
+		// grantor holds.
+		rule([]string{"apis.kcp.io"}, []string{"apiexports"}, []string{"bind"}),
+		rule([]string{"cache.kcp.io"},
+			[]string{"cachedresources", "cachedresourceendpointslices"}, readWrite),
+		// Resolving the workspace's own path (ApplyBindGrant's org check, the
+		// infrastructure operator's discovery).
+		rule([]string{"core.kcp.io"}, []string{"logicalclusters"}, []string{"get", "list", "watch"}),
+		// The provider self-registers its CatalogEntry here and the hub reads
+		// its status back; the provider updates it on every chart upgrade.
+		rule([]string{"providers.faros.sh"},
+			[]string{"catalogentries", "catalogentries/status"},
+			[]string{"get", "list", "watch", "create", "update", "patch"}),
+		// The bind grant (ClusterRole + ClusterRoleBinding), created and — for
+		// org-owned workspaces — removed again by ApplyBindGrant.
+		rule([]string{"rbac.authorization.k8s.io"},
+			[]string{"clusterroles", "clusterrolebindings"},
+			[]string{"get", "list", "watch", "create", "update", "delete"}),
+		// Per-template CRDs (infrastructure) and any provider that serves
+		// workspace-local types.
+		rule([]string{"apiextensions.k8s.io"}, []string{"customresourcedefinitions"}, readWrite),
+		// Runtime identity minting (infrastructure), controller-runtime event
+		// recorders, and the Secrets a provider keeps for itself.
+		rule([]string{""},
+			[]string{"serviceaccounts", "secrets", "configmaps", "namespaces", "events"},
+			readWrite),
+		// Leader election (provider-sdk/leaderelection, kuery engagement
+		// claims, the edges tunnel registry).
+		rule([]string{"coordination.k8s.io"}, []string{"leases"}, readWrite),
+		// Providers that authenticate their own data-plane callers delegate the
+		// decision back to kcp rather than parsing JWTs.
+		rule([]string{"authentication.k8s.io"}, []string{"tokenreviews"}, []string{"create"}),
+		rule([]string{"authorization.k8s.io"},
+			[]string{"subjectaccessreviews", "selfsubjectaccessreviews", "selfsubjectrulesreviews"},
+			[]string{"create"}),
+		// Discovery and RESTMapper construction for every client-go and
+		// controller-runtime client built from the provider kubeconfig.
+		map[string]any{
+			"nonResourceURLs": toAnySlice([]string{
+				"/api", "/api/*", "/apis", "/apis/*", "/version",
+				"/openapi", "/openapi/*", "/healthz", "/livez", "/readyz",
+			}),
+			"verbs": toAnySlice([]string{"get"}),
+		},
+	}
+}
+
+func toAnySlice(in []string) []any {
+	out := make([]any, 0, len(in))
+	for _, s := range in {
+		out = append(out, s)
+	}
+	return out
+}
 
 // EnsureProviderSA creates the "provider" ServiceAccount in the platform
 // provider's sub-workspace (root:faros:providers/{name}) and grants it
@@ -136,29 +350,75 @@ func (p *Provisioner) EnsureProviderSAAtPath(ctx context.Context, workspacePath 
 		return fmt.Errorf("creating ServiceAccount %s/%s: %w", ProviderSANamespace, ProviderSAName, err)
 	}
 
-	// cluster-admin in the sub-workspace only. The provider pod reaches
-	// other workspaces via the APIExport's virtual workspace + accepted
-	// permission claims — NOT via this SA.
-	crbName := "faros:providers:sa:" + ProviderSAName
+	// Bound in the sub-workspace only, to whichever role this hub selected.
+	// The provider pod reaches other workspaces via the APIExport's virtual
+	// workspace + accepted permission claims — NOT via this SA.
+	return p.ensureProviderRoleBinding(ctx, cl)
+}
+
+// ensureProviderRoleBinding binds the provider ServiceAccount to cluster-admin
+// or to the generated faros:provider role, depending on the hub's
+// --provider-workspace-cluster-admin setting, and moves an existing binding
+// when the setting changed.
+//
+// roleRef is immutable in RBAC, so switching roles means delete-then-create
+// rather than an update. The window between the two is a few milliseconds in
+// which the provider's SA has no rights in its own workspace; its controllers
+// retry, and the alternative — a second binding under a different name — would
+// leave the wide grant in place forever, which is the thing being removed.
+func (p *Provisioner) ensureProviderRoleBinding(ctx context.Context, cl dynamic.Interface) error {
+	roleName := "cluster-admin"
+	if !p.workspaceClusterAdmin {
+		roleName = ProviderClusterRoleName
+		cr := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata":   map[string]any{"name": ProviderClusterRoleName},
+			"rules":      providerClusterRoleRules(),
+		}}
+		if err := applyUnstructured(ctx, cl, clusterRoleGVR, cr); err != nil {
+			return fmt.Errorf("applying ClusterRole %s: %w", ProviderClusterRoleName, err)
+		}
+	}
+
 	crb := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "rbac.authorization.k8s.io/v1",
 		"kind":       "ClusterRoleBinding",
-		"metadata":   map[string]any{"name": crbName},
+		"metadata":   map[string]any{"name": providerSABindingName},
 		"roleRef": map[string]any{
 			"apiGroup": "rbac.authorization.k8s.io",
 			"kind":     "ClusterRole",
-			"name":     "cluster-admin",
+			"name":     roleName,
 		},
 		"subjects": []any{
 			map[string]any{
 				"kind":      "ServiceAccount",
 				"name":      ProviderSAName,
-				"namespace": "default",
+				"namespace": ProviderSANamespace,
 			},
 		},
 	}}
-	if err := applyUnstructured(ctx, cl, clusterRoleBindingGVR, crb); err != nil {
-		return fmt.Errorf("applying %s: %w", crbName, err)
+
+	existing, err := cl.Resource(clusterRoleBindingGVR).Get(ctx, providerSABindingName, metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(err):
+	case err != nil:
+		return fmt.Errorf("getting %s: %w", providerSABindingName, err)
+	default:
+		current, _, _ := unstructured.NestedString(existing.Object, "roleRef", "name")
+		if current == roleName {
+			crb.SetResourceVersion(existing.GetResourceVersion())
+			if _, err := cl.Resource(clusterRoleBindingGVR).Update(ctx, crb, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("updating %s: %w", providerSABindingName, err)
+			}
+			return nil
+		}
+		if err := cl.Resource(clusterRoleBindingGVR).Delete(ctx, providerSABindingName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting %s to move it from %s to %s: %w", providerSABindingName, current, roleName, err)
+		}
+	}
+	if _, err := cl.Resource(clusterRoleBindingGVR).Create(ctx, crb, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating %s: %w", providerSABindingName, err)
 	}
 	return nil
 }
@@ -194,11 +454,25 @@ func (p *Provisioner) MintProviderKubeconfigAtPath(ctx context.Context, workspac
 		return nil, fmt.Errorf("typed kube client for %s: %w", workspacePath, err)
 	}
 
-	token, err := ensureLegacySAToken(ctx, typed, "default", ProviderSAName, ProviderSAName+ProviderTokenSecretSuffix)
+	// Which Secret is current is recorded on the ServiceAccount by rotation;
+	// a workspace that has never rotated has no annotation and keeps the
+	// original name, so this returns the same token it always did.
+	secretName, err := activeTokenSecretName(ctx, typed)
+	if err != nil {
+		return nil, fmt.Errorf("resolving active token Secret for %s: %w", workspacePath, err)
+	}
+	token, err := ensureLegacySAToken(ctx, typed, ProviderSANamespace, ProviderSAName, secretName)
 	if err != nil {
 		return nil, fmt.Errorf("ensuring SA token for %s: %w", workspacePath, err)
 	}
 
+	return p.renderKubeconfig(ctx, cfg, hubExternalURL, token)
+}
+
+// renderKubeconfig turns a resolved bearer token into the provider kubeconfig,
+// resolving the workspace's logical cluster ID for the server URL. Shared by
+// minting and rotation so both hand back byte-identical shapes.
+func (p *Provisioner) renderKubeconfig(ctx context.Context, cfg *rest.Config, hubExternalURL, token string) ([]byte, error) {
 	// Resolve the provider workspace's logical cluster ID. The kubeconfig must
 	// address kcp by ID (/clusters/<id>), not by workspace path: kcp shards only
 	// resolve /clusters/<id>, and workspace-path resolution is front-proxy-only.
@@ -206,7 +480,7 @@ func (p *Provisioner) MintProviderKubeconfigAtPath(ctx context.Context, workspac
 	// shard (the SA token also carries this ID in its clusterName claim).
 	clusterID, err := resolveLogicalClusterID(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("resolving logical cluster ID for %s: %w", workspacePath, err)
+		return nil, fmt.Errorf("resolving logical cluster ID for %s: %w", cfg.Host, err)
 	}
 
 	server := hubExternalURL
@@ -300,6 +574,245 @@ func ensureLegacySAToken(ctx context.Context, cs kubernetes.Interface, namespace
 		return "", fmt.Errorf("waiting for token controller to populate Secret %s/%s: %w", namespace, secretName, err)
 	}
 	return token, nil
+}
+
+// activeTokenSecretName reads the provider ServiceAccount's pointer to the
+// token Secret currently in use. A ServiceAccount without the annotation —
+// every workspace provisioned before rotation existed — reports the original
+// name, so the answer is stable for a provider that has never rotated.
+func activeTokenSecretName(ctx context.Context, cs kubernetes.Interface) (string, error) {
+	sa, err := cs.CoreV1().ServiceAccounts(ProviderSANamespace).Get(ctx, ProviderSAName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting ServiceAccount %s/%s: %w", ProviderSANamespace, ProviderSAName, err)
+	}
+	if name := sa.Annotations[AnnotationActiveTokenSecret]; name != "" {
+		return name, nil
+	}
+	return ProviderTokenSecretName, nil
+}
+
+// RotatedCredential describes the outcome of a rotation.
+type RotatedCredential struct {
+	// Kubeconfig is the new credential, in the same shape registration
+	// returns.
+	Kubeconfig []byte
+	// SecretName is the token Secret the new credential came from.
+	SecretName string
+	// PreviousSecretName is the Secret that was current before, empty when
+	// there was none to retire.
+	PreviousSecretName string
+	// PreviousValidUntil is when the previous credential stops working. Zero
+	// when nothing was retired. Until then BOTH tokens authenticate as the
+	// same ServiceAccount, so anything that checks the provider's identity —
+	// the heartbeat's TokenReview included — keeps accepting the old one while
+	// the provider is rolled onto the new one.
+	PreviousValidUntil time.Time
+	// RotatedAt is the rotation's wall-clock time, recorded on the
+	// CatalogEntry status.
+	RotatedAt time.Time
+}
+
+// RotateProviderCredential rotates the platform provider at
+// root:faros:providers/{name}.
+func (p *Provisioner) RotateProviderCredential(ctx context.Context, providerName, hubExternalURL string) (*RotatedCredential, error) {
+	return p.RotateProviderCredentialAtPath(ctx, providersParentWorkspace+":"+providerName, providerName, hubExternalURL)
+}
+
+// RotateProviderCredentialAtPath issues a SECOND long-lived token for the
+// provider's ServiceAccount, makes it the one the hub hands out, and schedules
+// the previous one for deletion after the grace period.
+//
+// Both tokens belong to the same ServiceAccount, so during the grace period the
+// provider authenticates identically with either: the identity kcp reports is
+// system:serviceaccount:default:provider in both cases, which is what every
+// hub-side check keys on. That is what makes rotation a rolling change rather
+// than an outage — the operator installs the new kubeconfig whenever it suits
+// them, and the old credential stops working on its own.
+//
+// providerName is only used to record status.credentialsRotatedAt on the
+// provider's CatalogEntry; pass "" to skip that.
+func (p *Provisioner) RotateProviderCredentialAtPath(ctx context.Context, workspacePath, providerName, hubExternalURL string) (*RotatedCredential, error) {
+	cfg := rest.CopyConfig(p.kcpConfig)
+	cfg.Host = apiurl.KCPClusterURL(cfg.Host, workspacePath)
+	typed, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("typed kube client for %s: %w", workspacePath, err)
+	}
+
+	out, token, err := p.rotateToken(ctx, typed)
+	if err != nil {
+		return nil, fmt.Errorf("rotating provider credential in %s: %w", workspacePath, err)
+	}
+
+	kc, err := p.renderKubeconfig(ctx, cfg, hubExternalURL, token)
+	if err != nil {
+		return nil, err
+	}
+	out.Kubeconfig = kc
+
+	if providerName != "" {
+		// Best-effort: the CatalogEntry only exists once the provider's chart
+		// has run. A rotation before that is still a valid rotation.
+		if err := p.recordCredentialsRotated(ctx, cfg, providerName, out.RotatedAt); err != nil {
+			klog.FromContext(ctx).V(2).Info("could not record credentialsRotatedAt on CatalogEntry",
+				"provider", providerName, "workspace", workspacePath, "err", err.Error())
+		}
+	}
+	return out, nil
+}
+
+// rotateToken is the workspace-client half of a rotation: mint a second token
+// for the same ServiceAccount, repoint the hub at it, and give the previous one
+// a deadline. Split out from RotateProviderCredentialAtPath so it can be
+// exercised against an injected clientset — everything it does is Secret and
+// ServiceAccount bookkeeping, while its caller additionally needs a live kcp to
+// resolve the workspace's logical cluster ID.
+func (p *Provisioner) rotateToken(ctx context.Context, cs kubernetes.Interface) (*RotatedCredential, string, error) {
+	previous, err := activeTokenSecretName(ctx, cs)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving active token Secret: %w", err)
+	}
+
+	now := p.now()
+	next := fmt.Sprintf("%s-%s", ProviderTokenSecretName, now.UTC().Format("20060102150405"))
+	if next == previous {
+		// Two rotations inside the same second would otherwise re-point at the
+		// Secret being retired and immediately schedule the live credential for
+		// deletion.
+		return nil, "", fmt.Errorf("a rotation already happened this second; retry")
+	}
+
+	token, err := ensureLegacySAToken(ctx, cs, ProviderSANamespace, ProviderSAName, next)
+	if err != nil {
+		return nil, "", fmt.Errorf("minting rotated SA token: %w", err)
+	}
+
+	// Move the pointer BEFORE retiring the old Secret. The reverse order has a
+	// window where the old credential is expiring and nothing yet says the new
+	// one is current, so a concurrent kubeconfig fetch would hand out the
+	// credential that is on its way out.
+	patch := fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, AnnotationActiveTokenSecret, next)
+	if _, err := cs.CoreV1().ServiceAccounts(ProviderSANamespace).Patch(
+		ctx, ProviderSAName, types.MergePatchType, []byte(patch), metav1.PatchOptions{},
+	); err != nil {
+		return nil, "", fmt.Errorf("recording active token Secret on the ServiceAccount: %w", err)
+	}
+
+	out := &RotatedCredential{SecretName: next, RotatedAt: now}
+	if previous == "" || previous == next {
+		return out, token, nil
+	}
+	expiry := now.Add(p.gracePeriod())
+	retire := fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, AnnotationTokenSecretExpiry, expiry.UTC().Format(time.RFC3339))
+	switch _, err := cs.CoreV1().Secrets(ProviderSANamespace).Patch(
+		ctx, previous, types.MergePatchType, []byte(retire), metav1.PatchOptions{},
+	); {
+	case apierrors.IsNotFound(err):
+		// Nothing to retire: the pointer named a Secret that is already gone.
+	case err != nil:
+		return nil, "", fmt.Errorf("scheduling previous token Secret %s for deletion: %w", previous, err)
+	default:
+		out.PreviousSecretName = previous
+		out.PreviousValidUntil = expiry
+	}
+	return out, token, nil
+}
+
+// recordCredentialsRotated stamps status.credentialsRotatedAt on the provider's
+// CatalogEntry so an operator can see, from the object the platform already
+// shows them, when the credential they hold was issued.
+func (p *Provisioner) recordCredentialsRotated(ctx context.Context, cfg *rest.Config, providerName string, at time.Time) error {
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("dynamic client: %w", err)
+	}
+	patch := fmt.Sprintf(`{"status":{"credentialsRotatedAt":%q}}`, at.UTC().Format(time.RFC3339))
+	_, err = dyn.Resource(catalogEntryGVR).Patch(
+		ctx, providerName, types.MergePatchType, []byte(patch), metav1.PatchOptions{}, "status",
+	)
+	return err
+}
+
+// SweepExpiredProviderTokens deletes the provider token Secrets in a provider
+// workspace whose grace period has passed, and reports when the next one lapses
+// (zero when none is pending).
+//
+// It is what actually ends the old credential's life: rotation only writes the
+// expiry. Running it from the catalog reconciler means it runs wherever a
+// provider is known, including org-owned workspaces the hub never lists.
+//
+// cluster may be a workspace path or a logical cluster ID.
+func (p *Provisioner) SweepExpiredProviderTokens(ctx context.Context, cluster string) (deleted int, nextExpiry time.Time, err error) {
+	if p.kcpConfig == nil {
+		// Registry-only mode: no kcp to sweep in, and no credentials to have
+		// rotated in the first place.
+		return 0, time.Time{}, nil
+	}
+	cfg := rest.CopyConfig(p.kcpConfig)
+	cfg.Host = apiurl.KCPClusterURL(cfg.Host, cluster)
+	typed, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("typed kube client for %s: %w", cluster, err)
+	}
+	deleted, nextExpiry, err = p.sweepExpiredTokens(ctx, typed)
+	if err != nil {
+		return deleted, nextExpiry, fmt.Errorf("sweeping expired provider tokens in %s: %w", cluster, err)
+	}
+	return deleted, nextExpiry, nil
+}
+
+// sweepExpiredTokens is SweepExpiredProviderTokens against an already-built
+// clientset, so it can be exercised without a live kcp.
+func (p *Provisioner) sweepExpiredTokens(ctx context.Context, cs kubernetes.Interface) (deleted int, nextExpiry time.Time, err error) {
+	active, err := activeTokenSecretName(ctx, cs)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// No provider ServiceAccount: not a provider workspace, or not
+			// provisioned yet. Nothing to sweep either way.
+			return 0, time.Time{}, nil
+		}
+		return 0, time.Time{}, err
+	}
+	list, err := cs.CoreV1().Secrets(ProviderSANamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("listing Secrets: %w", err)
+	}
+	now := p.now()
+	for i := range list.Items {
+		s := &list.Items[i]
+		if s.Name == active || s.Type != corev1.SecretTypeServiceAccountToken {
+			continue
+		}
+		if s.Annotations[corev1.ServiceAccountNameKey] != ProviderSAName {
+			continue
+		}
+		raw := s.Annotations[AnnotationTokenSecretExpiry]
+		if raw == "" {
+			// Never retired — the credential a workspace that has not rotated
+			// still holds. Deleting it would be an outage.
+			continue
+		}
+		expiry, parseErr := time.Parse(time.RFC3339, raw)
+		if parseErr != nil {
+			// An unparseable expiry is not a licence to keep a retired
+			// credential alive forever, but deleting on a value we cannot read
+			// is worse. Surface it and leave the Secret.
+			klog.FromContext(ctx).Info("provider token Secret has an unparseable expiry annotation; leaving it in place",
+				"secret", s.Name, "value", raw)
+			continue
+		}
+		if now.Before(expiry) {
+			if nextExpiry.IsZero() || expiry.Before(nextExpiry) {
+				nextExpiry = expiry
+			}
+			continue
+		}
+		if delErr := cs.CoreV1().Secrets(ProviderSANamespace).Delete(ctx, s.Name, metav1.DeleteOptions{}); delErr != nil && !apierrors.IsNotFound(delErr) {
+			return deleted, nextExpiry, fmt.Errorf("deleting expired token Secret %s: %w", s.Name, delErr)
+		}
+		deleted++
+	}
+	return deleted, nextExpiry, nil
 }
 
 // EncodeKubeconfig is a tiny helper for status reporting — surface the

--- a/pkg/hub/providers/provision_test.go
+++ b/pkg/hub/providers/provision_test.go
@@ -1,0 +1,483 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newRBACDynamicFake is a dynamic client that serves the two RBAC kinds
+// ensureProviderRoleBinding writes, so the binding logic — including the
+// delete-and-recreate a RoleRef change forces — runs for real.
+func newRBACDynamicFake() dynamic.Interface {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			clusterRoleGVR:        "ClusterRoleList",
+			clusterRoleBindingGVR: "ClusterRoleBindingList",
+		},
+	)
+}
+
+// ===== the generated faros:provider role =====
+
+// rulesFor collects every rule covering (group, resource). More than one is
+// normal: apiexports carries an ordinary CRUD rule and a separate `bind` rule.
+func rulesFor(group, resource string) []map[string]any {
+	var out []map[string]any
+	for _, raw := range providerClusterRoleRules() {
+		rule, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		groups, _ := rule["apiGroups"].([]any)
+		resources, _ := rule["resources"].([]any)
+		if containsAny(groups, group) && containsAny(resources, resource) {
+			out = append(out, rule)
+		}
+	}
+	return out
+}
+
+// grants reports whether the role permits verb on (group, resource) through
+// any of its rules, and returns the verbs it does permit for the failure
+// message.
+func grants(group, resource, verb string) (bool, []string) {
+	var seen []string
+	for _, rule := range rulesFor(group, resource) {
+		seen = append(seen, ruleVerbs(rule)...)
+		if hasVerb(rule, verb) {
+			return true, seen
+		}
+	}
+	return false, seen
+}
+
+func containsAny(list []any, want string) bool {
+	for _, v := range list {
+		if s, _ := v.(string); s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func ruleVerbs(rule map[string]any) []string {
+	raw, _ := rule["verbs"].([]any)
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func hasVerb(rule map[string]any, verb string) bool {
+	for _, v := range ruleVerbs(rule) {
+		if v == verb || v == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+// Everything a provider's own `init` and runtime do inside its workspace has to
+// be covered, or narrowing the role turns into an outage the first time a chart
+// is installed. Each row names the caller so a future reader can check it
+// against the code rather than against this list.
+func TestProviderClusterRoleCoversWhatProvidersActuallyDo(t *testing.T) {
+	for _, tc := range []struct {
+		group, resource, verb, why string
+	}{
+		{"apis.kcp.io", "apiresourceschemas", "create", "install.ApplySchemasFromDir"},
+		{"apis.kcp.io", "apiexports", "update", "install.ApplyAPIExport on upgrade"},
+		{"apis.kcp.io", "apiexportendpointslices", "delete", "install.EnsureAPIExportEndpointSlice recreates on a path change"},
+		{"apis.kcp.io", "apibindings", "list", "the apiexport multicluster provider enumerates bound clusters"},
+		{"apis.kcp.io", "apiexports/content", "get", "the APIExport VW authorizer SARs the in-flight verb"},
+		{"apis.kcp.io", "apiexports", "bind", "install.ApplyBindGrant writes the tenant bind ClusterRole"},
+		{"cache.kcp.io", "cachedresources", "create", "the infrastructure provider's virtual storage"},
+		{"core.kcp.io", "logicalclusters", "get", "install.workspacePathOf, the org-owned check"},
+		{"providers.faros.sh", "catalogentries", "update", "install.ApplyCatalogEntry self-registration"},
+		{"providers.faros.sh", "catalogentries/status", "patch", "the provider reports its own status"},
+		{"rbac.authorization.k8s.io", "clusterrolebindings", "delete", "install.removeBindGrant for org-owned workspaces"},
+		{"apiextensions.k8s.io", "customresourcedefinitions", "create", "per-template CRDs"},
+		{"", "secrets", "create", "runtime identity minting"},
+		{"", "serviceaccounts", "create", "runtime identity minting"},
+		{"coordination.k8s.io", "leases", "update", "provider-sdk leader election"},
+		{"authentication.k8s.io", "tokenreviews", "create", "providers that authenticate their own callers"},
+		{"authorization.k8s.io", "subjectaccessreviews", "create", "providers that authorize their own callers"},
+	} {
+		if ok, verbs := grants(tc.group, tc.resource, tc.verb); !ok {
+			t.Errorf("%s/%s lacks verb %q (needed by %s); grants %v", tc.group, tc.resource, tc.verb, tc.why, verbs)
+		}
+	}
+
+	// The APIExport VW passes the request's own verb into its SAR, discovery
+	// included, so this one rule cannot be an enumerated verb list.
+	content := rulesFor("apis.kcp.io", "apiexports/content")
+	if len(content) != 1 {
+		t.Fatalf("apiexports/content rules = %d, want exactly 1", len(content))
+	}
+	if got := ruleVerbs(content[0]); len(got) != 1 || got[0] != "*" {
+		t.Errorf("apiexports/content verbs = %v, want [*]", got)
+	}
+
+	// Discovery: every client-go built from the provider kubeconfig does it
+	// before it can construct a single informer.
+	var discovery bool
+	for _, raw := range providerClusterRoleRules() {
+		rule, _ := raw.(map[string]any)
+		if urls, ok := rule["nonResourceURLs"].([]any); ok && containsAny(urls, "/apis") {
+			discovery = true
+		}
+	}
+	if !discovery {
+		t.Error("no nonResourceURLs rule granting discovery")
+	}
+}
+
+// The point of the narrower role is that a provider cannot climb back out of
+// it. escalate/impersonate/bind-on-clusterroles would each let it do exactly
+// that, and tenancy writes would let it delete the workspace it lives in.
+func TestProviderClusterRoleWithholdsEscalationPaths(t *testing.T) {
+	for _, raw := range providerClusterRoleRules() {
+		rule, _ := raw.(map[string]any)
+		groups, _ := rule["apiGroups"].([]any)
+		resources, _ := rule["resources"].([]any)
+		if containsAny(groups, "*") || containsAny(resources, "*") {
+			t.Errorf("wildcard rule defeats the narrowing: %v", rule)
+		}
+		if containsAny(groups, "tenancy.kcp.io") {
+			t.Errorf("provider role must not reach tenancy.kcp.io: %v", rule)
+		}
+		if containsAny(groups, "rbac.authorization.k8s.io") {
+			for _, verb := range ruleVerbs(rule) {
+				switch verb {
+				case "escalate", "bind", "impersonate", "*":
+					t.Errorf("provider role grants %q on RBAC, which re-opens cluster-admin: %v", verb, rule)
+				}
+			}
+		}
+		for _, verb := range ruleVerbs(rule) {
+			if verb == "impersonate" {
+				t.Errorf("provider role grants impersonate: %v", rule)
+			}
+		}
+	}
+}
+
+// ===== the --provider-workspace-cluster-admin flag =====
+
+// The flag decides one thing: which ClusterRole the provider SA is bound to in
+// its own workspace. Default keeps cluster-admin so this release changes
+// nothing for an operator who does not opt in.
+func TestEnsureProviderRoleBindingHonoursTheFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		clusterAdmin bool
+		wantRole     string
+		wantRole1    bool
+	}{
+		{"default keeps cluster-admin", true, "cluster-admin", false},
+		{"opting in binds the generated role", false, ProviderClusterRoleName, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := newRBACDynamicFake()
+			p := NewProvisioner(nil, WithWorkspaceClusterAdmin(tc.clusterAdmin))
+			if err := p.ensureProviderRoleBinding(context.Background(), cl); err != nil {
+				t.Fatalf("ensureProviderRoleBinding: %v", err)
+			}
+			crb, err := cl.Resource(clusterRoleBindingGVR).Get(context.Background(), providerSABindingName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("getting binding: %v", err)
+			}
+			if got, _, _ := unstructured.NestedString(crb.Object, "roleRef", "name"); got != tc.wantRole {
+				t.Fatalf("roleRef = %q, want %q", got, tc.wantRole)
+			}
+			_, err = cl.Resource(clusterRoleGVR).Get(context.Background(), ProviderClusterRoleName, metav1.GetOptions{})
+			if got := err == nil; got != tc.wantRole1 {
+				t.Fatalf("ClusterRole %s present = %v, want %v", ProviderClusterRoleName, got, tc.wantRole1)
+			}
+		})
+	}
+}
+
+// RoleRef is immutable, so narrowing an EXISTING provider means the hub has to
+// delete the cluster-admin binding and recreate it. A hub that only tried to
+// update would leave every already-onboarded provider on cluster-admin — the
+// exact set the change is for.
+func TestEnsureProviderRoleBindingReplacesAnExistingClusterAdminBinding(t *testing.T) {
+	ctx := context.Background()
+	cl := newRBACDynamicFake()
+
+	wide := NewProvisioner(nil, WithWorkspaceClusterAdmin(true))
+	if err := wide.ensureProviderRoleBinding(ctx, cl); err != nil {
+		t.Fatalf("initial binding: %v", err)
+	}
+
+	narrow := NewProvisioner(nil, WithWorkspaceClusterAdmin(false))
+	if err := narrow.ensureProviderRoleBinding(ctx, cl); err != nil {
+		t.Fatalf("narrowing: %v", err)
+	}
+	crb, err := cl.Resource(clusterRoleBindingGVR).Get(ctx, providerSABindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting binding: %v", err)
+	}
+	if got, _, _ := unstructured.NestedString(crb.Object, "roleRef", "name"); got != ProviderClusterRoleName {
+		t.Fatalf("roleRef after narrowing = %q, want %q", got, ProviderClusterRoleName)
+	}
+	// One binding, under the historical name: a second one under a new name
+	// would leave the cluster-admin grant in force.
+	list, err := cl.Resource(clusterRoleBindingGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("listing bindings: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("bindings = %d, want exactly 1", len(list.Items))
+	}
+
+	// And back again, for the operator who staged the change and rolled it
+	// back.
+	if err := wide.ensureProviderRoleBinding(ctx, cl); err != nil {
+		t.Fatalf("rolling back: %v", err)
+	}
+	crb, err = cl.Resource(clusterRoleBindingGVR).Get(ctx, providerSABindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting binding: %v", err)
+	}
+	if got, _, _ := unstructured.NestedString(crb.Object, "roleRef", "name"); got != "cluster-admin" {
+		t.Fatalf("roleRef after rollback = %q, want cluster-admin", got)
+	}
+}
+
+// ===== rotation =====
+
+// providerSA is the ServiceAccount every provider workspace holds.
+func providerSA(annotations map[string]string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name: ProviderSAName, Namespace: ProviderSANamespace, Annotations: annotations,
+	}}
+}
+
+func tokenSecret(name string, annotations map[string]string, token string) *corev1.Secret {
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[corev1.ServiceAccountNameKey] = ProviderSAName
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ProviderSANamespace, Annotations: annotations},
+		Type:       corev1.SecretTypeServiceAccountToken,
+		Data:       map[string][]byte{corev1.ServiceAccountTokenKey: []byte(token)},
+	}
+}
+
+// tokenPopulatingClientset stands in for kcp's token controller: it fills in
+// the token of any service-account-token Secret as it is created, which is what
+// ensureLegacySAToken polls for.
+func tokenPopulatingClientset(objects ...runtime.Object) *fake.Clientset {
+	cs := fake.NewClientset(objects...)
+	cs.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		secret, ok := action.(k8stesting.CreateAction).GetObject().(*corev1.Secret)
+		if !ok || secret.Type != corev1.SecretTypeServiceAccountToken {
+			return false, nil, nil
+		}
+		out := secret.DeepCopy()
+		out.Data = map[string][]byte{corev1.ServiceAccountTokenKey: []byte("token-for-" + secret.Name)}
+		return false, nil, cs.Tracker().Add(out)
+	})
+	return cs
+}
+
+// A rotation must produce a NEW token, point the hub at it, and give the old
+// one a deadline rather than deleting it — the provider is still using it.
+func TestRotateMintsANewTokenAndRetiresThePreviousOne(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	cs := tokenPopulatingClientset(
+		providerSA(nil),
+		tokenSecret(ProviderTokenSecretName, nil, "original-token"),
+	)
+	p := &Provisioner{clock: func() time.Time { return now }}
+
+	previous, err := activeTokenSecretName(ctx, cs)
+	if err != nil {
+		t.Fatalf("active secret: %v", err)
+	}
+	if previous != ProviderTokenSecretName {
+		t.Fatalf("active secret before rotation = %q, want %q", previous, ProviderTokenSecretName)
+	}
+
+	rotated, token, err := p.rotateToken(ctx, cs)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	next := rotated.SecretName
+	if next == ProviderTokenSecretName {
+		t.Fatal("rotation reused the original Secret name")
+	}
+	if token == "original-token" || token == "" {
+		t.Fatalf("rotated token = %q, want a new one", token)
+	}
+	if rotated.PreviousSecretName != ProviderTokenSecretName {
+		t.Fatalf("PreviousSecretName = %q, want %q", rotated.PreviousSecretName, ProviderTokenSecretName)
+	}
+	if want := now.Add(DefaultCredentialGracePeriod); !rotated.PreviousValidUntil.Equal(want) {
+		t.Fatalf("PreviousValidUntil = %s, want %s", rotated.PreviousValidUntil, want)
+	}
+
+	// The hub now hands out the new one.
+	active, err := activeTokenSecretName(ctx, cs)
+	if err != nil {
+		t.Fatalf("active secret: %v", err)
+	}
+	if active != next {
+		t.Fatalf("active secret after rotation = %q, want %q", active, next)
+	}
+
+	// The old one is still there, still valid, with a deadline.
+	old, err := cs.CoreV1().Secrets(ProviderSANamespace).Get(ctx, ProviderTokenSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("previous Secret was deleted immediately: %v", err)
+	}
+	if string(old.Data[corev1.ServiceAccountTokenKey]) != "original-token" {
+		t.Fatal("previous token was altered; providers still holding it would break")
+	}
+	expiry, parseErr := time.Parse(time.RFC3339, old.Annotations[AnnotationTokenSecretExpiry])
+	if parseErr != nil {
+		t.Fatalf("previous Secret has no parseable expiry: %v", parseErr)
+	}
+	if want := now.Add(DefaultCredentialGracePeriod); !expiry.Equal(want) {
+		t.Fatalf("expiry = %s, want %s", expiry, want)
+	}
+}
+
+// The grace period is the whole point: both Secrets are tokens for the SAME
+// ServiceAccount, so anything that verifies the provider's identity — the
+// heartbeat's TokenReview (PR #627) above all — resolves both to the same
+// username and keeps accepting the old one while the chart is rolled forward.
+// The username never depends on which Secret the token came from.
+func TestBothCredentialsBelongToTheSameServiceAccountDuringTheGracePeriod(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	cs := tokenPopulatingClientset(
+		providerSA(nil),
+		tokenSecret(ProviderTokenSecretName, nil, "original-token"),
+	)
+	p := &Provisioner{clock: func() time.Time { return now }}
+	rotated, _, err := p.rotateToken(ctx, cs)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	next := rotated.SecretName
+
+	// The identity a TokenReview reports is derived from the Secret's
+	// service-account-name annotation, not from the Secret's name, so both
+	// tokens authenticate as system:serviceaccount:default:provider.
+	const wantUsername = "system:serviceaccount:" + ProviderSANamespace + ":" + ProviderSAName
+	for _, name := range []string{ProviderTokenSecretName, next} {
+		secret, err := cs.CoreV1().Secrets(ProviderSANamespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("getting %s: %v", name, err)
+		}
+		sa := secret.Annotations[corev1.ServiceAccountNameKey]
+		if sa != ProviderSAName {
+			t.Fatalf("Secret %s is bound to service account %q, want %q — its token would authenticate as a different identity", name, sa, ProviderSAName)
+		}
+		if got := "system:serviceaccount:" + secret.Namespace + ":" + sa; got != wantUsername {
+			t.Fatalf("Secret %s resolves to username %q, want %q", name, got, wantUsername)
+		}
+		if len(secret.Data[corev1.ServiceAccountTokenKey]) == 0 {
+			t.Fatalf("Secret %s carries no token; it would stop authenticating", name)
+		}
+	}
+}
+
+// Sweeping is what ends the old credential. Before the deadline it must leave
+// everything alone — deleting early is an outage for a provider mid-rollout.
+func TestSweepDeletesOnlyExpiredCredentials(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	expired := now.Add(-time.Minute).Format(time.RFC3339)
+	pending := now.Add(2 * time.Hour).Format(time.RFC3339)
+
+	cs := fake.NewClientset(
+		providerSA(map[string]string{AnnotationActiveTokenSecret: "provider-token-live"}),
+		tokenSecret("provider-token-live", nil, "live"),
+		tokenSecret("provider-token-old", map[string]string{AnnotationTokenSecretExpiry: expired}, "old"),
+		tokenSecret("provider-token-recent", map[string]string{AnnotationTokenSecretExpiry: pending}, "recent"),
+		// Never annotated: the credential a workspace that has not rotated
+		// still holds, or one whose retirement failed to stamp. Not ours to
+		// delete on a guess.
+		tokenSecret("provider-token", nil, "unannotated"),
+		// Someone else's Secret in the same namespace.
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "unrelated", Namespace: ProviderSANamespace,
+			Annotations: map[string]string{AnnotationTokenSecretExpiry: expired},
+		}, Type: corev1.SecretTypeOpaque},
+	)
+	p := &Provisioner{clock: func() time.Time { return now }}
+
+	deleted, next, err := p.sweepExpiredTokens(ctx, cs)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1 (only the lapsed credential)", deleted)
+	}
+	if want, _ := time.Parse(time.RFC3339, pending); !next.Equal(want) {
+		t.Fatalf("next expiry = %s, want %s", next, want)
+	}
+	for _, name := range []string{"provider-token-live", "provider-token-recent", "provider-token", "unrelated"} {
+		if _, err := cs.CoreV1().Secrets(ProviderSANamespace).Get(ctx, name, metav1.GetOptions{}); err != nil {
+			t.Errorf("sweep deleted %s, which was not expired: %v", name, err)
+		}
+	}
+	if _, err := cs.CoreV1().Secrets(ProviderSANamespace).Get(ctx, "provider-token-old", metav1.GetOptions{}); err == nil {
+		t.Error("expired credential survived the sweep")
+	}
+}
+
+// A workspace that never rotated reports the original Secret, so minting keeps
+// returning the same credential it always did.
+func TestActiveTokenSecretNameDefaultsToTheOriginal(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewClientset(providerSA(nil))
+	got, err := activeTokenSecretName(ctx, cs)
+	if err != nil {
+		t.Fatalf("activeTokenSecretName: %v", err)
+	}
+	if got != ProviderTokenSecretName {
+		t.Fatalf("active secret = %q, want %q", got, ProviderTokenSecretName)
+	}
+	if !strings.HasSuffix(ProviderTokenSecretName, ProviderTokenSecretSuffix) {
+		t.Fatalf("ProviderTokenSecretName %q no longer matches the name the token controller populates", ProviderTokenSecretName)
+	}
+}

--- a/pkg/hub/restapi/org_providers.go
+++ b/pkg/hub/restapi/org_providers.go
@@ -49,6 +49,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -84,6 +85,9 @@ type OrgProviderOps interface {
 type ProviderCredentialMinter interface {
 	EnsureProviderSAAtPath(ctx context.Context, workspacePath string) error
 	MintProviderKubeconfigAtPath(ctx context.Context, workspacePath, hubExternalURL string) ([]byte, error)
+	// RotateProviderCredentialAtPath issues a NEW token for the same
+	// ServiceAccount and retires the previous one after a grace period.
+	RotateProviderCredentialAtPath(ctx context.Context, workspacePath, providerName, hubExternalURL string) (*providers.RotatedCredential, error)
 }
 
 // orgProviderNameRE constrains a provider name to an RFC1123 label. The name
@@ -731,6 +735,103 @@ func (h *Handler) getOrgProviderKubeconfig(w http.ResponseWriter, r *http.Reques
 		// to leave without generated instructions.
 		Instructions: h.installInstructions(r.Context(), orgUUID, name, name),
 	})
+}
+
+// RotateOrgProviderCredentialResponse is the body of
+// POST /api/orgs/{org}/providers/{name}/credentials/rotate.
+type RotateOrgProviderCredentialResponse struct {
+	Provider OrgProviderView `json:"provider"`
+	// Kubeconfig is the NEW credential. Shown exactly once, like registration.
+	Kubeconfig string `json:"kubeconfig"`
+	// PreviousValidUntil is when the credential this call replaced stops
+	// working (RFC3339); empty when there was nothing to retire. It is the
+	// deadline for reinstalling the chart with the new kubeconfig: until then
+	// both tokens belong to the same ServiceAccount and the provider keeps
+	// working on either.
+	PreviousValidUntil string `json:"previousValidUntil,omitempty"`
+	RotatedAt          string `json:"rotatedAt"`
+	// Instructions are re-rendered alongside the credential — whoever rotates
+	// is about to run the install commands again.
+	Instructions *providers.InstallInstructions `json:"instructions,omitempty"`
+}
+
+// rotateOrgProviderCredential handles
+// POST /api/orgs/{org}/providers/{name}/credentials/rotate.
+//
+// Admin-only, unconditionally: unlike registration this is not gated on
+// spec.catalogEntryCreation. An Org that lets members register providers is
+// saying members may create NEW credentials for workspaces they made; it is not
+// saying a member may re-issue the credential for a provider someone else
+// registered and put the running one on a deletion clock. That is an admin's
+// call in every Org.
+func (h *Handler) rotateOrgProviderCredential(w http.ResponseWriter, r *http.Request) {
+	tc, ok := h.requireOrgProviderAccess(w, r, true /* mutating: hands out a credential */)
+	if !ok {
+		return
+	}
+	if !h.requireOrgAdminMembership(w, r, tc, "rotating a provider credential requires organization admin") {
+		return
+	}
+	orgUUID := tc.OrgUUID
+	name := mux.Vars(r)["name"]
+	if name == "" {
+		writeError(w, newValidationError("provider name is required"))
+		return
+	}
+	ws, err := h.mgr.orgProviders.GetOrgProviderWorkspace(r.Context(), orgUUID, name)
+	if err != nil {
+		writeStatus(w, http.StatusInternalServerError, "InternalError", "getting provider workspace: "+err.Error())
+		return
+	}
+	if ws == nil {
+		writeStatus(w, http.StatusNotFound, "NotFound", "provider "+name+" is not registered in this organization")
+		return
+	}
+	workspacePath := kcppaths.OrgProviderPath(orgUUID, name)
+	// Same reason the kubeconfig endpoint re-ensures: the workspace can exist
+	// with no ServiceAccount in it, and rotating a credential that was never
+	// created should produce one rather than an error.
+	if err := h.mgr.providerCreds.EnsureProviderSAAtPath(r.Context(), workspacePath); err != nil {
+		writeStatus(w, http.StatusInternalServerError, "InternalError", "ensuring provider service account: "+err.Error())
+		return
+	}
+	rotated, err := h.mgr.providerCreds.RotateProviderCredentialAtPath(r.Context(), workspacePath, name, h.mgr.kubeconfig.HubExternalURL)
+	if err != nil {
+		writeStatus(w, http.StatusInternalServerError, "InternalError", "rotating provider credential: "+err.Error())
+		return
+	}
+	resp := RotateOrgProviderCredentialResponse{
+		Provider:     h.orgProviderView(orgUUID, *ws),
+		Kubeconfig:   string(rotated.Kubeconfig),
+		RotatedAt:    rotated.RotatedAt.UTC().Format(time.RFC3339),
+		Instructions: h.installInstructions(r.Context(), orgUUID, name, name),
+	}
+	if !rotated.PreviousValidUntil.IsZero() {
+		resp.PreviousValidUntil = rotated.PreviousValidUntil.UTC().Format(time.RFC3339)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// requireOrgAdminMembership enforces the caller's ORG-scope Membership role,
+// for the endpoints that are admin-only whatever the Org's policy says.
+//
+// It reads the Membership rather than tc.Role for the same reason
+// requireOrgProviderAccess does: tc.Role is resolved against whichever
+// (org, workspace) pair the request headers name, and both scopes spell admin
+// the same way, so an org member who administers their own team workspace would
+// otherwise pass just by sending X-Faros-Workspace — which the portal attaches
+// to every request.
+func (h *Handler) requireOrgAdminMembership(w http.ResponseWriter, r *http.Request, tc tenant.TenantContext, message string) bool {
+	role, err := h.mgr.bootstrapper.GetOrgMembershipRole(r.Context(), tc.OrgUUID, tc.User)
+	if err != nil && !apierrors.IsNotFound(err) {
+		writeStatus(w, http.StatusInternalServerError, "InternalError", "resolving org membership: "+err.Error())
+		return false
+	}
+	if role != tenancyv1alpha1.MembershipRoleAdmin {
+		writeStatus(w, http.StatusForbidden, "Forbidden", message)
+		return false
+	}
+	return true
 }
 
 // deleteOrgProvider handles DELETE /api/orgs/{org}/providers/{name}.

--- a/pkg/hub/restapi/org_providers_test.go
+++ b/pkg/hub/restapi/org_providers_test.go
@@ -15,7 +15,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -62,7 +64,16 @@ func (f *fakeOrgProviderOps) ListOrgProviderWorkspaces(context.Context, string) 
 	return f.workspaces, nil
 }
 
-func (f *fakeOrgProviderOps) GetOrgProviderWorkspace(context.Context, string, string) (*kcp.OrgProviderWorkspace, error) {
+// GetOrgProviderWorkspace answers from the same list ListOrgProviderWorkspaces
+// serves, so "registered" means the same thing to every endpoint. A name the
+// Org never registered returns (nil, nil) — the not-found signal the handlers
+// turn into a 404.
+func (f *fakeOrgProviderOps) GetOrgProviderWorkspace(_ context.Context, _, name string) (*kcp.OrgProviderWorkspace, error) {
+	for i := range f.workspaces {
+		if f.workspaces[i].Name == name {
+			return &f.workspaces[i], nil
+		}
+	}
 	return nil, nil
 }
 
@@ -85,13 +96,51 @@ func (f *fakeOrgProviderOps) GetEdgeInstallTarget(_ context.Context, _, wsUUID, 
 
 // fakeCredMinter is the credential half of the org-provider wiring. It records
 // whether it was ever asked for a credential.
-type fakeCredMinter struct{ minted int }
+type fakeCredMinter struct {
+	minted  int
+	rotated []string
+}
 
 func (f *fakeCredMinter) EnsureProviderSAAtPath(context.Context, string) error { return nil }
 
 func (f *fakeCredMinter) MintProviderKubeconfigAtPath(context.Context, string, string) ([]byte, error) {
 	f.minted++
-	return []byte("apiVersion: v1\nkind: Config\n"), nil
+	return []byte(fakeKubeconfig("minted-token")), nil
+}
+
+func (f *fakeCredMinter) RotateProviderCredentialAtPath(_ context.Context, workspacePath, providerName, _ string) (*providers.RotatedCredential, error) {
+	f.rotated = append(f.rotated, workspacePath)
+	at := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	return &providers.RotatedCredential{
+		Kubeconfig:         []byte(fakeKubeconfig("rotated-token-for-" + providerName)),
+		SecretName:         "provider-token-20260905120000",
+		PreviousSecretName: "provider-token",
+		PreviousValidUntil: at.Add(24 * time.Hour),
+		RotatedAt:          at,
+	}, nil
+}
+
+// fakeKubeconfig is the shape MintProviderKubeconfigAtPath produces, so the
+// tests can assert the rotate endpoint returns a real kubeconfig rather than
+// some other blob.
+func fakeKubeconfig(token string) string {
+	return `apiVersion: v1
+kind: Config
+clusters:
+- name: faros
+  cluster:
+    server: https://hub.test/clusters/abcd1234
+    insecure-skip-tls-verify: true
+contexts:
+- name: faros
+  context:
+    cluster: faros
+    user: faros
+current-context: faros
+users:
+- name: faros
+  user:
+    token: ` + token + "\n"
 }
 
 // newOrgProviderTestServer wires the org-provider surface as an ORG ADMIN, with
@@ -604,5 +653,142 @@ func TestOrgProviders_NotWiredReturns501(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNotImplemented {
 		t.Fatalf("status: got %d, want 501", resp.StatusCode)
+	}
+}
+
+// ===== credential rotation =====
+
+// postRotate calls the org rotate endpoint for a provider.
+func postRotate(t *testing.T, base, provider string) *http.Response {
+	t.Helper()
+	resp, err := http.Post(base+"/api/orgs/org-a/providers/"+provider+"/credentials/rotate", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST rotate: %v", err)
+	}
+	return resp
+}
+
+// registeredOrgProvider wires a server whose Org already has one registered
+// provider, with the caller's org-scope role and the Org's registration policy
+// under test.
+func registeredOrgProvider(t *testing.T, tc tenant.TenantContext, policy, orgRole string) (*fakeOrgProviderOps, *fakeCredMinter, func() string) {
+	t.Helper()
+	umi := &tenancyv1alpha1.UserMembershipIndex{
+		ObjectMeta: metav1.ObjectMeta{Name: tc.User},
+		Spec: tenancyv1alpha1.UserMembershipIndexSpec{
+			Entries: []tenancyv1alpha1.MembershipIndexEntry{
+				{OrgUUID: "org-a", WorkspaceUUID: "ws-1", Role: tenancyv1alpha1.MembershipRoleMember},
+			},
+		},
+	}
+	ops, creds, url := newOrgProviderTestServerWithPolicy(t,
+		[]kcp.EdgeInstallTarget{connectedEdge("ws-1", "prod")}, tc, []runtime.Object{umi}, policy, orgRole)
+	ops.workspaces = []kcp.OrgProviderWorkspace{{Name: "vault", Cluster: "cluster-vault", Phase: "Ready"}}
+	return ops, creds, url
+}
+
+// Rotation hands out a live cluster credential and puts the running one on a
+// deletion clock, so it is admin-only in EVERY Org — including one that opened
+// registration to members. A member registering a provider they will run is a
+// different act from re-issuing the credential of a provider someone else runs.
+func TestRotateOrgProviderCredential_IsAdminOnlyWhateverThePolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		policy     string
+		caller     tenant.TenantContext
+		orgRole    string
+		wantStatus int
+	}{
+		{"org admin may rotate", "", adminTC("alice", "org-a", "ws-1"), tenancyv1alpha1.MembershipRoleAdmin, http.StatusOK},
+		{"member may not, on the default policy", "", memberTC("alice", "org-a", "ws-1"), tenancyv1alpha1.MembershipRoleMember, http.StatusForbidden},
+		{
+			"member may not, even where members may register",
+			tenancyv1alpha1.CatalogEntryCreationMembers,
+			memberTC("alice", "org-a", "ws-1"),
+			tenancyv1alpha1.MembershipRoleMember,
+			http.StatusForbidden,
+		},
+		{
+			// The portal attaches X-Faros-Workspace to every request, so a
+			// workspace admin who is merely an org member must not slip through
+			// on the role the headers name.
+			"workspace admin who is only an org member may not",
+			tenancyv1alpha1.CatalogEntryCreationMembers,
+			adminTC("alice", "org-a", "ws-1"),
+			tenancyv1alpha1.MembershipRoleMember,
+			http.StatusForbidden,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, creds, url := registeredOrgProvider(t, tc.caller, tc.policy, tc.orgRole)
+			resp := postRotate(t, url(), "vault")
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+			if tc.wantStatus != http.StatusOK && len(creds.rotated) != 0 {
+				t.Fatalf("rotated %v despite a %d", creds.rotated, resp.StatusCode)
+			}
+		})
+	}
+}
+
+// The response is the only place the new credential is ever shown, so it has to
+// be a usable kubeconfig — the same shape registration returns — and it has to
+// say when the credential it replaced stops working, which is the operator's
+// deadline for the rollout.
+func TestRotateOrgProviderCredential_ReturnsAKubeconfigAndTheGraceDeadline(t *testing.T) {
+	ops, creds, url := registeredOrgProvider(t, adminTC("alice", "org-a", "ws-1"), "", tenancyv1alpha1.MembershipRoleAdmin)
+	resp := postRotate(t, url(), "vault")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got RotateOrgProviderCredentialResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Provider.Name != "vault" || got.Provider.WorkspacePath != kcppaths.OrgProviderPath("org-a", "vault") {
+		t.Fatalf("provider = %+v, want the org's vault workspace", got.Provider)
+	}
+	for _, want := range []string{"apiVersion: v1", "kind: Config", "token: rotated-token-for-vault"} {
+		if !strings.Contains(got.Kubeconfig, want) {
+			t.Fatalf("kubeconfig missing %q:\n%s", want, got.Kubeconfig)
+		}
+	}
+	if got.Kubeconfig == fakeKubeconfig("minted-token") {
+		t.Fatal("rotation returned the OLD credential")
+	}
+	rotatedAt, err := time.Parse(time.RFC3339, got.RotatedAt)
+	if err != nil {
+		t.Fatalf("rotatedAt %q: %v", got.RotatedAt, err)
+	}
+	validUntil, err := time.Parse(time.RFC3339, got.PreviousValidUntil)
+	if err != nil {
+		t.Fatalf("previousValidUntil %q: %v", got.PreviousValidUntil, err)
+	}
+	if !validUntil.After(rotatedAt) {
+		t.Fatalf("previousValidUntil %s is not after rotatedAt %s; there would be no window to roll the provider forward", validUntil, rotatedAt)
+	}
+	if len(creds.rotated) != 1 || creds.rotated[0] != kcppaths.OrgProviderPath("org-a", "vault") {
+		t.Fatalf("rotated %v, want exactly the org's own provider workspace", creds.rotated)
+	}
+	if len(ops.registered) != 0 {
+		t.Fatalf("rotation created workspaces: %v", ops.registered)
+	}
+}
+
+// Rotating a provider this Org never registered must not reach kcp at all:
+// otherwise the workspace path is caller-chosen, and a name belonging to
+// another Org would be minted against.
+func TestRotateOrgProviderCredential_UnknownProviderIs404(t *testing.T) {
+	_, creds, url := registeredOrgProvider(t, adminTC("alice", "org-a", "ws-1"), "", tenancyv1alpha1.MembershipRoleAdmin)
+	resp := postRotate(t, url(), "someone-elses")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	if len(creds.rotated) != 0 {
+		t.Fatalf("rotated %v for a provider the org never registered", creds.rotated)
 	}
 }

--- a/pkg/hub/restapi/restapi.go
+++ b/pkg/hub/restapi/restapi.go
@@ -315,6 +315,10 @@ func (h *Handler) RegisterTenantScoped(r *mux.Router) {
 	r.HandleFunc("/{org}/providers", h.registerOrgProvider).Methods(http.MethodPost)
 	r.HandleFunc("/{org}/providers/{name}", h.deleteOrgProvider).Methods(http.MethodDelete)
 	r.HandleFunc("/{org}/providers/{name}/kubeconfig", h.getOrgProviderKubeconfig).Methods(http.MethodGet)
+	// Rotation is its own POST rather than a variant of the kubeconfig GET:
+	// that endpoint deliberately returns the same credential every time, so
+	// asking for a different one has to be explicit. Org admin only.
+	r.HandleFunc("/{org}/providers/{name}/credentials/rotate", h.rotateOrgProviderCredential).Methods(http.MethodPost)
 
 	r.HandleFunc("/{org}/memberships", h.listOrgMemberships).Methods(http.MethodGet)
 	r.HandleFunc("/{org}/memberships", h.addOrgMembership).Methods(http.MethodPost)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -754,7 +754,7 @@ func (s *Server) Run(ctx context.Context) error {
 			// the Org's provider workspaces, the Provisioner mints the
 			// workspace-scoped install credential. Both need kcp, so this is
 			// inside the same kcp-gated branch as the rest of the REST surface.
-			apiMgr.WithOrgProviders(bootstrapper, providers.NewProvisioner(kcpConfig))
+			apiMgr.WithOrgProviders(bootstrapper, providers.NewProvisioner(kcpConfig, s.providerProvisionerOptions()...))
 			// Per-workspace kubeconfig download — OIDC mode emits an exec
 			// credential plugin entry (faros get-token), static-token mode
 			// embeds the caller's bearer token. Either way the cluster URL
@@ -832,7 +832,7 @@ func (s *Server) Run(ctx context.Context) error {
 					}
 					return false
 				})
-				adminSvc := admin.NewService(kcpConfig, s.opts.HubExternalURL, s.opts.HubInternalURL)
+				adminSvc := admin.NewService(kcpConfig, s.opts.HubExternalURL, s.opts.HubInternalURL, s.providerProvisionerOptions()...)
 				adminSub := router.PathPrefix("/api/admin").Subrouter()
 				adminSub.Use(admin.Middleware(adminResolver, adminChecker))
 				admin.NewHandler(adminSvc, userClient, providerRegistry).Register(adminSub)
@@ -894,6 +894,10 @@ func (s *Server) Run(ctx context.Context) error {
 			// pkg/hub/providers, so the two EdgeRoute types are mirrored rather
 			// than shared, exactly as ProviderClaim is.
 			EdgeRoutes: edgeRouteResolver{bootstrapper},
+			// The catalog reconciler sweeps rotated-out provider credentials
+			// once their grace period lapses, so it needs the same Provisioner
+			// configuration as the paths that mint them.
+			Provisioner: s.providerProvisionerOptions(),
 		}); err != nil {
 			return fmt.Errorf("setting up provider catalog controller: %w", err)
 		}
@@ -962,6 +966,7 @@ func (s *Server) Run(ctx context.Context) error {
 			if err := providers.SetupProviderWithManager(adminMgr, kcpConfig, providers.CatalogReconcilerOptions{
 				HubExternalURL: s.opts.HubExternalURL,
 				HubInternalURL: s.opts.HubInternalURL,
+				Provisioner:    s.providerProvisionerOptions(),
 			}); err != nil {
 				logger.Error(err, "Setting up provider provisioning controller failed")
 				return
@@ -1163,6 +1168,17 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// providerProvisionerOptions is the one place the hub's provider-credential
+// policy is turned into Provisioner options. Every path that creates a provider
+// ServiceAccount — admin onboarding, the Provider reconciler, org-owned
+// registration — and the catalog reconciler that sweeps rotated credentials go
+// through it, so they cannot disagree about which role a provider is bound to.
+func (s *Server) providerProvisionerOptions() []providers.ProvisionerOption {
+	return []providers.ProvisionerOption{
+		providers.WithWorkspaceClusterAdmin(s.opts.ProviderWorkspaceClusterAdmin),
+	}
 }
 
 func (s *Server) buildRestConfig() (*rest.Config, error) {


### PR DESCRIPTION
**Stacked on #635 — must merge after it.** Its base is `sec/1.2-delegated-tokens-for-org-providers`; both branches edit `pkg/hub/restapi/org_providers.go`. Review this one's diff against that base, not against `main`.

Item 3.4 of the security remediation plan.

## Problem

Provider registration mints exactly one credential per provider workspace, and it is the widest and longest-lived one the platform issues:

- **Non-expiring.** `MintProviderKubeconfigAtPath` reads a legacy `kubernetes.io/service-account-token` Secret, which is valid until the Secret or its ServiceAccount is deleted. There is no TTL and no rotation path — the only way to replace a suspect credential was to delete and re-register the provider, which cascades the workspace and everything in it.
- **cluster-admin.** `EnsureProviderSAAtPath` bound the SA to `cluster-admin` in its own workspace, so a provider could rewrite its own RBAC, mint further credentials for itself, and read or delete anything else in there.

The workspace boundary itself is sound — cross-workspace reach only ever comes from accepted permission claims — but "cluster-admin, forever, no way to re-issue" is more than any provider needs.

## Change

**A narrower role.** A generated `faros:provider` ClusterRole replaces the `cluster-admin` binding. The rules come from what actually runs against the minted kubeconfig — `provider-sdk/install` (every provider's `init`), the APIExport virtual-workspace clients, the SDK's leader election, and the infrastructure provider's runtime bootstrap:

| Group | Resources | Verbs |
|---|---|---|
| `apis.kcp.io` | apiresourceschemas, apiexports, apiexportendpointslices, apibindings | get,list,watch,create,update,patch,delete |
| `apis.kcp.io` | apiexports/content | `*` — the VW authorizer SARs the in-flight request's own verb, discovery included |
| `apis.kcp.io` | apiexports | bind — lets `ApplyBindGrant` write the tenant bind role without `escalate` |
| `cache.kcp.io` | cachedresources, cachedresourceendpointslices | get,list,watch,create,update,patch,delete |
| `core.kcp.io` | logicalclusters | get,list,watch |
| `providers.faros.sh` | catalogentries, catalogentries/status | get,list,watch,create,update,patch |
| `rbac.authorization.k8s.io` | clusterroles, clusterrolebindings | get,list,watch,create,update,delete |
| `apiextensions.k8s.io` | customresourcedefinitions | get,list,watch,create,update,patch,delete |
| (core) | serviceaccounts, secrets, configmaps, namespaces, events | get,list,watch,create,update,patch,delete |
| `coordination.k8s.io` | leases | get,list,watch,create,update,patch,delete |
| `authentication.k8s.io` | tokenreviews | create |
| `authorization.k8s.io` | subjectaccessreviews, selfsubjectaccessreviews, selfsubjectrulesreviews | create |
| — | discovery non-resource URLs (`/api`, `/apis`, `/openapi`, …) | get |

It deliberately withholds `escalate` on RBAC (escalation-prevention then holds a provider to rights it already has, so it cannot promote itself back to cluster-admin), `impersonate`, and any write to `tenancy.kcp.io`.

**Rotation.** `POST /api/admin/providers/{name}/credentials/rotate` (platform admin) and `POST /api/orgs/{org}/providers/{name}/credentials/rotate` (org admin). Each issues a *second* token Secret for the same ServiceAccount, records which is current on the SA (`providers.faros.sh/active-token-secret`), stamps the previous one with `providers.faros.sh/delete-after` (24h), and returns a kubeconfig in the same shape registration does. The catalog reconciler deletes retired Secrets once the grace period lapses. `CatalogEntry.status.credentialsRotatedAt` records the rotation (new field, codegen committed).

The org endpoint is admin-only **unconditionally**, not gated on `spec.catalogEntryCreation`: an Org that lets members register providers is saying members may create new credentials for workspaces they made, not that a member may re-issue the running credential of a provider someone else operates. It reads the org-scope Membership rather than `tc.Role`, for the same reason registration does — the portal attaches `X-Faros-Workspace` to every request, so a workspace admin who is only an org member must not slip through.

No `faros` CLI subcommand: the CLI has no admin/provider command group to hang one off, so the curl call is documented instead.

## Compatibility

**Existing providers keep working, untouched.** `--provider-workspace-cluster-admin` defaults to **true** this release, so nothing about an existing deployment changes until an operator opts in; the flag help and the option's doc comment both say the next release flips it. Providers that never rotate keep reading `provider-token` — the active-secret annotation is absent and resolves to exactly that name, so `MintProviderKubeconfigAtPath` returns the credential it always did.

**How an operator rotates.**
1. `POST …/credentials/rotate`, keep `kubeconfig` and note `previousValidUntil`.
2. Reinstall the provider's chart with the new kubeconfig before that time.
3. Nothing else — the hub deletes the old Secret on its own.

**How an operator narrows the role.** Start the hub with `--provider-workspace-cluster-admin=false`, watch the providers, and flip back if one needs a right the allow-list does not grant. Known case: the `infrastructure` provider both defines CRDs in its workspace and writes objects of them, which escalation-prevention blocks — it must stay on `true` until it declares what it needs. Because RoleRef is immutable, changing the flag **deletes and recreates** the binding rather than adding a second one beside it (a second binding would leave the cluster-admin grant in force, which is the thing being removed). The few-millisecond gap is covered by controller retries.

**Heartbeat interplay with #627.** #627 authenticates the heartbeat by TokenReview of the provider kubeconfig's bearer, requiring username `system:serviceaccount:default:provider`. Rotation is safe for it by construction: both Secrets are tokens for the **same** ServiceAccount, so kcp resolves either to that same username — the identity does not depend on which Secret the token came from. A provider still on the old kubeconfig therefore keeps heartbeating for the whole grace period, in `warn` and in `enforce` mode alike. `TestBothCredentialsBelongToTheSameServiceAccountDuringTheGracePeriod` pins that property here so it cannot regress from this side; #627 is not in this branch, so the assertion is on the Secrets' service-account binding rather than on its authenticator directly.

## Tests

- `pkg/hub/providers/provision_test.go` — the role covers every call `init` and the runtime make (each row names the caller); it grants no wildcard, no `escalate`/`impersonate`/`bind` on RBAC, no tenancy; the flag picks the right role in both directions; narrowing an existing provider replaces the cluster-admin binding and leaves exactly one binding behind, and rolls back; rotation mints a new token, repoints the SA and dates the old Secret; both credentials resolve to the same SA username during the grace period; the sweep deletes only lapsed credentials and leaves live, pending and never-retired ones alone.
- `pkg/hub/providers/controller_test.go` — the reconciler sweeps in the provider's own cluster and requeues while an expiry is pending; a sweep failure does not drop the provider from the registry.
- `pkg/hub/restapi/org_providers_test.go` — org admin 200, member 403 on the default policy, member 403 *even where members may register*, workspace-admin-who-is-an-org-member 403, and none of them reaches the minter; the 200 returns a real kubeconfig carrying the new token with `previousValidUntil` after `rotatedAt`, against the Org's own workspace path; an unregistered name is 404 with no mint.
- `pkg/hub/admin/handler_test.go` — the platform route sits behind the admin gate (403 non-admin, 401 unidentified), is POST-only, and rejects an unknown `server` mode before minting anything.

Commands run: `GOWORK=off go build ./...`, `go vet ./pkg/...`, `go test -count=1 ./pkg/...` (all pass), `make fix-lint && make lint` (0 issues), `make verify-codegen` and `make verify-boilerplate` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
