### PR TITLE
fix: close the three review comments left open on #660

### DIFF
--- a/pkg/hub/providers/heartbeat_auth.go
+++ b/pkg/hub/providers/heartbeat_auth.go
@@ -136,7 +136,8 @@ type tokenReviewAuthenticator struct {
 	now         func() time.Time
 	cacheTTL    time.Duration
 	negativeTTL time.Duration
-	// negativeMax caps len(negative); zero means heartbeatAuthNegativeCacheMax.
+	// negativeMax caps len(negativeOrder) and, through it, len(negative);
+	// zero means heartbeatAuthNegativeCacheMax.
 	negativeMax int
 
 	mu    sync.Mutex
@@ -147,8 +148,9 @@ type tokenReviewAuthenticator struct {
 	// negativeOrder lists negative's entries oldest first. The TTL is a
 	// constant, so insertion order is expiry order: pruning pops expired
 	// entries off the front and eviction at capacity pops the oldest, and
-	// neither visits an entry that is still live. A key rejected again after
-	// its entry lapsed is appended anew; the stale front entry is skipped
+	// neither visits an entry that is still live. A key rejected again while
+	// its entry is live keeps the slot it has; one rejected again after its
+	// entry lapsed is appended anew, and the stale front entry is skipped
 	// when its recorded expiry no longer matches the map's.
 	negativeOrder []heartbeatAuthNegativeEntry
 	// negativeVisited counts the queue entries pruning and eviction examined.
@@ -284,10 +286,11 @@ func (a *tokenReviewAuthenticator) rejected(key heartbeatAuthCacheKey, now time.
 
 // reject records a definitive rejection for key and returns err. It is only
 // reached after a TokenReview, so kcp's round trip already paces it. Before
-// inserting it drops the entries that have expired and, if the cache is still
-// at heartbeatAuthNegativeCacheMax, the oldest live ones; both come off the
-// front of negativeOrder, so each entry is examined once in its lifetime and
-// the cost is amortised O(1) per rejection.
+// inserting it drops the entries that have expired and, if negativeOrder is
+// still at heartbeatAuthNegativeCacheMax, the oldest live ones; both come off
+// the front, so each entry is examined once in its lifetime and the cost is
+// amortised O(1) per rejection. The slice is the bound: every map key has a
+// slot in it, so capping the slice caps the map.
 func (a *tokenReviewAuthenticator) reject(key heartbeatAuthCacheKey, now time.Time, err error) error {
 	if a.negativeTTL <= 0 {
 		return err
@@ -297,6 +300,15 @@ func (a *tokenReviewAuthenticator) reject(key heartbeatAuthCacheKey, now time.Ti
 	if a.negative == nil {
 		a.negative = map[heartbeatAuthCacheKey]heartbeatAuthRejection{}
 	}
+	// Two beats with the same bad token can both miss the negative cache and
+	// both go to kcp before either records the answer. The one that arrives
+	// here second finds a live entry and must not take a second slot for it;
+	// otherwise a flood of one token, at high enough concurrency, would grow
+	// negativeOrder by its in-flight count every TTL. The earlier expiry is
+	// kept: a repeat rejection does not extend how long the token is remembered.
+	if r, ok := a.negative[key]; ok && now.Before(r.until) {
+		return err
+	}
 	for len(a.negativeOrder) > 0 && !now.Before(a.negativeOrder[0].until) {
 		a.popNegativeLocked()
 	}
@@ -304,7 +316,7 @@ func (a *tokenReviewAuthenticator) reject(key heartbeatAuthCacheKey, now time.Ti
 	if limit <= 0 {
 		limit = heartbeatAuthNegativeCacheMax
 	}
-	for len(a.negative) >= limit && len(a.negativeOrder) > 0 {
+	for len(a.negativeOrder) >= limit {
 		a.popNegativeLocked()
 	}
 	until := now.Add(a.negativeTTL)

--- a/pkg/hub/providers/heartbeat_auth.go
+++ b/pkg/hub/providers/heartbeat_auth.go
@@ -100,6 +100,17 @@ const heartbeatAuthCacheTTL = HeartbeatTTL / 2
 // (ErrHeartbeatAuthUnavailable) are never cached: the provider retries those.
 const heartbeatAuthNegativeCacheTTL = 30 * time.Second
 
+// heartbeatAuthNegativeCacheMax bounds how many rejections are remembered at
+// once. The endpoint is unauthenticated, so the negative cache is filled by
+// whoever sends distinct bad tokens; without a cap a flood of them would grow
+// it without bound and the cache built to shield kcp would become the hub's
+// own memory amplifier. At capacity the oldest entry — the one expiring first
+// — makes room, so a flooding caller only ever evicts its own garbage, and a
+// token evicted early costs kcp one review again: the pre-cache cost, not an
+// amplification of it. Ten thousand entries is a few megabytes and far more
+// than the distinct bad tokens a legitimate deployment produces in a TTL.
+const heartbeatAuthNegativeCacheMax = 10_000
+
 // ProviderSAUsername is the username kcp reports for the provider's own
 // service account: the one MintProviderKubeconfigAtPath issues the provider
 // kubeconfig for. Every provider's heartbeat must authenticate as exactly it.
@@ -125,12 +136,31 @@ type tokenReviewAuthenticator struct {
 	now         func() time.Time
 	cacheTTL    time.Duration
 	negativeTTL time.Duration
+	// negativeMax caps len(negative); zero means heartbeatAuthNegativeCacheMax.
+	negativeMax int
 
 	mu    sync.Mutex
 	cache map[heartbeatAuthCacheKey]time.Time
 	// negative remembers rejected (token, provider) pairs with the error to
 	// repeat, until the recorded time.
 	negative map[heartbeatAuthCacheKey]heartbeatAuthRejection
+	// negativeOrder lists negative's entries oldest first. The TTL is a
+	// constant, so insertion order is expiry order: pruning pops expired
+	// entries off the front and eviction at capacity pops the oldest, and
+	// neither visits an entry that is still live. A key rejected again after
+	// its entry lapsed is appended anew; the stale front entry is skipped
+	// when its recorded expiry no longer matches the map's.
+	negativeOrder []heartbeatAuthNegativeEntry
+	// negativeVisited counts the queue entries pruning and eviction examined.
+	// Tests read it to show that a lookup examines none.
+	negativeVisited int
+}
+
+// heartbeatAuthNegativeEntry is one negativeOrder slot: the key and the expiry
+// it was recorded with.
+type heartbeatAuthNegativeEntry struct {
+	key   heartbeatAuthCacheKey
+	until time.Time
 }
 
 // heartbeatAuthRejection is one negatively cached outcome.
@@ -151,7 +181,8 @@ type heartbeatAuthCacheKey struct {
 // accepts a beat for provider N only when its bearer token authenticates, via
 // TokenReview in N's own workspace, as that workspace's provider service
 // account. Successful verifications are cached for heartbeatAuthCacheTTL and
-// rejections for heartbeatAuthNegativeCacheTTL.
+// rejections for heartbeatAuthNegativeCacheTTL, at most
+// heartbeatAuthNegativeCacheMax of them at once.
 func NewTokenReviewHeartbeatAuthenticator(kcpConfig *rest.Config, clusters ClusterResolver) (HeartbeatAuthenticator, error) {
 	if kcpConfig == nil {
 		return nil, fmt.Errorf("kcp config is required")
@@ -169,6 +200,7 @@ func NewTokenReviewHeartbeatAuthenticator(kcpConfig *rest.Config, clusters Clust
 		now:         time.Now,
 		cacheTTL:    heartbeatAuthCacheTTL,
 		negativeTTL: heartbeatAuthNegativeCacheTTL,
+		negativeMax: heartbeatAuthNegativeCacheMax,
 		cache:       map[heartbeatAuthCacheKey]time.Time{},
 		negative:    map[heartbeatAuthCacheKey]heartbeatAuthRejection{},
 	}
@@ -231,37 +263,69 @@ func (a *tokenReviewAuthenticator) cached(key heartbeatAuthCacheKey, now time.Ti
 	return ok && now.Before(until)
 }
 
-// rejected returns the remembered rejection for key if one is still live (nil
-// otherwise), dropping expired entries as it goes. Only what kcp answered is
-// cached, so a caller cycling through guessed tokens still costs one review
-// per distinct token; what it can no longer do is turn one bad token into a
-// review per beat.
+// rejected returns the remembered rejection for key if one is still live, nil
+// otherwise. Only what kcp answered is cached, so a caller cycling through
+// guessed tokens still costs one review per distinct token; what it can no
+// longer do is turn one bad token into a review per beat.
+//
+// This is one map lookup and nothing else. The negative cache is filled by
+// whoever sends distinct bad tokens, so a sweep here would cost every beat —
+// including every legitimate one — time proportional to the flood, and the
+// cache meant to shield kcp would be the hub's own CPU amplifier. Expired
+// entries are dropped in reject, off the front of negativeOrder.
 func (a *tokenReviewAuthenticator) rejected(key heartbeatAuthCacheKey, now time.Time) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	for k, r := range a.negative {
-		if !now.Before(r.until) {
-			delete(a.negative, k)
-		}
-	}
 	if r, ok := a.negative[key]; ok && now.Before(r.until) {
 		return r.err
 	}
 	return nil
 }
 
-// reject records a definitive rejection for key and returns err.
+// reject records a definitive rejection for key and returns err. It is only
+// reached after a TokenReview, so kcp's round trip already paces it. Before
+// inserting it drops the entries that have expired and, if the cache is still
+// at heartbeatAuthNegativeCacheMax, the oldest live ones; both come off the
+// front of negativeOrder, so each entry is examined once in its lifetime and
+// the cost is amortised O(1) per rejection.
 func (a *tokenReviewAuthenticator) reject(key heartbeatAuthCacheKey, now time.Time, err error) error {
 	if a.negativeTTL <= 0 {
 		return err
 	}
 	a.mu.Lock()
+	defer a.mu.Unlock()
 	if a.negative == nil {
 		a.negative = map[heartbeatAuthCacheKey]heartbeatAuthRejection{}
 	}
-	a.negative[key] = heartbeatAuthRejection{err: err, until: now.Add(a.negativeTTL)}
-	a.mu.Unlock()
+	for len(a.negativeOrder) > 0 && !now.Before(a.negativeOrder[0].until) {
+		a.popNegativeLocked()
+	}
+	limit := a.negativeMax
+	if limit <= 0 {
+		limit = heartbeatAuthNegativeCacheMax
+	}
+	for len(a.negative) >= limit && len(a.negativeOrder) > 0 {
+		a.popNegativeLocked()
+	}
+	until := now.Add(a.negativeTTL)
+	a.negative[key] = heartbeatAuthRejection{err: err, until: until}
+	a.negativeOrder = append(a.negativeOrder, heartbeatAuthNegativeEntry{key: key, until: until})
 	return err
+}
+
+// popNegativeLocked drops the oldest negativeOrder entry, and the map entry it
+// stands for unless that has since been re-recorded with a later expiry. The
+// front slot is zeroed so the backing array does not keep the key alive; the
+// array itself is bounded because append copies only the live tail when it
+// reallocates.
+func (a *tokenReviewAuthenticator) popNegativeLocked() {
+	e := a.negativeOrder[0]
+	a.negativeOrder[0] = heartbeatAuthNegativeEntry{}
+	a.negativeOrder = a.negativeOrder[1:]
+	a.negativeVisited++
+	if r, ok := a.negative[e.key]; ok && r.until.Equal(e.until) {
+		delete(a.negative, e.key)
+	}
 }
 
 // bearerToken extracts the token from an Authorization: Bearer header.

--- a/pkg/hub/providers/heartbeat_auth_test.go
+++ b/pkg/hub/providers/heartbeat_auth_test.go
@@ -599,6 +599,65 @@ func TestTokenReviewAuthenticatorNegativeCacheIsBounded(t *testing.T) {
 	}
 }
 
+// Two beats with the same bad token can both miss the negative cache while
+// the first TokenReview is in flight, and both then record the rejection. The
+// second must not take a second order slot: the slice is the bound, and a
+// flood of one token at high concurrency must not grow it by the in-flight
+// count every TTL.
+func TestTokenReviewAuthenticatorNegativeCacheRepeatRejectionKeepsOneSlot(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true, CatalogEntryCluster: "code-cluster"})
+	f := &tokenReviewFake{status: authnv1.TokenReviewStatus{Authenticated: false}}
+	now := time.Now()
+	a := newTestTokenReviewAuthenticator(reg, f, &now)
+	a.negativeMax = 8
+	key := func(token string) heartbeatAuthCacheKey {
+		return heartbeatAuthCacheKey{tokenHash: sha256.Sum256([]byte(token)), provider: "code"}
+	}
+	garbage := key("garbage")
+
+	// A hundred beats that all saw no cached rejection and all came back
+	// from kcp with the same answer.
+	for range 100 {
+		if err := a.reject(garbage, now, ErrHeartbeatTokenRejected); !errors.Is(err, ErrHeartbeatTokenRejected) {
+			t.Fatalf("reject: err = %v, want ErrHeartbeatTokenRejected", err)
+		}
+	}
+	if len(a.negative) != 1 || len(a.negativeOrder) != 1 {
+		t.Fatalf("after 100 in-flight rejections of one token: len(negative) = %d, len(negativeOrder) = %d, want 1 each", len(a.negative), len(a.negativeOrder))
+	}
+	first := a.negative[garbage].until
+
+	// A repeat does not extend how long the token is remembered.
+	a.reject(garbage, now.Add(a.negativeTTL/2), ErrHeartbeatTokenRejected)
+	if got := a.negative[garbage].until; !got.Equal(first) {
+		t.Fatalf("a repeat rejection moved the expiry from %v to %v", first, got)
+	}
+	if len(a.negativeOrder) != 1 {
+		t.Fatalf("a repeat rejection took a slot: len(negativeOrder) = %d, want 1", len(a.negativeOrder))
+	}
+
+	// Once the entry lapses the token is recorded anew, again in one slot.
+	lapsed := first.Add(time.Nanosecond)
+	a.reject(garbage, lapsed, ErrHeartbeatTokenRejected)
+	if len(a.negative) != 1 || len(a.negativeOrder) != 1 {
+		t.Fatalf("after the entry lapsed: len(negative) = %d, len(negativeOrder) = %d, want 1 each", len(a.negative), len(a.negativeOrder))
+	}
+	if got := a.negative[garbage].until; !got.After(first) {
+		t.Fatalf("a rejection after the entry lapsed kept the old expiry %v", got)
+	}
+
+	// Interleaved with a flood of distinct tokens, the repeats still cost no
+	// slots and the queue never exceeds the cap.
+	for i := range 1000 {
+		a.reject(key(fmt.Sprintf("flood-%d", i)), lapsed, ErrHeartbeatTokenRejected)
+		a.reject(garbage, lapsed, ErrHeartbeatTokenRejected)
+	}
+	if len(a.negative) > a.negativeMax || len(a.negativeOrder) > a.negativeMax {
+		t.Fatalf("after a flood with repeats: len(negative) = %d, len(negativeOrder) = %d, cap %d", len(a.negative), len(a.negativeOrder), a.negativeMax)
+	}
+}
+
 // A lookup must not pay for the cache's size: after a flood of distinct
 // rejections, a beat must be a map lookup, not a sweep of the flood. Expired
 // entries are dropped when a rejection is recorded, off the front of the

--- a/pkg/hub/providers/heartbeat_auth_test.go
+++ b/pkg/hub/providers/heartbeat_auth_test.go
@@ -629,7 +629,7 @@ func TestTokenReviewAuthenticatorNegativeCacheRepeatRejectionKeepsOneSlot(t *tes
 	first := a.negative[garbage].until
 
 	// A repeat does not extend how long the token is remembered.
-	a.reject(garbage, now.Add(a.negativeTTL/2), ErrHeartbeatTokenRejected)
+	_ = a.reject(garbage, now.Add(a.negativeTTL/2), ErrHeartbeatTokenRejected)
 	if got := a.negative[garbage].until; !got.Equal(first) {
 		t.Fatalf("a repeat rejection moved the expiry from %v to %v", first, got)
 	}
@@ -639,7 +639,7 @@ func TestTokenReviewAuthenticatorNegativeCacheRepeatRejectionKeepsOneSlot(t *tes
 
 	// Once the entry lapses the token is recorded anew, again in one slot.
 	lapsed := first.Add(time.Nanosecond)
-	a.reject(garbage, lapsed, ErrHeartbeatTokenRejected)
+	_ = a.reject(garbage, lapsed, ErrHeartbeatTokenRejected)
 	if len(a.negative) != 1 || len(a.negativeOrder) != 1 {
 		t.Fatalf("after the entry lapsed: len(negative) = %d, len(negativeOrder) = %d, want 1 each", len(a.negative), len(a.negativeOrder))
 	}
@@ -650,8 +650,8 @@ func TestTokenReviewAuthenticatorNegativeCacheRepeatRejectionKeepsOneSlot(t *tes
 	// Interleaved with a flood of distinct tokens, the repeats still cost no
 	// slots and the queue never exceeds the cap.
 	for i := range 1000 {
-		a.reject(key(fmt.Sprintf("flood-%d", i)), lapsed, ErrHeartbeatTokenRejected)
-		a.reject(garbage, lapsed, ErrHeartbeatTokenRejected)
+		_ = a.reject(key(fmt.Sprintf("flood-%d", i)), lapsed, ErrHeartbeatTokenRejected)
+		_ = a.reject(garbage, lapsed, ErrHeartbeatTokenRejected)
 	}
 	if len(a.negative) > a.negativeMax || len(a.negativeOrder) > a.negativeMax {
 		t.Fatalf("after a flood with repeats: len(negative) = %d, len(negativeOrder) = %d, cap %d", len(a.negative), len(a.negativeOrder), a.negativeMax)

--- a/pkg/hub/providers/heartbeat_auth_test.go
+++ b/pkg/hub/providers/heartbeat_auth_test.go
@@ -18,6 +18,7 @@ package providers
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/http"
@@ -529,6 +530,132 @@ func TestTokenReviewAuthenticatorNegativelyCachesRejections(t *testing.T) {
 	reg.Upsert(Provider{Name: "late", EndpointsValid: true, CatalogEntryCluster: "late-cluster"})
 	if err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("late", "tok"), "late"); err != nil {
 		t.Fatalf("once the cluster is known: %v", err)
+	}
+}
+
+// The negative cache is filled by whoever sends distinct bad tokens, so it has
+// a hard cap: at capacity the oldest rejection (the one expiring first) makes
+// room, the newest is still cached, and the map never exceeds the cap. A
+// caller flooding it therefore only ever evicts its own garbage, and a token
+// evicted early costs kcp one review again — the pre-cache cost, not more.
+func TestTokenReviewAuthenticatorNegativeCacheIsBounded(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true, CatalogEntryCluster: "code-cluster"})
+	f := &tokenReviewFake{status: authnv1.TokenReviewStatus{Authenticated: false}}
+	now := time.Now()
+	a := newTestTokenReviewAuthenticator(reg, f, &now)
+	a.negativeMax = 8
+	beat := func(token string) {
+		t.Helper()
+		if err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("code", token), "code"); !errors.Is(err, ErrHeartbeatTokenRejected) {
+			t.Fatalf("beat with %q: err = %v, want ErrHeartbeatTokenRejected", token, err)
+		}
+	}
+	key := func(token string) heartbeatAuthCacheKey {
+		return heartbeatAuthCacheKey{tokenHash: sha256.Sum256([]byte(token)), provider: "code"}
+	}
+
+	for i := range a.negativeMax {
+		beat(fmt.Sprintf("garbage-%d", i))
+	}
+	if len(a.negative) != a.negativeMax {
+		t.Fatalf("len(negative) = %d, want %d", len(a.negative), a.negativeMax)
+	}
+
+	// One past capacity: still cached (the repeat costs no review), the map
+	// does not grow, and the oldest entry is what made room.
+	beat("garbage-8")
+	beat("garbage-8")
+	if f.reviews != a.negativeMax+1 {
+		t.Fatalf("reviews = %d, want %d (a rejection at capacity is still cached)", f.reviews, a.negativeMax+1)
+	}
+	if len(a.negative) > a.negativeMax {
+		t.Fatalf("len(negative) = %d, exceeds the cap %d", len(a.negative), a.negativeMax)
+	}
+	if _, ok := a.negative[key("garbage-8")]; !ok {
+		t.Fatal("the newest rejection is not in the cache")
+	}
+	if _, ok := a.negative[key("garbage-0")]; ok {
+		t.Fatal("the oldest rejection is still in the cache; it should have been evicted")
+	}
+	if _, ok := a.negative[key("garbage-1")]; !ok {
+		t.Fatal("only the oldest rejection should have been evicted")
+	}
+	beat("garbage-0")
+	if f.reviews != a.negativeMax+2 {
+		t.Fatalf("reviews = %d, want %d (an evicted token is reviewed once more)", f.reviews, a.negativeMax+2)
+	}
+
+	// A flood of distinct tokens never grows either the map or its order
+	// queue past the cap.
+	for i := range 1000 {
+		beat(fmt.Sprintf("flood-%d", i))
+	}
+	if len(a.negative) > a.negativeMax || len(a.negativeOrder) > a.negativeMax {
+		t.Fatalf("after a flood: len(negative) = %d, len(negativeOrder) = %d, cap %d", len(a.negative), len(a.negativeOrder), a.negativeMax)
+	}
+	if heartbeatAuthNegativeCacheMax <= 0 {
+		t.Fatalf("heartbeatAuthNegativeCacheMax = %d, want a positive default cap", heartbeatAuthNegativeCacheMax)
+	}
+}
+
+// A lookup must not pay for the cache's size: after a flood of distinct
+// rejections, a beat must be a map lookup, not a sweep of the flood. Expired
+// entries are dropped when a rejection is recorded, off the front of the
+// order queue, never by scanning the map on a lookup.
+func TestTokenReviewAuthenticatorNegativeCacheLookupDoesNotSweep(t *testing.T) {
+	reg := NewRegistry()
+	reg.Upsert(Provider{Name: "code", EndpointsValid: true, CatalogEntryCluster: "code-cluster"})
+	f := &tokenReviewFake{status: authnv1.TokenReviewStatus{Authenticated: false}}
+	now := time.Now()
+	a := newTestTokenReviewAuthenticator(reg, f, &now)
+	// One clientset for the whole test: building one per beat is what would
+	// dominate ten thousand beats, not the cache.
+	cs, err := f.newClient("code-cluster")
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.newClient = func(string) (kubernetes.Interface, error) { return cs, nil }
+	beat := func(token string) {
+		t.Helper()
+		if err := a.Authenticate(context.Background(), heartbeatRequestWithBearer("code", token), "code"); !errors.Is(err, ErrHeartbeatTokenRejected) {
+			t.Fatalf("beat with %q: err = %v, want ErrHeartbeatTokenRejected", token, err)
+		}
+	}
+
+	const flood = 10_000
+	a.negativeMax = flood
+	for i := range flood {
+		beat(fmt.Sprintf("flood-%d", i))
+	}
+	if f.reviews != flood || len(a.negative) != flood {
+		t.Fatalf("reviews = %d, len(negative) = %d, want %d each", f.reviews, len(a.negative), flood)
+	}
+
+	visited := a.negativeVisited
+	for i := range flood {
+		beat(fmt.Sprintf("flood-%d", i))
+	}
+	if f.reviews != flood {
+		t.Fatalf("reviews = %d after repeating the flood, want %d (every repeat is a cache hit)", f.reviews, flood)
+	}
+	if a.negativeVisited != visited {
+		t.Fatalf("%d cache hits examined %d queue entries, want 0: a lookup must not sweep the cache", flood, a.negativeVisited-visited)
+	}
+
+	// Once the flood has expired a repeat is a miss, still without a sweep;
+	// the review it triggers records a rejection, and that is what prunes
+	// the expired flood — every expired entry once, off the front.
+	now = now.Add(heartbeatAuthNegativeCacheTTL + time.Second)
+	beat("flood-0")
+	if f.reviews != flood+1 {
+		t.Fatalf("reviews = %d after the flood expired, want %d", f.reviews, flood+1)
+	}
+	if len(a.negative) != 1 || len(a.negativeOrder) != 1 {
+		t.Fatalf("after pruning: len(negative) = %d, len(negativeOrder) = %d, want 1 each", len(a.negative), len(a.negativeOrder))
+	}
+	if examined := a.negativeVisited - visited; examined != flood {
+		t.Fatalf("pruning examined %d queue entries, want %d (each expired entry exactly once)", examined, flood)
 	}
 }
 

--- a/providers/agents/api/quarantine.go
+++ b/providers/agents/api/quarantine.go
@@ -81,7 +81,7 @@ func quarantineMetaValue(v string) string {
 	v = strings.TrimSpace(v)
 	v = strings.Map(func(r rune) rune {
 		switch r {
-		case '\n', '\r', '\v', '\f', '', ' ', ' ':
+		case '\n', '\r', '\v', '\f', '\u0085', '\u2028', '\u2029':
 			return ' '
 		}
 		return r

--- a/providers/app-studio/api/assistant_spend.go
+++ b/providers/app-studio/api/assistant_spend.go
@@ -311,11 +311,15 @@ func (g *projectEinoAssistantOrgSpendGuard) Record(ctx context.Context, usage *s
 	}
 	inputTokens := int64(max(usage.PromptTokens, 0))
 	outputTokens := int64(max(usage.CompletionTokens, 0))
-	delta := store.OrganizationSpendDelta{
+	return g.record(ctx, store.OrganizationSpendDelta{
 		InputTokens:  inputTokens,
 		OutputTokens: outputTokens,
 		USDMicros:    projectAssistantModelCostMicros(g.model, inputTokens, outputTokens),
-	}
+	})
+}
+
+// record adds one priced delta to the organization's ledger.
+func (g *projectEinoAssistantOrgSpendGuard) record(ctx context.Context, delta store.OrganizationSpendDelta) error {
 	now := g.now()
 	// The provider has already billed this response, so the ledger write must
 	// outlive the client. On the request context a caller could cancel in the
@@ -343,19 +347,38 @@ func (g *projectEinoAssistantOrgSpendGuard) Record(ctx context.Context, usage *s
 // tokens; recording nothing would let the cap be evaded by cancelling every
 // call before its last chunk. The estimate is the same one the compaction
 // planner uses, charged at the model's input rate; it is a floor, not a bill.
+//
+// A prompt the estimator cannot price — empty, or one it fails to marshal —
+// is still a call the provider billed, so it is charged
+// projectAssistantSpendFloorInputTokens at the model's rate and never less
+// than projectAssistantSpendFloorUSDMicros. The ledger never records zero for
+// a billed call: a zero is exactly what a caller bypassing the cap would
+// arrange, by cancelling every stream early and shaping the prompt so the
+// estimate comes out empty.
 func (g *projectEinoAssistantOrgSpendGuard) RecordAtLeastPrompt(ctx context.Context, input []*schema.Message, usage *schema.TokenUsage) error {
 	if g == nil {
 		return nil
 	}
-	if usage == nil {
-		estimate := projectEinoAssistantMessagesTokenEstimate(input)
-		if estimate <= 0 {
-			return nil
-		}
-		usage = &schema.TokenUsage{PromptTokens: estimate}
+	if usage != nil {
+		return g.Record(ctx, usage)
 	}
-	return g.Record(ctx, usage)
+	inputTokens := max(int64(projectEinoAssistantMessagesTokenEstimate(input)), projectAssistantSpendFloorInputTokens)
+	return g.record(ctx, store.OrganizationSpendDelta{
+		InputTokens: inputTokens,
+		USDMicros:   max(projectAssistantModelCostMicros(g.model, inputTokens, 0), projectAssistantSpendFloorUSDMicros),
+	})
 }
+
+// projectAssistantSpendFloorInputTokens and projectAssistantSpendFloorUSDMicros
+// are the least RecordAtLeastPrompt charges for a call that ended without a
+// usage report and whose prompt could not be estimated: one input token at the
+// model's rate, and never less than one micro-USD, the smallest amount the
+// ledger can express. Without the second floor a model priced under one
+// micro-USD per input token would round the floor token back to zero.
+const (
+	projectAssistantSpendFloorInputTokens int64 = 1
+	projectAssistantSpendFloorUSDMicros   int64 = 1
+)
 
 // reportCapReached appends the run's one durable cap notice. It is detached
 // for the same reason the ledger write is: the notice explains why the run

--- a/providers/app-studio/api/assistant_spend_test.go
+++ b/providers/app-studio/api/assistant_spend_test.go
@@ -519,6 +519,80 @@ func TestProjectEinoAssistantOrgSpendRecordsPromptWhenStreamEndsWithoutUsage(t *
 	}
 }
 
+// A billed call whose prompt cannot be estimated — empty, or one the estimator
+// fails to marshal — must still land in the ledger. A zero there is exactly
+// what a caller bypassing the cap would arrange: cancel every stream before its
+// usage chunk and hand the provider a prompt the estimator gives up on.
+func TestProjectEinoAssistantOrgSpendRecordsFloorForUnestimatablePrompt(t *testing.T) {
+	memory := store.NewMemoryStore()
+	now := time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC)
+	guard := newProjectEinoAssistantOrgSpendGuard(memory, "org-a", "gpt-4o", 10_000_000, nil)
+	guard.now = func() time.Time { return now }
+	model := projectEinoAssistantOrgSpendModelWithGuard(projectAssistantSpendCancellableStreamModel{}, guard)
+
+	var prompt []*schema.Message
+	if estimate := projectEinoAssistantMessagesTokenEstimate(prompt); estimate != 0 {
+		t.Fatalf("precondition: an empty prompt estimates to %d tokens, want 0", estimate)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	reader, err := model.Stream(ctx, prompt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if message, err := reader.Recv(); err != nil || message == nil || message.Content != "partial" {
+		t.Fatalf("first chunk = %#v, %v", message, err)
+	}
+	cancel()
+	for {
+		if _, err := reader.Recv(); err != nil {
+			break
+		}
+	}
+	reader.Close()
+
+	spend, err := memory.GetOrganizationSpend(context.Background(), "org-a", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spend.InputTokens <= 0 || spend.USDMicros <= 0 {
+		t.Fatalf("ledger after a cancelled stream with an un-estimatable prompt = %#v, want spend > 0 (the provider billed the call)", spend)
+	}
+
+	// The floor holds in micro-USD as well as tokens: a model priced under one
+	// micro-USD per input token must not round the floor token back to zero.
+	if cost := projectAssistantModelCostMicros("gpt-5-nano", 1, 0); cost != 0 {
+		t.Fatalf("precondition: one gpt-5-nano input token prices to %d micro-USD, want 0 (this case is what the micro-USD floor is for)", cost)
+	}
+	cheap := newProjectEinoAssistantOrgSpendGuard(memory, "org-b", "gpt-5-nano", 10_000_000, nil)
+	cheap.now = func() time.Time { return now }
+	if err := cheap.RecordAtLeastPrompt(context.Background(), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	spend, err = memory.GetOrganizationSpend(context.Background(), "org-b", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spend.InputTokens < 1 || spend.USDMicros < 1 {
+		t.Fatalf("ledger for a sub-micro model with an un-estimatable prompt = %#v, want at least one token and one micro-USD", spend)
+	}
+
+	// A prompt the estimator can price is still charged at its estimate, not
+	// the floor.
+	priced := newProjectEinoAssistantOrgSpendGuard(memory, "org-c", "gpt-4o", 10_000_000, nil)
+	priced.now = func() time.Time { return now }
+	long := []*schema.Message{schema.UserMessage(strings.Repeat("build me a dashboard ", 200))}
+	if err := priced.RecordAtLeastPrompt(context.Background(), long, nil); err != nil {
+		t.Fatal(err)
+	}
+	spend, err = memory.GetOrganizationSpend(context.Background(), "org-c", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := int64(projectEinoAssistantMessagesTokenEstimate(long)); spend.InputTokens != want || want <= 1 {
+		t.Fatalf("ledger for an estimatable prompt = %#v, want its estimate of %d input tokens", spend, want)
+	}
+}
+
 // The spend guard is installed for runs that have no event ledger. Reaching
 // the cap on such a run must report through the guard without faulting.
 func TestProjectEinoAssistantOrgSpendModelForToleratesNilEventLedger(t *testing.T) {


### PR DESCRIPTION
Follow-up to #660, which merged with three Copilot review comments still open. All three were valid; each is fixed in its own commit with a test that fails on the previous code where the finding was behavioural.

## 1. `pkg/hub/providers/heartbeat_auth.go` — bounded negative cache, O(1) lookup ([comment](https://github.com/faroshq/faros/pull/660#discussion_r3944507116))

`rejected()` swept the whole negative cache on every `Authenticate` call and nothing bounded the cache. The endpoint is unauthenticated, so an attacker sending distinct bad tokens made every beat (legitimate ones included) pay O(flood) CPU and grew the hub's memory without bound — the cache built to shield kcp was the hub's own amplifier.

A lookup is now a single map read. Entries also sit in an insertion-order queue (constant TTL, so that is expiry order); `reject`, reached only after a TokenReview, pops expired entries off the front and at the new `heartbeatAuthNegativeCacheMax` (10,000) evicts the oldest. Each entry is examined once in its lifetime. A flooder only ever evicts its own garbage; an evicted token costs kcp one review again, the pre-cache cost.

Tests: at capacity a new rejection is still cached, the oldest made room, the map never exceeds the cap (fails on the previous code, 9 > 8); 10,000 cache hits examine zero queue entries; pruning examines each expired entry exactly once.

## 2. `providers/app-studio/api/assistant_spend.go` — non-zero spend floor ([comment](https://github.com/faroshq/faros/pull/660#discussion_r3944507133))

`RecordAtLeastPrompt` returned without recording when the prompt estimate was `<= 0`, so cancelling every stream before its usage chunk with a prompt the estimator gives up on (empty, or un-marshalable) left the monthly ledger at zero — a cap bypass. With nil usage the ledger now always gets a floor: the estimate when positive, else one input token at the model's rate and never less than one micro-USD (a sub-micro model such as gpt-5-nano would otherwise round the floor token back to zero).

Test: a cancelled stream with an empty prompt records spend > 0 (fails on the previous code with the ledger at zero); a sub-micro model records >= 1 token and >= 1 micro-USD; an estimatable prompt is still charged its estimate.

## 3. `providers/agents/api/quarantine.go` — explicit escapes ([comment](https://github.com/faroshq/faros/pull/660#discussion_r3944507159))

The NEL / U+2028 / U+2029 rune literals were raw invisible characters. They are now explicit `\uXXXX` escapes for U+0085, U+2028 and U+2029; behaviour identical, existing envelope tests unchanged.

## Verification

- `GOWORK=off go build ./... && GOWORK=off go vet ./pkg/... && GOWORK=off go test -race -count=1 ./pkg/hub/providers/...`
- `providers/app-studio`: `GOWORK=off go test -race -count=1 ./api/...`
- `providers/agents`: `GOWORK=off go test -race -count=1 ./api/...`
- `GOWORK=off make lint` (0 issues), `make verify-boilerplate`, `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
