### PR TITLE
fix(app-studio): restore project MCP access and scope stop state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,6 +383,15 @@ test:
 test-util:
 	go test ./pkg/util/...
 
+.PHONY: test-app-studio-mcp-access lint-app-studio-mcp-access
+test-app-studio-mcp-access: ## Verify MCP workload authorization and App Studio identity provisioning
+	go test -count=1 ./pkg/hub/mcpaggregate
+	cd providers/app-studio && go test -count=1 ./controller/project ./hubmcp
+
+lint-app-studio-mcp-access: $(GOLANGCI_LINT) ## Lint the MCP authorization integration across both modules
+	$(GOLANGCI_LINT) run ./pkg/hub/mcpaggregate
+	cd providers/app-studio && $(CURDIR)/$(GOLANGCI_LINT) run ./controller/project ./hubmcp
+
 lint: $(GOLANGCI_LINT) ## Run golangci-lint
 	$(GOLANGCI_LINT) run ./...
 

--- a/docs/mcp-architecture.md
+++ b/docs/mcp-architecture.md
@@ -163,13 +163,24 @@ AI client ──Bearer T──▶ hub aggregate VW              (T = the MCPServ
 the per-request server it runs a `TokenReview` in the tenant cluster named by
 the URL and requires the reviewed identity to be that MCPServer's own
 ServiceAccount (`system:serviceaccount:default:{name}-mcp`, the account the
-`MCPServer` controller provisions). A hub user bearer (static token or OIDC,
+`MCPServer` controller provisions). Other authenticated tenant ServiceAccounts
+must pass a `SubjectAccessReview` in that same workspace for verb `use` on
+`faros.sh/mcpservers`, restricted to the requested server name (cluster-scoped,
+no namespace). The review uses the identity, groups, UID and extras returned by
+TokenReview. Access is denied unless explicitly allowed; review failures fail
+closed before any federation. The original caller bearer is still forwarded,
+so this permission grants endpoint admission, not downstream provider rights.
+New App Studio project identities receive `use` on `mcpservers/default`; existing
+identity roles are not migrated by this change.
+
+A hub user bearer (static token or OIDC,
 as used by `faros mcp` and the e2e suites) is accepted instead when the hub's
 normal identity path resolves it and the user holds a live Membership covering
 the cluster's Organization or Workspace per the `UserMembershipIndex`. Anything
 else is answered with `401` (unrecognised) or `403` (valid, but for another
 tenant or MCPServer) and no provider is contacted. Successful verifications
-are cached by `sha256(token)+cluster+name` for 60 seconds, and uncached
+are cached by `sha256(token)+cluster+name` for 60 seconds (including workload
+authorization, so grant revocation takes up to 60 seconds), and uncached
 attempts are rate-limited per client address with the same limiter that
 protects `/api/auth/token-login`, so the endpoint cannot be used as a token
 oracle against providers.

--- a/pkg/hub/mcpaggregate/verifier.go
+++ b/pkg/hub/mcpaggregate/verifier.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	authnv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -85,7 +86,7 @@ var logicalClusterGVR = schema.GroupVersionResource{
 	Group: "core.kcp.io", Version: "v1alpha1", Resource: "logicalclusters",
 }
 
-// Verifier is the production BearerVerifier. It accepts exactly two kinds of
+// Verifier is the production BearerVerifier. It accepts three kinds of
 // bearer:
 //
 //  1. The MCPServer's own ServiceAccount token, which the mcpserver controller
@@ -97,6 +98,9 @@ var logicalClusterGVR = schema.GroupVersionResource{
 //     hub's normal identity path; the CLI's `faros mcp` and the e2e suites
 //     use these. The user must hold a live Membership covering the tenant
 //     the cluster belongs to, per the UserMembershipIndex.
+//  3. Other tenant ServiceAccounts with explicit RBAC permission to use the
+//     named MCPServer. TokenReview authenticates them before SubjectAccessReview
+//     authorizes access; downstream calls retain the original bearer.
 //
 // Signatures and claims are never trusted offline; both paths are online
 // checks against kcp.
@@ -192,8 +196,9 @@ func (v *Verifier) Verify(r *http.Request, token, cluster, mcpServerName string)
 	return v.verifyServiceAccount(ctx, token, cluster, mcpServerName)
 }
 
-// verifyServiceAccount runs a TokenReview in the tenant cluster and requires
-// the reviewed identity to be the MCPServer's own ServiceAccount. No audience
+// verifyServiceAccount runs a TokenReview in the tenant cluster. The server's
+// own identity is accepted; other ServiceAccounts require explicit use access.
+// No audience
 // is requested: the controller mints legacy Secret-backed tokens, which carry
 // the API server's implicit audience only.
 func (v *Verifier) verifyServiceAccount(ctx context.Context, token, cluster, mcpServerName string) error {
@@ -214,8 +219,33 @@ func (v *Verifier) verifyServiceAccount(ctx context.Context, token, cluster, mcp
 	if !review.Status.Authenticated {
 		return ErrUnauthenticated
 	}
-	if review.Status.User.Username != ServiceAccountUsername(mcpServerName) {
-		return fmt.Errorf("%w: reviewed identity %q is not the MCPServer service account", ErrForbidden, review.Status.User.Username)
+	user := review.Status.User
+	if user.Username == ServiceAccountUsername(mcpServerName) {
+		return nil
+	}
+	if !strings.HasPrefix(user.Username, serviceAccountPrefix) {
+		return ErrForbidden
+	}
+	extra := make(map[string]authorizationv1.ExtraValue, len(user.Extra))
+	for key, values := range user.Extra {
+		extra[key] = authorizationv1.ExtraValue(values)
+	}
+	access, err := cs.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User: user.Username, UID: user.UID, Groups: user.Groups, Extra: extra,
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Group: "faros.sh", Resource: "mcpservers", Name: mcpServerName, Verb: "use",
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("authorizing MCPServer use in cluster %q: %w", cluster, err)
+	}
+	if access.Status.EvaluationError != "" {
+		return fmt.Errorf("evaluating MCPServer use: %s", access.Status.EvaluationError)
+	}
+	if !access.Status.Allowed || access.Status.Denied {
+		return fmt.Errorf("%w: reviewed identity %q cannot use MCPServer %q", ErrForbidden, user.Username, mcpServerName)
 	}
 	return nil
 }

--- a/pkg/hub/mcpaggregate/verifier_test.go
+++ b/pkg/hub/mcpaggregate/verifier_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	authnv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -59,6 +60,9 @@ func (f *fakeKCP) clusterConfig(cluster string) *rest.Config {
 func (f *fakeKCP) newClient(cfg *rest.Config) (kubernetes.Interface, error) {
 	cluster := strings.TrimPrefix(cfg.Host, "https://kcp.test/clusters/")
 	cs := kubefake.NewClientset()
+	cs.PrependReactor("create", "subjectaccessreviews", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, &authorizationv1.SubjectAccessReview{}, nil // no explicit workload grants
+	})
 	cs.PrependReactor("create", "tokenreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
 		f.reviews++
 		review := action.(clienttesting.CreateAction).GetObject().(*authnv1.TokenReview)

--- a/pkg/hub/mcpaggregate/workload_authorization_test.go
+++ b/pkg/hub/mcpaggregate/workload_authorization_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpaggregate
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	authnv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestWorkloadMCPAuthorization(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		status        authorizationv1.SubjectAccessReviewStatus
+		reviewErr     error
+		wantErr       bool
+		wantForbidden bool
+	}{
+		{name: "explicit grant", status: authorizationv1.SubjectAccessReviewStatus{Allowed: true}},
+		{name: "no grant", wantErr: true, wantForbidden: true},
+		{name: "explicit denial wins", status: authorizationv1.SubjectAccessReviewStatus{Allowed: true, Denied: true}, wantErr: true, wantForbidden: true},
+		{name: "review outage", reviewErr: errors.New("unavailable"), wantErr: true},
+		{name: "evaluation error", status: authorizationv1.SubjectAccessReviewStatus{Allowed: true, EvaluationError: "authorizer unavailable"}, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			user := authnv1.UserInfo{Username: "system:serviceaccount:default:project", UID: "project-uid", Groups: []string{"system:serviceaccounts"}, Extra: map[string]authnv1.ExtraValue{"scope": {"verified"}}}
+			cs := kubefake.NewClientset()
+			cs.PrependReactor("create", "tokenreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				req := action.(clienttesting.CreateAction).GetObject().(*authnv1.TokenReview)
+				if req.Spec.Token != "project-token" {
+					t.Fatalf("unexpected token review: %#v", req.Spec)
+				}
+				return true, &authnv1.TokenReview{Status: authnv1.TokenReviewStatus{Authenticated: true, User: user}}, nil
+			})
+			checked := false
+			cs.PrependReactor("create", "subjectaccessreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				checked = true
+				req := action.(clienttesting.CreateAction).GetObject().(*authorizationv1.SubjectAccessReview)
+				want := authorizationv1.SubjectAccessReviewSpec{User: user.Username, UID: user.UID, Groups: user.Groups, Extra: map[string]authorizationv1.ExtraValue{"scope": {"verified"}}, ResourceAttributes: &authorizationv1.ResourceAttributes{Group: "faros.sh", Resource: "mcpservers", Name: "default", Verb: "use"}}
+				if !reflect.DeepEqual(req.Spec, want) {
+					t.Fatalf("review = %#v, want %#v", req.Spec, want)
+				}
+				return true, &authorizationv1.SubjectAccessReview{Status: tc.status}, tc.reviewErr
+			})
+			v := NewVerifier(func(cluster string) *rest.Config {
+				if cluster != "tenant-a" {
+					t.Fatalf("unexpected tenant %q", cluster)
+				}
+				return &rest.Config{Host: "https://kcp.test/clusters/tenant-a"}
+			}, WithKubeClientFactory(func(cfg *rest.Config) (kubernetes.Interface, error) {
+				if cfg.Host != "https://kcp.test/clusters/tenant-a" {
+					t.Fatalf("wrong review workspace: %s", cfg.Host)
+				}
+				return cs, nil
+			}))
+			err := v.Verify(request(t, "project-token"), "project-token", "tenant-a", "default")
+			if (err != nil) != tc.wantErr || errors.Is(err, ErrForbidden) != tc.wantForbidden {
+				t.Fatalf("Verify() = %v", err)
+			}
+			if !checked {
+				t.Fatal("workload authorization was skipped")
+			}
+			// Exercise the real handler gate: a denial or review failure must
+			// not even enumerate providers, let alone forward the credential.
+			if tc.wantErr {
+				h := New(Options{Verifier: v, Providers: func(context.Context) []ProviderTarget {
+					t.Fatal("rejected workload reached federation")
+					return nil
+				}})
+				response := toolsList(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					r.URL.Path = "/tenant-a/apis/faros.sh/v1alpha1/mcpservers/default/mcp"
+					h.ServeHTTP(w, r)
+				}), "project-token")
+				wantStatus := http.StatusServiceUnavailable
+				if tc.wantForbidden {
+					wantStatus = http.StatusForbidden
+				}
+				if response.Code != wantStatus {
+					t.Fatalf("handler status = %d, want %d", response.Code, wantStatus)
+				}
+			}
+		})
+	}
+}

