### PR TITLE
fix(hub): authenticate workload catalog reads for Actions SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,10 @@ test:
 test-util:
 	go test ./pkg/util/...
 
-.PHONY: test-app-studio-mcp-access lint-app-studio-mcp-access
+.PHONY: test-provider-catalog-auth test-app-studio-mcp-access lint-app-studio-mcp-access
+test-provider-catalog-auth: ## Verify tenant-scoped workload catalog authentication
+	go test -count=1 ./pkg/hub -run 'TestProviderCatalog|TestKCPTenantResolver'
+	go test -count=1 ./pkg/hub/tenant ./pkg/hub/providers ./pkg/hub/serviceaccounts
 test-app-studio-mcp-access: ## Verify MCP workload authorization and App Studio identity provisioning
 	go test -count=1 ./pkg/hub/mcpaggregate
 	cd providers/app-studio && go test -count=1 ./controller/project ./hubmcp

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -247,6 +247,15 @@ retained historical proposal in
 
 ### Provider Actions
 
+Authenticated workload callers can read `GET /api/providers` to validate action
+grants against the live catalog. The hub verifies their bearer online with the
+workload audience in the selected tenant workspace and checks the backing
+ServiceAccount. Delegated user identities also require the hub's signed proof.
+Catalog visibility is scoped to the verified organization; this read does not
+grant a membership role, mutation access, or bypass action authorization.
+Anonymous callers remain rejected, and human catalog discovery retains its
+optional-organization behavior.
+
 Provider Actions extends the isolation boundary with catalog-declared,
 versioned capabilities served on the provider's **embedded virtual
 workspace** — the same resource-addressed data-plane shape as the

