### PR TITLE
feat(chart): expose the hub's provider hardening flags as values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,9 @@ test-hub-chart: ## Lint and render the faros-hub chart's provider hardening valu
 			--set hub.security.providerWorkspaceClusterAdmin=true >"$$tmp_dir/admin-true.yaml"; \
 		grep -q -- '- --provider-workspace-cluster-admin=true$$' "$$tmp_dir/admin-true.yaml"; \
 		helm template faros "$$chart" --set hub.hubExternalURL="$$url" \
+			--set-string hub.security.providerWorkspaceClusterAdmin=false >"$$tmp_dir/admin-false-string.yaml"; \
+		grep -q -- '- --provider-workspace-cluster-admin=false$$' "$$tmp_dir/admin-false-string.yaml"; \
+		helm template faros "$$chart" --set hub.hubExternalURL="$$url" \
 			--set 'hub.extraArgs={--providers=edges\,infrastructure,--graphql-playground}' >"$$tmp_dir/extra.yaml"; \
 		grep -q -- '- "--providers=edges,infrastructure"$$' "$$tmp_dir/extra.yaml"; \
 		grep -q -- '- "--graphql-playground"$$' "$$tmp_dir/extra.yaml"; \
@@ -280,8 +283,17 @@ test-hub-chart: ## Lint and render the faros-hub chart's provider hardening valu
 		if helm template faros "$$chart" --set hub.hubExternalURL="$$url" --set hub.security.providerDelegatedTokens=some >/dev/null 2>&1; then \
 			echo "invalid providerDelegatedTokens unexpectedly rendered"; exit 1; \
 		fi; \
+		if helm template faros "$$chart" --set hub.hubExternalURL="$$url" --set hub.security.providerWorkspaceClusterAdmin=maybe >/dev/null 2>&1; then \
+			echo "invalid providerWorkspaceClusterAdmin unexpectedly rendered"; exit 1; \
+		fi; \
 		if helm template faros "$$chart" --set hub.hubExternalURL="$$url" --set 'hub.extraArgs={--dev-mode}' >/dev/null 2>&1; then \
 			echo "extraArgs repeating a modelled flag unexpectedly rendered"; exit 1; \
+		fi; \
+		if helm template faros "$$chart" --set hub.hubExternalURL="$$url" --set 'hub.extraArgs={--provider-heartbeat-auth=enforce}' >/dev/null 2>&1; then \
+			echo "extraArgs repeating --provider-heartbeat-auth unexpectedly rendered"; exit 1; \
+		fi; \
+		if helm template faros "$$chart" --set hub.hubExternalURL="$$url" --set 'hub.extraArgs={--provider-delegated-tokens=platform}' >/dev/null 2>&1; then \
+			echo "extraArgs repeating --provider-delegated-tokens unexpectedly rendered"; exit 1; \
 		fi
 
 ## Generate deepcopy methods + CRD YAML for the infrastructure provider's

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,46 @@ test-databricks-provider-chart: ## Lint and render both supported Databricks boo
 			echo "external bootstrap unexpectedly rendered a CatalogEntry"; exit 1; \
 		fi
 
