### PR TITLE
fix: follow-ups from review comments left open on the security PRs

### DIFF
--- a/hack/govulncheck/main.go
+++ b/hack/govulncheck/main.go
@@ -313,6 +313,8 @@ func loadAllowlist(path string) (map[string]allowEntry, []string, error) {
 			return nil, nil, fmt.Errorf("%s: entry %s is missing `module`", path, e.ID)
 		case e.Reason == "":
 			return nil, nil, fmt.Errorf("%s: entry %s is missing `reason`", path, e.ID)
+		case e.Exposure == "":
+			return nil, nil, fmt.Errorf("%s: entry %s is missing `exposure`", path, e.ID)
 		case e.ReviewBy == "":
 			return nil, nil, fmt.Errorf("%s: entry %s is missing `reviewBy`", path, e.ID)
 		}

--- a/hack/govulncheck/main_test.go
+++ b/hack/govulncheck/main_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// allowlistFields is one complete entry, in the order the header documents
+// them. Every one is required.
+var allowlistFields = [][2]string{
+	{"id", "GO-2026-0001"},
+	{"module", "example.com/dep"},
+	{"reason", "no upstream fix"},
+	{"exposure", "the vulnerable symbol is only reachable from a test helper"},
+	{"reviewBy", "2026-12-01"},
+}
+
+// renderAllowlist writes a one-entry allowlist with the named field omitted
+// ("" omits nothing) and returns its path.
+func renderAllowlist(t *testing.T, omit string) string {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("allow:\n")
+	first := true
+	for _, f := range allowlistFields {
+		if f[0] == omit {
+			continue
+		}
+		prefix := "    "
+		if first {
+			prefix, first = "  - ", false
+		}
+		b.WriteString(prefix + f[0] + ": " + f[1] + "\n")
+	}
+	p := filepath.Join(t.TempDir(), "allow.yaml")
+	if err := os.WriteFile(p, []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestLoadAllowlistRequiresEveryDocumentedField pins the contract the
+// allowlist header states: an entry without one of id / module / reason /
+// exposure / reviewBy is rejected, so a suppression never lands without the
+// faros-specific justification the review depends on.
+func TestLoadAllowlistRequiresEveryDocumentedField(t *testing.T) {
+	entries, order, err := loadAllowlist(renderAllowlist(t, ""))
+	if err != nil {
+		t.Fatalf("complete entry rejected: %v", err)
+	}
+	if len(entries) != 1 || len(order) != 1 || order[0] != "GO-2026-0001" {
+		t.Fatalf("entries = %v order = %v", entries, order)
+	}
+
+	for _, f := range allowlistFields {
+		field := f[0]
+		t.Run("missing "+field, func(t *testing.T) {
+			_, _, err := loadAllowlist(renderAllowlist(t, field))
+			if err == nil {
+				t.Fatalf("entry without %s was accepted", field)
+			}
+			if !strings.Contains(err.Error(), "`"+field+"`") {
+				t.Fatalf("error does not name the missing field %s: %v", field, err)
+			}
+		})
+	}
+}

--- a/hack/install/lib.sh
+++ b/hack/install/lib.sh
@@ -98,8 +98,10 @@ if [[ -z "${FAROS_STATIC_TOKEN:-}" ]]; then
   else
     FAROS_STATIC_TOKEN="$(random_token)"
     (umask 077 && printf '%s\n' "${FAROS_STATIC_TOKEN}" > "${FAROS_STATIC_TOKEN_FILE}")
-    echo "Generated a new static auth token for this install:" >&2
-    echo "  ${FAROS_STATIC_TOKEN}" >&2
+    # The value itself is deliberately not printed: it lives in the 0600 file,
+    # and the login line below reads it from there, so echoing it would only
+    # copy the token into terminal scrollback and CI logs.
+    echo "Generated a new static auth token for this install." >&2
     echo "Saved to ${FAROS_STATIC_TOKEN_FILE} (mode 0600);" >&2
     echo "every hack/install script reuses it from there. To log in later:" >&2
     echo "  faros login --hub-url ${HUB_EXTERNAL_URL} --token \"\$(cat ${FAROS_STATIC_TOKEN_FILE})\" --insecure-skip-tls-verify" >&2

--- a/pkg/agent/tunnel/svc.go
+++ b/pkg/agent/tunnel/svc.go
@@ -17,8 +17,10 @@ limitations under the License.
 package tunnel
 
 import (
+	"bufio"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -148,7 +150,7 @@ func newSvcProxyHandler(cfg svcProxyConfig) http.HandlerFunc {
 		r.Header.Del(svcTLSInsecureHeader)
 
 		if isUpgradeRequest(r) {
-			handleSvcUpgrade(w, r, target, svcPath, dial, tlsConfig, logger)
+			handleSvcUpgrade(w, r, target, svcPath, dial, tlsConfig, warned, logger)
 			return
 		}
 
@@ -166,13 +168,24 @@ func newSvcProxyHandler(cfg svcProxyConfig) http.HandlerFunc {
 				pr.Out.Header.Del(svcTLSInsecureHeader)
 			},
 		}
-		if warned {
-			proxy.ModifyResponse = func(resp *http.Response) error {
-				resp.Header.Set(svcPolicyHeader, string(SvcPolicyWarn))
-				return nil
-			}
+		proxy.ModifyResponse = func(resp *http.Response) error {
+			stampSvcPolicy(resp.Header, warned)
+			return nil
 		}
 		proxy.ServeHTTP(w, r)
+	}
+}
+
+// stampSvcPolicy makes X-Faros-Svc-Policy on a proxied response say exactly
+// what this hop decided. The header is the agent's verdict, which the provider
+// turns into EdgeService conditions (a 403 carrying "enforce" is read as "the
+// agent refused spec.host"), so whatever the upstream service put there is
+// dropped before the agent's own value — "warn" only when this hop dialed a
+// target it would refuse under enforce — is set.
+func stampSvcPolicy(h http.Header, warned bool) {
+	h.Del(svcPolicyHeader)
+	if warned {
+		h.Set(svcPolicyHeader, string(SvcPolicyWarn))
 	}
 }
 
@@ -192,8 +205,11 @@ func writeSvcDenied(w http.ResponseWriter, reason string) {
 // handleSvcUpgrade proxies a protocol-upgrade request (WebSocket) to the
 // vetted target by hijacking the tunnel connection and piping raw bytes. The
 // dial is pinned (dial), and TLS is layered on top with tlsConfig so the
-// upgrade path verifies certificates exactly like the plain-HTTP path.
-func handleSvcUpgrade(w http.ResponseWriter, r *http.Request, target *url.URL, svcPath string, dial svcDialer, tlsConfig *tls.Config, logger klog.Logger) {
+// upgrade path verifies certificates exactly like the plain-HTTP path. The
+// upstream's response head is parsed and re-emitted so the policy header is
+// stamped by this hop (stampSvcPolicy) rather than copied from the service;
+// everything after the head is piped untouched.
+func handleSvcUpgrade(w http.ResponseWriter, r *http.Request, target *url.URL, svcPath string, dial svcDialer, tlsConfig *tls.Config, warned bool, logger klog.Logger) {
 	backendConn, err := dial(r.Context(), "tcp", hostWithPort(target))
 	if err == nil && target.Scheme == "https" {
 		tc := tls.Client(backendConn, tlsConfig)
@@ -234,10 +250,39 @@ func handleSvcUpgrade(w http.ResponseWriter, r *http.Request, target *url.URL, s
 		return
 	}
 
+	// Read the response head off the backend, restamp the policy header and
+	// hand the head to the client; br keeps any bytes read past the head.
+	br := bufio.NewReader(backendConn)
+	resp, err := http.ReadResponse(br, r)
+	if err != nil {
+		logger.Error(err, "failed to read upgrade response from svc target", "target", target.String())
+		return
+	}
+	stampSvcPolicy(resp.Header, warned)
+	if err := writeResponseHead(clientConn, resp); err != nil {
+		logger.Error(err, "failed to forward upgrade response to caller")
+		return
+	}
+
 	errc := make(chan error, 2)
 	go func() { _, e := io.Copy(backendConn, clientConn); errc <- e }()
-	go func() { _, e := io.Copy(clientConn, backendConn); errc <- e }()
+	go func() { _, e := io.Copy(clientConn, br); errc <- e }()
 	<-errc
+}
+
+// writeResponseHead writes resp's status line and headers, byte-faithful to
+// what the upstream sent apart from the header edits made on resp.Header. The
+// body (if the upgrade was refused with one) is not consumed here; the caller
+// pipes the remaining bytes as-is.
+func writeResponseHead(w io.Writer, resp *http.Response) error {
+	if _, err := fmt.Fprintf(w, "HTTP/%d.%d %s\r\n", resp.ProtoMajor, resp.ProtoMinor, resp.Status); err != nil {
+		return err
+	}
+	if err := resp.Header.Write(w); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, "\r\n")
+	return err
 }
 
 // hostWithPort returns host:port, defaulting the port from the scheme.

--- a/pkg/agent/tunnel/svc_test.go
+++ b/pkg/agent/tunnel/svc_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tunnel
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -471,5 +472,130 @@ func TestSvcProxyHandlerBadTarget(t *testing.T) {
 	}
 	if n := dialer.n.Load(); n != 0 {
 		t.Errorf("dialed %d times, want 0", n)
+	}
+}
+
+// hostileUpstream is a loopback service that stamps X-Faros-Svc-Policy on its
+// own responses, both on plain HTTP and on a WebSocket upgrade (which it
+// answers with a 101 and then echoes bytes). The header is the agent's to set,
+// so nothing an upstream puts there may reach the provider.
+func hostileUpstream(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isUpgradeRequest(r) {
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("upstream hijack: %v", err)
+				return
+			}
+			defer conn.Close() //nolint:errcheck
+			_, _ = io.WriteString(conn, "HTTP/1.1 101 Switching Protocols\r\n"+
+				"Upgrade: websocket\r\nConnection: Upgrade\r\n"+
+				svcPolicyHeader+": "+string(SvcPolicyEnforce)+"\r\n\r\n")
+			_, _ = io.Copy(conn, conn) // echo
+			return
+		}
+		w.Header().Set(svcPolicyHeader, string(SvcPolicyEnforce))
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, "from upstream")
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestSvcProxyHandlerStripsUpstreamPolicyHeader: a proxied service cannot
+// forge the agent's policy verdict. An upstream 403 carrying "enforce" must
+// arrive as a plain 403 (otherwise the provider marks the tenant's own
+// EdgeService HostNotAllowed), and under warn the agent's own "warn" wins
+// over whatever the upstream sent.
+func TestSvcProxyHandlerStripsUpstreamPolicyHeader(t *testing.T) {
+	t.Run("allowed target", func(t *testing.T) {
+		cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: SvcPolicyEnforce}}
+		upstream := hostileUpstream(t, http.StatusForbidden)
+		dialer := &countingDialer{}
+		cfg.dial = dialer.dial
+		h := newSvcProxyHandler(cfg)
+
+		req := httptest.NewRequest(http.MethodGet, "/svc/api/ping", nil)
+		req.Header.Set(svcTargetHeader, upstream.URL)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		resp := rec.Result()
+		body := readBody(t, resp)
+		if resp.StatusCode != http.StatusForbidden || body != "from upstream" {
+			t.Fatalf("status = %d body = %q, want the upstream 403 passed through", resp.StatusCode, body)
+		}
+		if got := resp.Header.Get(svcPolicyHeader); got != "" {
+			t.Errorf("%s = %q leaked from upstream, want it stripped", svcPolicyHeader, got)
+		}
+	})
+	t.Run("warned target", func(t *testing.T) {
+		cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: SvcPolicyWarn},
+			resolve: fixedResolver(map[string][]string{"printer.lan": {"192.0.2.1", "127.0.0.1"}})}
+		upstream := hostileUpstream(t, http.StatusOK)
+		dialer := &countingDialer{fail: func(addr string) bool { return strings.HasPrefix(addr, "192.0.2.1:") }}
+		cfg.dial = dialer.dial
+		h := newSvcProxyHandler(cfg)
+
+		req := httptest.NewRequest(http.MethodGet, "/svc/api/ping", nil)
+		req.Header.Set(svcTargetHeader, "http://printer.lan:"+upstreamPort(t, upstream))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		resp := rec.Result()
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		if got := resp.Header.Get(svcPolicyHeader); got != string(SvcPolicyWarn) {
+			t.Errorf("%s = %q, want the agent's own %q", svcPolicyHeader, got, SvcPolicyWarn)
+		}
+	})
+}
+
+// TestSvcUpgradeStripsUpstreamPolicyHeader covers the hijacked WebSocket path,
+// which pipes raw bytes: the 101 headers are rewritten so the upstream's
+// policy header does not reach the provider, and the bytes after the headers
+// still flow both ways.
+func TestSvcUpgradeStripsUpstreamPolicyHeader(t *testing.T) {
+	upstream := hostileUpstream(t, http.StatusOK)
+	cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: SvcPolicyEnforce}}
+	dialer := &countingDialer{}
+	cfg.dial = dialer.dial
+	front := httptest.NewServer(newSvcProxyHandler(cfg))
+	t.Cleanup(front.Close)
+
+	conn, err := net.Dial("tcp", strings.TrimPrefix(front.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close() //nolint:errcheck
+	req, _ := http.NewRequest(http.MethodGet, "/svc/api/websocket", nil)
+	req.Host = "edge"
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set(svcTargetHeader, upstream.URL)
+	if err := req.Write(conn); err != nil {
+		t.Fatal(err)
+	}
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want 101", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Upgrade"); got != "websocket" {
+		t.Errorf("Upgrade = %q, want the upstream's header kept", got)
+	}
+	if got := resp.Header.Get(svcPolicyHeader); got != "" {
+		t.Errorf("%s = %q leaked through the upgrade response, want it stripped", svcPolicyHeader, got)
+	}
+	if _, err := io.WriteString(conn, "ping"); err != nil {
+		t.Fatal(err)
+	}
+	echo := make([]byte, 4)
+	if _, err := io.ReadFull(br, echo); err != nil || string(echo) != "ping" {
+		t.Fatalf("echo = %q, %v; want ping", echo, err)
 	}
 }

