### PR TITLE
Make organization switching and creation easier to discover

### DIFF
--- a/portal/src/components/AccountAccessMenu.vue
+++ b/portal/src/components/AccountAccessMenu.vue
@@ -96,10 +96,10 @@ const orgDetail = computed(() => {
   if (org.personal) return 'Personal organization'
   return org.role === 'admin' ? 'Organization admin' : 'Organization member'
 })
-const organizationDestination = computed(() => tenant.orgs.length > 1
-  ? { path: '/organizations', query: { from: route.fullPath } }
-  : { path: '/settings/organizations' },
-)
+const organizationDestination = computed(() => ({
+  path: '/organizations',
+  query: { from: route.fullPath },
+}))
 const initials = computed(() => {
   const value = email.value === 'Authenticated user' ? '' : email.value
   const parts = value.split(/[@.\s_-]+/).filter(Boolean)

--- a/portal/src/pages/OrganizationsWorkspace.conformance.test.mjs
+++ b/portal/src/pages/OrganizationsWorkspace.conformance.test.mjs
@@ -82,18 +82,16 @@ test('organization settings are scoped to the selected org and gate governance w
   assert.match(orgSection, /v-if="canManageOrg"/)
 })
 
-test('organization metadata links back to the chooser with a scoped return path', () => {
-  const orgSectionStart = tenantSettingsPage.indexOf('<template v-else-if="activeSection === \'organizations\'">')
-  const orgSectionEnd = tenantSettingsPage.indexOf('<!-- Issued-token modal.', orgSectionStart)
-  assert.ok(orgSectionStart >= 0 && orgSectionEnd > orgSectionStart)
-  const orgSection = tenantSettingsPage.slice(orgSectionStart, orgSectionEnd)
-  const linkStart = orgSection.indexOf('<router-link')
-  const dangerStart = orgSection.indexOf('<div v-if="canManageOrg"')
-  assert.ok(linkStart >= 0 && dangerStart > linkStart)
-  const link = orgSection.slice(linkStart, dangerStart)
-  assert.match(link, /:to="\{ path: '\/organizations', query: \{ from: '\/settings\/organizations' \} \}"/)
-  assert.match(link, />\s*Change organization\s*[\s\S]*<ExternalLink/)
-  assert.equal((link.match(/Change organization/g) ?? []).length, 1)
+test('organization switching sits beside the organization name, outside the page header', () => {
+  const header = tenantSettingsPage.slice(tenantSettingsPage.indexOf('<header'), tenantSettingsPage.indexOf('</header>'))
+  assert.doesNotMatch(header, /Switch organization|Switch or create organization/)
+  const titleStart = tenantSettingsPage.indexOf('<h2 id="organization-settings-title"')
+  const identityRow = tenantSettingsPage.slice(titleStart, tenantSettingsPage.indexOf('</div>', titleStart))
+  assert.match(identityRow, /organizationSettingsOrg\.displayName/)
+  assert.match(identityRow, /:to="\{ path: '\/organizations', query: \{ from: '\/settings\/organizations' \} \}"/)
+  assert.match(identityRow, /class="k-btn k-btn--ghost shrink-0"/)
+  assert.match(identityRow, /Switch organization/)
+  assert.doesNotMatch(tenantSettingsPage, /Switch or create organization|>\s*Change organization\s*</)
 })
 
 test('organization settings use the org MemberList contract and lifecycle actions', () => {
@@ -154,7 +152,7 @@ test('account access keeps identity and organization rows compact', () => {
   const identityAndOrganizationRows = accountMenu.slice(identityRow, organizationRow)
   assert.doesNotMatch(identityAndOrganizationRows, /<span class="k-eyebrow">(?:Identity|Organization)<\/span>/)
   assert.doesNotMatch(identityAndOrganizationRows, /h-px bg-border-subtle/)
-  assert.match(accountMenu, /const organizationDestination = computed\(\(\) => tenant\.orgs\.length > 1[\s\S]*\{ path: '\/settings\/organizations' \}/)
+  assert.match(accountMenu, /const organizationDestination = computed\(\(\) => \(\{\s*path: '\/organizations',\s*query: \{ from: route\.fullPath \},\s*\}\)\)/)
   assert.match(memberList, /memberColumns[\s\S]*\{ key: 'actions', label: '', ariaLabel: 'Actions' \}/)
 })
 
@@ -780,11 +778,15 @@ function extractValidatedInternalPath() {
   return new Function(`return ${signature}${body}`)()
 }
 
-test('Account & Access routes zero/one org to settings and many orgs to the chooser', () => {
-  assert.match(accountMenu, /tenant\.orgs\.length > 1/)
-  assert.match(accountMenu, /path: '\/organizations'/)
-  assert.match(accountMenu, /query: \{ from: route\.fullPath \}/)
-  assert.match(accountMenu, /: \{ path: '\/settings\/organizations' \}/)
+test('Account & Access opens the chooser regardless of organization count', () => {
+  const match = accountMenu.match(/const organizationDestination = computed\(\(\) => (\([\s\S]*?\))\)/)
+  assert.ok(match)
+  for (const count of [0, 1, 2]) {
+    const destination = new Function('tenant', 'route', `return ${match[1]}`)(
+      { orgs: Array(count).fill({}) }, { fullPath: '/settings/organizations' },
+    )
+    assert.deepEqual(destination, { path: '/organizations', query: { from: '/settings/organizations' } })
+  }
   assert.match(router, /path: '\/organizations'/)
 })
 

--- a/portal/src/pages/TenantSettingsPage.vue
+++ b/portal/src/pages/TenantSettingsPage.vue
@@ -47,7 +47,6 @@ import {
   Check,
   Copy,
   Download,
-  ExternalLink,
   FolderTree,
   KeyRound,
   Loader2,
@@ -2118,9 +2117,18 @@ function fmtDate(s?: string | null): string {
             <div class="mb-4 flex items-start justify-between gap-3">
               <div class="min-w-0">
                 <p class="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Organization</p>
-                <h2 id="organization-settings-title" class="mt-1 truncate text-lg font-semibold text-text-primary">
-                  {{ organizationSettingsOrg.displayName }}
-                </h2>
+                <div class="mt-1 flex flex-wrap items-center gap-3">
+                  <h2 id="organization-settings-title" class="min-w-0 break-words text-lg font-semibold text-text-primary">
+                    {{ organizationSettingsOrg.displayName }}
+                  </h2>
+                  <router-link
+                    :to="{ path: '/organizations', query: { from: '/settings/organizations' } }"
+                    class="k-btn k-btn--ghost shrink-0"
+                  >
+                    <Building2 class="h-4 w-4" :stroke-width="1.75" aria-hidden="true" />
+                    Switch organization
+                  </router-link>
+                </div>
                 <p class="mt-1 text-[12px] text-text-muted">
                   Organization metadata and lifecycle for this selected organization.
                 </p>
@@ -2199,14 +2207,6 @@ function fmtDate(s?: string | null): string {
                 </button>
               </div>
             </div>
-
-            <router-link
-              class="mt-4 inline-flex items-center gap-1.5 text-[11px] text-text-muted transition-colors hover:text-accent"
-              :to="{ path: '/organizations', query: { from: '/settings/organizations' } }"
-            >
-              Change organization
-              <ExternalLink class="h-3 w-3" :stroke-width="1.75" />
-            </router-link>
 
             <div v-if="canManageOrg" class="mt-4">
               <h3 class="mb-2 text-[10px] font-semibold uppercase tracking-wider text-danger/80">Danger zone</h3>


### PR DESCRIPTION
Users with a single organization were sent to organization settings when clicking their org name, bypassing the picker that offers organization creation. The remaining picker link was small and buried below the display-name field.

Always open the organization picker from the account menu, regardless of org count. Replace the buried settings link with a standard outlined **Switch organization** button beside the organization name; it wraps beneath the name on narrow screens. **Create organization** remains prominent in the picker.

Validation:
- `make build-portal`
- `make verify-design-docs verify-portalkit verify-ui-conformance`
- Updated regression coverage for zero/one/multiple-org routing and button placement.
- Browser checks of the built portal against the local hub API: account menu → picker and settings → picker → creation route; light/dark rendering at 390px, 1440px, and 3840px widths. The local UI endpoint was unavailable, so Chromium served the built assets through request interception while API requests used the local hub.
