### PR TITLE
fix(edges): fail closed on SSH host keys and audit sessions

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -248,13 +248,34 @@ The provider verifies the sshd host key on every SSH session and fails closed
   (env `FAROS_EDGES_ALLOW_UNVERIFIED_SSH_HOST_KEY=true`, chart value
   `allowUnverifiedSSHHostKey`) opens sessions to edges with no known key
   without verification. It is logged at verbosity 0 on startup and on every
-  use, and never affects an edge whose key is known.
+  use, and never affects an edge whose key is known. A malformed value for the
+  env form (e.g. `treu`) is a startup error rather than a silent `false`.
+
+The handshake itself is bounded: `newSSHClient` arms a deadline on the tunnelled
+connection (the caller's context deadline, else 30s) before
+`gossh.NewClientConn`, which takes no context, and clears it once the session is
+up. Without it a stalled tunnel pins the handler goroutine indefinitely.
 
 Every session emits two structured lines at verbosity 0: `SSH session opened`
 (cluster, edge, caller, SSH user, mode, exec command, remote address, host key
 fingerprint) and `SSH session ended` (plus duration and error). A session
 refused before opening still gets the `ended` line with `opened=false`. When the
 caller's TokenReview fails the lines carry `caller=unknown` and `callerError`.
+
+Two properties keep those lines trustworthy:
+
+- **`remoteAddr` is the LAST `X-Forwarded-For` hop**, not the first. Exactly one
+  trusted proxy (the hub backend) fronts this handler and *appends* the peer it
+  saw; every entry to its left is caller-supplied and forgeable. With no header
+  the peer address is used, port stripped. The value is always a parsed IP or
+  `unknown` — junk is never echoed.
+- **`exec` is escaped and bounded.** The command is a raw query parameter;
+  control characters (newlines above all, which would otherwise forge extra
+  audit records) are escaped rather than dropped, and the value is truncated at
+  256 runes with an explicit `...[truncated]` marker.
+
+Fingerprints in conditions and audit lines distinguish `unknown` (no key
+recorded) from `unparseable` (a key is recorded but malformed).
 
 ### SSH username mapping (OIDC)
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -227,6 +227,35 @@ When the agent starts with `--token` and `--ssh-user`/`--ssh-password`:
 4. `storeSSHCredentials` creates a `faros-ssh-<name>` Secret in `faros-system`.
 5. `edge.status.sshCredentials` is populated with the username and secret ref.
 
+### SSH host key verification
+
+The provider verifies the sshd host key on every SSH session and fails closed
+(`providers/edges/internal/tunnel/agent_proxy_builder.go`, `newSSHClient`):
+
+- **Key source.** `spec.sshHostKey` (operator pin, authorized_keys format) wins.
+  Otherwise `status.sshHostKey`, which the agent reports once on tunnel connect
+  (`X-Faros-SSH-HostKey`). The provider records the reported key **write-once**:
+  a later report with a different fingerprint is not applied and instead sets
+  the `SSHHostKeyChanged` condition (both fingerprints in the message). Resolve
+  it by pinning `spec.sshHostKey` or clearing `status.sshHostKey`.
+- **Unparseable key** → the session is refused.
+- **No key known** → `spec.sshHostKeyPolicy` decides:
+  - `strict` (default): the session is refused until a key is pinned or
+    reported.
+  - `tofu`: the key presented on the first session is trusted, recorded in
+    `status.sshHostKey`, and enforced from then on.
+- **Legacy escape hatch.** `edges-provider serve --allow-unverified-ssh-host-key`
+  (env `FAROS_EDGES_ALLOW_UNVERIFIED_SSH_HOST_KEY=true`, chart value
+  `allowUnverifiedSSHHostKey`) opens sessions to edges with no known key
+  without verification. It is logged at verbosity 0 on startup and on every
+  use, and never affects an edge whose key is known.
+
+Every session emits two structured lines at verbosity 0: `SSH session opened`
+(cluster, edge, caller, SSH user, mode, exec command, remote address, host key
+fingerprint) and `SSH session ended` (plus duration and error). A session
+refused before opening still gets the `ended` line with `opened=false`. When the
+caller's TokenReview fails the lines carry `caller=unknown` and `callerError`.
+
 ### SSH username mapping (OIDC)
 
 With OIDC auth, the SSH username is derived from the user's token claim:

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -884,10 +884,15 @@ func (a *Agent) runServerMode(ctx context.Context, logger klog.Logger, hubClient
 
 	// In join-token mode, pass SSH credentials as WebSocket headers so the hub
 	// can store them server-side (the agent's join token is not a valid kcp
-	// credential for creating secrets).
+	// credential for creating secrets). The sshd host key travels on EVERY
+	// connect, whatever the mode: the provider records it write-once (it is
+	// no longer re-asserted via the heartbeat status patch), so an agent that
+	// first connects with a saved kubeconfig must still get to report it.
 	var sshHeaders http.Header
 	if a.opts.Token != "" {
 		sshHeaders = a.buildSSHHeaders()
+	} else {
+		sshHeaders = a.sshHostKeyHeader()
 	}
 
 	// downstreamConfig is nil in server mode; the tunnel only serves /ssh.
@@ -1102,10 +1107,19 @@ func (a *Agent) buildSSHHeaders() http.Header {
 			klog.Warningf("Failed to read SSH private key from %s: %v", a.opts.SSHPrivateKeyPath, err)
 		}
 	}
-	// Probe the local sshd for its host public key so the hub can pin it for
-	// strict host-key verification (avoids the InsecureIgnoreHostKey fallback
-	// in pkg/virtual/builder/agent_proxy_builder.go). Best-effort: an empty
-	// result simply leaves the hub on its existing fallback path.
+	for k, v := range a.sshHostKeyHeader() {
+		h[k] = v
+	}
+	return h
+}
+
+// sshHostKeyHeader probes the local sshd for its host public key and returns
+// it as the X-Faros-SSH-HostKey header so the provider can record it
+// (write-once) and verify SSH sessions against it. Best-effort: an empty
+// result sends nothing, and the provider's sshHostKeyPolicy decides what
+// happens to sessions until a key is known.
+func (a *Agent) sshHostKeyHeader() http.Header {
+	h := http.Header{}
 	if a.opts.SSHProxyPort > 0 {
 		if hostKey := agentStatus.DialAndFetchSSHHostKey(a.opts.SSHProxyPort, klog.Background()); hostKey != "" {
 			h.Set("X-Faros-SSH-HostKey", base64.StdEncoding.EncodeToString([]byte(hostKey)))

--- a/pkg/agent/status/edge_reporter.go
+++ b/pkg/agent/status/edge_reporter.go
@@ -161,14 +161,12 @@ func (r *EdgeReporter) sendHeartbeat(ctx context.Context, logger klog.Logger) {
 		"lastHeartbeatTime": metav1.Now(),
 	}
 
-	// Report the sshd host public key so the hub can verify the agent's identity.
-	// We dial the SSH server directly to fetch its actual key, which works for
-	// both the real sshd (production) and the embedded TestSSHServer (e2e tests).
-	if r.sshProxyPort > 0 {
-		if hostKey := DialAndFetchSSHHostKey(r.sshProxyPort, logger); hostKey != "" {
-			statusPatch["sshHostKey"] = hostKey
-		}
-	}
+	// The sshd host public key is NOT patched here. It is reported once, on
+	// tunnel connect (X-Faros-SSH-HostKey, see agent.go), and the provider
+	// records it write-once: re-asserting it on every heartbeat would let a
+	// compromised agent rotate the key the hub pins SSH sessions to.
+	// sshProxyPort stays so DialAndFetchSSHHostKey remains available to the
+	// connect path and tests.
 
 	patch := map[string]interface{}{
 		"status": statusPatch,

--- a/providers/edges/apis/v1alpha1/types_linuxserver.go
+++ b/providers/edges/apis/v1alpha1/types_linuxserver.go
@@ -80,6 +80,23 @@ type LinuxServerSpec struct {
 	// SSHCredentialsRef references a Secret with admin-configured SSH credentials.
 	// +optional
 	SSHCredentialsRef *corev1.SecretReference `json:"sshCredentialsRef,omitempty"`
+
+	// SSHHostKey pins the sshd host public key (authorized_keys format, e.g.
+	// "ssh-ed25519 AAAA...") the provider verifies SSH sessions against. When
+	// set it takes precedence over the agent-reported status.sshHostKey, which
+	// a compromised agent could otherwise assert.
+	// +optional
+	SSHHostKey string `json:"sshHostKey,omitempty"`
+
+	// SSHHostKeyPolicy controls what happens when no host key is known (neither
+	// spec.sshHostKey nor status.sshHostKey is set): "strict" refuses the SSH
+	// session; "tofu" trusts the key presented on the first session, records it
+	// in status.sshHostKey and enforces it from then on. A known key is always
+	// enforced regardless of the policy.
+	// +kubebuilder:validation:Enum=strict;tofu
+	// +kubebuilder:default=strict
+	// +optional
+	SSHHostKeyPolicy edgeapi.SSHHostKeyPolicy `json:"sshHostKeyPolicy,omitempty"`
 }
 
 // LinuxServerStatus defines the observed state of a LinuxServer.
@@ -91,7 +108,10 @@ type LinuxServerStatus struct {
 	// +optional
 	SSHCredentials *edgeapi.SSHCredentials `json:"sshCredentials,omitempty"`
 
-	// SSHHostKey is the SSH host public key reported by the agent (authorized_keys format).
+	// SSHHostKey is the SSH host public key reported by the agent (authorized_keys
+	// format). Recorded once, on the first report (or on the first "tofu"
+	// session), and never replaced automatically: a differing later report sets
+	// the SSHHostKeyChanged condition instead. Overridden by spec.sshHostKey.
 	// +optional
 	SSHHostKey string `json:"sshHostKey,omitempty"`
 }

--- a/providers/edges/config/crds/edges.faros.sh_linuxservers.yaml
+++ b/providers/edges/config/crds/edges.faros.sh_linuxservers.yaml
@@ -75,6 +75,25 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              sshHostKey:
+                description: |-
+                  SSHHostKey pins the sshd host public key (authorized_keys format, e.g.
+                  "ssh-ed25519 AAAA...") the provider verifies SSH sessions against. When
+                  set it takes precedence over the agent-reported status.sshHostKey, which
+                  a compromised agent could otherwise assert.
+                type: string
+              sshHostKeyPolicy:
+                default: strict
+                description: |-
+                  SSHHostKeyPolicy controls what happens when no host key is known (neither
+                  spec.sshHostKey nor status.sshHostKey is set): "strict" refuses the SSH
+                  session; "tofu" trusts the key presented on the first session, records it
+                  in status.sshHostKey and enforces it from then on. A known key is always
+                  enforced regardless of the policy.
+                enum:
+                - strict
+                - tofu
+                type: string
               sshKeySecretRef:
                 description: 'SSHKeySecretRef references a Secret containing the SSH
                   private key (key: id_rsa).'
@@ -234,8 +253,11 @@ spec:
                 - username
                 type: object
               sshHostKey:
-                description: SSHHostKey is the SSH host public key reported by the
-                  agent (authorized_keys format).
+                description: |-
+                  SSHHostKey is the SSH host public key reported by the agent (authorized_keys
+                  format). Recorded once, on the first report (or on the first "tofu"
+                  session), and never replaced automatically: a differing later report sets
+                  the SSHHostKeyChanged condition instead. Overridden by spec.sshHostKey.
                 type: string
               workspacePath:
                 description: WorkspacePath is the kcp workspace path this resource

--- a/providers/edges/config/kcp/apiexport-edges.faros.sh.yaml
+++ b/providers/edges/config/kcp/apiexport-edges.faros.sh.yaml
@@ -11,7 +11,7 @@ spec:
       crd: {}
   - group: edges.faros.sh
     name: linuxservers
-    schema: v260715-d4e8aa2.linuxservers.edges.faros.sh
+    schema: v260904-9ab06b67.linuxservers.edges.faros.sh
     storage:
       crd: {}
   - group: edges.faros.sh

--- a/providers/edges/config/kcp/apiresourceschema-linuxservers.edges.faros.sh.yaml
+++ b/providers/edges/config/kcp/apiresourceschema-linuxservers.edges.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260715-d4e8aa2.linuxservers.edges.faros.sh
+  name: v260904-9ab06b67.linuxservers.edges.faros.sh
 spec:
   group: edges.faros.sh
   names:
@@ -71,6 +71,25 @@ spec:
                   type: string
               type: object
               x-kubernetes-map-type: atomic
+            sshHostKey:
+              description: |-
+                SSHHostKey pins the sshd host public key (authorized_keys format, e.g.
+                "ssh-ed25519 AAAA...") the provider verifies SSH sessions against. When
+                set it takes precedence over the agent-reported status.sshHostKey, which
+                a compromised agent could otherwise assert.
+              type: string
+            sshHostKeyPolicy:
+              default: strict
+              description: |-
+                SSHHostKeyPolicy controls what happens when no host key is known (neither
+                spec.sshHostKey nor status.sshHostKey is set): "strict" refuses the SSH
+                session; "tofu" trusts the key presented on the first session, records it
+                in status.sshHostKey and enforces it from then on. A known key is always
+                enforced regardless of the policy.
+              enum:
+              - strict
+              - tofu
+              type: string
             sshKeySecretRef:
               description: 'SSHKeySecretRef references a Secret containing the SSH
                 private key (key: id_rsa).'
@@ -230,8 +249,11 @@ spec:
               - username
               type: object
             sshHostKey:
-              description: SSHHostKey is the SSH host public key reported by the agent
-                (authorized_keys format).
+              description: |-
+                SSHHostKey is the SSH host public key reported by the agent (authorized_keys
+                format). Recorded once, on the first report (or on the first "tofu"
+                session), and never replaced automatically: a differing later report sets
+                the SSHHostKeyChanged condition instead. Overridden by spec.sshHostKey.
               type: string
             workspacePath:
               description: WorkspacePath is the kcp workspace path this resource lives

--- a/providers/edges/deploy/chart/README.md
+++ b/providers/edges/deploy/chart/README.md
@@ -53,6 +53,7 @@ helm upgrade --install edges oci://ghcr.io/faroshq/charts/faros-edges-provider \
 | `hub.caSecretRef.name` | `""` |  |
 | `hub.caSecretRef.key` | `ca.crt` |  |
 | `devMode` | `false` | Enables dev-mode shortcuts in the controllers (e.g. relaxed kubeconfig CA). |
+| `allowUnverifiedSSHHostKey` | `false` | Legacy escape hatch: open SSH sessions to LinuxServers that have NO known sshd host key (no spec.sshHostKey pin and no agent-reported status.sshHostKey) without verifying the server. Edges with a known key are always verified. Prefer pinning spec.sshHostKey or sshHostKeyPolicy=tofu on the edge instead. |
 | `providerKubeconfig` |  | Secret holding the workspace-admin kubeconfig minted via /bonkers (admin onboarding). Used by BOTH the init container (bootstrap APIExport/schemas) and the serve container (token validation + cross-tenant controllers). Key must be "kubeconfig". |
 | `providerKubeconfig.secretName` | `faros-provider-kubeconfig` |  |
 | `catalogEntry` |  | Render the CatalogEntry into a ConfigMap the init container applies into the provider workspace (it is a kcp resource, not a host-cluster one). |

--- a/providers/edges/deploy/chart/files/schemas/linuxservers.edges.faros.sh.yaml
+++ b/providers/edges/deploy/chart/files/schemas/linuxservers.edges.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260715-d4e8aa2.linuxservers.edges.faros.sh
+  name: v260904-9ab06b67.linuxservers.edges.faros.sh
 spec:
   group: edges.faros.sh
   names:
@@ -71,6 +71,25 @@ spec:
                   type: string
               type: object
               x-kubernetes-map-type: atomic
+            sshHostKey:
+              description: |-
+                SSHHostKey pins the sshd host public key (authorized_keys format, e.g.
+                "ssh-ed25519 AAAA...") the provider verifies SSH sessions against. When
+                set it takes precedence over the agent-reported status.sshHostKey, which
+                a compromised agent could otherwise assert.
+              type: string
+            sshHostKeyPolicy:
+              default: strict
+              description: |-
+                SSHHostKeyPolicy controls what happens when no host key is known (neither
+                spec.sshHostKey nor status.sshHostKey is set): "strict" refuses the SSH
+                session; "tofu" trusts the key presented on the first session, records it
+                in status.sshHostKey and enforces it from then on. A known key is always
+                enforced regardless of the policy.
+              enum:
+              - strict
+              - tofu
+              type: string
             sshKeySecretRef:
               description: 'SSHKeySecretRef references a Secret containing the SSH
                 private key (key: id_rsa).'
@@ -230,8 +249,11 @@ spec:
               - username
               type: object
             sshHostKey:
-              description: SSHHostKey is the SSH host public key reported by the agent
-                (authorized_keys format).
+              description: |-
+                SSHHostKey is the SSH host public key reported by the agent (authorized_keys
+                format). Recorded once, on the first report (or on the first "tofu"
+                session), and never replaced automatically: a differing later report sets
+                the SSHHostKeyChanged condition instead. Overridden by spec.sshHostKey.
               type: string
             workspacePath:
               description: WorkspacePath is the kcp workspace path this resource lives

--- a/providers/edges/deploy/chart/templates/deployment.yaml
+++ b/providers/edges/deploy/chart/templates/deployment.yaml
@@ -109,6 +109,10 @@ spec:
             - name: FAROS_DEV_MODE
               value: "true"
             {{- end }}
+            {{- if .Values.allowUnverifiedSSHHostKey }}
+            - name: FAROS_EDGES_ALLOW_UNVERIFIED_SSH_HOST_KEY
+              value: "true"
+            {{- end }}
             {{- if .Values.hub.insecure }}
             - name: FAROS_HUB_INSECURE
               value: "true"

--- a/providers/edges/deploy/chart/values.yaml
+++ b/providers/edges/deploy/chart/values.yaml
@@ -55,6 +55,12 @@ hub:
 # Enables dev-mode shortcuts in the controllers (e.g. relaxed kubeconfig CA).
 devMode: false
 
+# Legacy escape hatch: open SSH sessions to LinuxServers that have NO known
+# sshd host key (no spec.sshHostKey pin and no agent-reported status.sshHostKey)
+# without verifying the server. Edges with a known key are always verified.
+# Prefer pinning spec.sshHostKey or sshHostKeyPolicy=tofu on the edge instead.
+allowUnverifiedSSHHostKey: false
+
 # Secret holding the workspace-admin kubeconfig minted via /bonkers (admin
 # onboarding). Used by BOTH the init container (bootstrap APIExport/schemas) and
 # the serve container (token validation + cross-tenant controllers). Key must be

--- a/providers/edges/internal/edgeapi/types.go
+++ b/providers/edges/internal/edgeapi/types.go
@@ -47,6 +47,13 @@ const ConnectionConditionRegistered = "Registered"
 // separate lookup.
 const ConnectionConditionUpgradeAvailable = "UpgradeAvailable"
 
+// ConnectionConditionSSHHostKeyChanged is set True on an SSH-server kind when a
+// reconnecting agent reports an sshd host key whose fingerprint differs from the
+// key already recorded in status.sshHostKey. The recorded key is never replaced
+// automatically (the report is agent-asserted); an operator resolves the
+// condition by pinning spec.sshHostKey or clearing status.sshHostKey.
+const ConnectionConditionSSHHostKeyChanged = "SSHHostKeyChanged"
+
 // AnnotationRegenerateJoinToken, set on a connectable resource, instructs the
 // token reconciler to mint a fresh bootstrap join token.
 const AnnotationRegenerateJoinToken = "edges.faros.sh/regenerate-join-token"
@@ -101,6 +108,20 @@ const (
 	SSHUserMappingInherited SSHUserMappingMode = "inherited"
 	SSHUserMappingProvided  SSHUserMappingMode = "provided"
 	SSHUserMappingIdentity  SSHUserMappingMode = "identity"
+)
+
+// SSHHostKeyPolicy controls what the provider does when it opens an SSH session
+// to a server-kind edge for which no host key is known (neither spec.sshHostKey
+// nor status.sshHostKey is set). A known key is always enforced.
+type SSHHostKeyPolicy string
+
+const (
+	// SSHHostKeyPolicyStrict refuses the session until a key is known. Default.
+	SSHHostKeyPolicyStrict SSHHostKeyPolicy = "strict"
+	// SSHHostKeyPolicyTOFU (trust on first use) accepts the key the server
+	// presents on the first session, records it in status.sshHostKey, and
+	// enforces it from then on.
+	SSHHostKeyPolicyTOFU SSHHostKeyPolicy = "tofu"
 )
 
 // SSHCredentials holds SSH authentication credentials for SSH-server kinds.

--- a/providers/edges/internal/tunnel/agent_proxy_builder.go
+++ b/providers/edges/internal/tunnel/agent_proxy_builder.go
@@ -18,6 +18,7 @@ package tunnel
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -27,8 +28,9 @@ import (
 
 	"github.com/gorilla/websocket"
 	gossh "golang.org/x/crypto/ssh"
-
 	"k8s.io/klog/v2"
+
+	edgeapi "github.com/faroshq/provider-edges/internal/edgeapi"
 )
 
 // sshExec runs remoteCmd on the SSH client via a non-interactive exec channel
@@ -133,32 +135,57 @@ type SSHClientCredentials struct {
 	Username   string
 	Password   string // non-empty if password auth is available
 	PrivateKey []byte // non-empty if key auth is available
-	// SSHHostKey is the agent's sshd host public key in authorized_keys format
-	// (e.g. "ssh-ed25519 AAAA..."). Used for strict host key verification.
+	// SSHHostKey is the sshd host public key in authorized_keys format (e.g.
+	// "ssh-ed25519 AAAA...") the session is verified against: the operator pin
+	// (spec.sshHostKey) when set, else the agent-reported status.sshHostKey.
 	SSHHostKey string
+	// SSHHostKeyPolicy applies when SSHHostKey is empty (see
+	// edgeapi.SSHHostKeyPolicy). Empty means strict.
+	SSHHostKeyPolicy edgeapi.SSHHostKeyPolicy
 }
 
-// newSSHClient creates an SSH client through a device connection.
-// If creds is nil or empty, falls back to empty password authentication.
-// hostKey is the SSH host public key in authorized_keys format (as stored in
-// Edge.Status.SSHHostKey). When non-empty it is used for strict host key
-// verification via gossh.FixedHostKey; when empty the client falls back to
-// InsecureIgnoreHostKey and logs a warning.
-func newSSHClient(_ context.Context, deviceConn net.Conn, creds *SSHClientCredentials, hostKey string, logger klog.Logger) (*gossh.Client, error) {
-	// Default to root user with empty password if no credentials provided.
-	sshUser := "root"
-	var authMethods []gossh.AuthMethod
+// sshHostKeyVerification describes how newSSHClient verifies the server's host
+// key.
+type sshHostKeyVerification struct {
+	// Key is the expected host public key in authorized_keys format. Empty
+	// means no key is known.
+	Key string
+	// Policy applies only when Key is empty: strict (the default) refuses the
+	// session; tofu accepts the key the server presents and reports it as the
+	// learned key so the caller can record it.
+	Policy edgeapi.SSHHostKeyPolicy
+	// AllowUnverified is the provider-wide legacy escape hatch
+	// (--allow-unverified-ssh-host-key): an empty Key is accepted without
+	// verification or recording. It never applies to an unparseable Key.
+	AllowUnverified bool
+}
 
+// sshUsername returns the SSH login the session authenticates as: the resolved
+// credential's username, else root.
+func sshUsername(creds *SSHClientCredentials) string {
 	if creds != nil && creds.Username != "" {
-		sshUser = creds.Username
+		return creds.Username
 	}
+	return "root"
+}
+
+// newSSHClient creates an SSH client through a device connection. If creds is
+// nil or empty, falls back to empty password authentication.
+//
+// Host key verification fails closed: a key that does not parse is an error,
+// and an empty key is an error under the strict policy. Under tofu the key the
+// server presents is accepted and returned as learnedKey (empty otherwise) so
+// the caller can record it in status.sshHostKey and enforce it from then on.
+func newSSHClient(_ context.Context, deviceConn net.Conn, creds *SSHClientCredentials, hk sshHostKeyVerification, logger klog.Logger) (client *gossh.Client, learnedKey string, err error) {
+	sshUser := sshUsername(creds)
+	var authMethods []gossh.AuthMethod
 
 	if creds != nil {
 		// Prefer private key auth if available.
 		if len(creds.PrivateKey) > 0 {
 			signer, err := gossh.ParsePrivateKey(creds.PrivateKey)
 			if err != nil {
-				return nil, fmt.Errorf("parsing SSH private key: %w", err)
+				return nil, "", fmt.Errorf("parsing SSH private key: %w", err)
 			}
 			authMethods = append(authMethods, gossh.PublicKeys(signer))
 			logger.V(4).Info("Using SSH public key authentication", "user", sshUser)
@@ -177,23 +204,32 @@ func newSSHClient(_ context.Context, deviceConn net.Conn, creds *SSHClientCreden
 		logger.V(4).Info("Using empty password authentication (fallback)", "user", sshUser)
 	}
 
-	// Determine host key verification strategy.
-	// Prefer FixedHostKey when the agent has reported its sshd public key in
-	// Edge.Status.SSHHostKey; fall back to InsecureIgnoreHostKey with a warning
-	// for backward compatibility with agents that predate this feature.
+	// Host key verification. A known key (operator pin or the recorded agent
+	// report) is always enforced. With no key known the per-edge policy
+	// decides: strict refuses, tofu learns. The provider-wide escape hatch
+	// restores the legacy unverified behaviour for agents that never reported
+	// a key; it is logged at V(0) on every use.
 	var hostKeyCallback gossh.HostKeyCallback
-	if hostKey != "" {
-		pk, _, _, _, err := gossh.ParseAuthorizedKey([]byte(hostKey))
+	var presented gossh.PublicKey
+	switch {
+	case hk.Key != "":
+		pk, _, _, _, err := gossh.ParseAuthorizedKey([]byte(hk.Key))
 		if err != nil {
-			logger.Error(err, "failed to parse SSH host key from Edge status; falling back to InsecureIgnoreHostKey")
-			hostKeyCallback = gossh.InsecureIgnoreHostKey() //nolint:gosec // parse error fallback
-		} else {
-			hostKeyCallback = gossh.FixedHostKey(pk)
-			logger.V(4).Info("Using strict SSH host key verification", "keyType", pk.Type())
+			return nil, "", fmt.Errorf("parsing SSH host key: %w", err)
 		}
-	} else {
-		logger.Info("WARNING: no SSH host key in Edge status — falling back to InsecureIgnoreHostKey (MITM risk)")
-		hostKeyCallback = gossh.InsecureIgnoreHostKey() //nolint:gosec // no host key yet; backward compat
+		hostKeyCallback = gossh.FixedHostKey(pk)
+		logger.V(4).Info("Using strict SSH host key verification", "keyType", pk.Type())
+	case hk.Policy == edgeapi.SSHHostKeyPolicyTOFU:
+		hostKeyCallback = func(_ string, _ net.Addr, key gossh.PublicKey) error {
+			presented = key
+			return nil
+		}
+		logger.Info("no SSH host key known for edge; trusting the key presented on this first session (sshHostKeyPolicy=tofu)")
+	case hk.AllowUnverified:
+		hostKeyCallback = gossh.InsecureIgnoreHostKey() //nolint:gosec // explicit operator escape hatch, logged
+		logger.Info("WARNING: no SSH host key known for edge and --allow-unverified-ssh-host-key is set; host identity is NOT verified (MITM risk)")
+	default:
+		return nil, "", fmt.Errorf("no SSH host key known for edge and sshHostKeyPolicy is strict: pin spec.sshHostKey, wait for the agent to report one, or set sshHostKeyPolicy=tofu")
 	}
 
 	sshConfig := &gossh.ClientConfig{
@@ -204,10 +240,36 @@ func newSSHClient(_ context.Context, deviceConn net.Conn, creds *SSHClientCreden
 
 	sshConn, chans, reqs, err := gossh.NewClientConn(deviceConn, "agent:22", sshConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SSH client connection: %w", err)
+		return nil, "", fmt.Errorf("failed to create SSH client connection: %w", err)
 	}
 
-	return gossh.NewClient(sshConn, chans, reqs), nil
+	if presented != nil {
+		learnedKey = strings.TrimSpace(string(gossh.MarshalAuthorizedKey(presented)))
+	}
+	return gossh.NewClient(sshConn, chans, reqs), learnedKey, nil
+}
+
+// sshHostKeyFingerprint returns the SHA256 fingerprint of an authorized_keys
+// format host key, or "unparseable" when it does not parse. Used in conditions
+// and audit lines so raw keys never need to be compared by eye.
+func sshHostKeyFingerprint(key string) string {
+	pk, _, _, _, err := gossh.ParseAuthorizedKey([]byte(key))
+	if err != nil {
+		return "unparseable"
+	}
+	return gossh.FingerprintSHA256(pk)
+}
+
+// sameSSHHostKey reports whether two authorized_keys format keys denote the
+// same public key (ignoring comments and whitespace). Unparseable keys compare
+// by exact string.
+func sameSSHHostKey(a, b string) bool {
+	pa, _, _, _, errA := gossh.ParseAuthorizedKey([]byte(a))
+	pb, _, _, _, errB := gossh.ParseAuthorizedKey([]byte(b))
+	if errA != nil || errB != nil {
+		return strings.TrimSpace(a) == strings.TrimSpace(b)
+	}
+	return bytes.Equal(pa.Marshal(), pb.Marshal())
 }
 
 // isUpgradeRequest checks if the request is a protocol upgrade.

--- a/providers/edges/internal/tunnel/agent_proxy_builder.go
+++ b/providers/edges/internal/tunnel/agent_proxy_builder.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gorilla/websocket"
 	gossh "golang.org/x/crypto/ssh"
@@ -70,7 +71,9 @@ func (p *Server) sshExec(ctx context.Context, wsConn *websocket.Conn, sshClient 
 
 	// Run the remote command (blocks until it exits).
 	if err := sshSession.Run(remoteCmd); err != nil {
-		logger.V(4).Info("SSH exec command finished", "cmd", remoteCmd, "err", err)
+		// remoteCmd is caller-controlled; escape and bound it before logging
+		// (see sanitizeAuditValue).
+		logger.V(4).Info("SSH exec command finished", "cmd", sanitizeAuditValue(remoteCmd), "err", err)
 	}
 
 	// Close the write end of the pipe so the forwarder goroutine sees EOF.
@@ -169,6 +172,11 @@ func sshUsername(creds *SSHClientCredentials) string {
 	return "root"
 }
 
+// sshHandshakeTimeout bounds the SSH version + key exchange when the caller's
+// context carries no deadline. The SSH data-plane path is a WebSocket upgrade,
+// whose request context has none.
+const sshHandshakeTimeout = 30 * time.Second
+
 // newSSHClient creates an SSH client through a device connection. If creds is
 // nil or empty, falls back to empty password authentication.
 //
@@ -176,7 +184,10 @@ func sshUsername(creds *SSHClientCredentials) string {
 // and an empty key is an error under the strict policy. Under tofu the key the
 // server presents is accepted and returned as learnedKey (empty otherwise) so
 // the caller can record it in status.sshHostKey and enforce it from then on.
-func newSSHClient(_ context.Context, deviceConn net.Conn, creds *SSHClientCredentials, hk sshHostKeyVerification, logger klog.Logger) (client *gossh.Client, learnedKey string, err error) {
+//
+// ctx bounds the handshake only (see sshHandshakeTimeout); the established
+// session outlives it.
+func newSSHClient(ctx context.Context, deviceConn net.Conn, creds *SSHClientCredentials, hk sshHostKeyVerification, logger klog.Logger) (client *gossh.Client, learnedKey string, err error) {
 	sshUser := sshUsername(creds)
 	var authMethods []gossh.AuthMethod
 
@@ -238,10 +249,24 @@ func newSSHClient(_ context.Context, deviceConn net.Conn, creds *SSHClientCreden
 		HostKeyCallback: hostKeyCallback,
 	}
 
+	// gossh.NewClientConn takes no context and blocks for as long as the peer
+	// keeps the socket open without completing the version exchange or key
+	// exchange — a stalled tunnel would pin this handler goroutine forever.
+	// Bound it on the connection, the same way remoteDialer.Dial bounds its
+	// relay handshake: honour the caller's deadline when it has one, else a
+	// short default; clear it once the connection is up so the session itself
+	// is not time-limited.
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = deviceConn.SetDeadline(deadline)
+	} else {
+		_ = deviceConn.SetDeadline(time.Now().Add(sshHandshakeTimeout))
+	}
 	sshConn, chans, reqs, err := gossh.NewClientConn(deviceConn, "agent:22", sshConfig)
 	if err != nil {
+		_ = deviceConn.SetDeadline(time.Time{})
 		return nil, "", fmt.Errorf("failed to create SSH client connection: %w", err)
 	}
+	_ = deviceConn.SetDeadline(time.Time{})
 
 	if presented != nil {
 		learnedKey = strings.TrimSpace(string(gossh.MarshalAuthorizedKey(presented)))
@@ -249,13 +274,25 @@ func newSSHClient(_ context.Context, deviceConn net.Conn, creds *SSHClientCreden
 	return gossh.NewClient(sshConn, chans, reqs), learnedKey, nil
 }
 
+// Fingerprint placeholders for keys that have none. "no key recorded" and
+// "a key is recorded but it is malformed" are very different states in a
+// condition message or an audit line, so they never share a rendering.
+const (
+	sshHostKeyFingerprintUnknown     = "unknown"
+	sshHostKeyFingerprintUnparseable = "unparseable"
+)
+
 // sshHostKeyFingerprint returns the SHA256 fingerprint of an authorized_keys
-// format host key, or "unparseable" when it does not parse. Used in conditions
+// format host key. An empty (or whitespace-only) key yields "unknown"; a
+// non-empty key that does not parse yields "unparseable". Used in conditions
 // and audit lines so raw keys never need to be compared by eye.
 func sshHostKeyFingerprint(key string) string {
+	if strings.TrimSpace(key) == "" {
+		return sshHostKeyFingerprintUnknown
+	}
 	pk, _, _, _, err := gossh.ParseAuthorizedKey([]byte(key))
 	if err != nil {
-		return "unparseable"
+		return sshHostKeyFingerprintUnparseable
 	}
 	return gossh.FingerprintSHA256(pk)
 }

--- a/providers/edges/internal/tunnel/audit_test.go
+++ b/providers/edges/internal/tunnel/audit_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestClientAddrIgnoresForgedForwardedForHops pins the property the SSH audit
+// trail depends on: the trusted proxy in front of this handler APPENDS the peer
+// it saw to X-Forwarded-For, so only the last hop is trustworthy. Anything to
+// its left was chosen by the caller.
+func TestClientAddrIgnoresForgedForwardedForHops(t *testing.T) {
+	cases := []struct {
+		name       string
+		xff        string
+		remoteAddr string
+		want       string
+	}{{
+		name:       "forged leading hop is ignored, the appended hop wins",
+		xff:        "10.0.0.1, 203.0.113.9",
+		remoteAddr: "192.0.2.1:9999",
+		want:       "203.0.113.9",
+	}, {
+		name:       "several forged leading hops are ignored",
+		xff:        "1.2.3.4, 5.6.7.8,9.10.11.12,  203.0.113.9",
+		remoteAddr: "192.0.2.1:9999",
+		want:       "203.0.113.9",
+	}, {
+		name:       "junk in a leading hop does not poison the result",
+		xff:        "not-an-ip\nfake audit line, 203.0.113.9",
+		remoteAddr: "192.0.2.1:9999",
+		want:       "203.0.113.9",
+	}, {
+		name:       "a single hop is the appended one",
+		xff:        "203.0.113.9",
+		remoteAddr: "192.0.2.1:9999",
+		want:       "203.0.113.9",
+	}, {
+		name:       "bracketed IPv6 hop",
+		xff:        "10.0.0.1, [2001:db8::2]",
+		remoteAddr: "192.0.2.1:9999",
+		want:       "2001:db8::2",
+	}, {
+		name:       "junk in the appended hop yields the placeholder, never the junk",
+		xff:        "203.0.113.9, ../../etc/passwd",
+		remoteAddr: "192.0.2.1:9999",
+		want:       unknownAddr,
+	}, {
+		name:       "no header falls back to the peer, port stripped",
+		remoteAddr: "192.0.2.7:53124",
+		want:       "192.0.2.7",
+	}, {
+		name:       "no header, IPv6 peer, port stripped",
+		remoteAddr: "[2001:db8::1]:443",
+		want:       "2001:db8::1",
+	}, {
+		name:       "no header, peer without a port",
+		remoteAddr: "192.0.2.7",
+		want:       "192.0.2.7",
+	}, {
+		name:       "whitespace-only header falls back to the peer",
+		xff:        "   ",
+		remoteAddr: "192.0.2.7:53124",
+		want:       "192.0.2.7",
+	}, {
+		name:       "unparseable peer yields the placeholder",
+		remoteAddr: "not-an-address",
+		want:       unknownAddr,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &http.Request{Header: http.Header{}, RemoteAddr: tc.remoteAddr}
+			if tc.xff != "" {
+				r.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			if got := clientAddr(r); got != tc.want {
+				t.Fatalf("clientAddr = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeAuditValueCannotForgeALogLine covers the exec command, which
+// arrives as a raw query parameter and lands in a V(0) audit line.
+func TestSanitizeAuditValueCannotForgeALogLine(t *testing.T) {
+	forged := "uptime\n\"SSH session opened\" caller=\"root\" edge=\"other\""
+	got := sanitizeAuditValue(forged)
+	if strings.ContainsAny(got, "\n\r") {
+		t.Fatalf("sanitized value still carries a line break: %q", got)
+	}
+	if !strings.Contains(got, `\u000a`) {
+		t.Fatalf("newline was dropped rather than escaped: %q", got)
+	}
+	if !strings.Contains(got, "uptime") || !strings.Contains(got, "SSH session opened") {
+		t.Fatalf("sanitized value is not a faithful rendering: %q", got)
+	}
+
+	for _, ctrl := range []string{"\r", "\t", "\x00", "\x1b[2J", "\u2028"} {
+		s := sanitizeAuditValue("a" + ctrl + "b")
+		if strings.Contains(s, ctrl) {
+			t.Fatalf("control sequence %q survived sanitization: %q", ctrl, s)
+		}
+	}
+
+	if got := sanitizeAuditValue(`a\b`); got != `a\\b` {
+		t.Fatalf("backslash not escaped: %q", got)
+	}
+
+	// Ordinary commands, including non-ASCII text, pass through untouched.
+	for _, ok := range []string{"", "systemctl restart nginx", "echo 'héllo wörld'"} {
+		if got := sanitizeAuditValue(ok); got != ok {
+			t.Fatalf("sanitizeAuditValue(%q) = %q, want it unchanged", ok, got)
+		}
+	}
+}
+
+func TestSanitizeAuditValueTruncatesAndMarksIt(t *testing.T) {
+	long := strings.Repeat("a", maxAuditValueLen*3)
+	got := sanitizeAuditValue(long)
+	if !strings.HasSuffix(got, auditTruncationMarker) {
+		t.Fatalf("truncation is not marked: %q", got)
+	}
+	if want := maxAuditValueLen + len(auditTruncationMarker); len(got) != want {
+		t.Fatalf("truncated length = %d, want %d", len(got), want)
+	}
+	if s := sanitizeAuditValue(strings.Repeat("a", maxAuditValueLen)); strings.Contains(s, auditTruncationMarker) {
+		t.Fatalf("a value at the cap was marked truncated: %q", s)
+	}
+}

--- a/providers/edges/internal/tunnel/edge_status.go
+++ b/providers/edges/internal/tunnel/edge_status.go
@@ -118,25 +118,7 @@ func (p *Server) markEdgeConnected(ctx context.Context, gvr schema.GroupVersionR
 			Message:            "Agent has registered and received a durable ServiceAccount credential.",
 			LastTransitionTime: now,
 		}
-		condJSON, _ := json.Marshal(registeredCondition)
-		var condMap map[string]interface{}
-		_ = json.Unmarshal(condJSON, &condMap)
-
-		// Replace or append the Registered condition in the conditions array.
-		conditions, _, _ := unstructured.NestedSlice(status, "conditions")
-		found := false
-		for i, c := range conditions {
-			cMap, ok := c.(map[string]interface{})
-			if ok && cMap["type"] == edgeapi.ConnectionConditionRegistered {
-				conditions[i] = condMap
-				found = true
-				break
-			}
-		}
-		if !found {
-			conditions = append(conditions, condMap)
-		}
-		status["conditions"] = conditions
+		setStatusCondition(status, registeredCondition)
 
 		// If the agent sent SSH credentials, create a secret and set sshCredentials in status.
 		if sshCreds != nil && sshCreds.User != "" {
@@ -150,9 +132,9 @@ func (p *Server) markEdgeConnected(ctx context.Context, gvr schema.GroupVersionR
 		// Persist the agent's sshd host public key so the hub can perform strict
 		// host-key verification on subsequent SSH sessions. This is independent of
 		// auth credentials: an agent without password/privateKey still benefits
-		// from MITM protection.
+		// from MITM protection. Write-once: see applyReportedSSHHostKey.
 		if sshCreds != nil && sshCreds.HostKey != "" {
-			status["sshHostKey"] = sshCreds.HostKey
+			applyReportedSSHHostKey(status, sshCreds.HostKey, now)
 		}
 
 		if err := unstructured.SetNestedField(edge.Object, status, "status"); err != nil {
@@ -170,6 +152,86 @@ func (p *Server) markEdgeConnected(ctx context.Context, gvr schema.GroupVersionR
 
 	p.logger.Info("Edge marked Ready and registered on join-token tunnel open",
 		"cluster", cluster, "edge", name)
+}
+
+// applyReportedSSHHostKey records the agent-reported sshd host key into
+// status.sshHostKey the first time one is seen and never replaces it: the report
+// is agent-asserted, so letting every reconnect overwrite the recorded key would
+// let a compromised agent rotate the key the hub pins SSH sessions to, silently.
+// A later report of a different key sets the SSHHostKeyChanged condition (with
+// both fingerprints) for an operator to resolve by pinning spec.sshHostKey or
+// clearing status.sshHostKey; a report matching the recorded key clears it.
+func applyReportedSSHHostKey(status map[string]interface{}, reported string, now metav1.Time) {
+	existing, _, _ := unstructured.NestedString(status, "sshHostKey")
+	switch {
+	case existing == "":
+		status["sshHostKey"] = reported
+	case sameSSHHostKey(existing, reported):
+		if findStatusCondition(status, edgeapi.ConnectionConditionSSHHostKeyChanged) != nil {
+			setStatusCondition(status, metav1.Condition{
+				Type:               edgeapi.ConnectionConditionSSHHostKeyChanged,
+				Status:             metav1.ConditionFalse,
+				Reason:             "Match",
+				Message:            "The agent-reported SSH host key matches status.sshHostKey.",
+				LastTransitionTime: now,
+			})
+		}
+	default:
+		setStatusCondition(status, metav1.Condition{
+			Type:   edgeapi.ConnectionConditionSSHHostKeyChanged,
+			Status: metav1.ConditionTrue,
+			Reason: "FingerprintMismatch",
+			Message: fmt.Sprintf("The agent reported SSH host key %s but status.sshHostKey holds %s; the recorded key is kept. "+
+				"Pin spec.sshHostKey, or clear status.sshHostKey to accept the reported key.",
+				sshHostKeyFingerprint(reported), sshHostKeyFingerprint(existing)),
+			LastTransitionTime: now,
+		})
+	}
+}
+
+// findStatusCondition returns the condition of the given type from an
+// unstructured status map, or nil.
+func findStatusCondition(status map[string]interface{}, condType string) map[string]interface{} {
+	conditions, _, _ := unstructured.NestedSlice(status, "conditions")
+	for _, c := range conditions {
+		if cMap, ok := c.(map[string]interface{}); ok && cMap["type"] == condType {
+			return cMap
+		}
+	}
+	return nil
+}
+
+// setStatusCondition replaces (or appends) the condition of cond's type in an
+// unstructured status map. LastTransitionTime is preserved from the existing
+// condition when its status is unchanged.
+func setStatusCondition(status map[string]interface{}, cond metav1.Condition) {
+	if existing := findStatusCondition(status, cond.Type); existing != nil {
+		if existing["status"] == string(cond.Status) {
+			if ltt, ok := existing["lastTransitionTime"].(string); ok && ltt != "" {
+				if t, err := time.Parse(time.RFC3339, ltt); err == nil {
+					cond.LastTransitionTime = metav1.NewTime(t)
+				}
+			}
+		}
+	}
+	condJSON, _ := json.Marshal(cond)
+	var condMap map[string]interface{}
+	_ = json.Unmarshal(condJSON, &condMap)
+
+	conditions, _, _ := unstructured.NestedSlice(status, "conditions")
+	found := false
+	for i, c := range conditions {
+		cMap, ok := c.(map[string]interface{})
+		if ok && cMap["type"] == cond.Type {
+			conditions[i] = condMap
+			found = true
+			break
+		}
+	}
+	if !found {
+		conditions = append(conditions, condMap)
+	}
+	status["conditions"] = conditions
 }
 
 // storeSSHCredentials creates a Secret with the agent's SSH credentials and

--- a/providers/edges/internal/tunnel/edge_status.go
+++ b/providers/edges/internal/tunnel/edge_status.go
@@ -208,7 +208,10 @@ func setStatusCondition(status map[string]interface{}, cond metav1.Condition) {
 	if existing := findStatusCondition(status, cond.Type); existing != nil {
 		if existing["status"] == string(cond.Status) {
 			if ltt, ok := existing["lastTransitionTime"].(string); ok && ltt != "" {
-				if t, err := time.Parse(time.RFC3339, ltt); err == nil {
+				// RFC3339Nano parses the seconds-precision form as well, so it
+				// also tolerates a fractional-seconds value that reached the
+				// object by some other route than a metav1.Time marshal.
+				if t, err := time.Parse(time.RFC3339Nano, ltt); err == nil {
 					cond.LastTransitionTime = metav1.NewTime(t)
 				}
 			}

--- a/providers/edges/internal/tunnel/edges_proxy_builder.go
+++ b/providers/edges/internal/tunnel/edges_proxy_builder.go
@@ -25,9 +25,12 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/netip"
 	"net/url"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/gorilla/websocket"
 	authv1 "k8s.io/api/authentication/v1"
@@ -202,9 +205,12 @@ func (p *Server) edgesSSHHandler(ctx context.Context, w http.ResponseWriter, r *
 	if caller == "" {
 		caller = "unknown"
 	}
+	// remoteCmd is a raw query parameter. It is escaped and bounded before it
+	// reaches the audit line so it cannot forge extra records or dump an
+	// unbounded argument list into the log.
 	audit := logger.WithValues(
 		"cluster", cluster, "edge", edgeName, "caller", caller,
-		"mode", mode, "exec", remoteCmd, "remoteAddr", clientAddr(r))
+		"mode", mode, "exec", sanitizeAuditValue(remoteCmd), "remoteAddr", clientAddr(r))
 	if callerErr != nil {
 		audit = audit.WithValues("callerError", callerErr.Error())
 	}
@@ -319,17 +325,85 @@ func (p *Server) edgesSSHHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 }
 
-// clientAddr returns the caller's address for audit lines: the first
-// X-Forwarded-For hop when the request came through the hub backend proxy
-// (r.RemoteAddr is then the hub), else r.RemoteAddr.
+// unknownAddr is recorded when no address can be trusted or the candidate is
+// not an IP. Better a placeholder than junk echoed into the audit trail.
+const unknownAddr = "unknown"
+
+// clientAddr returns the caller's address for audit lines.
+//
+// Exactly one trusted proxy fronts this handler (the hub backend proxy), and a
+// forwarding proxy APPENDS the peer it saw to X-Forwarded-For. So the LAST hop
+// is the address that proxy observed, and every entry to its left is whatever
+// the client chose to send — an attacker can prepend anything. Taking the last
+// hop is what makes the audit line worth writing. If several trusted proxies
+// were ever chained in front of this handler, the rule would become "count back
+// from the right by the number of trusted hops" — the leading entries stay
+// untrustworthy either way.
+//
+// With no XFF header the immediate peer (r.RemoteAddr) is the client; its port
+// is stripped since only the host identifies the caller. The result is always a
+// parsed IP or unknownAddr.
 func clientAddr(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if first, _, ok := strings.Cut(xff, ","); ok {
-			return strings.TrimSpace(first)
-		}
-		return strings.TrimSpace(xff)
+	if xff := r.Header.Get("X-Forwarded-For"); strings.TrimSpace(xff) != "" {
+		hops := strings.Split(xff, ",")
+		return auditIP(hops[len(hops)-1])
 	}
-	return r.RemoteAddr
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return auditIP(host)
+	}
+	return auditIP(r.RemoteAddr)
+}
+
+// auditIP validates that s is an IP address and returns its canonical form, or
+// unknownAddr. Bracketed IPv6 ("[::1]") is accepted.
+func auditIP(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
+		s = s[1 : len(s)-1]
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return unknownAddr
+	}
+	return addr.String()
+}
+
+// maxAuditValueLen bounds a caller-controlled value in an audit line, in runes.
+const maxAuditValueLen = 256
+
+// auditTruncationMarker is appended when sanitizeAuditValue cuts a value short,
+// so a reader never mistakes a truncated command for the whole one.
+const auditTruncationMarker = "...[truncated]"
+
+// sanitizeAuditValue makes a caller-controlled string safe to place in an audit
+// line. Newlines and other control characters would otherwise let a caller
+// forge additional audit records, and an unbounded value can carry a lot of
+// (possibly sensitive) argument text into the log.
+//
+// Non-printable runes are escaped rather than dropped: this is an audit record,
+// so it must stay a faithful, reversible rendering of what was requested.
+func sanitizeAuditValue(s string) string {
+	var b strings.Builder
+	runes := 0
+	for _, r := range s {
+		if runes >= maxAuditValueLen {
+			b.WriteString(auditTruncationMarker)
+			break
+		}
+		runes++
+		switch {
+		case r == '\\':
+			b.WriteString(`\\`)
+		case r == utf8.RuneError:
+			// Invalid UTF-8 in the input; range yields RuneError per bad byte.
+			b.WriteString(`�`)
+		case unicode.IsPrint(r):
+			b.WriteRune(r)
+		default:
+			fmt.Fprintf(&b, `\u%04x`, r)
+		}
+	}
+	return b.String()
 }
 
 func firstNonEmpty(values ...string) string {

--- a/providers/edges/internal/tunnel/edges_proxy_builder.go
+++ b/providers/edges/internal/tunnel/edges_proxy_builder.go
@@ -19,6 +19,7 @@ package tunnel
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -32,11 +33,13 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	edgeapi "github.com/faroshq/provider-edges/internal/edgeapi"
@@ -120,11 +123,13 @@ func (p *Server) buildEdgesProxyHandler() http.Handler {
 		case "k8s":
 			p.edgesK8sHandler(r.Context(), w, r, key, dialer)
 		case "ssh":
-			// Resolve caller identity for identity-mode SSH mapping.
-			// Best-effort: empty string is fine for inherited/provided modes.
-			callerIdentity := resolveCallerIdentity(r.Context(), p.kcpConfig, token, p.logger)
+			// Resolve caller identity for identity-mode SSH mapping and the
+			// session audit line. Best-effort: inherited/provided modes work
+			// without it (the token already passed authorizeFn above); the audit
+			// line then records caller=unknown with the reason.
+			callerIdentity, callerErr := resolveCallerIdentity(r.Context(), p.kcpConfig, token)
 			gvr, _, _ := p.gvrForResource(resource)
-			p.edgesSSHHandler(r.Context(), w, r, key, dialer, callerIdentity, gvr)
+			p.edgesSSHHandler(r.Context(), w, r, key, dialer, callerIdentity, callerErr, gvr)
 		default:
 			p.logger.Info("unknown subresource requested", "subresource", subresource, "cluster", cluster, "name", name)
 			http.Error(w, "unknown subresource", http.StatusNotFound)
@@ -174,9 +179,13 @@ func (p *Server) edgesK8sHandler(ctx context.Context, w http.ResponseWriter, r *
 // edgesSSHHandler establishes a WebSocket SSH session to the edge agent.
 // It dials the agent via the revdial.Dialer, opens the agent-side SSH tunnel,
 // and then bridges the caller's WebSocket to the SSH session.
+//
+// Every session produces two V(0) audit lines: "SSH session opened" once the
+// SSH client is established, and "SSH session ended" when the handler returns
+// (also for sessions refused before opening, with opened=false and the reason).
 func (p *Server) edgesSSHHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, key string, dialer interface {
 	Dial(context.Context) (net.Conn, error)
-}, callerIdentity string, gvr schema.GroupVersionResource) {
+}, callerIdentity string, callerErr error, gvr schema.GroupVersionResource) {
 	logger := klog.FromContext(ctx)
 
 	// Parse cluster and edge name from the key (format: "edges/{cluster}/{name}")
@@ -184,12 +193,38 @@ func (p *Server) edgesSSHHandler(ctx context.Context, w http.ResponseWriter, r *
 
 	// Optional non-interactive exec mode (e.g. `faros ssh <name> -- <cmd>`).
 	remoteCmd := r.URL.Query().Get("cmd")
+	mode := "interactive"
+	if remoteCmd != "" {
+		mode = "exec"
+	}
+
+	caller := callerIdentity
+	if caller == "" {
+		caller = "unknown"
+	}
+	audit := logger.WithValues(
+		"cluster", cluster, "edge", edgeName, "caller", caller,
+		"mode", mode, "exec", remoteCmd, "remoteAddr", clientAddr(r))
+	if callerErr != nil {
+		audit = audit.WithValues("callerError", callerErr.Error())
+	}
+	start := time.Now()
+	opened := false
+	var outcome error
+	defer func() {
+		kv := []interface{}{"opened", opened, "durationSeconds", time.Since(start).Seconds()}
+		if outcome != nil {
+			kv = append(kv, "error", outcome.Error())
+		}
+		audit.Info("SSH session ended", kv...)
+	}()
 
 	// Fetch SSH credentials from Edge status, applying the configured user mapping.
 	creds, err := p.fetchSSHCredentials(ctx, cluster, edgeName, callerIdentity, gvr, logger)
 	if err != nil {
 		logger.Error(err, "failed to fetch SSH credentials", "key", key)
-		// Continue with nil credentials - will fall back to empty password auth
+		// Continue with nil credentials: auth falls back to an empty password and
+		// host key verification to the strict policy, which fails closed below.
 	}
 
 	logger.V(4).Info("Edges SSH handler", "key", key, "hasCredentials", creds != nil, "exec", remoteCmd != "")
@@ -197,6 +232,7 @@ func (p *Server) edgesSSHHandler(ctx context.Context, w http.ResponseWriter, r *
 	// Dial the agent via the reverse tunnel.
 	deviceConn, err := dialer.Dial(ctx)
 	if err != nil {
+		outcome = fmt.Errorf("dialing edge agent: %w", err)
 		logger.Error(err, "failed to dial edge agent for SSH", "key", key)
 		http.Error(w, "failed to connect to edge agent", http.StatusBadGateway)
 		return
@@ -205,6 +241,7 @@ func (p *Server) edgesSSHHandler(ctx context.Context, w http.ResponseWriter, r *
 	// Open the SSH tunnel over the raw reverse-tunnel connection.
 	sshConn, err := openAgentSSHTunnel(ctx, deviceConn)
 	if err != nil {
+		outcome = fmt.Errorf("opening agent SSH tunnel: %w", err)
 		logger.Error(err, "failed to open SSH tunnel to edge agent", "key", key)
 		http.Error(w, "failed to open SSH tunnel", http.StatusBadGateway)
 		return
@@ -223,24 +260,43 @@ func (p *Server) edgesSSHHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 	wsConn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
+		outcome = fmt.Errorf("upgrading caller connection: %w", err)
 		logger.Error(err, "failed to upgrade caller connection to WebSocket")
 		return
 	}
 	defer wsConn.Close() //nolint:errcheck
 
-	// Extract the host key from the credentials (may be empty for older agents).
-	var sshHostKey string
+	// Host key verification inputs: the pinned/recorded key and the per-edge
+	// policy come from the edge object (via creds); the escape hatch is
+	// provider-wide.
+	hk := sshHostKeyVerification{AllowUnverified: p.allowUnverifiedSSHHostKey}
 	if creds != nil {
-		sshHostKey = creds.SSHHostKey
+		hk.Key = creds.SSHHostKey
+		hk.Policy = creds.SSHHostKeyPolicy
 	}
 
 	// Build the SSH client over the tunnelled raw connection.
-	sshClient, err := newSSHClient(ctx, sshConn, creds, sshHostKey, logger)
+	sshClient, learnedKey, err := newSSHClient(ctx, sshConn, creds, hk, logger)
 	if err != nil {
+		outcome = fmt.Errorf("establishing SSH client: %w", err)
 		logger.Error(err, "failed to create SSH client for edge")
 		return
 	}
 	defer sshClient.Close() //nolint:errcheck
+	opened = true
+	audit.Info("SSH session opened", "sshUser", sshUsername(creds),
+		"hostKeyFingerprint", sshHostKeyFingerprint(firstNonEmpty(learnedKey, hk.Key)))
+
+	// tofu: persist the key this first session trusted so every later session
+	// enforces it. Best-effort — a failed write only means the next session
+	// trusts on first use again.
+	if learnedKey != "" {
+		if rerr := p.recordSSHHostKey(ctx, gvr, cluster, edgeName, learnedKey); rerr != nil {
+			logger.Error(rerr, "failed to record SSH host key learned on first use", "key", key)
+		} else {
+			audit.Info("SSH host key recorded on first use", "hostKeyFingerprint", sshHostKeyFingerprint(learnedKey))
+		}
+	}
 
 	if remoteCmd != "" {
 		// Non-interactive exec: run command, stream output, close.
@@ -251,14 +307,71 @@ func (p *Server) edgesSSHHandler(ctx context.Context, w http.ResponseWriter, r *
 	// Interactive PTY + shell session over WebSocket.
 	session, err := utilssh.NewSocketSSHSession(logger, 120, 40, sshClient, wsConn)
 	if err != nil {
+		outcome = fmt.Errorf("creating SSH session: %w", err)
 		logger.Error(err, "failed to create SSH session for edge")
 		return
 	}
 	defer session.Close()
 
 	if err := session.Run(ctx); err != nil {
+		outcome = err
 		logger.Error(err, "SSH session error for edge")
 	}
+}
+
+// clientAddr returns the caller's address for audit lines: the first
+// X-Forwarded-For hop when the request came through the hub backend proxy
+// (r.RemoteAddr is then the hub), else r.RemoteAddr.
+func clientAddr(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if first, _, ok := strings.Cut(xff, ","); ok {
+			return strings.TrimSpace(first)
+		}
+		return strings.TrimSpace(xff)
+	}
+	return r.RemoteAddr
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// recordSSHHostKey persists a host key learned on a tofu first session into
+// status.sshHostKey, unless a key has been recorded in the meantime (the
+// recorded key is never replaced automatically; see applyReportedSSHHostKey).
+func (p *Server) recordSSHHostKey(ctx context.Context, gvr schema.GroupVersionResource, cluster, edgeName, hostKey string) error {
+	cfg, err := p.tenantConfigFor(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("resolving tenant config: %w", err)
+	}
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("creating dynamic client: %w", err)
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		edge, err := dynClient.Resource(gvr).Get(ctx, edgeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		status, _, _ := unstructured.NestedMap(edge.Object, "status")
+		if status == nil {
+			status = map[string]interface{}{}
+		}
+		if existing, _, _ := unstructured.NestedString(status, "sshHostKey"); existing != "" {
+			return nil
+		}
+		status["sshHostKey"] = hostKey
+		if err := unstructured.SetNestedField(edge.Object, status, "status"); err != nil {
+			return fmt.Errorf("setting status: %w", err)
+		}
+		_, err = dynClient.Resource(gvr).UpdateStatus(ctx, edge, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 // parseEdgeConnKey extracts cluster and name from the connection key.
@@ -311,8 +424,16 @@ func (p *Server) fetchSSHCredentials(ctx context.Context, cluster, edgeName, cal
 		return nil, fmt.Errorf("decoding edge %s: %w", edgeName, err)
 	}
 
-	// SSHHostKey is carried through regardless of mapping mode.
-	hostKey := edge.Status.SSHHostKey
+	// Host key verification inputs are carried through regardless of mapping
+	// mode.
+	hostKey, policy := sshHostKeyFor(edge)
+	withHostKey := func(creds *SSHClientCredentials) *SSHClientCredentials {
+		if creds != nil {
+			creds.SSHHostKey = hostKey
+			creds.SSHHostKeyPolicy = policy
+		}
+		return creds
+	}
 
 	switch edge.Spec.SSHUserMapping {
 	case edgeapi.SSHUserMappingProvided:
@@ -325,10 +446,7 @@ func (p *Server) fetchSSHCredentials(ctx context.Context, cluster, edgeName, cal
 		if err != nil {
 			return nil, err
 		}
-		if creds != nil {
-			creds.SSHHostKey = hostKey
-		}
-		return creds, nil
+		return withHostKey(creds), nil
 
 	case edgeapi.SSHUserMappingIdentity:
 		// Username = caller identity; key from sshCredentialsRef or status creds.
@@ -340,10 +458,7 @@ func (p *Server) fetchSSHCredentials(ctx context.Context, cluster, edgeName, cal
 			if err != nil {
 				return nil, err
 			}
-			if creds != nil {
-				creds.SSHHostKey = hostKey
-			}
-			return creds, nil
+			return withHostKey(creds), nil
 		}
 		// Fall back to status credentials but override the username.
 		creds, err := p.readStatusSSHCreds(ctx, k8sClient, edge, logger)
@@ -354,8 +469,7 @@ func (p *Server) fetchSSHCredentials(ctx context.Context, cluster, edgeName, cal
 			return nil, fmt.Errorf("sshUserMapping=identity: no credentials available for edge %s (set sshCredentialsRef or ensure agent reports SSHCredentials)", edgeName)
 		}
 		creds.Username = callerIdentity
-		creds.SSHHostKey = hostKey
-		return creds, nil
+		return withHostKey(creds), nil
 
 	default:
 		// "inherited" (or empty default) → existing behavior: use agent-reported creds.
@@ -363,11 +477,30 @@ func (p *Server) fetchSSHCredentials(ctx context.Context, cluster, edgeName, cal
 		if err != nil {
 			return nil, err
 		}
-		if creds != nil {
-			creds.SSHHostKey = hostKey
+		if creds == nil {
+			// No credentials at all: still carry the host key inputs so the
+			// session is verified (and fails closed under strict) rather than
+			// silently falling back to an unverified empty-password attempt.
+			creds = &SSHClientCredentials{}
 		}
-		return creds, nil
+		return withHostKey(creds), nil
 	}
+}
+
+// sshHostKeyFor picks the host key an SSH session to the edge is verified
+// against and the policy that applies when there is none: the operator pin
+// (spec.sshHostKey) wins over the agent-reported status.sshHostKey; the policy
+// defaults to strict.
+func sshHostKeyFor(edge *sshEdgeView) (hostKey string, policy edgeapi.SSHHostKeyPolicy) {
+	hostKey = strings.TrimSpace(edge.Spec.SSHHostKey)
+	if hostKey == "" {
+		hostKey = strings.TrimSpace(edge.Status.SSHHostKey)
+	}
+	policy = edge.Spec.SSHHostKeyPolicy
+	if policy == "" {
+		policy = edgeapi.SSHHostKeyPolicyStrict
+	}
+	return hostKey, policy
 }
 
 // sshEdgeView is the ssh-relevant projection of a server-kind CR (e.g.
@@ -399,6 +532,8 @@ type sshEdgeView struct {
 	Spec struct {
 		SSHUserMapping    edgeapi.SSHUserMappingMode `json:"sshUserMapping,omitempty"`
 		SSHCredentialsRef *corev1.SecretReference    `json:"sshCredentialsRef,omitempty"`
+		SSHHostKey        string                     `json:"sshHostKey,omitempty"`
+		SSHHostKeyPolicy  edgeapi.SSHHostKeyPolicy   `json:"sshHostKeyPolicy,omitempty"`
 	} `json:"spec"`
 	Status struct {
 		SSHHostKey     string                  `json:"sshHostKey,omitempty"`
@@ -469,16 +604,20 @@ func (p *Server) readSSHCredsFromSecret(ctx context.Context, k8sClient kubernete
 	return creds, nil
 }
 
-// resolveCallerIdentity performs a kcp TokenReview to extract the caller's username.
-// Returns empty string on any error (non-fatal: inherited/provided modes don't need it).
-func resolveCallerIdentity(ctx context.Context, kcpConfig *rest.Config, token string, logger klog.Logger) string {
-	if kcpConfig == nil || token == "" {
-		return ""
+// resolveCallerIdentity performs a kcp TokenReview to extract the caller's
+// username. Returns an empty identity and the reason on failure; the caller
+// decides whether that is fatal (identity-mode SSH mapping) or only affects the
+// audit line (inherited/provided modes).
+func resolveCallerIdentity(ctx context.Context, kcpConfig *rest.Config, token string) (string, error) {
+	if kcpConfig == nil {
+		return "", errors.New("no kcp config")
+	}
+	if token == "" {
+		return "", errors.New("no bearer token")
 	}
 	client, err := kubernetes.NewForConfig(kcpConfig)
 	if err != nil {
-		logger.V(4).Info("resolveCallerIdentity: failed to create client", "err", err)
-		return ""
+		return "", fmt.Errorf("creating token-review client: %w", err)
 	}
 	// This runs on the SSH data-plane path BEFORE the tunnel dial, and the
 	// request context is a WebSocket upgrade with no deadline. A TokenReview that
@@ -492,11 +631,13 @@ func resolveCallerIdentity(ctx context.Context, kcpConfig *rest.Config, token st
 		Spec: authv1.TokenReviewSpec{Token: token},
 	}
 	result, err := client.AuthenticationV1().TokenReviews().Create(trCtx, tr, metav1.CreateOptions{})
-	if err != nil || !result.Status.Authenticated {
-		logger.V(4).Info("resolveCallerIdentity: token review failed or unauthenticated", "err", err)
-		return ""
+	if err != nil {
+		return "", fmt.Errorf("token review: %w", err)
 	}
-	return result.Status.User.Username
+	if !result.Status.Authenticated {
+		return "", errors.New("token review: not authenticated")
+	}
+	return result.Status.User.Username, nil
 }
 
 // edgesHandleK8sUpgrade handles upgrade requests (exec, port-forward) to an

--- a/providers/edges/internal/tunnel/server.go
+++ b/providers/edges/internal/tunnel/server.go
@@ -113,6 +113,11 @@ type Server struct {
 	// bearers. main.go never sets it, so production always fails closed.
 	allowStaticTokenBypass bool
 
+	// allowUnverifiedSSHHostKey is the provider-wide legacy escape hatch that
+	// lets an SSH session to an edge with no known host key proceed
+	// unverified. Logged at V(0) on startup and on every use.
+	allowUnverifiedSSHHostKey bool
+
 	// hubExternalURL is embedded into agent kubeconfigs. hubInternalURL is used
 	// for internal MCP→edgeproxy calls to avoid CDN loops; falls back to
 	// hubExternalURL when empty.
@@ -208,7 +213,12 @@ type Config struct {
 	AllowStaticTokenBypass bool
 	HubExternalURL         string
 	HubInternalURL         string
-	Logger                 klog.Logger
+	// AllowUnverifiedSSHHostKey restores the legacy behaviour of opening SSH
+	// sessions to edges with no known host key without verifying the server
+	// (--allow-unverified-ssh-host-key). Never affects an edge whose key is
+	// known or pinned; those are always enforced.
+	AllowUnverifiedSSHHostKey bool
+	Logger                    klog.Logger
 }
 
 // New constructs the tunnel Server for one or more connectable kinds.
@@ -240,19 +250,20 @@ func New(cfg Config) (*Server, error) {
 		}
 	}
 	return &Server{
-		kinds:                  kinds,
-		group:                  group,
-		version:                version,
-		edgeConnManager:        NewConnManager(),
-		kcpConfig:              cfg.KCPConfig,
-		staticTokens:           tokenSet,
-		allowStaticTokenBypass: cfg.AllowStaticTokenBypass,
-		hubExternalURL:         cfg.HubExternalURL,
-		hubInternalURL:         cfg.HubInternalURL,
-		agentPickupPath:        cfg.AgentPickupPath,
-		edgeProxyPublicPath:    cfg.EdgeProxyPublicPath,
-		authorizeFn:            authorize,
-		logger:                 cfg.Logger.WithName("edge-tunnel"),
+		kinds:                     kinds,
+		group:                     group,
+		version:                   version,
+		edgeConnManager:           NewConnManager(),
+		kcpConfig:                 cfg.KCPConfig,
+		staticTokens:              tokenSet,
+		allowStaticTokenBypass:    cfg.AllowStaticTokenBypass,
+		hubExternalURL:            cfg.HubExternalURL,
+		hubInternalURL:            cfg.HubInternalURL,
+		agentPickupPath:           cfg.AgentPickupPath,
+		edgeProxyPublicPath:       cfg.EdgeProxyPublicPath,
+		allowUnverifiedSSHHostKey: cfg.AllowUnverifiedSSHHostKey,
+		authorizeFn:               authorize,
+		logger:                    cfg.Logger.WithName("edge-tunnel"),
 	}, nil
 }
 

--- a/providers/edges/internal/tunnel/ssh_hostkey_test.go
+++ b/providers/edges/internal/tunnel/ssh_hostkey_test.go
@@ -20,9 +20,12 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	gossh "golang.org/x/crypto/ssh"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,21 +100,6 @@ func TestNewSSHClientHostKeyVerification(t *testing.T) {
 		wantLearned string
 	}{
 		{
-			name:    "garbage key errors before dialing",
-			hk:      sshHostKeyVerification{Key: "not a key", Policy: edgeapi.SSHHostKeyPolicyTOFU, AllowUnverified: true},
-			wantErr: "parsing SSH host key",
-		},
-		{
-			name:    "empty key with strict policy errors",
-			hk:      sshHostKeyVerification{Policy: edgeapi.SSHHostKeyPolicyStrict},
-			wantErr: "no SSH host key known",
-		},
-		{
-			name:    "empty key with no policy defaults to strict",
-			hk:      sshHostKeyVerification{},
-			wantErr: "no SSH host key known",
-		},
-		{
 			name:        "empty key with tofu succeeds and learns the presented key",
 			hk:          sshHostKeyVerification{Policy: edgeapi.SSHHostKeyPolicyTOFU},
 			wantLearned: serverKey,
@@ -153,6 +141,172 @@ func TestNewSSHClientHostKeyVerification(t *testing.T) {
 				t.Fatalf("learned key = %q, want %q", learned, tc.wantLearned)
 			}
 		})
+	}
+}
+
+// refusedConn is a net.Conn that records any attempt to use it and refuses.
+//
+// Cases that must be refused BEFORE a handshake are asserted against it: a real
+// socket cannot prove that nothing was sent, and net.Pipe is not an option
+// either — the SSH version exchange writes before it reads on both sides, which
+// deadlocks on an unbuffered pipe (see startTestSSHServer). Read/Write also
+// return an error rather than blocking, so a regression fails the assertion
+// instead of hanging the test.
+//
+// SetDeadline and friends deliberately do NOT count as use: newSSHClient arms
+// the handshake deadline on its way into gossh.NewClientConn, which a refused
+// session never reaches.
+type refusedConn struct {
+	mu   sync.Mutex
+	used []string
+}
+
+func (c *refusedConn) mark(op string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.used = append(c.used, op)
+	return fmt.Errorf("refusedConn: unexpected %s", op)
+}
+
+func (c *refusedConn) uses() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.used...)
+}
+
+func (c *refusedConn) Read([]byte) (int, error)         { return 0, c.mark("read") }
+func (c *refusedConn) Write([]byte) (int, error)        { return 0, c.mark("write") }
+func (c *refusedConn) Close() error                     { return nil }
+func (c *refusedConn) LocalAddr() net.Addr              { return refusedAddr{} }
+func (c *refusedConn) RemoteAddr() net.Addr             { return refusedAddr{} }
+func (c *refusedConn) SetDeadline(time.Time) error      { return nil }
+func (c *refusedConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *refusedConn) SetWriteDeadline(time.Time) error { return nil }
+
+type refusedAddr struct{}
+
+func (refusedAddr) Network() string { return "refused" }
+func (refusedAddr) String() string  { return "refused" }
+
+// TestNewSSHClientRefusesBeforeTouchingTheConnection asserts that a host key
+// that cannot be honoured is rejected without a single byte reaching the edge.
+func TestNewSSHClientRefusesBeforeTouchingTheConnection(t *testing.T) {
+	cases := []struct {
+		name    string
+		hk      sshHostKeyVerification
+		wantErr string
+	}{
+		{
+			name:    "garbage key, even with tofu and the escape hatch set",
+			hk:      sshHostKeyVerification{Key: "not a key", Policy: edgeapi.SSHHostKeyPolicyTOFU, AllowUnverified: true},
+			wantErr: "parsing SSH host key",
+		},
+		{
+			name:    "empty key with strict policy",
+			hk:      sshHostKeyVerification{Policy: edgeapi.SSHHostKeyPolicyStrict},
+			wantErr: "no SSH host key known",
+		},
+		{
+			name:    "empty key with no policy defaults to strict",
+			hk:      sshHostKeyVerification{},
+			wantErr: "no SSH host key known",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &refusedConn{}
+			client, learned, err := newSSHClient(context.Background(), conn, nil, tc.hk, klog.Background())
+			if err == nil {
+				client.Close() //nolint:errcheck
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err, tc.wantErr)
+			}
+			if learned != "" {
+				t.Fatalf("refused session learned a key: %q", learned)
+			}
+			if used := conn.uses(); len(used) != 0 {
+				t.Fatalf("the connection was used before the refusal: %v", used)
+			}
+		})
+	}
+}
+
+// TestNewSSHClientBoundsTheHandshake covers a peer that accepts the connection
+// and then says nothing: gossh.NewClientConn takes no context, so without a
+// deadline on the connection the handler goroutine would block forever.
+func TestNewSSHClientBoundsTheHandshake(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listening: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() }) //nolint:errcheck
+
+	// Accept and hold the connection open without ever sending a version string.
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		<-time.After(time.Minute)
+		conn.Close() //nolint:errcheck
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dialling the stalled peer: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() }) //nolint:errcheck
+
+	// A short caller deadline stands in for the production default
+	// (sshHandshakeTimeout), which is too long for a test.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		client, _, err := newSSHClient(ctx, conn, nil, sshHostKeyVerification{AllowUnverified: true}, klog.Background())
+		if client != nil {
+			client.Close() //nolint:errcheck
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected the stalled handshake to fail")
+		}
+		if !strings.Contains(err.Error(), "failed to create SSH client connection") {
+			t.Fatalf("error = %q, want the client-connection failure", err)
+		}
+		if elapsed := time.Since(start); elapsed > 5*time.Second {
+			t.Fatalf("handshake took %s; the deadline was not honoured", elapsed)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("newSSHClient did not return: the SSH handshake is unbounded")
+	}
+}
+
+func TestSSHHostKeyFingerprintDistinguishesUnknownFromUnparseable(t *testing.T) {
+	// "no key recorded" and "a key is recorded but malformed" must not share a
+	// rendering: they call for different operator action.
+	for _, empty := range []string{"", "   ", "\n\t "} {
+		if got := sshHostKeyFingerprint(empty); got != sshHostKeyFingerprintUnknown {
+			t.Fatalf("sshHostKeyFingerprint(%q) = %q, want %q", empty, got, sshHostKeyFingerprintUnknown)
+		}
+	}
+	for _, bad := range []string{"not a key", "ssh-ed25519 !!!!"} {
+		if got := sshHostKeyFingerprint(bad); got != sshHostKeyFingerprintUnparseable {
+			t.Fatalf("sshHostKeyFingerprint(%q) = %q, want %q", bad, got, sshHostKeyFingerprintUnparseable)
+		}
+	}
+	_, key := newTestHostKey(t)
+	if got := sshHostKeyFingerprint(key); !strings.HasPrefix(got, "SHA256:") {
+		t.Fatalf("sshHostKeyFingerprint(valid key) = %q, want a SHA256 fingerprint", got)
 	}
 }
 

--- a/providers/edges/internal/tunnel/ssh_hostkey_test.go
+++ b/providers/edges/internal/tunnel/ssh_hostkey_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"strings"
+	"testing"
+
+	gossh "golang.org/x/crypto/ssh"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	edgeapi "github.com/faroshq/provider-edges/internal/edgeapi"
+)
+
+// newTestHostKey generates an sshd host key and returns its signer and its
+// authorized_keys form.
+func newTestHostKey(t *testing.T) (gossh.Signer, string) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generating host key: %v", err)
+	}
+	signer, err := gossh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("creating signer: %v", err)
+	}
+	return signer, strings.TrimSpace(string(gossh.MarshalAuthorizedKey(signer.PublicKey())))
+}
+
+// startTestSSHServer runs a minimal SSH server (no client auth) on a loopback
+// listener and returns a connection to it. A real socket rather than net.Pipe:
+// the SSH version exchange writes before it reads on both sides, which
+// deadlocks on an unbuffered pipe.
+func startTestSSHServer(t *testing.T, signer gossh.Signer) net.Conn {
+	t.Helper()
+	cfg := &gossh.ServerConfig{NoClientAuth: true}
+	cfg.AddHostKey(signer)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listening: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() }) //nolint:errcheck
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		sc, chans, reqs, err := gossh.NewServerConn(conn, cfg)
+		if err != nil {
+			conn.Close() //nolint:errcheck
+			return
+		}
+		defer sc.Close() //nolint:errcheck
+		go gossh.DiscardRequests(reqs)
+		for ch := range chans {
+			ch.Reject(gossh.Prohibited, "test server") //nolint:errcheck
+		}
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dialling test SSH server: %v", err)
+	}
+	t.Cleanup(func() { clientConn.Close() }) //nolint:errcheck
+	return clientConn
+}
+
+func TestNewSSHClientHostKeyVerification(t *testing.T) {
+	serverSigner, serverKey := newTestHostKey(t)
+	_, otherKey := newTestHostKey(t)
+
+	cases := []struct {
+		name        string
+		hk          sshHostKeyVerification
+		wantErr     string
+		wantLearned string
+	}{
+		{
+			name:    "garbage key errors before dialing",
+			hk:      sshHostKeyVerification{Key: "not a key", Policy: edgeapi.SSHHostKeyPolicyTOFU, AllowUnverified: true},
+			wantErr: "parsing SSH host key",
+		},
+		{
+			name:    "empty key with strict policy errors",
+			hk:      sshHostKeyVerification{Policy: edgeapi.SSHHostKeyPolicyStrict},
+			wantErr: "no SSH host key known",
+		},
+		{
+			name:    "empty key with no policy defaults to strict",
+			hk:      sshHostKeyVerification{},
+			wantErr: "no SSH host key known",
+		},
+		{
+			name:        "empty key with tofu succeeds and learns the presented key",
+			hk:          sshHostKeyVerification{Policy: edgeapi.SSHHostKeyPolicyTOFU},
+			wantLearned: serverKey,
+		},
+		{
+			name: "matching key succeeds and learns nothing",
+			hk:   sshHostKeyVerification{Key: serverKey, Policy: edgeapi.SSHHostKeyPolicyStrict},
+		},
+		{
+			name:    "mismatching key fails the handshake even under tofu and the escape hatch",
+			hk:      sshHostKeyVerification{Key: otherKey, Policy: edgeapi.SSHHostKeyPolicyTOFU, AllowUnverified: true},
+			wantErr: "failed to create SSH client connection",
+		},
+		{
+			name: "empty key with the escape hatch succeeds without learning",
+			hk:   sshHostKeyVerification{Policy: edgeapi.SSHHostKeyPolicyStrict, AllowUnverified: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := startTestSSHServer(t, serverSigner)
+			client, learned, err := newSSHClient(context.Background(), conn, nil, tc.hk, klog.Background())
+			if tc.wantErr != "" {
+				if err == nil {
+					client.Close() //nolint:errcheck
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %q, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("newSSHClient: %v", err)
+			}
+			defer client.Close() //nolint:errcheck
+			if learned != tc.wantLearned {
+				t.Fatalf("learned key = %q, want %q", learned, tc.wantLearned)
+			}
+		})
+	}
+}
+
+func TestApplyReportedSSHHostKeyIsWriteOnce(t *testing.T) {
+	_, first := newTestHostKey(t)
+	_, second := newTestHostKey(t)
+	now := metav1.Now()
+
+	status := map[string]interface{}{}
+	applyReportedSSHHostKey(status, first, now)
+	if status["sshHostKey"] != first {
+		t.Fatalf("first report not recorded: %v", status["sshHostKey"])
+	}
+	if c := findStatusCondition(status, edgeapi.ConnectionConditionSSHHostKeyChanged); c != nil {
+		t.Fatalf("unexpected condition after first report: %v", c)
+	}
+
+	// A different key is NOT recorded; the mismatch is surfaced as a condition
+	// that names both fingerprints.
+	applyReportedSSHHostKey(status, second, now)
+	if status["sshHostKey"] != first {
+		t.Fatalf("recorded key was replaced by a later report: %v", status["sshHostKey"])
+	}
+	c := findStatusCondition(status, edgeapi.ConnectionConditionSSHHostKeyChanged)
+	if c == nil {
+		t.Fatal("SSHHostKeyChanged condition not set on mismatch")
+	}
+	if c["status"] != string(metav1.ConditionTrue) || c["reason"] != "FingerprintMismatch" {
+		t.Fatalf("condition = %v, want True/FingerprintMismatch", c)
+	}
+	msg, _ := c["message"].(string)
+	for _, fp := range []string{sshHostKeyFingerprint(first), sshHostKeyFingerprint(second)} {
+		if !strings.Contains(msg, fp) {
+			t.Fatalf("condition message %q lacks fingerprint %s", msg, fp)
+		}
+	}
+
+	// The same key again (with a comment appended, as sshd tooling emits)
+	// keeps the record and clears the condition.
+	applyReportedSSHHostKey(status, first+" host@example", now)
+	if status["sshHostKey"] != first {
+		t.Fatalf("recorded key changed on a matching report: %v", status["sshHostKey"])
+	}
+	c = findStatusCondition(status, edgeapi.ConnectionConditionSSHHostKeyChanged)
+	if c == nil || c["status"] != string(metav1.ConditionFalse) {
+		t.Fatalf("condition after matching report = %v, want False", c)
+	}
+}
+
+func TestSSHHostKeyForPrefersSpecPin(t *testing.T) {
+	edge := &sshEdgeView{}
+	edge.Status.SSHHostKey = "ssh-ed25519 AAAAstatus"
+
+	key, policy := sshHostKeyFor(edge)
+	if key != "ssh-ed25519 AAAAstatus" || policy != edgeapi.SSHHostKeyPolicyStrict {
+		t.Fatalf("status key / default policy = %q / %q", key, policy)
+	}
+
+	edge.Spec.SSHHostKey = " ssh-ed25519 AAAApinned \n"
+	edge.Spec.SSHHostKeyPolicy = edgeapi.SSHHostKeyPolicyTOFU
+	key, policy = sshHostKeyFor(edge)
+	if key != "ssh-ed25519 AAAApinned" {
+		t.Fatalf("spec pin did not win over status: %q", key)
+	}
+	if policy != edgeapi.SSHHostKeyPolicyTOFU {
+		t.Fatalf("policy = %q, want tofu", policy)
+	}
+}

--- a/providers/edges/main.go
+++ b/providers/edges/main.go
@@ -115,16 +115,30 @@ type serveOptions struct {
 	allowUnverifiedSSHHostKey bool
 }
 
+// allowUnverifiedEnvVar is the env form of --allow-unverified-ssh-host-key
+// (the chart sets it).
+const allowUnverifiedEnvVar = "FAROS_EDGES_ALLOW_UNVERIFIED_SSH_HOST_KEY"
+
 func parseServeOptions(args []string) (serveOptions, error) {
 	var opts serveOptions
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	fs.BoolVar(&opts.allowUnverifiedSSHHostKey, "allow-unverified-ssh-host-key", false,
-		"open SSH sessions to LinuxServers with no known host key without verifying the server (legacy escape hatch; env FAROS_EDGES_ALLOW_UNVERIFIED_SSH_HOST_KEY=true)")
+		"open SSH sessions to LinuxServers with no known host key without verifying the server (legacy escape hatch; env "+allowUnverifiedEnvVar+"=true)")
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
-	if v, _ := strconv.ParseBool(os.Getenv("FAROS_EDGES_ALLOW_UNVERIFIED_SSH_HOST_KEY")); v {
-		opts.allowUnverifiedSSHHostKey = true
+	// A malformed value is refused rather than silently read as false: this
+	// switch decides whether SSH sessions verify the server at all, and a typo
+	// ("treu") must not quietly land on a different security posture than the
+	// operator asked for — in either direction.
+	if raw, set := os.LookupEnv(allowUnverifiedEnvVar); set && raw != "" {
+		v, err := strconv.ParseBool(raw)
+		if err != nil {
+			return opts, fmt.Errorf("%s=%q is not a boolean: %w (use true or false)", allowUnverifiedEnvVar, raw, err)
+		}
+		if v {
+			opts.allowUnverifiedSSHHostKey = true
+		}
 	}
 	return opts, nil
 }

--- a/providers/edges/main.go
+++ b/providers/edges/main.go
@@ -34,10 +34,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -84,18 +86,55 @@ func main() {
 		case "serve":
 			// fall through
 		default:
-			fmt.Fprintf(os.Stderr, "unknown subcommand: %s\nusage: edges-provider [init|serve]\n", os.Args[1])
+			fmt.Fprintf(os.Stderr, "unknown subcommand: %s\nusage: edges-provider [init|serve [--allow-unverified-ssh-host-key]]\n", os.Args[1])
 			os.Exit(2)
 		}
 	}
-	if err := runServe(); err != nil {
+	var serveArgs []string
+	if len(os.Args) > 2 {
+		serveArgs = os.Args[2:]
+	}
+	opts, err := parseServeOptions(serveArgs)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "serve:", err)
+		os.Exit(2)
+	}
+	if err := runServe(opts); err != nil {
 		fmt.Fprintln(os.Stderr, "serve:", err)
 		os.Exit(1)
 	}
 }
 
-func runServe() error {
+// serveOptions are the serve-time switches. Each has a flag and an env form
+// (the chart sets the env); either enables it.
+type serveOptions struct {
+	// allowUnverifiedSSHHostKey is the legacy escape hatch for LinuxServers
+	// whose agents never reported an sshd host key: SSH sessions to them are
+	// opened without verifying the server. Edges with a known or pinned key
+	// are always verified regardless.
+	allowUnverifiedSSHHostKey bool
+}
+
+func parseServeOptions(args []string) (serveOptions, error) {
+	var opts serveOptions
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	fs.BoolVar(&opts.allowUnverifiedSSHHostKey, "allow-unverified-ssh-host-key", false,
+		"open SSH sessions to LinuxServers with no known host key without verifying the server (legacy escape hatch; env FAROS_EDGES_ALLOW_UNVERIFIED_SSH_HOST_KEY=true)")
+	if err := fs.Parse(args); err != nil {
+		return opts, err
+	}
+	if v, _ := strconv.ParseBool(os.Getenv("FAROS_EDGES_ALLOW_UNVERIFIED_SSH_HOST_KEY")); v {
+		opts.allowUnverifiedSSHHostKey = true
+	}
+	return opts, nil
+}
+
+func runServe(opts serveOptions) error {
 	log := klog.Background().WithName("edges")
+
+	if opts.allowUnverifiedSSHHostKey {
+		log.Info("WARNING: --allow-unverified-ssh-host-key is set: SSH sessions to LinuxServers with no known host key will NOT verify the server (MITM risk); pin spec.sshHostKey or let agents report keys, then remove the flag")
+	}
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -144,12 +183,13 @@ func runServe() error {
 			{GVR: edgesv1alpha1.KubernetesClusterGVR, Kind: "KubernetesCluster"},
 			{GVR: edgesv1alpha1.LinuxServerGVR, Kind: "LinuxServer"},
 		},
-		AgentPickupPath:     agentPickupPath,
-		EdgeProxyPublicPath: edgeProxyPublicPath,
-		KCPConfig:           kcpConfig,
-		HubExternalURL:      hubExternalURL,
-		HubInternalURL:      os.Getenv("FAROS_HUB_INTERNAL_URL"),
-		Logger:              log,
+		AgentPickupPath:           agentPickupPath,
+		EdgeProxyPublicPath:       edgeProxyPublicPath,
+		KCPConfig:                 kcpConfig,
+		HubExternalURL:            hubExternalURL,
+		HubInternalURL:            os.Getenv("FAROS_HUB_INTERNAL_URL"),
+		AllowUnverifiedSSHHostKey: opts.allowUnverifiedSSHHostKey,
+		Logger:                    log,
 	})
 	if err != nil {
 		return fmt.Errorf("build tunnel server: %w", err)

--- a/providers/edges/serveoptions_test.go
+++ b/providers/edges/serveoptions_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestParseServeOptionsAllowUnverifiedEnv pins the env form of the host key
+// escape hatch. A malformed value must not be read as "false": that silently
+// puts the provider on a different security posture than the operator asked
+// for, in whichever direction the typo went.
+func TestParseServeOptionsAllowUnverifiedEnv(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     string
+		unset   bool
+		args    []string
+		want    bool
+		wantErr bool
+	}{
+		{name: "unset", unset: true},
+		{name: "empty is treated as unset", env: ""},
+		{name: "true", env: "true", want: true},
+		{name: "1", env: "1", want: true},
+		{name: "TRUE", env: "TRUE", want: true},
+		{name: "false", env: "false"},
+		{name: "0", env: "0"},
+		{name: "typo is rejected, not read as false", env: "treu", wantErr: true},
+		{name: "yes is rejected", env: "yes", wantErr: true},
+		{name: "the flag still works with the env unset", unset: true, args: []string{"--allow-unverified-ssh-host-key"}, want: true},
+		{name: "env=false does not turn the flag off", env: "false", args: []string{"--allow-unverified-ssh-host-key"}, want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				// t.Setenv has no unset form; set-then-unset keeps its
+				// restore-on-cleanup behaviour.
+				t.Setenv(allowUnverifiedEnvVar, "placeholder")
+				if err := os.Unsetenv(allowUnverifiedEnvVar); err != nil {
+					t.Fatalf("unsetting %s: %v", allowUnverifiedEnvVar, err)
+				}
+			} else {
+				t.Setenv(allowUnverifiedEnvVar, tc.env)
+			}
+
+			opts, err := parseServeOptions(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %s=%q, got none (allowUnverifiedSSHHostKey=%v)", allowUnverifiedEnvVar, tc.env, opts.allowUnverifiedSSHHostKey)
+				}
+				if !strings.Contains(err.Error(), allowUnverifiedEnvVar) || !strings.Contains(err.Error(), tc.env) {
+					t.Fatalf("error %q should name both the variable and the value %q", err, tc.env)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseServeOptions: %v", err)
+			}
+			if opts.allowUnverifiedSSHHostKey != tc.want {
+				t.Fatalf("allowUnverifiedSSHHostKey = %v, want %v", opts.allowUnverifiedSSHHostKey, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Security remediation plan item 2.3 (finding 7). Branched from `main` at 9ab06b67, independent of #631 (item 2.2).

## Problem

`providers/edges/internal/tunnel/agent_proxy_builder.go` (`newSSHClient`) fell back to `ssh.InsecureIgnoreHostKey()` when the edge's host key did not parse, and on an empty key with only an Info log. So an SSH session to a LinuxServer whose agent had never reported a key ran with no host identity check at all.

The key is agent-asserted (`pkg/agent/status/edge_reporter.go` probes the local sshd and reports it on connect and on every heartbeat), and `edge_status.go` overwrote `status.sshHostKey` on every reconnect — a compromised agent could rotate the pinned key silently. The only per-session log was `edges_proxy_builder.go` at V(4), without the caller; `resolveCallerIdentity` logged its failures at V(4) only.

## Change

1. **Fail closed in `newSSHClient`.** An unparseable key is an error. An empty key is an error unless the LinuxServer sets the new `spec.sshHostKeyPolicy` (enum `strict|tofu`, default `strict`); `tofu` trusts the key the server presents on the first session, returns it to the handler, which records it in `status.sshHostKey` and enforces it from then on. Provider-wide legacy escape hatch `--allow-unverified-ssh-host-key` (env `FAROS_EDGES_ALLOW_UNVERIFIED_SSH_HOST_KEY`, chart value `allowUnverifiedSSHHostKey`), logged at V(0) on startup and on every use; it never affects an edge whose key is known.
2. **Operator pin + write-once status.** New `spec.sshHostKey` wins over `status.sshHostKey`. `applyReportedSSHHostKey` records the reported key once and never replaces it: a later report with a different fingerprint sets the new `SSHHostKeyChanged` condition naming both fingerprints (cleared when a matching key is reported again). The agent consequently stops re-asserting the key in its heartbeat status patch and instead sends `X-Faros-SSH-HostKey` on tunnel connect in every mode, not just join-token mode — otherwise an agent that first connects with a saved kubeconfig could never report one.
3. **Session audit.** `edgesSSHHandler` emits `SSH session opened` and `SSH session ended` at V(0) with cluster, edge, caller, SSH user, mode, exec command, remote address (first `X-Forwarded-For` hop behind the hub proxy), host key fingerprint and duration. A session refused before opening still gets the close line with `opened=false` and the reason. `resolveCallerIdentity` now returns its failure reason, which rides the audit line as `caller=unknown` + `callerError`; it stays non-fatal so `inherited`/`provided` mappings keep working (`identity` mapping already errors on an empty caller).

Also: credentials-less edges now still carry the host key inputs instead of silently falling through to an unverified empty-password attempt.

## Compatibility

- **Behaviour change:** SSH to a LinuxServer with no known host key is now refused by default. Agents at the current version report their key on connect, so an edge that reconnects once is verified automatically. For legacy agents, either pin `spec.sshHostKey`, set `spec.sshHostKeyPolicy: tofu`, or run the provider with `--allow-unverified-ssh-host-key`.
- `make codegen-edges-provider` was run from the repo root. Besides the LinuxServer schema it also regenerates a **pre-existing** docstring drift in the `workloads` schema and rewrites both schema version stamps in the APIExport; that honest output is committed as-is.
- The CatalogEntry (`manifest.yaml` / chart `catalogentry.yaml`) does not inline the LinuxServer schema — the chart ships it via `files/schemas`, which codegen updated — so no AGENTS.md 5.1 mirror was needed.

## Tests

New `internal/tunnel/ssh_hostkey_test.go` against a loopback SSH server: garbage key errors before dialing; empty key with `strict` (and with no policy set) errors; empty key with `tofu` succeeds and returns the presented key; a matching pin succeeds; a mismatching pin fails the handshake even under `tofu` and the escape hatch; the escape hatch succeeds without learning. Plus `applyReportedSSHHostKey` write-once behaviour and the `SSHHostKeyChanged` condition (both fingerprints in the message, cleared on a match, comment-insensitive comparison), and `sshHostKeyFor` preferring the spec pin and defaulting to strict.

Commands (all `GOWORK=off`): `go build ./...`, `go test -count=1 ./internal/... ./apis/...` in `providers/edges` — all pass; `go vet ./pkg/agent/...` and `go test -count=1 ./pkg/agent/...` — pass; `hack/ensure-boilerplate.sh` clean; `gofmt -l` clean on every changed file; `golangci-lint run` on the edges module reports the same 14 findings as `main`.

Docs: DEVELOPERS.md gains an "SSH host key verification" section covering the key source, the policy, the escape hatch and the audit lines; the chart README documents the new value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
