### PR TITLE
fix(agent): do not pipe a non-101 upgrade response as a raw tunnel (stranded from #661)

### DIFF
--- a/pkg/agent/tunnel/svc.go
+++ b/pkg/agent/tunnel/svc.go
@@ -250,15 +250,34 @@ func handleSvcUpgrade(w http.ResponseWriter, r *http.Request, target *url.URL, s
 		return
 	}
 
-	// Read the response head off the backend, restamp the policy header and
-	// hand the head to the client; br keeps any bytes read past the head.
+	// Read the response head off the backend and restamp the policy header;
+	// br keeps any bytes read past the head. A backend that hangs up or sends
+	// garbage before a complete head gets a 502 relayed to the caller (the
+	// connection is hijacked, so nothing else would answer) and both sides
+	// are closed by the deferred Close calls above.
 	br := bufio.NewReader(backendConn)
 	resp, err := http.ReadResponse(br, r)
 	if err != nil {
 		logger.Error(err, "failed to read upgrade response from svc target", "target", target.String())
+		_, _ = io.WriteString(clientConn, "HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\nContent-Length: 0\r\n\r\n")
 		return
 	}
+	defer resp.Body.Close() //nolint:errcheck
 	stampSvcPolicy(resp.Header, warned)
+
+	// Anything but a 101 means the backend declined the upgrade: the reply is
+	// an ordinary HTTP response, not the start of a raw stream. Relay it whole
+	// (resp.Write frames the body from resp.ContentLength/TransferEncoding),
+	// mark it Connection: close and return; the deferred Close calls end both
+	// sides. Piping raw bytes here instead would leave both copy goroutines
+	// blocked on a keep-alive backend, leaking the hijacked client connection.
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		resp.Close = true
+		if err := resp.Write(clientConn); err != nil {
+			logger.Error(err, "failed to forward refused upgrade response to caller")
+		}
+		return
+	}
 	if err := writeResponseHead(clientConn, resp); err != nil {
 		logger.Error(err, "failed to forward upgrade response to caller")
 		return

--- a/pkg/agent/tunnel/svc.go
+++ b/pkg/agent/tunnel/svc.go
@@ -289,10 +289,12 @@ func handleSvcUpgrade(w http.ResponseWriter, r *http.Request, target *url.URL, s
 	<-errc
 }
 
-// writeResponseHead writes resp's status line and headers, byte-faithful to
-// what the upstream sent apart from the header edits made on resp.Header. The
-// body (if the upgrade was refused with one) is not consumed here; the caller
-// pipes the remaining bytes as-is.
+// writeResponseHead writes resp's status line and headers for a 101 the
+// upstream sent, with the header edits made on resp.Header applied. It is not
+// a byte-for-byte replay: http.Header.Write canonicalises key names and emits
+// headers in sorted order, which is fine for WebSocket negotiation (peers match
+// on names case-insensitively and do not depend on order). No body is written;
+// the caller pipes the bytes after the head as-is.
 func writeResponseHead(w io.Writer, resp *http.Response) error {
 	if _, err := fmt.Fprintf(w, "HTTP/%d.%d %s\r\n", resp.ProtoMajor, resp.ProtoMinor, resp.Status); err != nil {
 		return err

--- a/pkg/agent/tunnel/svc_test.go
+++ b/pkg/agent/tunnel/svc_test.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestIsLoopbackHost(t *testing.T) {
@@ -620,5 +621,146 @@ func TestSvcUpgradeStripsUpstreamPolicyHeader(t *testing.T) {
 	echo := make([]byte, 4)
 	if _, err := io.ReadFull(br, echo); err != nil || string(echo) != "ping" {
 		t.Fatalf("echo = %q, %v; want ping", echo, err)
+	}
+}
+
+// upgradeFront serves h behind a real listener, wraps it so the test can wait
+// for ServeHTTP to return, and sends an upgrade request for target over a raw
+// TCP connection so the hijacked path is exercised end to end. It returns the
+// client side of the connection, a reader over it, the request (for
+// http.ReadResponse) and the channel closed when the handler returns.
+func upgradeFront(t *testing.T, h http.Handler, target string) (net.Conn, *bufio.Reader, *http.Request, <-chan struct{}) {
+	t.Helper()
+	done := make(chan struct{})
+	front := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(done)
+		h.ServeHTTP(w, r)
+	}))
+	t.Cleanup(front.Close)
+
+	conn, err := net.Dial("tcp", strings.TrimPrefix(front.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	req, _ := http.NewRequest(http.MethodGet, "/svc/api/websocket", nil)
+	req.Host = "edge"
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set(svcTargetHeader, target)
+	if err := req.Write(conn); err != nil {
+		t.Fatal(err)
+	}
+	return conn, bufio.NewReader(conn), req, done
+}
+
+// waitHandlerDone fails the test if the svc handler is still running after
+// the client has read the whole reply while keeping its side open: that is
+// the leaked upgrade, both copy goroutines parked on a keep-alive backend
+// that will never send another byte.
+func waitHandlerDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("svc upgrade handler still running after the backend refused the upgrade: connection leaked")
+	}
+}
+
+// TestSvcUpgradeRefusedIsNotPiped: a backend that answers an upgrade request
+// with anything but a 101 (here a keep-alive 403) has sent an ordinary HTTP
+// response, not the head of a raw stream. The agent must relay status, headers
+// and body, close the hijacked connection and return, instead of parking two
+// io.Copy goroutines on a backend that will never send more.
+func TestSvcUpgradeRefusedIsNotPiped(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isUpgradeRequest(r) {
+			t.Errorf("upstream got a non-upgrade request %s %s", r.Method, r.URL)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set(svcPolicyHeader, string(SvcPolicyEnforce)) // must still be stripped
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "upgrade refused")
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: SvcPolicyEnforce}}
+	dialer := &countingDialer{}
+	cfg.dial = dialer.dial
+	conn, br, req, done := upgradeFront(t, newSvcProxyHandler(cfg), upstream.URL)
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	resp, err := http.ReadResponse(br, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want the upstream 403 relayed", resp.StatusCode)
+	}
+	if got := resp.Header.Get(svcPolicyHeader); got != "" {
+		t.Errorf("%s = %q leaked through the refused upgrade, want it stripped", svcPolicyHeader, got)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "text/plain" {
+		t.Errorf("Content-Type = %q, want the upstream's header kept", got)
+	}
+	if !resp.Close {
+		t.Errorf("Connection = %q, want close: the agent ends the connection after a refused upgrade", resp.Header.Get("Connection"))
+	}
+	if body := readBody(t, resp); body != "upgrade refused" {
+		t.Errorf("body = %q, want the upstream body relayed", body)
+	}
+
+	// The handler must finish on its own, with the client still connected.
+	waitHandlerDone(t, done)
+
+	// And the agent closed our side: nothing more arrives, no hang.
+	if _, err := br.ReadByte(); !errors.Is(err, io.EOF) {
+		t.Errorf("read after refused upgrade = %v, want EOF from the agent closing the connection", err)
+	}
+	if n := dialer.n.Load(); n != 1 {
+		t.Errorf("dialed %d times, want 1", n)
+	}
+}
+
+// TestSvcUpgradeBackendHangsUpBeforeHead: a backend that closes without a
+// complete response head must not hang the handler or leave the hijacked
+// client waiting; the client gets a 502 and the connection is closed.
+func TestSvcUpgradeBackendHangsUpBeforeHead(t *testing.T) {
+	for name, partial := range map[string]string{
+		"eof before any bytes": "",
+		"truncated head":       "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n",
+		"malformed head":       "this is not http\r\n\r\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				c, _, err := w.(http.Hijacker).Hijack()
+				if err != nil {
+					t.Errorf("upstream hijack: %v", err)
+					return
+				}
+				_, _ = io.WriteString(c, partial)
+				_ = c.Close()
+			}))
+			t.Cleanup(upstream.Close)
+
+			cfg := svcProxyConfig{SvcProxyOptions: SvcProxyOptions{Policy: SvcPolicyEnforce}}
+			dialer := &countingDialer{}
+			cfg.dial = dialer.dial
+			conn, br, req, done := upgradeFront(t, newSvcProxyHandler(cfg), upstream.URL)
+
+			_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+			resp, err := http.ReadResponse(br, req)
+			if err != nil {
+				t.Fatalf("reading the agent's reply: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadGateway {
+				t.Fatalf("status = %d, want 502", resp.StatusCode)
+			}
+			_ = resp.Body.Close()
+			waitHandlerDone(t, done)
+			if _, err := br.ReadByte(); !errors.Is(err, io.EOF) {
+				t.Errorf("read after 502 = %v, want EOF", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

PR #661 was squash-merged while its last two commits were still in CI, so they never reached `main`. The important one fixes a leak that #661 itself introduced.

#661's header-restamp change made the agent's WebSocket/upgrade path read the backend's response head with `http.ReadResponse` and re-emit it. After that it started the bidirectional raw pipe **unconditionally**. A backend that answers a non-101 status and keeps the connection alive, which a 4xx or 5xx commonly does, leaves both `io.Copy` goroutines blocked forever and the hijacked client connection leaked, once per upgrade attempt. Repeated upgrade attempts exhaust the agent.

## Change

The two stranded commits, unchanged:

1. `fix(agent): do not pipe a non-101 upgrade response as a raw tunnel` — after writing the response head, any status other than 101 is treated as an ordinary HTTP response: the body is copied to the client, both sides are closed, and the handler returns without starting the pipe. A backend that closes without a full head is handled without a hang.
2. `docs(agent): stop calling writeResponseHead byte-faithful` — `http.Header.Write` canonicalises keys and may reorder headers; the comment no longer promises byte fidelity.

## Compatibility

None. Genuine 101 upgrades behave exactly as before.

## Tests

The new test drives an upgrade request against an `httptest` backend that answers 403 with keep-alive, and asserts the client receives the 403 body, the handler returns, and no goroutine is left blocked. It hangs on the code currently on `main`. `pkg/agent/tunnel` passes three consecutive times under the race detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
