### PR TITLE
fix(hub): retry on conflict when recording a provider edge binding

### DIFF
--- a/pkg/hub/kcp/edgeroute.go
+++ b/pkg/hub/kcp/edgeroute.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/faroshq/faros/pkg/kcppaths"
@@ -88,21 +89,27 @@ func (b *Bootstrapper) RecordProviderEdgeBinding(ctx context.Context, orgUUID, p
 	if err != nil {
 		return fmt.Errorf("creating org providers workspace client: %w", err)
 	}
-	ws, err := parent.Resource(workspaceGVR).Get(ctx, providerName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("getting org provider workspace %s: %w", providerName, err)
-	}
-	annotations := ws.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	if annotations[EdgeRouteWorkspaceAnnotation] == wsUUID && annotations[EdgeRouteEdgeAnnotation] == edgeName {
-		return nil
-	}
-	annotations[EdgeRouteWorkspaceAnnotation] = wsUUID
-	annotations[EdgeRouteEdgeAnnotation] = edgeName
-	ws.SetAnnotations(annotations)
-	if _, err := parent.Resource(workspaceGVR).Update(ctx, ws, metav1.UpdateOptions{}); err != nil {
+	// The workspace is usually seconds old here and its own controllers are
+	// still writing to it, so a read-modify-write races them. Re-read inside
+	// the retry: a stale object would only lose the race again.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ws, err := parent.Resource(workspaceGVR).Get(ctx, providerName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		annotations := ws.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		if annotations[EdgeRouteWorkspaceAnnotation] == wsUUID && annotations[EdgeRouteEdgeAnnotation] == edgeName {
+			return nil
+		}
+		annotations[EdgeRouteWorkspaceAnnotation] = wsUUID
+		annotations[EdgeRouteEdgeAnnotation] = edgeName
+		ws.SetAnnotations(annotations)
+		_, err = parent.Resource(workspaceGVR).Update(ctx, ws, metav1.UpdateOptions{})
+		return err
+	}); err != nil {
 		return fmt.Errorf("recording edge binding on org provider workspace %s: %w", providerName, err)
 	}
 	klog.FromContext(ctx).Info("Recorded provider edge binding",


### PR DESCRIPTION
## Problem

`RecordProviderEdgeBinding` reads the org provider `Workspace` and updates its annotations with no conflict retry. The workspace is created moments earlier during registration and its own controllers are still writing to it, so the update loses the optimistic-concurrency race intermittently:

```
recording edge binding on org provider workspace rogue-target: Operation cannot
be fulfilled on workspaces.tenancy.kcp.io "rogue-target": the object has been
modified; please apply your changes to the latest version and try again
```

Two consequences:

1. **A tenant sees a 500** from `POST /api/orgs/{org}/providers` for what is a retryable conflict, leaving registration half-done.
2. **`TestBYOProviderRegistrationLifecycle` is flaky.** That is how this was found: the `refuses a backend address that is not cluster DNS` subtest expects a clean rejection and instead got the 500 above, failing the Edges connectivity suite on an unrelated PR.

## Change

Wrap the read-modify-write in `retry.RetryOnConflict(retry.DefaultRetry, ...)`, re-reading the workspace inside the closure so each attempt starts from the current resource version. The early-return for an already-correct binding stays inside the loop, so a concurrent writer that sets the same values still short-circuits.

No behaviour change on the success path, and non-conflict errors surface exactly as before.

## Compatibility

None. Internal robustness fix, no API, schema, or config change.

## Tests

- `go build ./pkg/hub/...`, `go vet ./pkg/hub/kcp/`, `go test -count=1 ./pkg/hub/kcp/` all pass.
- The flaky e2e subtest is covered by the existing `TestBYOProviderRegistrationLifecycle` in `test/e2e/suites/edgesconn`; this removes the race it was hitting rather than adding a new test, since reproducing the conflict deterministically would mean faking the dynamic client at a level the package does not currently stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