--- a/providers/app-studio/controller/project/identity.go
+++ b/providers/app-studio/controller/project/identity.go
@@ -62,6 +62,14 @@ func projectOwnerRef(p *aiv1alpha1.Project) metav1.OwnerReference {
 func (r *Reconciler) ensureIdentity(ctx context.Context, c client.Client, p *aiv1alpha1.Project) (string, error) {
 	rules := []rbacv1.PolicyRule{
 		{
+			// Admission to the aggregate does not grant downstream provider
+			// permissions: federation retains this project's bearer.
+			APIGroups:     []string{"faros.sh"},
+			Resources:     []string{"mcpservers"},
+			ResourceNames: []string{"default"},
+			Verbs:         []string{"use"},
+		},
+		{
 			// Full lifecycle: the reconciler creates, converges, and (on
 			// Project deletion) deletes the project's environment instances.
 			APIGroups: []string{"infrastructure.faros.sh"},

--- a/providers/app-studio/controller/project/identity_test.go
+++ b/providers/app-studio/controller/project/identity_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package project
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	aiv1alpha1 "github.com/faroshq/provider-app-studio/apis/ai/v1alpha1"
+)
+
+func TestNewProjectIdentityMCPGrant(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := rbacv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	p := &aiv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "demo", UID: "project-uid"}}
+	name := identityName(p.Name)
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name + "-token", Namespace: "default"}, Data: map[string][]byte{corev1.ServiceAccountTokenKey: []byte("test-token")}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	r := &Reconciler{}
+	ctx := context.Background()
+	if token, err := r.ensureIdentity(ctx, c, p); err != nil || token != "test-token" {
+		t.Fatalf("ensureIdentity = %q, %v", token, err)
+	}
+	role := &rbacv1.ClusterRole{}
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, role); err != nil {
+		t.Fatal(err)
+	}
+	want := rbacv1.PolicyRule{APIGroups: []string{"faros.sh"}, Resources: []string{"mcpservers"}, ResourceNames: []string{"default"}, Verbs: []string{"use"}}
+	found := 0
+	for _, rule := range role.Rules {
+		if reflect.DeepEqual(rule.APIGroups, []string{"faros.sh"}) {
+			found++
+			if !reflect.DeepEqual(rule, want) {
+				t.Fatalf("unexpected MCP grant: %#v", rule)
+			}
+		}
+	}
+	if found != 1 {
+		t.Fatalf("MCP grants = %d, want one", found)
+	}
+	binding := &rbacv1.ClusterRoleBinding{}
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, binding); err != nil {
+		t.Fatal(err)
+	}
+	if binding.RoleRef.Name != name || !reflect.DeepEqual(binding.Subjects, []rbacv1.Subject{{Kind: "ServiceAccount", Name: name, Namespace: "default"}}) {
+		t.Fatalf("wrong identity binding: %#v", binding)
+	}
+	// Existing roles remain outside the forward-only provisioning contract.
+	role.Rules = nil
+	if err := c.Update(ctx, role); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.ensureIdentity(ctx, c, p); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, role); err != nil {
+		t.Fatal(err)
+	}
+	if len(role.Rules) != 0 {
+		t.Fatal("existing identity was backfilled")
+	}
+}