--- a/pkg/cli/cmd/agent.go
+++ b/pkg/cli/cmd/agent.go
@@ -307,18 +307,9 @@ func agentJoinServer(opts *agent.Options) error {
 	}
 
 	unitName := "faros-agent-" + opts.EdgeName
-	data := systemdUnitData{
-		BinaryPath:      binaryPath,
-		HubKubeconfig:   absKubeconfig,
-		HubURL:          opts.HubURL,
-		Token:           opts.Token,
-		EdgeName:        opts.EdgeName,
-		Type:            string(opts.Type),
-		SSHProxyPort:    opts.SSHProxyPort,
-		SSHUser:         opts.SSHUser,
-		SSHPrivateKey:   opts.SSHPrivateKeyPath,
-		Cluster:         opts.Cluster,
-		InsecureSkipTLS: opts.InsecureSkipTLSVerify,
+	data, err := joinServerUnitData(opts, binaryPath, absKubeconfig)
+	if err != nil {
+		return err
 	}
 
 	tmpl, err := template.New("unit").Parse(systemdUnitTemplate)
@@ -355,6 +346,39 @@ func agentJoinServer(opts *agent.Options) error {
 	fmt.Printf("  View logs:     journalctl -u %s -f\n", unitName)
 	fmt.Printf("  Uninstall:     faros agent uninstall --edge-name %s\n", opts.EdgeName)
 	return nil
+}
+
+// joinServerUnitData builds the systemd unit data for `faros agent join
+// --type server` from the run flags. The Service proxy policy flags are
+// carried into the unit exactly as `agent install` does: the allow list
+// always, the policy only when it differs from the built-in default. Leaving
+// them out would silently run the installed agent at the default policy with
+// no allow list while the operator believes they configured enforce.
+func joinServerUnitData(opts *agent.Options, binaryPath, absKubeconfig string) (systemdUnitData, error) {
+	data := systemdUnitData{
+		BinaryPath:      binaryPath,
+		HubKubeconfig:   absKubeconfig,
+		HubURL:          opts.HubURL,
+		Token:           opts.Token,
+		EdgeName:        opts.EdgeName,
+		Type:            string(opts.Type),
+		SSHProxyPort:    opts.SSHProxyPort,
+		SSHUser:         opts.SSHUser,
+		SSHPrivateKey:   opts.SSHPrivateKeyPath,
+		Cluster:         opts.Cluster,
+		InsecureSkipTLS: opts.InsecureSkipTLSVerify,
+		SvcAllowCIDRs:   opts.SvcAllowedCIDRs,
+	}
+	if opts.SvcPolicy != "" && opts.SvcPolicy != string(tunnel.DefaultSvcPolicy) {
+		if _, err := tunnel.ParseSvcPolicy(opts.SvcPolicy); err != nil {
+			return systemdUnitData{}, err
+		}
+		data.SvcPolicy = opts.SvcPolicy
+	}
+	if _, err := tunnel.ParseSvcAllowedCIDRs(opts.SvcAllowedCIDRs); err != nil {
+		return systemdUnitData{}, err
+	}
+	return data, nil
 }
 
 // agentJoinKubernetes applies a Deployment + RBAC to the target cluster so the
@@ -794,7 +818,7 @@ func newAgentInstallCommand() *cobra.Command {
 		Long: `Install the faros agent as a systemd service on the current host.
 
 This creates a systemd unit file, reloads the daemon, enables and starts the
-service. The systemd unit runs "faros agent join" so you get both the agent
+service. The systemd unit runs "faros agent run" so you get both the agent
 and the full faros CLI on the server.
 
 Requires root privileges.

--- a/pkg/cli/cmd/agent_test.go
+++ b/pkg/cli/cmd/agent_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/faroshq/faros/pkg/agent"
+	"github.com/faroshq/faros/pkg/agent/tunnel"
+)
+
+func renderUnit(t *testing.T, data systemdUnitData) string {
+	t.Helper()
+	tmpl, err := template.New("unit").Parse(systemdUnitTemplate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if err := tmpl.Execute(&b, data); err != nil {
+		t.Fatal(err)
+	}
+	return b.String()
+}
+
+// TestJoinServerUnitCarriesSvcPolicyFlags: `faros agent join --type server`
+// accepts --svc-allow-cidr / --svc-policy, so the unit it installs must run
+// the agent with them. Dropping them silently downgrades an operator's
+// "enforce" to the built-in default with no allow list.
+func TestJoinServerUnitCarriesSvcPolicyFlags(t *testing.T) {
+	opts := &agent.Options{
+		EdgeName:        "edge-1",
+		Type:            agent.AgentTypeServer,
+		HubURL:          "https://hub.example",
+		Token:           "join-token",
+		SvcAllowedCIDRs: []string{"192.168.1.0/24", "10.0.0.0/8"},
+		SvcPolicy:       string(tunnel.SvcPolicyEnforce),
+	}
+	data, err := joinServerUnitData(opts, "/usr/local/bin/faros", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit := renderUnit(t, data)
+	for _, want := range []string{
+		"agent run",
+		"--svc-allow-cidr 192.168.1.0/24",
+		"--svc-allow-cidr 10.0.0.0/8",
+		"--svc-policy enforce",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("rendered unit lacks %q:\n%s", want, unit)
+		}
+	}
+}
+
+// TestJoinServerUnitOmitsDefaultPolicy: like `agent install`, the policy is
+// only rendered when it differs from the built-in default, so installs pick
+// up the next release's default flip without a reinstall.
+func TestJoinServerUnitOmitsDefaultPolicy(t *testing.T) {
+	opts := &agent.Options{
+		EdgeName:  "edge-1",
+		Type:      agent.AgentTypeServer,
+		HubURL:    "https://hub.example",
+		Token:     "join-token",
+		SvcPolicy: string(tunnel.DefaultSvcPolicy),
+	}
+	data, err := joinServerUnitData(opts, "/usr/local/bin/faros", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unit := renderUnit(t, data); strings.Contains(unit, "--svc-policy") {
+		t.Errorf("default policy must not be pinned into the unit:\n%s", unit)
+	}
+}
+
+// TestJoinServerUnitRejectsBadPolicyAndCIDR: invalid values fail the join
+// rather than being written into a unit that then fails to start.
+func TestJoinServerUnitRejectsBadPolicyAndCIDR(t *testing.T) {
+	base := agent.Options{EdgeName: "edge-1", Type: agent.AgentTypeServer, HubURL: "https://hub.example", Token: "t"}
+
+	bad := base
+	bad.SvcPolicy = "sometimes"
+	if _, err := joinServerUnitData(&bad, "/bin/faros", ""); err == nil {
+		t.Error("invalid --svc-policy was accepted")
+	}
+
+	bad = base
+	bad.SvcAllowedCIDRs = []string{"not-a-cidr"}
+	if _, err := joinServerUnitData(&bad, "/bin/faros", ""); err == nil {
+		t.Error("invalid --svc-allow-cidr was accepted")
+	}
+}

--- a/pkg/hub/mcpaggregate/handler.go
+++ b/pkg/hub/mcpaggregate/handler.go
@@ -195,22 +195,32 @@ func (h *handler) cached(key string) bool {
 }
 
 // maxVerifiedEntries bounds the cache; expired entries are swept once it is
-// exceeded so a flood of distinct bearers cannot grow it without limit.
+// reached, and if that frees nothing the entry nearest expiry is evicted so
+// a flood of distinct bearers can neither grow it without limit nor lock a
+// newly verified client out of the cache (which would push every request of
+// that client through online verification and the per-IP budget).
 const maxVerifiedEntries = 4096
 
 func (h *handler) remember(key string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	now := time.Now()
-	if len(h.verified) >= maxVerifiedEntries {
+	if _, ok := h.verified[key]; !ok && len(h.verified) >= maxVerifiedEntries {
 		for k, exp := range h.verified {
 			if now.After(exp) {
 				delete(h.verified, k)
 			}
 		}
 	}
-	if len(h.verified) >= maxVerifiedEntries {
-		return
+	if _, ok := h.verified[key]; !ok && len(h.verified) >= maxVerifiedEntries {
+		var victim string
+		var soonest time.Time
+		for k, exp := range h.verified {
+			if victim == "" || exp.Before(soonest) {
+				victim, soonest = k, exp
+			}
+		}
+		delete(h.verified, victim)
 	}
 	h.verified[key] = now.Add(h.opts.VerifyCacheTTL)
 }

--- a/pkg/hub/mcpaggregate/handler_test.go
+++ b/pkg/hub/mcpaggregate/handler_test.go
@@ -19,6 +19,7 @@ package mcpaggregate
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -191,6 +192,32 @@ func TestVerificationCacheExpires(t *testing.T) {
 	}
 	if got := v.calls.Load(); got != 2 {
 		t.Fatalf("verifier calls with expired cache = %d, want 2", got)
+	}
+}
+
+// TestVerificationCacheEvictsAtCapacity: with maxVerifiedEntries live
+// bearers cached, a newly verified bearer is still admitted (one existing
+// entry is evicted) rather than dropped, so a client that verified a moment
+// ago is not pushed back through online verification on every request.
+func TestVerificationCacheEvictsAtCapacity(t *testing.T) {
+	h := New(Options{Providers: func(context.Context) []ProviderTarget { return nil }, Verifier: allowAll}).(*handler)
+	for i := 0; i < maxVerifiedEntries; i++ {
+		h.remember(fmt.Sprintf("bearer-%d|c|n", i))
+	}
+	if n := len(h.verified); n != maxVerifiedEntries {
+		t.Fatalf("cache holds %d entries, want %d", n, maxVerifiedEntries)
+	}
+	h.remember("fresh|c|n")
+	if !h.cached("fresh|c|n") {
+		t.Fatal("a bearer verified at capacity was not cached")
+	}
+	if n := len(h.verified); n != maxVerifiedEntries {
+		t.Fatalf("cache holds %d entries after eviction, want %d", n, maxVerifiedEntries)
+	}
+	// Refreshing a key already present evicts nothing.
+	h.remember("fresh|c|n")
+	if n := len(h.verified); n != maxVerifiedEntries {
+		t.Fatalf("cache holds %d entries after a refresh, want %d", n, maxVerifiedEntries)
 	}
 }
 

--- a/pkg/hub/mcpaggregate/verifier.go
+++ b/pkg/hub/mcpaggregate/verifier.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	authnv1 "k8s.io/api/authentication/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -229,6 +230,13 @@ func (v *Verifier) verifyMember(ctx context.Context, user, cluster string) error
 
 	path, err := v.resolvePath(ctx, cluster)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// A cluster ID with no LogicalCluster behind it is not a
+			// verification outage: the bearer is a real hub user asking for
+			// a tenant that does not exist. 403, not 503, so a typo in a
+			// client config does not show up as an availability incident.
+			return fmt.Errorf("%w: cluster %q does not exist", ErrForbidden, cluster)
+		}
 		return err
 	}
 	orgUUID, wsUUID, ok := tenantFromPath(path)

--- a/pkg/hub/mcpaggregate/verifier_test.go
+++ b/pkg/hub/mcpaggregate/verifier_test.go
@@ -19,14 +19,17 @@ package mcpaggregate
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	authnv1 "k8s.io/api/authentication/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -226,6 +229,33 @@ func TestVerifierUnknownUserFallsThroughToServiceAccount(t *testing.T) {
 	)
 	if err := v.Verify(request(t, "sa-other-a"), "sa-other-a", "tenant-a", "default"); !errors.Is(err, ErrForbidden) {
 		t.Fatalf("SA-shaped user identity: %v, want ErrForbidden", err)
+	}
+}
+
+// TestVerifierUnknownClusterIsForbiddenNotUnavailable: a hub user addressing
+// a cluster ID that has no LogicalCluster (a typo, a deleted tenant) is 403.
+// Only NotFound is mapped; any other lookup failure stays an infrastructure
+// error so the handler keeps failing closed with 503.
+func TestVerifierUnknownClusterIsForbiddenNotUnavailable(t *testing.T) {
+	notFound := apierrors.NewNotFound(schema.GroupResource{Group: "core.kcp.io", Resource: "logicalclusters"}, "cluster")
+	v, kcp := newTestVerifier(t, WithClusterPathResolver(func(_ context.Context, cluster string) (string, error) {
+		if cluster == "no-such-cluster" {
+			return "", fmt.Errorf("getting LogicalCluster for cluster %q: %w", cluster, notFound)
+		}
+		return "", errors.New("kcp unreachable")
+	}))
+	v.SetUserIdentity(
+		func(*http.Request) (string, error) { return "alice", nil },
+		func(context.Context, string) (*tenancyv1alpha1.UserMembershipIndex, error) { return nil, nil },
+	)
+	if err := v.Verify(request(t, "u"), "u", "no-such-cluster", "default"); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("nonexistent cluster: Verify() = %v, want ErrForbidden", err)
+	}
+	if err := v.Verify(request(t, "u"), "u", "lc-outage", "default"); err == nil || errors.Is(err, ErrForbidden) || errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("lookup outage: Verify() = %v, want an infrastructure error", err)
+	}
+	if kcp.reviews != 0 {
+		t.Fatalf("a hub user bearer was sent to TokenReview %d times, want 0", kcp.reviews)
 	}
 }
 

--- a/provider-sdk/hubclient/heartbeat.go
+++ b/provider-sdk/hubclient/heartbeat.go
@@ -52,6 +52,9 @@ const (
 
 	// maxHeartbeatErrorBody bounds how much of a rejection body is logged.
 	maxHeartbeatErrorBody = 512
+	// maxHeartbeatDrainBody bounds how much of a 2xx body is read to free the
+	// connection for reuse; the hub answers with a few bytes of JSON.
+	maxHeartbeatDrainBody = 64 << 10
 )
 
 // HeartbeatConfig describes one provider's heartbeat to the hub.
@@ -184,6 +187,11 @@ func RunHeartbeat(ctx context.Context, cfg HeartbeatConfig) {
 				"url", url, "status", resp.StatusCode, "provider", cfg.ProviderName, "tokenConfigured", cfg.Token != "", "reason", strings.TrimSpace(string(reason)))
 		case resp.StatusCode >= 300:
 			log.Info("heartbeat non-2xx", "url", url, "status", resp.StatusCode)
+		default:
+			// Drain the (small) 2xx body so the transport can reuse the
+			// connection; an unread body makes every beat pay for a fresh
+			// TCP + TLS handshake.
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxHeartbeatDrainBody))
 		}
 	}
 

--- a/provider-sdk/hubclient/heartbeat_test.go
+++ b/provider-sdk/hubclient/heartbeat_test.go
@@ -19,10 +19,13 @@ package hubclient
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -152,6 +155,53 @@ func TestRunHeartbeatPostsVersionWithBearerAndStopsOnCancel(t *testing.T) {
 	}
 	if logs := rec.joined(); strings.Contains(logs, "rejected") || strings.Contains(logs, "non-2xx") {
 		t.Fatalf("unexpected failure logs on a healthy hub:\n%s", logs)
+	}
+}
+
+// TestRunHeartbeatReusesTheConnection: the hub answers 2xx with a small JSON
+// body. Unless that body is drained before Close, the transport cannot reuse
+// the connection and every beat opens a new one (TCP + TLS in production).
+func TestRunHeartbeatReusesTheConnection(t *testing.T) {
+	var conns atomic.Int32
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	srv.Config.ConnState = func(_ net.Conn, s http.ConnState) {
+		if s == http.StateNew {
+			conns.Add(1)
+		}
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	var beats atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		RunHeartbeat(ctx, HeartbeatConfig{
+			HubURL:       srv.URL,
+			ProviderName: "quickstart",
+			Version:      "1.2.3",
+			Token:        "sa-token",
+			Interval:     10 * time.Millisecond,
+			Logger:       (&recordingLogger{}).logger(),
+			CanSend:      func() bool { beats.Add(1); return true },
+		})
+	}()
+	deadline := time.Now().Add(5 * time.Second)
+	for beats.Load() < 5 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+	if n := beats.Load(); n < 5 {
+		t.Fatalf("only %d beats were sent", n)
+	}
+	if n := conns.Load(); n != 1 {
+		t.Fatalf("%d connections opened for %d beats, want 1 (2xx body not drained before Close)", n, beats.Load())
 	}
 }
 

--- a/providers/agents/executor/executor.go
+++ b/providers/agents/executor/executor.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sync/atomic"
 	"time"
 )
 
@@ -110,7 +111,10 @@ type InProcess struct {
 	timeout time.Duration
 	workers int
 	cancel  context.CancelFunc
-	running bool
+	// stopped is closed by Stop (via the worker context) so a Submit parked
+	// on a full queue returns ErrStopped instead of waiting out SubmitWait.
+	stopped <-chan struct{}
+	running atomic.Bool
 }
 
 // NewInProcess builds the in-house executor. workers bounds concurrency;
@@ -131,14 +135,15 @@ func NewInProcess(h Handler, workers int, defaultTimeout time.Duration) *InProce
 }
 
 func (e *InProcess) Start(ctx context.Context) error {
-	if e.running {
+	if e.running.Load() {
 		return nil
 	}
 	ctx, e.cancel = context.WithCancel(ctx)
+	e.stopped = ctx.Done()
 	for i := 0; i < e.workers; i++ {
 		go e.worker(ctx)
 	}
-	e.running = true
+	e.running.Store(true)
 	return nil
 }
 
@@ -149,7 +154,7 @@ func (e *InProcess) Start(ctx context.Context) error {
 // explicit ErrQueueFull to turn into a retryable response. Jobs are still not
 // durable across a restart — a persistent queue is a follow-up.
 func (e *InProcess) Submit(ctx context.Context, job Job) error {
-	if !e.running {
+	if !e.running.Load() {
 		return ErrStopped
 	}
 	select {
@@ -176,6 +181,11 @@ func (e *InProcess) Submit(ctx context.Context, job Job) error {
 				len(e.jobs), cap(e.jobs), job.Kind, job.SourceName, waited.Round(time.Millisecond))
 		}
 		return nil
+	case <-e.stopped:
+		// Stop ran while we waited: the workers are gone, so no slot will
+		// free. ErrQueueFull would tell the caller to retry against an
+		// executor that no longer exists.
+		return fmt.Errorf("%w — job %s/%s not accepted", ErrStopped, job.Kind, job.SourceName)
 	case <-wait.Done():
 		return fmt.Errorf("%w (%d/%d queued) — job %s/%s not accepted: %v", ErrQueueFull, len(e.jobs), cap(e.jobs), job.Kind, job.SourceName, wait.Err())
 	}
@@ -185,10 +195,10 @@ func (e *InProcess) Submit(ctx context.Context, job Job) error {
 func (e *InProcess) Depth() int { return len(e.jobs) }
 
 func (e *InProcess) Stop() {
+	e.running.Store(false)
 	if e.cancel != nil {
 		e.cancel()
 	}
-	e.running = false
 }
 
 func (e *InProcess) worker(ctx context.Context) {

--- a/providers/agents/executor/executor_test.go
+++ b/providers/agents/executor/executor_test.go
@@ -124,6 +124,42 @@ func TestSubmitCancelledContextFailsFast(t *testing.T) {
 	}
 }
 
+// TestSubmitReturnsErrStoppedWhenStoppedMidWait: a Submit parked on a full
+// queue must notice Stop at once and say the executor is gone, rather than
+// wait out SubmitWait and report ErrQueueFull, which reads as "retry later".
+func TestSubmitReturnsErrStoppedWhenStoppedMidWait(t *testing.T) {
+	e, release := blockedExecutor(t)
+	defer release()
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		done <- e.Submit(ctx, Job{ID: "late", Kind: KindChannel, SourceName: "slack-1"})
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("Submit returned before Stop: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	begin := time.Now()
+	e.Stop()
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrStopped) {
+			t.Fatalf("want ErrStopped after Stop, got %v", err)
+		}
+		if errors.Is(err, ErrQueueFull) {
+			t.Fatalf("a stopped executor must not report a retryable queue-full: %v", err)
+		}
+		if waited := time.Since(begin); waited > time.Second {
+			t.Fatalf("Submit took %s to notice Stop", waited)
+		}
+	case <-time.After(SubmitWait + 5*time.Second):
+		t.Fatal("Submit never returned after Stop")
+	}
+}
+
 func TestSubmitBeforeStart(t *testing.T) {
 	e := NewInProcess(func(context.Context, Job) error { return nil }, 1, time.Minute)
 	if err := e.Submit(context.Background(), Job{}); !errors.Is(err, ErrStopped) {

--- a/providers/edges/internal/tunnel/audit_test.go
+++ b/providers/edges/internal/tunnel/audit_test.go
@@ -132,6 +132,26 @@ func TestSanitizeAuditValueCannotForgeALogLine(t *testing.T) {
 	}
 }
 
+// TestAuditSSHUserCannotForgeALogLine: the SSH username in the "SSH session
+// opened" audit line comes from the agent-reported sshCredentials, and klog
+// renders a string carrying "\n" as an unquoted multi-line block.
+func TestAuditSSHUserCannotForgeALogLine(t *testing.T) {
+	forged := "root\n\"SSH session opened\" caller=\"eve\" edge=\"other\""
+	got := auditSSHUser(&SSHClientCredentials{Username: forged})
+	if strings.ContainsAny(got, "\n\r") {
+		t.Fatalf("audit username still carries a line break: %q", got)
+	}
+	if !strings.Contains(got, `\u000a`) || !strings.Contains(got, "root") {
+		t.Fatalf("audit username is not a faithful escaped rendering: %q", got)
+	}
+	if got := auditSSHUser(&SSHClientCredentials{Username: "deploy"}); got != "deploy" {
+		t.Fatalf("ordinary username changed: %q", got)
+	}
+	if got := auditSSHUser(nil); got != "root" {
+		t.Fatalf("nil credentials: %q, want the default user", got)
+	}
+}
+
 func TestSanitizeAuditValueTruncatesAndMarksIt(t *testing.T) {
 	long := strings.Repeat("a", maxAuditValueLen*3)
 	got := sanitizeAuditValue(long)

--- a/providers/edges/internal/tunnel/edges_proxy_builder.go
+++ b/providers/edges/internal/tunnel/edges_proxy_builder.go
@@ -290,7 +290,7 @@ func (p *Server) edgesSSHHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 	defer sshClient.Close() //nolint:errcheck
 	opened = true
-	audit.Info("SSH session opened", "sshUser", sshUsername(creds),
+	audit.Info("SSH session opened", "sshUser", auditSSHUser(creds),
 		"hostKeyFingerprint", sshHostKeyFingerprint(firstNonEmpty(learnedKey, hk.Key)))
 
 	// tofu: persist the key this first session trusted so every later session
@@ -404,6 +404,14 @@ func sanitizeAuditValue(s string) string {
 		}
 	}
 	return b.String()
+}
+
+// auditSSHUser renders the SSH username for the audit line. The name is not
+// operator-typed on the hub: it is what the agent reported in sshCredentials
+// (edge_status.go), so a compromised or misbehaving edge could put a newline
+// in it and forge audit records exactly like the exec command could.
+func auditSSHUser(creds *SSHClientCredentials) string {
+	return sanitizeAuditValue(sshUsername(creds))
 }
 
 func firstNonEmpty(values ...string) string {


### PR DESCRIPTION
## Problem

Several review comments on the security PRs (#623, #624, #626, #629, #632, #634, #655) were still open when those PRs merged. A read-only triage against main at f58ef1d3 confirmed each one; this PR fixes the ones that are real and cheap, and lists the two that are design changes.

The one that matters most is fail-open: `faros agent join --type server` accepts `--svc-allow-cidr` / `--svc-policy` but never wrote them into the systemd unit it installs, so the agent ran at the default `warn` policy with no allow list while the operator believed they had configured `enforce`.

## Change

- **A** (#626) `pkg/cli/cmd/agent.go`: `agent join` now carries `--svc-allow-cidr` / `--svc-policy` into the systemd unit exactly like `agent install` (allow list always, policy only when it differs from the default, both validated). `agent install` help no longer claims the unit runs `agent join`; it runs `agent run`.
- **B** (#626) `pkg/agent/tunnel/svc.go`: `X-Faros-Svc-Policy` on a proxied response is always stripped and re-set only when this hop actually warned, on both the HTTP path (`ModifyResponse`) and the hijacked WebSocket path (the 101 head is parsed, restamped and re-emitted; the rest is piped untouched). A proxied service can no longer answer `403 + enforce` and have the edges reconciler mark the tenant's own EdgeService `HostNotAllowed`.
- **C** (#655) `providers/edges/internal/tunnel/edges_proxy_builder.go`: the SSH username in the "SSH session opened" audit line goes through `sanitizeAuditValue` like the exec command already does. It comes from agent-reported `sshCredentials`, and klog renders a `\n` in a string as an unquoted multi-line block.
- **D** (#624) `hack/govulncheck/main.go`: `loadAllowlist` rejects an entry without `exposure`, which the allowlist header already says is required.
- **E** (#623) `hack/install/lib.sh`: the generated hub token is no longer echoed to stderr; it is written 0600 to `.faros-install/hub-token` and the printed `faros login` line already reads it from there.
- **F** (#632) `provider-sdk/hubclient/heartbeat.go`: the 2xx response body is drained (bounded) before Close so the transport reuses the connection instead of paying a TCP+TLS handshake per beat.
- **G** (#634) `providers/agents/executor/executor.go`: a `Submit` parked on a full queue now returns `ErrStopped` as soon as `Stop` runs, instead of waiting out `SubmitWait` and reporting the retryable `ErrQueueFull`. `running` became an `atomic.Bool` (it was read by `Submit` and written by `Stop` unsynchronized).
- **H** (#629) `pkg/hub/mcpaggregate/verifier.go`: a hub-user bearer addressing a cluster ID with no LogicalCluster (NotFound) is 403, not 503 "verification unavailable". Every other lookup failure still fails closed with 503.
- **I** (#629) `pkg/hub/mcpaggregate/handler.go`: the verified-bearer cache evicts the entry nearest expiry when full instead of refusing to insert, so a newly verified client is never pushed back through online verification plus the per-IP budget just because 4096 other bearers are live.

## Compatibility

No API or wire-format changes. A/B/C change only what the agent writes into a unit file / a response header / a log line. F is a client-side transport optimisation. G changes the error a caller sees only in the Stop-during-wait window. H turns a 503 into a 403 for a request that was already refused. I changes cache eviction only at capacity.

## Tests

Every new test was run against the pre-fix code first and failed there:

- `TestJoinServerUnitCarriesSvcPolicyFlags` / `...OmitsDefaultPolicy` / `...RejectsBadPolicyAndCIDR` (unit rendered without either flag; invalid values accepted).
- `TestSvcProxyHandlerStripsUpstreamPolicyHeader` (both subtests: `enforce` leaked from upstream) and `TestSvcUpgradeStripsUpstreamPolicyHeader` (leaked through the 101).
- `TestAuditSSHUserCannotForgeALogLine` (username still carried the line break).
- `TestLoadAllowlistRequiresEveryDocumentedField` (`missing exposure` subtest accepted the entry).
- `TestRunHeartbeatReusesTheConnection` (5 connections for 5 beats).
- `TestSubmitReturnsErrStoppedWhenStoppedMidWait` (returned nil and the race detector flagged `running`).
- `TestVerifierUnknownClusterIsForbiddenNotUnavailable` (plain NotFound error, not `ErrForbidden`).
- `TestVerificationCacheEvictsAtCapacity` (new key not cached at capacity).

Verified with `GOWORK=off go build ./... && go vet ./pkg/... && go test -race ./pkg/agent/... ./pkg/cli/... ./pkg/hub/mcpaggregate/...`, `hack/govulncheck`, `providers/edges ./internal/tunnel/...`, `providers/agents ./executor/...`, `provider-sdk ./hubclient/...` (all `-race -count=1`), `bash -n hack/install/lib.sh`, `make lint`, `make verify-boilerplate`.

## Deferred (design changes, not in this PR)

- #628 `operator.yaml` ~62: the operator has cluster-wide Secrets CRUD. Narrowing to a named ClusterRole + `bind` + per-namespace RoleBinding is feasible but a design change.
- #631 `server.go` ~306: under the test-only `AllowStaticTokenBypass`, egress skips `authorizeFn` for any non-empty bearer; hardening would require the bearer to be in `staticTokens`. Unreachable from `main.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