--- a/pkg/hub/provider_catalog_auth.go
+++ b/pkg/hub/provider_catalog_auth.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hub
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/faroshq/faros/pkg/hub/tenant"
+)
+
+// providerCatalogMiddleware admits online-verified workload/delegated tokens
+// only to the read-only catalog. It does not turn them into human sessions or
+// assign a membership role. Human callers retain the existing optional-org flow.
+func providerCatalogMiddleware(human func(http.Handler) http.Handler, verify func(*http.Request) (string, string, error)) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fallback := human(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet && r.URL.Path == "/api/providers" {
+				user, path, err := verify(r)
+				parts := strings.Split(path, ":")
+				if err == nil && user != "" && len(parts) == 5 && strings.Join(parts[:3], ":") == workspacePathRoot && parts[3] != "" && parts[4] != "" {
+					tc := tenant.TenantContext{User: user, OrgUUID: parts[3], WorkspaceUUID: parts[4]}
+					next.ServeHTTP(w, r.WithContext(tenant.WithContext(r.Context(), tc)))
+					return
+				}
+			}
+			fallback.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/hub/provider_catalog_auth_test.go
+++ b/pkg/hub/provider_catalog_auth_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hub
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/faroshq/faros/pkg/hub/tenant"
+)
+
+func TestProviderCatalogPreservesHumanMiddleware(t *testing.T) {
+	called := false
+	human := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			next.ServeHTTP(w, r.WithContext(tenant.WithContext(r.Context(), tenant.TenantContext{User: "human"})))
+		})
+	}
+	handler := providerCatalogMiddleware(human, func(*http.Request) (string, string, error) {
+		return "", "", errors.New("not a workload token")
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tc, _ := tenant.FromContext(r.Context())
+		if tc.User != "human" || tc.OrgUUID != "" {
+			t.Errorf("human context changed: %#v", tc)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/providers", nil))
+	if !called || w.Code != http.StatusNoContent {
+		t.Fatalf("human middleware not preserved: called=%v status=%d", called, w.Code)
+	}
+}
+
+func TestProviderCatalogWorkloadAuthentication(t *testing.T) {
+	for _, tc := range []struct {
+		name, token, org, workspace, method, path string
+		delegated, forged, allowed                bool
+	}{
+		{name: "workload", token: "runtime", org: "org", workspace: "workspace", allowed: true},
+		{name: "delegated", token: "runtime", org: "org", workspace: "workspace", delegated: true, allowed: true},
+		{name: "forged delegated", token: "runtime", org: "org", workspace: "workspace", delegated: true, forged: true},
+		{name: "wrong tenant", token: "runtime", org: "other", workspace: "workspace"},
+		{name: "missing workspace", token: "runtime", org: "org"},
+		{name: "invalid token", token: "invalid", org: "org", workspace: "workspace"},
+		{name: "anonymous", org: "org", workspace: "workspace"},
+		{name: "no mutations", token: "runtime", org: "org", workspace: "workspace", method: http.MethodPost},
+		{name: "no other routes", token: "runtime", org: "org", workspace: "workspace", path: "/api/other"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := workloadResolverRoundTripper{token: "runtime", serviceAccount: "faros-wi-test", tenantPath: "root:faros:tenants:org:workspace", forged: tc.forged}
+			if tc.delegated {
+				transport.delegatedUser = "alice"
+			}
+			resolver := &kcpTenantResolver{workloadConfig: &resolverConfigBuilder{cfg: &rest.Config{Host: "https://workload.test", Transport: transport}}, proofKeys: resolverProofKeys}
+			human := func(http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusUnauthorized) })
+			}
+			handler := providerCatalogMiddleware(human, resolver.resolveWorkloadServiceAccount)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				context, ok := tenant.FromContext(r.Context())
+				if !ok || context.OrgUUID != "org" || context.WorkspaceUUID != "workspace" || context.Role != "" {
+					t.Errorf("unexpected tenant context: %#v", context)
+				}
+				if r.Header.Get("Authorization") != "Bearer runtime" {
+					t.Error("bearer changed")
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			method, path := tc.method, tc.path
+			if method == "" {
+				method = http.MethodGet
+			}
+			if path == "" {
+				path = "/api/providers"
+			}
+			r := httptest.NewRequest(method, path, nil)
+			if tc.token != "" {
+				r.Header.Set("Authorization", "Bearer "+tc.token)
+			}
+			r.Header.Set("X-Faros-Org", tc.org)
+			r.Header.Set("X-Faros-Workspace", tc.workspace)
+			r.Header.Set("X-Faros-Tenant", "root:faros:tenants:spoofed:workspace")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+			want := http.StatusUnauthorized
+			if tc.allowed {
+				want = http.StatusNoContent
+			}
+			if w.Code != want {
+				t.Fatalf("status = %d, want %d", w.Code, want)
+			}
+		})
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -730,12 +730,14 @@ func (s *Server) Run(ctx context.Context) error {
 			// endpoint with their own bearer, gated on tenant membership.
 			mcpVerifier.SetUserIdentity(kcpProxy.IdentifyUser, membershipLookup.GetUserMembershipIndex)
 
-			// GET /api/providers: authenticated, Org optional. The catalog
+			// GET /api/providers: human callers have optional Org selection.
+			// Workload callers require online verification in a concrete tenant
+			// (middleware installed below after the proof keys are available).
+			// The catalog
 			// describes what this deployment runs, so it is not enumerable
 			// anonymously; the Org is optional because the portal fetches it
 			// before one is selected, and an Org only takes effect once the
 			// caller's membership in it is verified.
-			providerListHandler.SetMiddleware(tenant.OptionalOrgMiddleware(userResolver, membershipLookup))
 
 			// Wire the backend-proxy tenant resolver. With this in place
 			// every authenticated request to /services/providers/{name}/*
@@ -756,6 +758,11 @@ func (s *Server) Run(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("creating delegated-identity proof key source: %w", err)
 			}
+			catalogWorkloads := &kcpTenantResolver{workloadConfig: bootstrapper, proofKeys: delegatedProofKeys}
+			providerListHandler.SetMiddleware(providerCatalogMiddleware(
+				tenant.OptionalOrgMiddleware(userResolver, membershipLookup),
+				catalogWorkloads.resolveWorkloadServiceAccount,
+			))
 			backendProxy.SetTenantResolver(newKCPTenantResolver(kcpProxy, userClient, bootstrapper, delegatedProofKeys))
 			// Inject X-Faros-Cluster (the resolved tenant's logical-cluster
 			// ID) so providers can address per-workspace surfaces that key on


### PR DESCRIPTION
## Summary

Fix the hub catalog authentication failure that prevented generated apps from invoking Provider Actions through the Actions SDK.

App Studio revalidates a persisted action grant against the live `/api/providers` catalog before forwarding an invocation. Workload tokens already passed the provider proxy's tenant-scoped authentication, but the catalog used human-only optional-organization middleware. The catalog returned 401, App Studio returned 503, and generated API handlers surfaced a generic 502.

## Change and security boundaries

- Add catalog-specific middleware that reuses the existing online workload ServiceAccount verifier (audience-bound TokenReview, selected tenant, backing ServiceAccount checks, and signed proof for delegated user identities).
- Restrict workload admission to `GET /api/providers`; derive catalog organization/workspace context from the verified tenant path, not spoofable identity headers.
- Preserve the existing human optional-organization flow. Do not assign a membership role or widen mutation access.
- Preserve action grant, schema-digest, bound-resource, downstream authorization, and TLS checks. Forward the original bearer unchanged.
- Document the catalog authentication contract and add a focused Makefile verification target.

## Verification

- `make test-provider-catalog-auth` passed on the clean main-based PR branch: focused hub tests plus tenant, provider, and ServiceAccount suites.
- `make fix-lint` and `make lint` passed with zero issues, reusing the repository-pinned golangci-lint binary; `git diff --check` passed.
- Coverage includes workload and delegated identities, forged delegated proof, wrong tenant, missing workspace, invalid/absent bearer, non-GET/other-route rejection, original bearer preservation, and human middleware continuity.
- Live Tilt: existing workload catalog request returned 200; wrong-workspace and anonymous requests returned 401.
- Live bounded SDK invocation from the existing app runtime returned action version v1 and one Databricks row with the authoritative four-column schema. No row values or credentials were printed.
- Subsequently, App Studio repaired its own generated projection/mapping; independent verification of its `/api/reviews?limit=1` returned 200 and one row. Assistant completion/browser verification remained affected by model rate limits and a preview-URL issue; this is not a claim of full UI acceptance.

## Scope and operational prerequisites

This PR contains no Tiltfile changes, `.env` files, cluster-specific URLs, CA paths, generated application code, resource cleanup, or unrelated checkout changes.

Live verification also required local configuration to use a reachable, certificate-verified HTTPS hub origin for server-side forwarding and the supported CA bundle for runtime token exchange. Those operator settings remain local and are intentionally excluded. The catalog fix does not replace correct deployment URL/TLS configuration.