+test-hub-chart: ## Lint and render the faros-hub chart's provider hardening values
+	@set -eu; \
+		tmp_parent="$${CODEX_BUILD_CACHE_ROOT:-/var/tmp/codex-build}"; \
+		mkdir -p "$$tmp_parent"; \
+		tmp_dir="$$(mktemp -d "$$tmp_parent/faros-hub-chart.XXXXXX")"; \
+		cleanup() { rm -rf -- "$$tmp_dir"; }; \
+		trap cleanup EXIT HUP INT TERM; \
+		chart=deploy/charts/faros-hub; url=https://faros.example.com; \
+		helm lint "$$chart" --set hub.hubExternalURL="$$url"; \
+		helm template faros "$$chart" --set hub.hubExternalURL="$$url" >"$$tmp_dir/default.yaml"; \
+		if grep -q -- '--provider-' "$$tmp_dir/default.yaml"; then \
+			echo "default values rendered a provider hardening flag; they must leave the binary default"; exit 1; \
+		fi; \
+		helm template faros "$$chart" --set hub.hubExternalURL="$$url" \
+			--set hub.security.providerHeartbeatAuth=enforce \
+			--set hub.security.providerDelegatedTokens=platform \
+			--set 'hub.security.providerDelegatedTokensExclude={edges,mcp}' \
+			--set hub.security.providerWorkspaceClusterAdmin=false >"$$tmp_dir/hardened.yaml"; \
+		grep -q -- '- --provider-heartbeat-auth=enforce$$' "$$tmp_dir/hardened.yaml"; \
+		grep -q -- '- --provider-delegated-tokens=platform$$' "$$tmp_dir/hardened.yaml"; \
+		grep -q -- '- --provider-delegated-tokens-exclude=edges$$' "$$tmp_dir/hardened.yaml"; \
+		grep -q -- '- --provider-delegated-tokens-exclude=mcp$$' "$$tmp_dir/hardened.yaml"; \
+		grep -q -- '- --provider-workspace-cluster-admin=false$$' "$$tmp_dir/hardened.yaml"; \
+		helm template faros "$$chart" --set hub.hubExternalURL="$$url" \
+			--set hub.security.providerWorkspaceClusterAdmin=true >"$$tmp_dir/admin-true.yaml"; \
+		grep -q -- '- --provider-workspace-cluster-admin=true$$' "$$tmp_dir/admin-true.yaml"; \
+		helm template faros "$$chart" --set hub.hubExternalURL="$$url" \
+			--set 'hub.extraArgs={--providers=edges\,infrastructure,--graphql-playground}' >"$$tmp_dir/extra.yaml"; \
+		grep -q -- '- "--providers=edges,infrastructure"$$' "$$tmp_dir/extra.yaml"; \
+		grep -q -- '- "--graphql-playground"$$' "$$tmp_dir/extra.yaml"; \
+		if helm template faros "$$chart" --set hub.hubExternalURL="$$url" --set hub.security.providerHeartbeatAuth=maybe >/dev/null 2>&1; then \
+			echo "invalid providerHeartbeatAuth unexpectedly rendered"; exit 1; \
+		fi; \
+		if helm template faros "$$chart" --set hub.hubExternalURL="$$url" --set hub.security.providerDelegatedTokens=some >/dev/null 2>&1; then \
+			echo "invalid providerDelegatedTokens unexpectedly rendered"; exit 1; \
+		fi; \
+		if helm template faros "$$chart" --set hub.hubExternalURL="$$url" --set 'hub.extraArgs={--dev-mode}' >/dev/null 2>&1; then \
+			echo "extraArgs repeating a modelled flag unexpectedly rendered"; exit 1; \
+		fi
+
 ## Generate deepcopy methods + CRD YAML for the infrastructure provider's
 ## own API types (providers/infrastructure/apis/v1alpha1/...). The CRDs land
 ## under providers/infrastructure/config/crds/ and are embedded into the