--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -1028,6 +1028,10 @@ let activeAssistantSubscription: AbortController | null = null
 let activeAssistantRun: AssistantRun | null = null
 const activeAssistantRunRevision = ref(0)
 function setActiveAssistantRun(run: AssistantRun | null) {
+  if (run && assistantStopRequestedRunID.value && assistantStopRequestedRunID.value !== run.id) {
+    assistantStopRequestedRunID.value = ''
+    assistantStopError.value = null
+  }
   activeAssistantRun = run
   activeAssistantRunRevision.value += 1
 }
@@ -2015,6 +2019,29 @@ const assistantResumeBusy = computed(() => Object.keys(permissionBusy.value).len
 // is still in flight; tying the latch to it makes the primary action briefly
 // fall back to Send and then return to Stop.
 const assistantStopRequested = computed(() => Boolean(assistantStopRequestedRunID.value) || assistantPendingStartStopRequested.value)
+
+function resetAssistantStopState() {
+  assistantStopRequestedRunID.value = ''
+  assistantPendingStartStopRequested.value = false
+  assistantStopError.value = null
+  if (conversationStatus.value === 'Stopping') conversationStatus.value = ''
+}
+
+function assistantStopContextFingerprint(ctx: FarosContext | null): string {
+  return JSON.stringify([
+    ctx?.tenant ?? '', ctx?.orgUUID ?? '', ctx?.workspaceUUID ?? '',
+    ctx?.user?.userId ?? '', ctx?.user?.sub ?? '', ctx?.user?.email ?? '',
+  ])
+}
+
+// Keep the stop latch through same-conversation snapshot recovery, but never
+// across project/tenant navigation (including creation and same-name recreation).
+// Token refresh and sub-view navigation do not change conversation ownership.
+watch(
+  [() => assistantStopContextFingerprint(props.ctx), () => selected.value?.uid ?? selected.value?.name ?? ''],
+  () => resetAssistantStopState(),
+  { flush: 'sync' },
+)
 const assistantComposerStopControl = computed(() => assistantComposerStopControlState({
   // activeAssistantRun is intentionally kept outside Vue proxying because it
   // is also the controller's mutable durable snapshot. Its revision makes
@@ -5695,6 +5722,7 @@ async function selectAssistantThread(threadID: string): Promise<boolean> {
     // Do not strand the UI on a target thread until its history has loaded.
     // Commit the selection only after the request succeeds; a failure keeps
     // the prior thread, conversation, stream, and focus valid.
+    resetAssistantStopState()
     assistantRunController.disconnect()
     activeAssistantSubscription?.abort()
     setActiveAssistantRun(null)
@@ -5736,6 +5764,7 @@ async function createAssistantThread() {
   try {
     const thread = await api.createAssistantThread(props.ctx, projectName)
     if (!createIsCurrent()) return
+    resetAssistantStopState()
     assistantThreads.value = [thread, ...assistantThreads.value]
     activeAssistantThreadID.value = thread.id
     persistAssistantThreadFocus(assistantThreadFocusScope(projectName), thread.id)
@@ -7359,6 +7388,8 @@ async function sendMessage(activeRunIntent: 'queue' | 'steer' = 'queue'): Promis
 function cancelMessageStream() {
   const runID = activeAssistantRun?.id
   const projectName = selected.value?.name
+  const stopRequestSerial = assistantThreadRequestSerial
+  const stopContextFingerprint = assistantStopContextFingerprint(props.ctx)
   if (!projectName || assistantRunTerminal(activeAssistantRun?.status)) return
   if (!runID) {
     if (!messageStreaming.value || assistantPendingStartStopRequested.value) return
@@ -7372,11 +7403,17 @@ function cancelMessageStream() {
   assistantStopError.value = null
   conversationStatus.value = 'Stopping'
   void assistantRunController.stop().catch(async (e) => {
+    if (
+      assistantThreadRequestSerial !== stopRequestSerial ||
+      assistantStopContextFingerprint(props.ctx) !== stopContextFingerprint ||
+      selected.value?.name !== projectName ||
+      assistantStopRequestedRunID.value !== runID ||
+      (activeAssistantRun && activeAssistantRun.id !== runID)
+    ) return
     if (assistantStopRequestedRunID.value === runID) assistantStopRequestedRunID.value = ''
     assistantStopError.value = e instanceof Error && e.message.trim()
       ? `Could not stop the response: ${e.message}`
       : 'Could not stop the response. Try again.'
-    if (selected.value?.name !== projectName || activeAssistantRun?.id !== runID) return
     try {
       await recoverAssistantConversation(projectName)
     } catch {

--- a/providers/app-studio/portal/src/conversationResilience.test.mjs
+++ b/providers/app-studio/portal/src/conversationResilience.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 import ts from 'typescript'
-import { computed, ref } from 'vue'
+import { computed, effectScope, ref, watch } from 'vue'
 
 const source = await readFile(new URL('./conversationResilience.ts', import.meta.url), 'utf8')
 const { outputText } = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.ES2022, target: ts.ScriptTarget.ES2022 } })
@@ -10,6 +10,99 @@ const state = await import(`data:text/javascript;base64,${Buffer.from(outputText
 
 const message = (id, content) => ({ id, projectID: 'p', role: 'assistant', content, createdAt: '2026-01-01T00:00:00Z' })
 const snapshot = (revision, content, status = 'running') => ({ run: { id: 'run-1', mode: 'default', status, revision, activeMessageID: 'a-1' }, message: message('a-1', content) })
+
+// Execute the actual App stop-state boundaries with Vue reactivity, without
+// mounting unrelated project/preview services or duplicating their logic.
+async function stopStateHarness(t) {
+  const app = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
+  const script = app.slice(app.indexOf('>', app.indexOf('<script')) + 1, app.indexOf('</script>'))
+  const ast = ts.createSourceFile('App.ts', script, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  const functions = new Set(['setActiveAssistantRun', 'resetAssistantStopState', 'assistantStopContextFingerprint', 'cancelMessageStream'])
+  const statements = ast.statements.filter(node =>
+    ts.isFunctionDeclaration(node) && functions.has(node.name?.text) ||
+    ts.isVariableStatement(node) && node.declarationList.declarations.some(decl => decl.name.getText(ast) === 'assistantStopRequested') ||
+    ts.isExpressionStatement(node) && node.getText(ast).startsWith('watch(') && node.getText(ast).includes('() => resetAssistantStopState()'),
+  )
+  assert.equal(statements.length, 6)
+  const { outputText } = ts.transpileModule(statements.map(node => node.getText(ast)).join('\n'), { compilerOptions: { target: ts.ScriptTarget.ES2022 } })
+  const scope = effectScope()
+  t.after(() => scope.stop())
+  return scope.run(() => new Function('ref', 'computed', 'watch', 'assistantRunTerminal', `
+    const context = ref({ tenant: 'tenant-a', token: 'token-a', subPath: '/project-a' });
+    const props = { get ctx() { return context.value; } };
+    const selected = ref({ name: 'project-a', uid: 'uid-a' });
+    const assistantStopRequestedRunID = ref('');
+    const assistantPendingStartStopRequested = ref(false);
+    const assistantStopError = ref(null);
+    const conversationStatus = ref('');
+    const messageStreaming = ref(true);
+    const activeAssistantRunRevision = ref(0);
+    let activeAssistantRun = null;
+    let assistantThreadRequestSerial = 0;
+    let rejectStop;
+    let recovered = 0;
+    const assistantRunController = { stop: () => new Promise((_, reject) => { rejectStop = reject; }) };
+    const recoverAssistantConversation = async () => { recovered++; };
+    ${outputText}
+    return { selected, context, assistantStopRequested, assistantStopRequestedRunID,
+      assistantPendingStartStopRequested, assistantStopError, conversationStatus,
+      setActiveAssistantRun, resetAssistantStopState, cancelMessageStream,
+      rejectStop: () => rejectStop(new Error('network failure')),
+      recovered: () => recovered };
+  `)(ref, computed, watch, state.assistantRunTerminal))
+}
+
+test('stopping survives recovery but cannot follow project, tenant or run replacement', async t => {
+  for (const transition of ['project', 'recreated project', 'tenant', 'new run']) {
+    const h = await stopStateHarness(t)
+    h.setActiveAssistantRun({ id: 'run-a', status: 'running' })
+    h.cancelMessageStream()
+    assert.equal(h.assistantStopRequested.value, true)
+    h.context.value.token = 'refreshed-token'
+    h.context.value.subPath = '/project-a/settings'
+    assert.equal(h.assistantStopRequested.value, true, 'token refresh and sub-view navigation preserve ownership')
+    h.setActiveAssistantRun(null)
+    assert.equal(h.assistantStopRequested.value, true, 'same-conversation recovery stays latched')
+    h.setActiveAssistantRun({ id: 'run-a', status: 'running' })
+    if (transition === 'project') h.selected.value = { name: 'project-b', uid: 'uid-b' }
+    if (transition === 'recreated project') h.selected.value = { name: 'project-a', uid: 'uid-new' }
+    if (transition === 'tenant') h.context.value.tenant = 'tenant-b'
+    if (transition !== 'new run') assert.equal(h.assistantStopRequested.value, false, `${transition} clears immediately`)
+    h.setActiveAssistantRun({ id: 'run-b', status: 'running' })
+    assert.equal(h.assistantStopRequested.value, false, transition)
+    h.rejectStop()
+    await new Promise(resolve => setImmediate(resolve))
+    assert.equal(h.assistantStopError.value, null, 'late error must not enter the new conversation')
+    assert.equal(h.recovered(), 0)
+  }
+})
+
+test('pending-start stop clears on navigation and same-conversation stop failure remains actionable', async t => {
+  const h = await stopStateHarness(t)
+  h.cancelMessageStream()
+  assert.equal(h.assistantPendingStartStopRequested.value, true)
+  h.selected.value = { name: 'project-b', uid: 'uid-b' }
+  assert.equal(h.assistantPendingStartStopRequested.value, false)
+  assert.equal(h.conversationStatus.value, '')
+  h.setActiveAssistantRun({ id: 'run-b', status: 'running' })
+  h.cancelMessageStream()
+  h.setActiveAssistantRun(null)
+  h.rejectStop()
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(h.assistantStopRequested.value, false)
+  assert.match(h.assistantStopError.value, /Could not stop the response: network failure/)
+  assert.equal(h.recovered(), 1)
+})
+
+test('committed thread switches and thread creation clear their local stop state', async () => {
+  const app = await readFile(new URL('./App.vue', import.meta.url), 'utf8')
+  const select = app.slice(app.indexOf('async function selectAssistantThread('), app.indexOf('async function createAssistantThread('))
+  const create = app.slice(app.indexOf('async function createAssistantThread('), app.indexOf('function beginAssistantThreadTitleRename('))
+  assert.ok(select.indexOf('resetAssistantStopState()') > select.indexOf('await api.listAssistantThreadItemPage'))
+  assert.ok(select.indexOf('resetAssistantStopState()') < select.indexOf('activeAssistantThreadID.value = threadID'))
+  assert.ok(create.indexOf('resetAssistantStopState()') > create.indexOf('if (!createIsCurrent()) return'))
+  assert.ok(create.indexOf('resetAssistantStopState()') < create.indexOf('activeAssistantThreadID.value = thread.id'))
+})
 
 test('start fingerprint changes with one-turn skill, resource, and inline-part selections', () => {
   const base = { content: 'inspect this', collaborationMode: 'default' }


### PR DESCRIPTION
PR #629 correctly added authentication before MCP federation, but its service-account branch only accepted the MCPServer's own identity. App Studio's background Git convergence uses a project service account, so a valid project token began receiving 403 at MCP initialization.

This change admits additional service accounts only after tenant-scoped TokenReview and an explicit SubjectAccessReview allowing `use` on the requested `faros.sh/mcpservers` resource name. The review uses the authenticated username, UID, groups and extras. Denials, contradictory allow/deny responses, review outages and evaluation errors fail closed before provider enumeration or federation. The original caller bearer remains unchanged downstream. Existing MCPServer-token and hub-user membership paths remain intact.

New App Studio project identities receive only `use` on `mcpservers/default`, in addition to their existing provider permissions. This is forward-only: existing roles are not backfilled, no shared MCP credentials are copied, and no naming-prefix exception bypasses authorization. The existing successful-verification cache remains 60 seconds, including the bound on grant revocation.

The portal also fixes a separate stop-state leak between conversations. A local stop request for one project could leave a new project's running turn labeled "Stopping". Stop state now clears on project/tenant identity changes, committed thread switches and thread creation, and adoption of a different run. Late stop failures are ignored after their conversation becomes stale. Same-conversation recovery retains the stop latch, and token refresh or sub-view navigation does not clear it.

Validation:

- `make test-app-studio-mcp-access` passed: hub aggregate tests and App Studio project-controller tests, including real handler rejection before federation and new-project-only role provisioning.
- Existing Actions URL tests passed: missing/invalid origins are rejected for action grants before mutation, while actionless projects remain supported. That guard already exists and is unchanged.
- Live Tilt, new project `codex-mcp-use-0907`: automatically generated the narrow grant; MCP initialization returned 200. An ungranted project, a different MCPServer and a different tenant returned 403; an invalid token returned 401.
- Removed the test project's downstream repository permissions while retaining MCP admission: Code denied checkout as the original project service account. Removed its MCP grant: initialization returned 403 after the 60-second cache expired. Restored the original test role afterward.
- App Studio's background controller committed nine scaffold files to the private verification repository; verified GitHub commit `96fa03eff1213dc6d8b38365c8e374855ee281fb` in `cwilhit/codex-mcp-use-0907`.
- Portal stop-state regression tests execute the actual App state boundaries with Vue reactivity: project switch, same-name recreation, tenant switch, different run, pending-start stop, transient run loss, late rejection, and actionable same-conversation failure. Thread-switch and thread-creation wiring are checked. Conversation resilience, plan-popover and thread-projection suites pass.
- Portal typecheck, production build/bundle budget, `make verify-design-docs`, `make verify-portalkit`, and `make verify-ui-conformance` pass. The stop-label fix is verified through reactive state tests and compilation; a mounted browser reproduction was not run.

Verification limitations:

- Hub package lint passed. The focused provider lint reports four pre-existing issues, confirmed on the base revision: unchecked response-body close in `hubmcp/client.go` and three capitalized error messages in `controller/project/controller.go`. Root `make fix-lint` and `make lint` cannot typecheck `./...` because this checkout has a nested dependency cache under `hack/tools/dev-cache/go-mod` outside the selected modules.
- Full preview readiness is not claimed. The existing Tilt KRO `simple-webapp` graph is Inactive: its CRD upgrade rejects removal of `farosConnectionsSecretName` and `farosConnectionsRevision`. The test runtime therefore remains Pending despite successful MCP authorization and Git convergence. This predates the authorization change and is not modified here.
- Code and Infrastructure dev kubeconfigs were refreshed with their standard Tilt init tasks after hub rebuilds. Verification projects are retained for inspection; existing application identities were not migrated.
