### PR TITLE
docs: one front door — README, docs landing and getting-started describe the product that ships

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Thanks for your interest in contributing! This document covers building from sou
 
 | Tool | Version | Notes |
 |------|---------|-------|
-| Go | 1.25+ | `go env GOVERSION` |
+| Go | 1.26+ | `go env GOVERSION`; `go.mod` pins the exact version |
 | Docker | any recent | must be running |
 | kind | latest | for local clusters |
 | kubectl | 1.28+ | |

--- a/README.md
+++ b/README.md
@@ -1,171 +1,180 @@
 # faros
 
-faros connects your distributed Kubernetes clusters and servers through a single control plane — no VPNs, no open firewall ports, no kubeconfig juggling. Agents running on each edge establish outbound reverse tunnels to the hub, so clusters behind NAT, home-lab Raspberry Pis, and bare-metal machines in remote sites all become reachable through one authenticated endpoint.
+faros is an open-source control plane for platform teams, built on [kcp](https://github.com/kcp-dev/kcp).
 
-## Features
+Providers publish Kubernetes-style APIs, versioned actions and MCP tools into isolated tenant workspaces. Users, teams and organizations reach them through one portal, one CLI, one API and one MCP endpoint, and every call is authorized as the caller by the same RBAC. Edges extend the control plane to clusters and servers behind NAT through outbound tunnels, so the same workspace that holds an application also reaches the cluster it runs on.
 
-- **Reverse tunnel connectivity** — agents dial out; no inbound firewall rules needed
-- **Kubernetes edge support** — proxy `kubectl` to any registered cluster via the hub
-- **SSH server mode** — manage non-Kubernetes hosts (VMs, bare metal) through the same hub
-- **MCP integration** — expose all connected clusters as a single [Model Context Protocol](https://modelcontextprotocol.io) server for AI agents (Claude, Cursor, etc.)
-- **OIDC authentication** — plug in any OIDC provider (Dex, Auth0, Okta, …)
-- **Static token auth** — quick setup for home labs and dev environments
-- **Multi-tenant workspaces** — per-user/team kcp workspace isolation
-- **CLI-first** — register edges, get kubeconfigs, and SSH into servers with one command
+> **Status: alpha.** faros is at v0.1.x, every API is `v1alpha1`, and it is developed by a small team. There is no hosted service; you run the hub yourself. Expect breaking changes between minor versions until the APIs stabilize.
 
-## Architecture
+## What faros gives you
+
+- **Tenancy.** Organizations, teams and users are kcp workspaces. Membership and roles are first-party APIs. Authenticate with any OIDC provider or, for a single user, a static token.
+- **Providers.** Helm-installed extensions that bring an APIExport, controllers, a backend, a portal micro-frontend, MCP tools and actions. Tenants enable a provider in a workspace and get its APIs bound there. Organizations can also register providers they run themselves, reached over an edge ([BYO providers](docs/byo-providers.md)).
+- **Provider actions.** Versioned verbs on resources, granted through kcp RBAC, callable by people and by agents ([design](docs/provider-actions.md)).
+- **One MCP endpoint per workspace.** Tools from every enabled provider and every connected edge, aggregated into one Model Context Protocol server. Each tool call runs as the calling user ([architecture](docs/mcp-architecture.md)).
+- **Edges.** Kubernetes clusters and Linux servers join through an agent that dials out. The hub proxies `kubectl`, SSH and selected in-cluster services to them.
+- **A portal.** One web UI that hosts each provider's micro-frontend under the tenant's identity.
+
+## Providers in this repository
+
+| Provider | What it does |
+|---|---|
+| [edges](providers/edges) | Connectivity: `KubernetesCluster` and `LinuxServer` edges, the agent tunnel, `Service` connectors, per-edge MCP |
+| [infrastructure](providers/infrastructure) | Brokers [kro](https://github.com/kro-run/kro) application templates into tenant workspaces and runs them on a runtime cluster |
+| [app-studio](providers/app-studio) | Persistent AI project workspaces with a chat assistant, sandboxed development instances and publishing, on the tenant's own model credentials |
+| [agents](providers/agents) | Long-running personal agents with scheduled runs, tool use, approvals, budgets and memory, reachable from Slack, Telegram, Discord and email |
+| [code](providers/code) | Source repositories, deploy keys and collaborators as workspace resources, on GitHub today |
+| [databricks](providers/databricks) | Databricks connections, warehouses and tables as workspace resources, with a `query_table` action |
+| [kuery](providers/kuery) | Fleet-wide object search and relationship traversal across a workspace's connected clusters |
+| [quickstart](providers/quickstart) | A minimal reference provider that exercises the whole plugin surface |
+
+Provider directories are mirrored read-only to `faroshq/provider-*` repositories. Open changes here.
+
+## How it fits together
 
 ```
-   [ your laptop ]
-        │  faros CLI
-        ▼
-   ┌─────────────┐
-   │  faros hub  │  ◄── central control plane (Kubernetes + kcp + OIDC)
-   └──────┬──────┘
-          │  reverse tunnels (outbound from agents)
-    ┌─────┴──────────────────┐
-    │                        │
-┌───▼────┐             ┌─────▼──────┐
-│ agent  │             │   agent    │
-│ (k8s)  │             │  (server)  │
-│cluster │             │  bare metal│
-└────────┘             └────────────┘
+                 people · CLI · portal · AI agents (MCP)
+                                 │
+                        ┌────────▼────────┐
+                        │    faros hub    │   kcp workspaces, OIDC, RBAC,
+                        │                 │   provider registry, proxies
+                        └──┬─────┬─────┬──┘
+           provider APIs   │     │     │   outbound tunnels
+      ┌────────────────────┘     │     └────────────────────┐
+┌─────▼──────┐          ┌────────▼───────┐           ┌──────▼──────┐
+│  platform  │          │   org-owned    │           │    edges    │
+│  providers │          │   providers    │           │ clusters &  │
+│ (in-cluster│          │ (your cluster, │           │   servers   │
+│  with hub) │          │  over an edge) │           │ behind NAT  │
+└────────────┘          └────────────────┘           └─────────────┘
 ```
 
-The hub is the only component that needs to be publicly reachable. Agents connect outward — NAT and firewalls are not a problem.
+The hub is the only component that needs to be reachable. Providers register with the hub and serve their APIs inside their own kcp workspace; agents on edges connect outward. Traffic between the hub and everything else is HTTP/1.1 and WebSockets, so any reverse proxy, ingress or tunnel in front of the hub works.
 
-## Installation
+## Install
 
 ### Hub
 
-The hub is the only component that needs a public endpoint. Any device you're comfortable exposing works — a VPS, cloud VM, home server, or anything behind a Cloudflare Tunnel or ingress controller.
+```bash
+helm install faros-hub oci://ghcr.io/faroshq/charts/faros-hub \
+  --namespace faros --create-namespace \
+  --set hub.hubExternalURL=https://faros.example.com
+```
 
-→ **[Installation](https://faroshq.github.io/faros/helm.html)**
+That gives you a hub with embedded kcp. For TLS, OIDC, ingress and the provider hardening flags, see [Helm deployment](https://faroshq.github.io/faros/helm.html), [embedded kcp](https://faroshq.github.io/faros/install-embedded-kcp.html) and [external kcp](https://faroshq.github.io/faros/install-external-kcp.html).
+
+To try faros on a laptop, the CLI can create a local hub in a kind cluster:
+
+```bash
+faros dev init
+```
 
 ### CLI
 
-Install the `faros` CLI on any machine you want to interact with the hub from:
-
-**Binary (recommended)** — download from the [releases page](https://github.com/faroshq/faros/releases) and put the binary in your `$PATH`.
-
-**krew:**
+Download a binary from the [releases page](https://github.com/faroshq/faros/releases), or:
 
 ```bash
+# krew
 kubectl krew index add faros https://github.com/faroshq/krew-index.git
 kubectl krew install faros/faros
-```
 
-**From source:**
-
-```bash
+# from source
 go install github.com/faroshq/faros/cmd/faros@latest
 ```
 
 ## Quickstart
 
-### 1. Log in
-
-`--hub-url` defaults to `https://console.faros.sh`, the hosted hub. Pass your own to use a self-hosted hub.
+### 1. Log in and pick a workspace
 
 ```bash
-# Hosted hub
-faros login
-
-# Self-hosted hub
-faros login --hub-url https://faros.example.com
+faros login --hub-url https://faros.example.com          # OIDC in the browser
+faros login --hub-url https://faros.example.com --token <static-token>
+faros use                                                 # choose organization and workspace
 ```
 
-### 2. Connect a Kubernetes cluster
+`--hub-url` can also come from `FAROS_HUB_URL`.
+
+### 2. Connect a cluster
 
 ```bash
-# Register the edge on the hub
 faros edge create my-cluster --type kubernetes
-
-# Print the agent install command (includes the one-time join token)
-faros edge join-command my-cluster
+faros edge join-command my-cluster        # prints the agent install command with a one-time token
 ```
 
-Copy the printed command and run it on the target cluster. Once the agent connects:
+Run the printed command on the target cluster. Then:
 
 ```bash
-faros edge list                                # should show my-cluster as Ready
-faros kubeconfig edge my-cluster > kc.yaml    # get a kubeconfig for the edge
+faros edge list
+faros kubeconfig edge my-cluster > kc.yaml
 kubectl --kubeconfig kc.yaml get nodes
 ```
 
-### 3. Use MCP with AI agents (Claude, Cursor, …)
-
-faros exposes all your connected Kubernetes clusters as a single MCP server, letting AI coding assistants interact with your clusters directly.
-
-```bash
-# Print the MCP endpoint URL + ready-to-use setup commands
-faros mcp url --name default
-```
-
-Example output:
-```
-https://hub.example.com/services/mcp/root:faros:user-default/apis/faros.sh/v1alpha1/kubernetesmcps/default/mcp
-
-To add this MCP server to Claude Code:
-  claude mcp add --transport http faros "https://hub.example.com/..." -H "Authorization: Bearer <token>"
-
-To add to Claude Desktop (claude_desktop_config.json):
-  {
-    "mcpServers": {
-      "faros": {
-        "url": "https://hub.example.com/...",
-        "headers": { "Authorization": "Bearer <token>" }
-      }
-    }
-  }
-```
-
-The MCP server aggregates **all connected kubernetes-type clusters** into one endpoint. AI agents can list pods, describe deployments, apply manifests, and more — across all your clusters at once.
-
-### 4. Connect a server (SSH mode)
+### 3. Connect a server
 
 ```bash
 faros edge create my-server --type server
 faros edge join-command my-server
+faros ssh my-server -- uptime
 ```
 
-Run the printed command on the target host, then:
+### 4. Give an AI agent your workspace
 
 ```bash
-faros ssh my-server              # interactive shell
-faros ssh my-server -- df -h     # single command
+faros mcp url --name default
 ```
 
-## CLI Reference
+This prints the workspace's MCP endpoint and ready-to-paste configuration for Claude Code and Claude Desktop. The endpoint carries the tools of every enabled provider and every connected edge, and each call is authorized as you.
 
-| Command | Description |
+## Security
+
+The hub authenticates users with OIDC or a static token, and providers with their own workspace service-account token. Org-owned providers never see a user's bearer: they receive a short-lived, workspace-bound delegated token. Agents refuse to proxy to link-local and metadata addresses and can be locked to an allow-list. Webhooks into the agents provider are signature-checked. Details are in [Security](https://faroshq.github.io/faros/security.html).
+
+Some hardened behaviours ship off by default for one release so existing installs can roll forward; the Helm doc's section "Turning on the hardened defaults early" lists the values that turn them on.
+
+To report a vulnerability, open a private security advisory on this repository rather than a public issue.
+
+## CLI reference
+
+| Command | What it does |
 |---|---|
-| `faros login` | Authenticate with the hub (OIDC or static token) |
-| `faros edge create <name>` | Register a new edge |
-| `faros edge join-command <name>` | Print the agent run command with join token |
-| `faros edge list` | List all edges and their connection status |
-| `faros edge get <name>` | Show details for a specific edge |
-| `faros edge delete <name>` | Remove an edge |
-| `faros kubeconfig edge <name>` | Generate a kubeconfig for a Kubernetes-type edge |
-| `faros ssh <name>` | Open an SSH session to a server-mode edge |
-| `faros ssh <name> -- <cmd>` | Run a single command on a server-mode edge |
-| `faros agent run` | Start the agent as a foreground process |
-| `faros agent join` | Install the agent as a persistent service (systemd / Deployment) |
-| `faros mcp url --name <name>` | Print the Kubernetes multi-cluster MCP endpoint URL |
-| `faros mcp url --edge <name>` | Print the per-edge MCP endpoint URL |
+| `faros login` | Authenticate with a hub via OIDC or static token |
+| `faros use` | Switch the active organization and workspace |
+| `faros edge create\|list\|get\|delete <name>` | Manage edges |
+| `faros edge join-command <name>` | Print the agent join command for an edge |
+| `faros edge upgrade <name>` | Print upgrade instructions for an edge agent |
+| `faros kubeconfig edge <name>` | Generate a kubeconfig that reaches an edge through the hub |
+| `faros ssh <name> [-- cmd]` | Open a shell or run a command on a server edge |
+| `faros mcp url --name <name>` / `--edge <name>` | Print the workspace or per-edge MCP endpoint |
+| `faros get`, `faros apply` | Read and apply workspace resources |
+| `faros agent join\|run\|install\|uninstall\|upgrade` | Run or install the agent on a cluster or host |
+| `faros dev init\|update\|delete` | Manage a local kind-based environment |
+| `faros get-token` | OIDC token for a kubectl exec credential plugin |
+
+## Repository layout
+
+| Path | Contents |
+|---|---|
+| `cmd/` | `faros` CLI, `faros-hub`, `faros-agent`, GraphQL gateway |
+| `pkg/hub` | Hub: kcp bootstrap, tenancy, provider registry, proxies, MCP aggregation |
+| `pkg/agent` | Edge agent and tunnel |
+| `providers/` | The providers listed above, each its own Go module |
+| `deploy/charts` | Helm charts for the hub and the agent |
+| `docs/` | Published docs and design documents |
 
 ## Documentation
 
-- [Getting Started](https://faroshq.github.io/faros/getting-started.html)
-- [Helm Deployment](https://faroshq.github.io/faros/helm.html)
-- [Security & Auth](https://faroshq.github.io/faros/security.html)
-- [Ingress Setup](https://faroshq.github.io/faros/ingress/)
-- [Developer Guide](https://faroshq.github.io/faros/developers.html)
+Published: [Getting started](https://faroshq.github.io/faros/getting-started.html) · [Helm deployment](https://faroshq.github.io/faros/helm.html) · [Security](https://faroshq.github.io/faros/security.html) · [Ingress](https://faroshq.github.io/faros/ingress/) · [MCP architecture](https://faroshq.github.io/faros/mcp-architecture.html) · [Developer guide](https://faroshq.github.io/faros/developers.html)
+
+Design documents in this repository: [providers](docs/providers.md), [organizations and the workspace tree](docs/organizations.md), [provider scoping](docs/provider-scoping.md), [provider actions](docs/provider-actions.md), [BYO providers](docs/byo-providers.md), [MCP architecture](docs/mcp-architecture.md).
+
+## Relationship to kcp and Platform Mesh
+
+faros runs on kcp and its author maintains kcp. It shares that substrate, and its GraphQL gateway, with [Platform Mesh](https://github.com/platform-mesh), the SAP and NeoNephos reference architecture. faros is the smaller, opinionated end of that spectrum: a single-binary hub with an agent surface (MCP and actions), providers an organization can run in its own cluster over an edge, and connectivity to clusters and servers built in.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for build setup, running tests, and PR guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for building, running the local stack, tests and the pull-request workflow.
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE)
+Apache 2.0. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # faros
 
-faros is an open-source control plane for platform teams, built on [kcp](https://github.com/kcp-dev/kcp).
+faros is an open-source control plane for platform teams.
 
 Providers publish Kubernetes-style APIs, versioned actions and MCP tools into isolated tenant workspaces. Users, teams and organizations reach them through one portal, one CLI, one API and one MCP endpoint, and every call is authorized as the caller by the same RBAC. Edges extend the control plane to clusters and servers behind NAT through outbound tunnels, so the same workspace that holds an application also reaches the cluster it runs on.
 
@@ -8,9 +8,9 @@ Providers publish Kubernetes-style APIs, versioned actions and MCP tools into is
 
 ## What faros gives you
 
-- **Tenancy.** Organizations, teams and users are kcp workspaces. Membership and roles are first-party APIs. Authenticate with any OIDC provider or, for a single user, a static token.
+- **Tenancy.** Organizations, teams and users each get an isolated workspace with its own API surface. Membership and roles are first-party APIs. Authenticate with any OIDC provider or, for a single user, a static token.
 - **Providers.** Helm-installed extensions that bring an APIExport, controllers, a backend, a portal micro-frontend, MCP tools and actions. Tenants enable a provider in a workspace and get its APIs bound there. Organizations can also register providers they run themselves, reached over an edge ([BYO providers](docs/byo-providers.md)).
-- **Provider actions.** Versioned verbs on resources, granted through kcp RBAC, callable by people and by agents ([design](docs/provider-actions.md)).
+- **Provider actions.** Versioned verbs on resources, granted through the workspace's RBAC, callable by people and by agents ([design](docs/provider-actions.md)).
 - **One MCP endpoint per workspace.** Tools from every enabled provider and every connected edge, aggregated into one Model Context Protocol server. Each tool call runs as the calling user ([architecture](docs/mcp-architecture.md)).
 - **Edges.** Kubernetes clusters and Linux servers join through an agent that dials out. The hub proxies `kubectl`, SSH and selected in-cluster services to them.
 - **A portal.** One web UI that hosts each provider's micro-frontend under the tenant's identity.
@@ -36,7 +36,7 @@ Provider directories are mirrored read-only to `faroshq/provider-*` repositories
                  people · CLI · portal · AI agents (MCP)
                                  │
                         ┌────────▼────────┐
-                        │    faros hub    │   kcp workspaces, OIDC, RBAC,
+                        │    faros hub    │   workspaces, OIDC, RBAC,
                         │                 │   provider registry, proxies
                         └──┬─────┬─────┬──┘
            provider APIs   │     │     │   outbound tunnels
@@ -49,7 +49,7 @@ Provider directories are mirrored read-only to `faroshq/provider-*` repositories
 └────────────┘          └────────────────┘           └─────────────┘
 ```
 
-The hub is the only component that needs to be reachable. Providers register with the hub and serve their APIs inside their own kcp workspace; agents on edges connect outward. Traffic between the hub and everything else is HTTP/1.1 and WebSockets, so any reverse proxy, ingress or tunnel in front of the hub works.
+The hub is the only component that needs to be reachable. Providers register with the hub and serve their APIs inside their own workspace; agents on edges connect outward. Traffic between the hub and everything else is HTTP/1.1 and WebSockets, so any reverse proxy, ingress or tunnel in front of the hub works.
 
 ## Install
 
@@ -61,7 +61,7 @@ helm install faros-hub oci://ghcr.io/faroshq/charts/faros-hub \
   --set hub.hubExternalURL=https://faros.example.com
 ```
 
-That gives you a hub with embedded kcp. For TLS, OIDC, ingress and the provider hardening flags, see [Helm deployment](https://faroshq.github.io/faros/helm.html), [embedded kcp](https://faroshq.github.io/faros/install-embedded-kcp.html) and [external kcp](https://faroshq.github.io/faros/install-external-kcp.html).
+That is a complete single hub; its control-plane store runs inside the same release. For TLS, OIDC, ingress and the provider hardening flags, see [Helm deployment](https://faroshq.github.io/faros/helm.html). Larger installs can run the control-plane store as separate shards: [single hub](https://faroshq.github.io/faros/install-embedded-kcp.html), [multi-shard](https://faroshq.github.io/faros/install-external-kcp.html).
 
 To try faros on a laptop, the CLI can create a local hub in a kind cluster:
 
@@ -155,7 +155,7 @@ To report a vulnerability, open a private security advisory on this repository r
 | Path | Contents |
 |---|---|
 | `cmd/` | `faros` CLI, `faros-hub`, `faros-agent`, GraphQL gateway |
-| `pkg/hub` | Hub: kcp bootstrap, tenancy, provider registry, proxies, MCP aggregation |
+| `pkg/hub` | Hub: control-plane bootstrap, tenancy, provider registry, proxies, MCP aggregation |
 | `pkg/agent` | Edge agent and tunnel |
 | `providers/` | The providers listed above, each its own Go module |
 | `deploy/charts` | Helm charts for the hub and the agent |
@@ -167,9 +167,9 @@ Published: [Getting started](https://faroshq.github.io/faros/getting-started.htm
 
 Design documents in this repository: [providers](docs/providers.md), [organizations and the workspace tree](docs/organizations.md), [provider scoping](docs/provider-scoping.md), [provider actions](docs/provider-actions.md), [BYO providers](docs/byo-providers.md), [MCP architecture](docs/mcp-architecture.md).
 
-## Relationship to kcp and Platform Mesh
+## Under the hood
 
-faros runs on kcp and its author maintains kcp. It shares that substrate, and its GraphQL gateway, with [Platform Mesh](https://github.com/platform-mesh), the SAP and NeoNephos reference architecture. faros is the smaller, opinionated end of that spectrum: a single-binary hub with an agent surface (MCP and actions), providers an organization can run in its own cluster over an edge, and connectivity to clusters and servers built in.
+Workspaces are served by [kcp](https://github.com/kcp-dev/kcp), which gives every tenant a Kubernetes-style API server without a cluster per tenant; providers publish their APIs into it and tenants bind them. You meet this as an operator when you size and back up the hub, and as a provider author when you write one. Users see the portal, the CLI, the API and MCP.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ To report a vulnerability, open a private security advisory on this repository r
 
 | Path | Contents |
 |---|---|
-| `cmd/` | `faros` CLI, `faros-hub`, `faros-agent`, GraphQL gateway |
+| `cmd/` | `faros` CLI (which also runs the agent through `faros agent`), `faros-hub`, the GraphQL gateway, and the release helper |
 | `pkg/hub` | Hub: control-plane bootstrap, tenancy, provider registry, proxies, MCP aggregation |
 | `pkg/agent` | Edge agent and tunnel |
 | `providers/` | The providers listed above, each its own Go module |

--- a/deploy/charts/faros-hub/README.md
+++ b/deploy/charts/faros-hub/README.md
@@ -1,6 +1,6 @@
 # faros-hub Helm Chart
 
-Deploys the faros hub: the control plane that hosts kcp workspaces, authentication, the provider registry, the proxies to providers and edges, and the per-workspace MCP endpoint.
+Deploys the faros hub: the control plane that hosts workspaces, authentication, the provider registry, the proxies to providers and edges, and the per-workspace MCP endpoint.
 
 ## Quick Install
 

--- a/deploy/charts/faros-hub/README.md
+++ b/deploy/charts/faros-hub/README.md
@@ -1,6 +1,6 @@
 # faros-hub Helm Chart
 
-Deploys the faros hub — the central control plane for managing distributed edge clusters and servers.
+Deploys the faros hub: the control plane that hosts kcp workspaces, authentication, the provider registry, the proxies to providers and edges, and the per-workspace MCP endpoint.
 
 ## Quick Install
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: Faros Documentation
-description: Multi-tenant control plane for deploying and managing workloads across distributed edge sites
+description: An open-source control plane for platform teams, built on kcp
 baseurl: "/faros"
 url: "https://faroshq.github.io"
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: Faros Documentation
-description: An open-source control plane for platform teams, built on kcp
+description: An open-source control plane for platform teams
 baseurl: "/faros"
 url: "https://faroshq.github.io"
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ Run a local hub, connect a cluster, and hand a workspace to an AI agent.
 
 ## Overview
 
-This guide uses the CLI's built-in local environment: a kind cluster running the hub with embedded kcp, and optionally a second kind cluster that joins it as an edge. Nothing here is exposed to the internet. For a real install, follow [Helm deployment]({% link helm.md %}) instead; the CLI steps from section 3 onward are the same.
+This guide uses the CLI's built-in local environment: a kind cluster running the hub, and optionally a second kind cluster that joins it as an edge. Nothing here is exposed to the internet. For a real install, follow [Helm deployment]({% link helm.md %}) instead; the CLI steps from section 3 onward are the same.
 
 ## Prerequisites
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,9 +59,10 @@ faros use
 
 ## Step 3: Connect the worker cluster as an edge
 
-Register the edge, then hand its credentials to the agent in the worker cluster. Point `kubectl` at the hub kind cluster for the first two commands; `faros dev init` printed the kubeconfig path.
+Register the edge, then hand its credentials to the agent in the worker cluster. `faros dev init` wrote one kubeconfig per kind cluster into the current directory: `faros-hub.kubeconfig` and `faros-agent.kubeconfig`.
 
 ```bash
+export KUBECONFIG=faros-hub.kubeconfig
 faros edge create local --labels env=dev
 
 # the hub mints a kubeconfig for the edge; extract it
@@ -69,14 +70,14 @@ kubectl get secret -n faros-system edge-local-kubeconfig \
   -o jsonpath='{.data.kubeconfig}' | base64 -d > edge-kubeconfig
 
 # hand it to the worker cluster and install the agent there
-kubectl --context kind-faros-agent create namespace faros-agent
-kubectl --context kind-faros-agent -n faros-agent create secret generic edge-kubeconfig \
+kubectl --kubeconfig faros-agent.kubeconfig create namespace faros-agent
+kubectl --kubeconfig faros-agent.kubeconfig -n faros-agent create secret generic edge-kubeconfig \
   --from-file=kubeconfig=edge-kubeconfig
 
 HUB_IP=$(docker inspect faros-hub-control-plane \
   -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
 helm install faros-agent oci://ghcr.io/faroshq/charts/faros-agent \
-  --kube-context kind-faros-agent -n faros-agent \
+  --kubeconfig faros-agent.kubeconfig -n faros-agent \
   --set agent.edgeName=local \
   --set agent.hub.existingSecret=edge-kubeconfig \
   --set agent.hub.url=https://$HUB_IP:31443 \
@@ -118,7 +119,7 @@ faros dev delete --worker-count 1
 Check the agent's logs on the worker cluster:
 
 ```bash
-kubectl --context kind-faros-agent -n faros-agent logs deploy/faros-agent
+kubectl --kubeconfig faros-agent.kubeconfig -n faros-agent logs deploy/faros-agent
 ```
 
 A certificate error means `agent.hub.insecureSkipTLSVerify` was not set for the self-signed local hub. A connection refused or timeout means `agent.hub.url` is not the hub node's Docker-network address, or the two kind clusters are not on the same network; recreate with `faros dev init`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,13 +2,13 @@
 layout: default
 title: Getting Started
 nav_order: 2
-description: "Set up your first Faros hub and connect an edge"
+description: "Run a local faros hub, connect a cluster, and hand a workspace to an AI agent"
 ---
 
 # Getting Started
 {: .no_toc }
 
-Set up Faros and connect your first cluster in minutes.
+Run a local hub, connect a cluster, and hand a workspace to an AI agent.
 {: .fs-6 .fw-300 }
 
 ## Table of contents
@@ -21,235 +21,119 @@ Set up Faros and connect your first cluster in minutes.
 
 ## Overview
 
-This guide walks you through:
-
-1. Running the hub locally (development mode)
-2. Connecting an edge (k3s, k0s, kind, or any Kubernetes cluster)
-3. Deploying your first workload
-
-For production deployments, see [Helm Deployment]({% link helm.md %}) after completing this guide.
-
----
+This guide uses the CLI's built-in local environment: a kind cluster running the hub with embedded kcp, and optionally a second kind cluster that joins it as an edge. Nothing here is exposed to the internet. For a real install, follow [Helm deployment]({% link helm.md %}) instead; the CLI steps from section 3 onward are the same.
 
 ## Prerequisites
 
-| Tool | Description |
-|:-----|:------------|
-| [Go 1.25+](https://go.dev/doc/install) | Required to build from source |
-| [Docker](https://docs.docker.com/get-docker/) | Container runtime |
-| [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) | Local Kubernetes cluster (for dev mode) |
-| [kubectl](https://kubernetes.io/docs/tasks/tools/) | Kubernetes CLI |
+| Tool | Notes |
+|:-----|:------|
+| [Docker](https://docs.docker.com/get-docker/) | Runs the kind clusters |
+| [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) | Local Kubernetes |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | Talks to the clusters |
+| [Helm](https://helm.sh/docs/intro/install/) 3 | Installs the hub and agent charts |
+| `faros` CLI | A binary from the [releases page](https://github.com/faroshq/faros/releases), or `go install github.com/faroshq/faros/cmd/faros@latest` with Go 1.26+ |
 
----
-
-## Step 1: Build from Source
-
-Clone the repository and build all binaries:
+## Step 1: Create a local hub
 
 ```bash
-git clone https://github.com/faroshq/faros.git
-cd faros
-make build
+faros dev init --worker-count 1
 ```
 
-This builds three binaries in `bin/`:
+This creates two kind clusters on a shared Docker network: `faros-hub`, which runs the hub from the published Helm chart with a self-signed certificate, and `faros-agent`, a plain cluster you will connect as an edge. Leave `--worker-count` off for a hub-only environment. Use `--chart-path deploy/charts/faros-hub` to run the chart from a checkout.
 
-| Binary | Description |
-|:-------|:------------|
-| `faros-hub` | The central control plane server |
-| `faros-agent` | The agent that runs on each edge |
-| `faros` | The CLI for users |
+When it finishes, the command prints the remaining steps with the exact names it used. They are the ones below.
 
----
+The local hub runs in development mode with a static token, `dev-token`. That is fine on a laptop and nowhere else.
 
-## Step 2: Run the Development Stack
+## Step 2: Log in and pick a workspace
 
-The fastest way to try Faros is using the development mode, which runs the full stack locally:
+The hub answers on `https://faros.localhost:9443`. Add the name to `/etc/hosts` once, then log in:
 
 ```bash
-make dev
+echo '127.0.0.1 faros.localhost' | sudo tee -a /etc/hosts
+faros login --hub-url https://faros.localhost:9443 --insecure-skip-tls-verify --token dev-token
+faros use
 ```
 
-This starts:
+`faros use` lists your organizations and workspaces and makes one active. A static-token user gets a personal organization on first login.
 
-- **kcp** — Multi-tenant API server
-- **Dex** — OIDC identity provider
-- **Hub** — Faros control plane
-- **kind cluster** — A local Kubernetes cluster for the agent
+## Step 3: Connect the worker cluster as an edge
 
-{: .note }
-The dev stack uses hot-reload, so code changes are automatically picked up.
-
-Wait until you see the hub is ready:
-
-```
-faros-hub: listening on :9443
-```
-
----
-
-## Step 3: Log In
-
-Open a new terminal and authenticate:
+Register the edge, then hand its credentials to the agent in the worker cluster. Point `kubectl` at the hub kind cluster for the first two commands; `faros dev init` printed the kubeconfig path.
 
 ```bash
-make dev-login
+faros edge create local --labels env=dev
+
+# the hub mints a kubeconfig for the edge; extract it
+kubectl get secret -n faros-system edge-local-kubeconfig \
+  -o jsonpath='{.data.kubeconfig}' | base64 -d > edge-kubeconfig
+
+# hand it to the worker cluster and install the agent there
+kubectl --context kind-faros-agent create namespace faros-agent
+kubectl --context kind-faros-agent -n faros-agent create secret generic edge-kubeconfig \
+  --from-file=kubeconfig=edge-kubeconfig
+
+HUB_IP=$(docker inspect faros-hub-control-plane \
+  -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+helm install faros-agent oci://ghcr.io/faroshq/charts/faros-agent \
+  --kube-context kind-faros-agent -n faros-agent \
+  --set agent.edgeName=local \
+  --set agent.hub.existingSecret=edge-kubeconfig \
+  --set agent.hub.url=https://$HUB_IP:31443 \
+  --set agent.hub.insecureSkipTLSVerify=true
 ```
 
-This opens a browser for OIDC login. Use the development credentials:
-
-- **Email:** `admin@example.com`
-- **Password:** `password`
-
-After login, your kubeconfig is configured with a `faros` context.
-
----
-
-## Step 4: Register an Edge
-
-Create a new edge registration:
+The hub address override is needed because `faros.localhost` resolves only on your machine; inside the Docker network the hub is its kind node's address on NodePort 31443. When the agent connects:
 
 ```bash
-make dev-edge-create
+faros edge list                              # local shows Ready
+faros kubeconfig edge local > local.yaml
+kubectl --kubeconfig local.yaml get nodes    # reaches the worker through the hub
 ```
 
-This creates an `Edge` resource in the hub. You can view it:
+The kubeconfig points at the hub, which proxies to the edge and authorizes each request as you in the workspace. Against a real hub the same registration is one command: `faros edge join-command <name>` prints a Helm install that carries a one-time token.
+
+## Step 4: Hand the workspace to an AI agent
 
 ```bash
-kubectl --context=faros get edges
+faros mcp url --name default
 ```
 
----
+The command prints the workspace's MCP endpoint and configuration snippets for Claude Code and Claude Desktop. Add it, then ask the assistant to list nodes on `local`. Tools from every enabled provider appear on the same endpoint, and every call runs under your identity and RBAC.
 
-## Step 5: Start the Agent
+## Step 5: Enable a provider
 
-Start the agent on the local kind cluster:
+Providers are Helm releases that register with the hub. The [quickstart provider](https://github.com/faroshq/faros/tree/main/providers/quickstart) is the smallest one and a good first install; the [developer guide]({% link developers.md %}) covers installing it into the local environment and writing your own. Once a provider is registered, enable it for the workspace in the portal at `https://localhost:9443` and its APIs and tools appear.
+
+## Step 6: Clean up
 
 ```bash
-make dev-run-edge
+faros dev delete --worker-count 1
 ```
-
-The agent:
-
-1. Connects to the hub via a reverse tunnel
-2. Reports the edge status
-3. Watches for workloads to deploy
-
-Check that the edge shows as connected:
-
-```bash
-kubectl --context=faros get edges
-```
-
-The `READY` column should show `True`.
-
----
-
-## Step 6: Deploy a Workload
-
-Deploy a sample workload:
-
-```bash
-make dev-create-workload
-```
-
-This creates a `VirtualWorkload` resource. The hub schedules it to available sites, creating `Placement` resources:
-
-```bash
-# View the workload
-kubectl --context=faros get virtualworkloads
-
-# View the placement (binding to an edge)
-kubectl --context=faros get placements
-```
-
-The agent picks up the placement and reconciles the actual workload on the kind cluster:
-
-```bash
-kubectl --context=kind-faros-dev get pods
-```
-
----
-
-## What Just Happened?
-
-{% include excalidraw.html file="getting-started-flow.excalidraw" alt="Getting started flow showing workload deployment from hub to agent" %}
-
----
-
-## Connecting Your Own Cluster
-
-To connect a real cluster (k3s, k0s, etc.) instead of the dev kind cluster:
-
-### 1. Create an edge registration
-
-```bash
-faros edge create my-home-server
-```
-
-This outputs a bootstrap token.
-
-### 2. Run the agent
-
-On the target cluster, run the agent with the bootstrap token:
-
-```bash
-faros-agent \
-  --hub-url https://your-hub-url:9443 \
-  --bootstrap-token <token> \
-  --edge-name my-home-server
-```
-
-Or deploy via Helm (see agent chart documentation).
-
-### 3. Verify connection
-
-```bash
-kubectl --context=faros get edges
-```
-
----
-
-## Next Steps
-
-| Guide | Description |
-|:------|:------------|
-| [Security]({% link security.md %}) | Configure authentication — static tokens for personal use, OIDC for teams |
-| [Ingress]({% link ingress/index.md %}) | Expose the hub publicly so remote agents can connect |
-| [Helm Deployment]({% link helm.md %}) | Deploy the hub to a real Kubernetes cluster |
-
----
 
 ## Troubleshooting
 
-### Agent can't connect to hub
+### The edge never becomes Ready
 
-- Check that the hub is reachable from the agent
-- For local dev, both run on the same machine so `localhost` works
-- For remote agents, see [Ingress]({% link ingress/index.md %}) to expose the hub
-
-### Login fails
-
-- Check Dex is running: look for "dex: listening on :5556" in the dev output
-- Check the browser console for OIDC errors
-
-### Workload not deploying
+Check the agent's logs on the worker cluster:
 
 ```bash
-# Check edge status
-kubectl --context=faros describe edge <edge-name>
-
-# Check agent logs
-# (in dev mode, look at the terminal running make dev-run-edge)
-
-# Check placement status
-kubectl --context=faros describe placement <placement-name>
+kubectl --context kind-faros-agent -n faros-agent logs deploy/faros-agent
 ```
 
-### View hub logs
+A certificate error means `agent.hub.insecureSkipTLSVerify` was not set for the self-signed local hub. A connection refused or timeout means `agent.hub.url` is not the hub node's Docker-network address, or the two kind clusters are not on the same network; recreate with `faros dev init`.
 
-In dev mode, logs are printed to the terminal. For Helm deployments:
+### `faros login` says OIDC is not configured
 
-```bash
-kubectl -n faros-system logs -l app.kubernetes.io/name=faros-hub -c hub
-```
+The local hub uses a static token. Pass `--token dev-token`.
+
+### Port 9443 is already in use
+
+Delete any previous environment with `faros dev delete`, or stop whatever is bound to the port, then run `faros dev init` again.
+
+## Next steps
+
+- [Helm deployment]({% link helm.md %}): a real hub with TLS, OIDC and ingress
+- [Security]({% link security.md %}): authentication options and the provider hardening values
+- [MCP architecture]({% link mcp-architecture.md %}): how the endpoint is assembled
+- [Developer guide]({% link developers.md %}): building providers

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,109 +2,66 @@
 layout: default
 title: Home
 nav_order: 1
-description: "Faros - The ultimate home lab tool for managing distributed Kubernetes clusters"
+description: "faros: an open-source control plane for platform teams, built on kcp"
 permalink: /
 ---
 
-# Faros
+# faros
 {: .fs-9 }
 
-The ultimate home lab tool for managing distributed Kubernetes clusters.
+An open-source control plane for platform teams, built on kcp.
 {: .fs-6 .fw-300 }
 
-[Get Started]({% link getting-started.md %}){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Get started]({% link getting-started.md %}){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [View on GitHub](https://github.com/faroshq/faros){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---
 
-## Why Faros?
+## What faros is
 
-Managing multiple Kubernetes clusters across your home lab, remote locations, or edge sites is painful. You end up juggling kubeconfigs, SSH tunnels, VPNs, and port forwards. Faros solves this by providing a single control plane that connects all your clusters through secure reverse tunnels.
+Providers publish Kubernetes-style APIs, versioned actions and MCP tools into isolated tenant workspaces. Users, teams and organizations reach them through one portal, one CLI, one API and one MCP endpoint, and every call is authorized as the caller by the same RBAC. Edges extend the control plane to clusters and servers behind NAT through outbound tunnels.
 
-**Perfect for:**
+faros is alpha software at v0.1.x. There is no hosted service; you run the hub yourself.
 
-- **Home labs** — Manage k3s/k0s clusters on Raspberry Pis, NUCs, or old laptops from anywhere
-- **Remote sites** — Connect clusters behind NAT, firewalls, or without public IPs
-- **Edge deployments** — Deploy workloads to distributed locations with simple placement rules
-- **Small teams** — Multi-tenant workspaces with OIDC authentication
+## How it works
 
-## How It Works
+{% include excalidraw.html file="architecture.excalidraw" alt="faros architecture: hub with kcp workspaces, providers registering with it, and edge agents connecting outward" %}
 
-{% include excalidraw.html file="architecture.excalidraw" alt="Faros architecture diagram showing agents connecting to hub via reverse tunnels" %}
+1. **Run a hub.** One Helm release with embedded kcp, or an external multi-shard kcp for larger installs.
+2. **Enable providers.** Each provider registers with the hub and serves its APIs, portal and MCP tools inside its own workspace. Tenants enable the ones they want.
+3. **Connect edges.** Install the agent on a cluster or server; it dials out to the hub and becomes reachable for `kubectl`, SSH and AI agents.
 
-1. **Deploy a Hub** — Run the Faros hub on any reachable server (cloud VM, VPS, or your main home server)
-2. **Connect Sites** — Install the agent on each cluster; it establishes outbound tunnels to the hub
-3. **Manage Everything** — Use the CLI to deploy workloads, check status, and manage all clusters from one place
-
-## Key Features
+## Key features
 
 | Feature | Description |
 |:--------|:------------|
-| **Reverse tunnels** | Agents connect outbound — no port forwarding, no VPN, no public IPs needed |
-| **Multi-tenant** | Built on [kcp](https://github.com/kcp-dev/kcp) for workspace isolation |
-| **Flexible auth** | OIDC via [Dex](https://github.com/dexidp/dex) or simple static tokens for personal use |
-| **Placement rules** | Deploy workloads to clusters matching labels (location, arch, resources) |
-| **Lightweight** | Works with k3s, k0s, kind, or full Kubernetes |
-| **Simple networking** | HTTP/1.1 + WebSockets — works with any proxy, load balancer, or tunnel |
-
-## Why HTTP/1.1?
-
-Faros intentionally uses HTTP/1.1 with WebSockets for all communication. While HTTP/2 or HTTP/3 offer some benefits, they create significant deployment complexity — especially for home labs and small setups.
-
-With HTTP/1.1:
-
-- **Works everywhere** — Compatible with nginx, Cloudflare, Caddy, HAProxy, and any reverse proxy
-- **Easy debugging** — Standard tools like `curl` and browser DevTools work out of the box
-- **No special configuration** — No need for gRPC passthrough, HTTP/2 termination, or ALPN setup
-- **Tunnel-friendly** — WebSockets work through Cloudflare Tunnel, ngrok, and similar services
-
-This design choice prioritizes ease of deployment over marginal performance gains. For home labs managing a handful of clusters, simplicity wins.
+| **Tenancy** | Organizations, teams and users are [kcp](https://github.com/kcp-dev/kcp) workspaces with first-party membership and roles |
+| **Providers** | Helm-installed extensions: APIs, controllers, a portal micro-frontend, MCP tools and actions; organizations can run their own |
+| **Actions and MCP** | Versioned verbs on resources and one MCP endpoint per workspace, every call authorized as the caller |
+| **Edges** | Outbound agent tunnels for clusters and Linux servers; `kubectl`, SSH and service proxying through the hub |
+| **Auth** | Any OIDC provider, or a static token for a single user |
+| **Plain networking** | HTTP/1.1 and WebSockets only, so any reverse proxy, ingress or tunnel in front of the hub works, and `curl` still debugs it |
 
 ## Components
 
 | Component | Description |
 |:----------|:------------|
-| **Hub** (`faros-hub`) | Central control plane — hosts the API, authentication, tunnel endpoints, and scheduling |
-| **Agent** (`faros-agent`) | Runs on each site — establishes tunnels, reports status, reconciles workloads |
-| **CLI** (`faros`) | User tool — login, register sites, deploy workloads |
-
-## Resources
-
-| Resource | Scope | Description |
-|:---------|:------|:------------|
-| `Site` | Cluster | A connected Kubernetes cluster |
-| `VirtualWorkload` | Namespace | Workload definition with placement rules |
-| `Placement` | Namespace | Binding of a workload to a specific site |
-
----
+| **Hub** (`faros-hub`) | The control plane: kcp bootstrap, authentication, tenancy, provider registry, proxies and the MCP aggregate |
+| **Providers** | Out-of-process extensions installed by Helm; see the [repository](https://github.com/faroshq/faros/tree/main/providers) |
+| **Agent** (`faros-agent`) | Runs on each edge; establishes the tunnel and serves `kubectl`, SSH and service proxying |
+| **CLI** (`faros`) | Log in, pick a workspace, manage edges, print MCP endpoints, run a local environment |
 
 ## Documentation
 
 | Guide | Description |
 |:------|:------------|
-| [Getting Started]({% link getting-started.md %}) | Set up your first hub and connect a site |
-| [Security]({% link security.md %}) | Authentication options — static tokens and OIDC |
-| [Ingress]({% link ingress/index.md %}) | Expose the hub publicly for remote access |
-| [Helm Deployment]({% link helm.md %}) | Production deployment with Helm charts |
+| [Getting started]({% link getting-started.md %}) | Run a local hub, connect a cluster, hand a workspace to an AI agent |
+| [Helm deployment]({% link helm.md %}) | Production deployment, including the provider hardening values |
+| [Install with embedded kcp]({% link install-embedded-kcp.md %}) | Single-hub install behind Gateway API |
+| [Install with external kcp]({% link install-external-kcp.md %}) | Multi-shard kcp for larger installs |
+| [Security]({% link security.md %}) | Static tokens, OIDC, and what the hub does with provider and agent credentials |
+| [Ingress]({% link ingress/index.md %}) | Expose the hub through nginx, Gateway API or Cloudflare Tunnel |
+| [MCP architecture]({% link mcp-architecture.md %}) | How tools from providers and edges become one endpoint |
+| [Developer guide]({% link developers.md %}) | The local kind environment and provider development |
 
----
-
-## Quick Start
-
-```bash
-# Clone and build
-git clone https://github.com/faroshq/faros.git
-cd faros
-make build
-
-# Run the full dev stack locally
-make dev
-
-# In another terminal
-make dev-login           # Authenticate
-make dev-edge-create     # Register an edge
-make dev-run-edge       # Start the edge agent
-make dev-create-workload # Deploy a sample workload
-```
-
-See the [Getting Started guide]({% link getting-started.md %}) for the full walkthrough.
+Design documents live in the repository: [providers](https://github.com/faroshq/faros/blob/main/docs/providers.md), [organizations](https://github.com/faroshq/faros/blob/main/docs/organizations.md), [provider actions](https://github.com/faroshq/faros/blob/main/docs/provider-actions.md), [BYO providers](https://github.com/faroshq/faros/blob/main/docs/byo-providers.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,14 @@
 layout: default
 title: Home
 nav_order: 1
-description: "faros: an open-source control plane for platform teams, built on kcp"
+description: "faros: an open-source control plane for platform teams"
 permalink: /
 ---
 
 # faros
 {: .fs-9 }
 
-An open-source control plane for platform teams, built on kcp.
+An open-source control plane for platform teams.
 {: .fs-6 .fw-300 }
 
 [Get started]({% link getting-started.md %}){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
@@ -25,9 +25,9 @@ faros is alpha software at v0.1.x. There is no hosted service; you run the hub y
 
 ## How it works
 
-{% include excalidraw.html file="architecture.excalidraw" alt="faros architecture: hub with kcp workspaces, providers registering with it, and edge agents connecting outward" %}
+{% include excalidraw.html file="architecture.excalidraw" alt="faros architecture: hub with workspaces, providers registering with it, and edge agents connecting outward" %}
 
-1. **Run a hub.** One Helm release with embedded kcp, or an external multi-shard kcp for larger installs.
+1. **Run a hub.** One Helm release runs everything; larger installs can split the control-plane store into shards.
 2. **Enable providers.** Each provider registers with the hub and serves its APIs, portal and MCP tools inside its own workspace. Tenants enable the ones they want.
 3. **Connect edges.** Install the agent on a cluster or server; it dials out to the hub and becomes reachable for `kubectl`, SSH and AI agents.
 
@@ -35,7 +35,7 @@ faros is alpha software at v0.1.x. There is no hosted service; you run the hub y
 
 | Feature | Description |
 |:--------|:------------|
-| **Tenancy** | Organizations, teams and users are [kcp](https://github.com/kcp-dev/kcp) workspaces with first-party membership and roles |
+| **Tenancy** | Organizations, teams and users each get an isolated workspace, with first-party membership and roles |
 | **Providers** | Helm-installed extensions: APIs, controllers, a portal micro-frontend, MCP tools and actions; organizations can run their own |
 | **Actions and MCP** | Versioned verbs on resources and one MCP endpoint per workspace, every call authorized as the caller |
 | **Edges** | Outbound agent tunnels for clusters and Linux servers; `kubectl`, SSH and service proxying through the hub |
@@ -46,7 +46,7 @@ faros is alpha software at v0.1.x. There is no hosted service; you run the hub y
 
 | Component | Description |
 |:----------|:------------|
-| **Hub** (`faros-hub`) | The control plane: kcp bootstrap, authentication, tenancy, provider registry, proxies and the MCP aggregate |
+| **Hub** (`faros-hub`) | The control plane: authentication, tenancy, provider registry, proxies and the MCP aggregate |
 | **Providers** | Out-of-process extensions installed by Helm; see the [repository](https://github.com/faroshq/faros/tree/main/providers) |
 | **Agent** (`faros-agent`) | Runs on each edge; establishes the tunnel and serves `kubectl`, SSH and service proxying |
 | **CLI** (`faros`) | Log in, pick a workspace, manage edges, print MCP endpoints, run a local environment |
@@ -57,11 +57,11 @@ faros is alpha software at v0.1.x. There is no hosted service; you run the hub y
 |:------|:------------|
 | [Getting started]({% link getting-started.md %}) | Run a local hub, connect a cluster, hand a workspace to an AI agent |
 | [Helm deployment]({% link helm.md %}) | Production deployment, including the provider hardening values |
-| [Install with embedded kcp]({% link install-embedded-kcp.md %}) | Single-hub install behind Gateway API |
-| [Install with external kcp]({% link install-external-kcp.md %}) | Multi-shard kcp for larger installs |
+| [Single hub]({% link install-embedded-kcp.md %}) | One release behind Gateway API, control-plane store included |
+| [Multi-shard]({% link install-external-kcp.md %}) | The control-plane store split into shards for larger installs |
 | [Security]({% link security.md %}) | Static tokens, OIDC, and what the hub does with provider and agent credentials |
 | [Ingress]({% link ingress/index.md %}) | Expose the hub through nginx, Gateway API or Cloudflare Tunnel |
 | [MCP architecture]({% link mcp-architecture.md %}) | How tools from providers and edges become one endpoint |
 | [Developer guide]({% link developers.md %}) | The local kind environment and provider development |
 
-Design documents live in the repository: [providers](https://github.com/faroshq/faros/blob/main/docs/providers.md), [organizations](https://github.com/faroshq/faros/blob/main/docs/organizations.md), [provider actions](https://github.com/faroshq/faros/blob/main/docs/provider-actions.md), [BYO providers](https://github.com/faroshq/faros/blob/main/docs/byo-providers.md).
+Under the hood, workspaces are served by [kcp](https://github.com/kcp-dev/kcp); the [developer guide]({% link developers.md %}) covers what that means for operators and provider authors. Design documents live in the repository: [providers](https://github.com/faroshq/faros/blob/main/docs/providers.md), [organizations](https://github.com/faroshq/faros/blob/main/docs/organizations.md), [provider actions](https://github.com/faroshq/faros/blob/main/docs/provider-actions.md), [BYO providers](https://github.com/faroshq/faros/blob/main/docs/byo-providers.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ faros is alpha software at v0.1.x. There is no hosted service; you run the hub y
 |:----------|:------------|
 | **Hub** (`faros-hub`) | The control plane: authentication, tenancy, provider registry, proxies and the MCP aggregate |
 | **Providers** | Out-of-process extensions installed by Helm; see the [repository](https://github.com/faroshq/faros/tree/main/providers) |
-| **Agent** (`faros-agent`) | Runs on each edge; establishes the tunnel and serves `kubectl`, SSH and service proxying |
+| **Agent** (`faros agent`) | The CLI's agent mode, packaged as the agent image and chart; runs on each edge, establishes the tunnel and serves `kubectl`, SSH and service proxying |
 | **CLI** (`faros`) | Log in, pick a workspace, manage edges, print MCP endpoints, run a local environment |
 
 ## Documentation

--- a/docs/security.md
+++ b/docs/security.md
@@ -25,10 +25,10 @@ Faros supports two authentication methods:
 
 | Method | Use Case | Complexity |
 |:-------|:---------|:-----------|
-| **Static Token** | Personal home labs, development, CI/CD | Simple |
+| **Static Token** | Single user, development, CI | Simple |
 | **OIDC (Dex)** | Teams, production, audit requirements | More setup |
 
-For a single-user home lab, static tokens are the easiest option. For teams or when you need proper user management, use OIDC.
+For a single user or a development hub, static tokens are the easiest option. For teams, or whenever you need per-user identity and audit, use OIDC. Provider and agent credentials, and the hardening values that govern them, are covered in [Helm deployment]({% link helm.md %}).
 
 ---
 
@@ -38,7 +38,7 @@ Static tokens are the simplest way to secure your hub. A pre-shared token grants
 
 ### When to Use
 
-- Personal home lab with a single user
+- A single-user hub
 - Development and testing
 - CI/CD pipelines
 - Quick deployments without OIDC infrastructure

--- a/pkg/cli/cmd/login.go
+++ b/pkg/cli/cmd/login.go
@@ -41,8 +41,9 @@ import (
 	cliauth "github.com/faroshq/faros/pkg/cli/auth"
 )
 
-// DefaultHubURL is the hosted faros hub used when --hub-url is not specified.
-const DefaultHubURL = "https://console.faros.sh"
+// hubURLEnv names the environment variable consulted when --hub-url is not
+// given. There is no hosted faros hub, so there is no built-in default.
+const hubURLEnv = "FAROS_HUB_URL"
 
 func newLoginCommand() *cobra.Command {
 	var (
@@ -57,8 +58,10 @@ func newLoginCommand() *cobra.Command {
 		Short: "Authenticate with the faros hub via OIDC or static token",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if hubURL == "" {
-				hubURL = DefaultHubURL
-				fmt.Printf("Using default hub: %s (override with --hub-url)\n", hubURL)
+				hubURL = strings.TrimSpace(os.Getenv(hubURLEnv))
+			}
+			if hubURL == "" {
+				return fmt.Errorf("no hub configured: pass --hub-url https://<your-hub> or set %s", hubURLEnv)
 			}
 			hubURL = normalizeHubURL(hubURL)
 			if token != "" {
@@ -94,7 +97,7 @@ func newLoginCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&hubURL, "hub-url", "", "Hub server URL (defaults to "+DefaultHubURL+")")
+	cmd.Flags().StringVar(&hubURL, "hub-url", "", "Hub server URL (or set "+hubURLEnv+")")
 	cmd.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate verification")
 	cmd.Flags().StringVar(&token, "token", "", "Static bearer token (skips OIDC browser flow)")
 	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "After login, interactively pick the organization and workspace")

--- a/pkg/cli/cmd/root.go
+++ b/pkg/cli/cmd/root.go
@@ -31,7 +31,7 @@ import (
 func NewRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "faros",
-		Short: "faros: an open-source control plane for platform teams, built on kcp",
+		Short: "faros: an open-source control plane for platform teams",
 		Long: `Faros is an OSS control plane that combines multi-tenant API serving
 with reverse-dialer connectivity mesh and OIDC identity.
 

--- a/pkg/cli/cmd/root.go
+++ b/pkg/cli/cmd/root.go
@@ -31,7 +31,7 @@ import (
 func NewRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "faros",
-		Short: "Faros - workload management across edges",
+		Short: "faros: an open-source control plane for platform teams, built on kcp",
 		Long: `Faros is an OSS control plane that combines multi-tenant API serving
 with reverse-dialer connectivity mesh and OIDC identity.
 

--- a/providers/code/README.md
+++ b/providers/code/README.md
@@ -229,8 +229,8 @@ helm upgrade --install code oci://ghcr.io/faroshq/charts/faros-code-provider:0.0
   --set githubOAuth.clientId=<oauth-app-client-id> \
   --set githubOAuth.clientSecretRef.name=code-github-oauth \
   --set githubOAuth.clientSecretRef.key=clientSecret \
-  --set githubOAuth.redirectURL=https://console.faros.sh/services/providers/code/oauth/github/callback \
-  --set githubOAuth.portalOrigin=https://console.faros.sh
+  --set githubOAuth.redirectURL=https://faros.example.com/services/providers/code/oauth/github/callback \
+  --set githubOAuth.portalOrigin=https://faros.example.com
 ```
 
 Notes:
@@ -246,7 +246,7 @@ Notes:
   container keep `backend.url` in sync with the release namespace automatically.
 - After install, verify the OAuth probe returns `{"enabled":true}`:
   ```sh
-  curl -s https://console.faros.sh/services/providers/code/oauth/github/config
+  curl -s https://faros.example.com/services/providers/code/oauth/github/config
   ```
 
 `values.yaml` documents the full surface — image, replicas, hub URL + token


### PR DESCRIPTION
## Why

Three doors, three products. The README opened with "connects your distributed Kubernetes clusters and servers … no VPNs" and a hosted hub at `console.faros.sh` that does not resolve; the docs index called faros "the ultimate home lab tool" and listed `Site`, `VirtualWorkload` and `Placement`, resources the tree no longer has; the CLI's own description said "workload management across edges". None of them described the kcp-based control plane with providers, actions, per-workspace MCP and edges that actually ships.

## What changes

- **README.md**: rewritten. What faros is in one paragraph, an honest alpha status note, the providers in the tree with one line each, install via the OCI chart, a quickstart that matches the CLI as it is, the security posture and where the hardening values live, an accurate CLI reference, the repository layout, and the relationship to kcp and Platform Mesh in one paragraph.
- **docs/index.md**, **docs/_config.yml**: same story as the README; the stale resource table and home-lab framing are gone; the documentation table lists only pages that exist.
- **docs/getting-started.md**: rebuilt around `faros dev init`, mirroring the steps the command prints (`faros.localhost`, `dev-token`, the edge kubeconfig secret, the hub NodePort on the Docker network) instead of `make dev-*` targets and resources that no longer exist.
- **`faros login`**: no longer defaults to a hosted hub. It takes `--hub-url` or `FAROS_HUB_URL` and otherwise fails with `no hub configured: pass --hub-url https://<your-hub> or set FAROS_HUB_URL`. The root command's short description now matches the README.
- Small wording fixes in `docs/security.md`, the hub chart README, the code provider README's example hostname, and CONTRIBUTING's Go version.

## Not in this PR

- The kcp `ADOPTERS.md` entry still describes "control-plane-as-a-service to access & manage multiple Kubernetes clusters"; that is a PR to kcp-dev/kcp.
- The faros.sh site's headline is in a different repository.
- The GitHub Pages deploy is failing on a pre-existing Jekyll/Ruby incompatibility, so the published docs will not pick this up until that is fixed.

## Verification

`go build ./cmd/faros/`, `go vet ./pkg/cli/cmd/`, `gofmt -l`, and `go test ./pkg/cli/cmd/...` pass locally. Every command and flag named in the README and the guide was checked against `pkg/cli/cmd`; the guide's connect step follows the instructions `faros dev init` prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