--- a/deploy/charts/faros-hub/README.md
+++ b/deploy/charts/faros-hub/README.md
@@ -41,6 +41,22 @@ For a complete production setup (TLS, OIDC, ingress) see the [full docs](https:/
 | `hub.staticAuthTokens` | `[]` | Static bearer tokens for access. Each token creates its own user/workspace. Generate with `openssl rand -base64 32` |
 | `hub.adminUsers` | `[]` | Platform-admin identities allowed at `/api/admin/*` + the portal `/bonkers` area. Match a User by name, email, or rbacIdentity. Empty disables the admin surface (the `/bonkers` menu item stays hidden). For a static token the identity is `static-<first8chars>@faros.local`. |
 | `hub.resources` | see values | CPU/memory requests and limits (includes embedded kcp overhead) |
+| `hub.extraArgs` | `[]` | Extra hub command-line flags appended after the flags the chart renders, for flags the chart does not model yet (e.g. `--providers=edges,infrastructure`). The chart refuses an entry that repeats a flag it renders from a value — set the value instead. |
+
+### Provider hardening
+
+Every key is unset by default, which leaves the binary's own default for this
+release (the staged, soft posture) and renders nothing into the hub args. The
+next release flips the defaults to `enforce` / `platform` / `false`; set them
+here to move early. See the [docs](https://faroshq.github.io/faros/helm.html#turning-on-the-hardened-defaults-early)
+for the recommended production settings.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `hub.security.providerHeartbeatAuth` | `""` (binary: `warn`) | What the hub does with a provider heartbeat whose bearer token does not verify as that provider's own service account: `warn` logs and accepts it, `enforce` rejects it. Next release defaults to `enforce`. |
+| `hub.security.providerDelegatedTokens` | `""` (binary: `off`) | Which platform providers receive a short-lived workspace-scoped ServiceAccount token instead of the caller's own bearer on `/services/providers/*`: `off`, `platform` (all except `providerDelegatedTokensExclude`), or `all`. Org-owned providers are always delegated. Next release defaults to `platform`. |
+| `hub.security.providerDelegatedTokensExclude` | `[]` (binary: `[edges]`) | Platform providers that keep receiving the caller's bearer under `platform`. Setting it replaces the built-in list, so include `edges` if you still need it (its SSH data plane resolves the caller with a TokenReview on the bearer). |
+| `hub.security.providerWorkspaceClusterAdmin` | `null` (binary: `true`) | Role bound to each provider's ServiceAccount inside its own provider workspace: `true` keeps cluster-admin, `false` binds the narrower generated `faros:provider` ClusterRole. Opt-in this release: the infrastructure provider serves its own CRDs from its provider workspace, which the narrow role does not grant, so confirm your providers first. Next release defaults to `false`. Flipping replaces the existing binding. |
 
 ### TLS (Hub)
 

--- a/deploy/charts/faros-hub/templates/workload.yaml
+++ b/deploy/charts/faros-hub/templates/workload.yaml
@@ -119,6 +119,48 @@ spec:
             {{- if .Values.hub.embeddedGraphQL }}
             - --embedded-graphql
             {{- end }}
+            {{- /*
+            Provider hardening flags. Each renders only when set so an
+            unchanged values file keeps the binary's defaults for this release
+            (warn / off / cluster-admin) and the rendered workload is
+            byte-identical to earlier chart versions.
+            */}}
+            {{- with .Values.hub.security }}
+            {{- if .providerHeartbeatAuth }}
+            {{- if not (has .providerHeartbeatAuth (list "warn" "enforce")) }}
+            {{- fail (printf "hub.security.providerHeartbeatAuth must be \"warn\" or \"enforce\", got %q" .providerHeartbeatAuth) }}
+            {{- end }}
+            - --provider-heartbeat-auth={{ .providerHeartbeatAuth }}
+            {{- end }}
+            {{- if .providerDelegatedTokens }}
+            {{- if not (has .providerDelegatedTokens (list "off" "platform" "all")) }}
+            {{- fail (printf "hub.security.providerDelegatedTokens must be \"off\", \"platform\" or \"all\", got %q" .providerDelegatedTokens) }}
+            {{- end }}
+            - --provider-delegated-tokens={{ .providerDelegatedTokens }}
+            {{- end }}
+            {{- range .providerDelegatedTokensExclude }}
+            - --provider-delegated-tokens-exclude={{ . }}
+            {{- end }}
+            {{- /* Tri-state: null/absent leaves the binary default; a bool renders --flag=<bool> (pflag needs the explicit =value form for false). */}}
+            {{- if not (kindIs "invalid" .providerWorkspaceClusterAdmin) }}
+            - --provider-workspace-cluster-admin={{ .providerWorkspaceClusterAdmin }}
+            {{- end }}
+            {{- end }}
+            {{- /*
+            Escape hatch for flags the chart does not model yet. pflag takes
+            the LAST occurrence of a scalar flag, so an entry here that repeats
+            a flag rendered from a value above would silently override it;
+            refuse those so the modelled value stays the single source of
+            truth. Keep this list in step with the flags rendered above.
+            */}}
+            {{- $modelled := list "listen-addr" "external-kcp-kubeconfig" "embedded-kcp" "kcp-root-dir" "kcp-secure-port" "kcp-bind-address" "kcp-batteries-include" "kcp-tls-cert-file" "kcp-tls-key-file" "serving-cert-file" "serving-key-file" "hub-external-url" "hub-internal-url" "published-apps-domain" "idp-issuer-url" "idp-browser-auth-url" "idp-client-id" "idp-ca-file" "static-auth-token" "disable-token-login" "admin-users" "portal-frame-source" "dev-mode" "embedded-graphql" "provider-heartbeat-auth" "provider-delegated-tokens" "provider-delegated-tokens-exclude" "provider-workspace-cluster-admin" "data-dir" }}
+            {{- range .Values.hub.extraArgs }}
+            {{- $flag := regexReplaceAll "^--([A-Za-z0-9-]+).*$" (toString .) "${1}" }}
+            {{- if has $flag $modelled }}
+            {{- fail (printf "hub.extraArgs entry %q repeats --%s, which the chart renders from a value; set the value instead" (toString .) $flag) }}
+            {{- end }}
+            - {{ . | quote }}
+            {{- end }}
             - --data-dir=/data/hub
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/deploy/charts/faros-hub/templates/workload.yaml
+++ b/deploy/charts/faros-hub/templates/workload.yaml
@@ -141,9 +141,19 @@ spec:
             {{- range .providerDelegatedTokensExclude }}
             - --provider-delegated-tokens-exclude={{ . }}
             {{- end }}
-            {{- /* Tri-state: null/absent leaves the binary default; a bool renders --flag=<bool> (pflag needs the explicit =value form for false). */}}
+            {{- /*
+            Tri-state: null/absent leaves the binary default; true/false
+            renders --flag=<bool> (pflag needs the explicit =value form for
+            false). Accept the bool and its string spelling so --set-string
+            keeps working, and refuse anything else here rather than letting
+            a typo reach the hub's flag parser.
+            */}}
             {{- if not (kindIs "invalid" .providerWorkspaceClusterAdmin) }}
-            - --provider-workspace-cluster-admin={{ .providerWorkspaceClusterAdmin }}
+            {{- $clusterAdmin := toString .providerWorkspaceClusterAdmin }}
+            {{- if not (has $clusterAdmin (list "true" "false")) }}
+            {{- fail (printf "hub.security.providerWorkspaceClusterAdmin must be true or false, got %q" $clusterAdmin) }}
+            {{- end }}
+            - --provider-workspace-cluster-admin={{ $clusterAdmin }}
             {{- end }}
             {{- end }}
             {{- /*

--- a/deploy/charts/faros-hub/values.yaml
+++ b/deploy/charts/faros-hub/values.yaml
@@ -99,6 +99,52 @@ hub:
   # published-app access (public apps are unaffected — they never touch the
   # hub).
   publishedAppsDomain: ""
+  # -- Provider hardening. Every key here is unset by default, which leaves
+  # the binary's own default for this release; nothing is rendered into the
+  # hub args until you set a value. The binary defaults are the soft, staged
+  # ones (warn / off / cluster-admin) so providers installed from older charts
+  # keep working while they are rolled forward. The NEXT release flips them to
+  # enforce / platform / false; set them here to move to that posture early
+  # and shake out any provider that needs it. See docs/helm.md "Turning on the
+  # hardened defaults early".
+  security:
+    # What the hub does with a provider heartbeat whose bearer token does not
+    # verify as that provider's own service account: "warn" logs and accepts
+    # it, "enforce" rejects it. Binary default this release: warn. Next
+    # release: enforce. Recommended for production: enforce (once every
+    # provider runs a chart that sends its own service-account token).
+    providerHeartbeatAuth: ""
+    # Which platform providers receive a short-lived workspace-scoped
+    # ServiceAccount token instead of the caller's own hub bearer on
+    # /services/providers/*: "off" (caller's bearer, historical behaviour),
+    # "platform" (delegated, except the names in providerDelegatedTokensExclude),
+    # or "all" (delegated, exclusion list ignored). Org-owned providers are
+    # always delegated regardless. Binary default this release: off. Next
+    # release: platform. Recommended for production: platform.
+    providerDelegatedTokens: ""
+    # Platform providers that keep receiving the caller's bearer under
+    # providerDelegatedTokens=platform. Empty leaves the binary's built-in
+    # list (currently just "edges": its SSH data plane resolves the caller
+    # with a TokenReview on the bearer). Setting this REPLACES the built-in
+    # list rather than adding to it, so include edges if you still need it.
+    providerDelegatedTokensExclude: []
+    # Role bound to each provider's ServiceAccount inside its own provider
+    # workspace: true keeps cluster-admin, false binds the narrower generated
+    # faros:provider ClusterRole. null (default) leaves the binary default,
+    # which is true this release so an operator can stage the change; the
+    # next release defaults to false. The narrow role cannot be the default
+    # yet because the infrastructure provider defines and serves its own CRDs
+    # from its provider workspace, which the generated role does not grant, so
+    # flip this per deployment once you have confirmed your providers do not
+    # need it. Flipping either way replaces the existing binding (RoleRef is
+    # immutable; the hub deletes and recreates it).
+    providerWorkspaceClusterAdmin: null
+  # -- Extra command-line flags appended to the hub container after the flags
+  # the chart renders from the values above, for flags the chart does not
+  # model yet (e.g. "--providers=edges,infrastructure"). The chart refuses an
+  # entry that repeats a flag it already renders from a value: set the value
+  # instead, so the modelled setting stays the single source of truth.
+  extraArgs: []
   resources:
     requests:
       cpu: 100m

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -171,7 +171,8 @@ defaults so providers installed from older charts keep working while they are
 rolled forward; the next release flips each one. The chart leaves all three
 unset by default (nothing is rendered, the binary default applies), and
 `hub.security` lets you move to the hardened posture now instead of waiting
-for the flip. Recommended production values:
+for the flip. Recommended production values, safe with every provider this
+release ships:
 
 ```yaml
 hub:
@@ -185,19 +186,29 @@ hub:
     # are always delegated. `edges` stays excluded unless you replace the
     # list with providerDelegatedTokensExclude.
     providerDelegatedTokens: platform
-    # Bind provider service accounts to the narrow generated faros:provider
-    # ClusterRole instead of cluster-admin in their own workspace (binary
-    # default: true). Opt-in for now: the infrastructure provider defines
-    # and serves its own CRDs from its provider workspace, which the narrow
-    # role does not grant, so leave this unset (or true) while you run it.
+```
+
+The third flag, `providerWorkspaceClusterAdmin`, is deliberately not in that
+snippet. It binds provider service accounts to the narrow generated
+`faros:provider` ClusterRole instead of cluster-admin in their own workspace,
+and the infrastructure provider defines and serves its own CRDs from its
+provider workspace, which the narrow role does not grant. Leave it unset (or
+`true`) while you run the infrastructure provider. Once you have confirmed
+that none of your providers needs cluster-admin in its workspace, flip it
+separately:
+
+```yaml
+hub:
+  security:
+    # Only once your providers are verified: the hub replaces the binding in
+    # place, and setting this back to true restores cluster-admin.
     providerWorkspaceClusterAdmin: false
 ```
 
-Set `providerWorkspaceClusterAdmin` last and watch your providers after the
-upgrade: the hub replaces the binding in place, and flipping it back to `true`
-restores cluster-admin. Flags the chart does not model yet go in
-`hub.extraArgs` (for example `["--providers=edges,infrastructure"]`); the chart
-refuses an entry that repeats a flag it already renders from a value.
+Watch your providers after that upgrade. Flags the chart does not model yet
+go in `hub.extraArgs` (for example `["--providers=edges,infrastructure"]`);
+the chart refuses an entry that repeats a flag it already renders from a
+value.
 
 ---
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -164,6 +164,41 @@ ingress:
           pathType: ImplementationSpecific
 ```
 
+### Turning on the hardened defaults early
+
+Three provider-facing hub flags shipped in this release with deliberately soft
+defaults so providers installed from older charts keep working while they are
+rolled forward; the next release flips each one. The chart leaves all three
+unset by default (nothing is rendered, the binary default applies), and
+`hub.security` lets you move to the hardened posture now instead of waiting
+for the flip. Recommended production values:
+
+```yaml
+hub:
+  security:
+    # Reject provider heartbeats not signed by that provider's own service
+    # account (binary default this release: warn). Needs every provider on a
+    # chart that sends its service-account token as the heartbeat bearer.
+    providerHeartbeatAuth: enforce
+    # Hand platform providers a short-lived workspace-scoped token instead of
+    # the caller's own hub bearer (binary default: off). Org-owned providers
+    # are always delegated. `edges` stays excluded unless you replace the
+    # list with providerDelegatedTokensExclude.
+    providerDelegatedTokens: platform
+    # Bind provider service accounts to the narrow generated faros:provider
+    # ClusterRole instead of cluster-admin in their own workspace (binary
+    # default: true). Opt-in for now: the infrastructure provider defines
+    # and serves its own CRDs from its provider workspace, which the narrow
+    # role does not grant, so leave this unset (or true) while you run it.
+    providerWorkspaceClusterAdmin: false
+```
+
+Set `providerWorkspaceClusterAdmin` last and watch your providers after the
+upgrade: the hub replaces the binding in place, and flipping it back to `true`
+restores cluster-admin. Flags the chart does not model yet go in
+`hub.extraArgs` (for example `["--providers=edges,infrastructure"]`); the chart
+refuses an entry that repeats a flag it already renders from a value.
+
 ---
 
 ## Scaling the hub
@@ -270,6 +305,11 @@ kind delete cluster --name faros
 | `hub.listenAddr` | Hub listen address | `":9443"` |
 | `hub.devMode` | Skip TLS verification for OIDC issuer | `false` |
 | `hub.staticAuthToken` | Static bearer token (bypasses OIDC) | `""` |
+| `hub.security.providerHeartbeatAuth` | Provider heartbeat auth: `warn` (log and accept) or `enforce` (reject). Unset leaves the binary default; next release defaults to `enforce` | `""` (binary: `warn`) |
+| `hub.security.providerDelegatedTokens` | Delegated tokens for platform providers: `off`, `platform`, or `all`. Next release defaults to `platform` | `""` (binary: `off`) |
+| `hub.security.providerDelegatedTokensExclude` | Platform providers kept on the caller's bearer under `platform`; replaces the built-in list | `[]` (binary: `[edges]`) |
+| `hub.security.providerWorkspaceClusterAdmin` | `true` binds provider service accounts to cluster-admin in their workspace, `false` to the narrow `faros:provider` role. Next release defaults to `false` | `null` (binary: `true`) |
+| `hub.extraArgs` | Extra hub flags appended after the modelled ones; entries repeating a modelled flag are refused | `[]` |
 
 ### Identity Provider
 


### PR DESCRIPTION
## Problem

The security remediation added three hub flags with deliberately soft, staged defaults so providers installed from older charts keep working until the next release flips them:

- `--provider-heartbeat-auth` (`warn`|`enforce`, default `warn`) — #627
- `--provider-delegated-tokens` (`off`|`platform`|`all`, default `off`) and `--provider-delegated-tokens-exclude` (default `edges`) — #635 / #653
- `--provider-workspace-cluster-admin` (bool, default `true`) — #654

Every provider-side knob from that work got a surface (edges chart `allowUnverifiedSSHHostKey`, infrastructure chart `operator.clusterAdmin` / `sandbox.runtimeClassName`, agent CLI `--svc-policy` / `--svc-allow-cidr`). The hub side did not: `deploy/charts/faros-hub/templates/workload.yaml` renders a hardcoded `args:` list with no `extraArgs`, so a Helm-deployed hub was stuck on the soft defaults and could not be moved to the hardened posture without patching the chart.

## Change

`values.yaml`, under `hub:`:

```yaml
hub:
  security:
    providerHeartbeatAuth: ""              # warn | enforce   (binary default: warn)
    providerDelegatedTokens: ""            # off | platform | all   (binary default: off)
    providerDelegatedTokensExclude: []     # replaces the built-in [edges] list when set
    providerWorkspaceClusterAdmin: null    # tri-state; true | false   (binary default: true)
  extraArgs: []                            # flags the chart does not model yet
```

- Each value renders into `args:` only when set, so an unchanged values file produces an unchanged workload. `providerWorkspaceClusterAdmin` is tri-state: `null` leaves the binary default; a bool renders the explicit `--provider-workspace-cluster-admin=<bool>` form that pflag requires for `false` (`BoolVar` accepts `--flag=false`, not `--flag false`).
- The chart validates the two enum values with `fail`, matching the databricks chart's invalid-mode guard.
- `hub.extraArgs` is rendered after the modelled flags. Because pflag takes the last occurrence of a scalar flag, an entry that repeats a flag the chart renders from a value would silently override it, so the chart refuses those entries — the modelled value stays the single source of truth. The refusal list is the set of flags `workload.yaml` renders.
- `providerWorkspaceClusterAdmin: false` stays opt-in this release (per the #654 notes): the infrastructure provider defines and serves its own CRDs from its provider workspace, which the narrow generated `faros:provider` role does not grant, so the narrow role cannot be the default yet. The values comment, README, and docs say so.
- Docs: value rows in `deploy/charts/faros-hub/README.md` (new "Provider hardening" section) and `docs/helm.md` (values reference), plus a "Turning on the hardened defaults early" section in `docs/helm.md` with the recommended production values (`enforce` / `platform` / `false`, the last one only after confirming your providers).
- New `make test-hub-chart` target, following `test-databricks-provider-chart`: lint, default render must contain no `--provider-*` flag, hardened render, `cluster-admin=true` render, `extraArgs` render, and three refused renders.

Binary defaults are untouched; no Go changes.

## Compatibility

Default render is byte-identical to `origin/main`. Rendered both charts with `hub.tls.existingSecret` / `kcp.embedded.tls.existingSecret` set so the self-signed cert generation (random per render) does not mask the comparison:

| Mode | origin/main sha256 | this branch sha256 | `cmp` |
|---|---|---|---|
| embedded kcp (StatefulSet) | `d22221e1f05a0437…` | `d22221e1f05a0437…` | identical |
| external kcp (Deployment) | `0082893d31faba45…` | `0082893d31faba45…` | identical |

`hack/install/07-faros-hub-external.sh`, `hack/install/08-faros-hub-embedded.sh`, and the e2e framework (`faros dev init --chart-path`, `pkg/cli/cmd/dev/plugin/create*.go`) only set existing keys (`hub.hubExternalURL`, `hub.devMode`, `hub.embeddedGraphQL`, `hub.staticAuthTokens`, `hub.tls.selfSigned.dnsNames`, `image.hub.*`); the new keys merge in with their empty defaults and render nothing. The helm-images workflow's `helm lint` with default values still passes.

## Tests

`helm lint deploy/charts/faros-hub` — 0 failed. `make test-hub-chart` — pass. Rendered `args:` blocks (embedded kcp, `hub.hubExternalURL=https://faros.example.com`):

**(a) defaults — unchanged**

```yaml
          args:
            - --listen-addr=:9443
            # Embedded kcp mode (default): kcp runs in-process
            - --embedded-kcp
            - --kcp-root-dir=/data/kcp
            - --kcp-secure-port=6443
            - --kcp-bind-address=0.0.0.0
            - --kcp-batteries-include=admin,user
            - --kcp-tls-cert-file=/kcp-tls/tls.crt
            - --kcp-tls-key-file=/kcp-tls/tls.key
            - --serving-cert-file=/tls/tls.crt
            - --serving-key-file=/tls/tls.key
            - --hub-external-url=https://faros.example.com
            - --data-dir=/data/hub
```

**(b) all three set** (`providerHeartbeatAuth=enforce`, `providerDelegatedTokens=platform`, `providerDelegatedTokensExclude=[edges,mcp]`, `providerWorkspaceClusterAdmin=false`)

```yaml
            - --hub-external-url=https://faros.example.com
            - --provider-heartbeat-auth=enforce
            - --provider-delegated-tokens=platform
            - --provider-delegated-tokens-exclude=edges
            - --provider-delegated-tokens-exclude=mcp
            - --provider-workspace-cluster-admin=false
            - --data-dir=/data/hub
```

**(c) `extraArgs: ["--providers=edges,infrastructure", "--graphql-playground"]`**

```yaml
            - --hub-external-url=https://faros.example.com
            - "--providers=edges,infrastructure"
            - "--graphql-playground"
            - --data-dir=/data/hub
```

**(d) `providerWorkspaceClusterAdmin: true` / `false`** (via `--set` bool, `--set-string`, and a values file — all three forms render the same)

```yaml
            - --provider-workspace-cluster-admin=true
```
```yaml
            - --provider-workspace-cluster-admin=false
```

**Refused renders**

```
hub.security.providerHeartbeatAuth must be "warn" or "enforce", got "maybe"
hub.security.providerDelegatedTokens must be "off", "platform" or "all", got "some"
hub.extraArgs entry "--dev-mode" repeats --dev-mode, which the chart renders from a value; set the value instead
hub.extraArgs entry "--provider-heartbeat-auth=warn" repeats --provider-heartbeat-auth, which the chart renders from a value; set the value instead
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
