### PR TITLE
fix(app-studio): render the attachment quota as digits, not a float

### DIFF
--- a/providers/app-studio/chart_attachment_quota_test.go
+++ b/providers/app-studio/chart_attachment_quota_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Helm decodes bare YAML integers as float64, so the shipped default of
+// 1073741824 used to render as "1.073741824e+09" and the provider refused to
+// start ("attachment quota must be a non-negative byte count or IEC value").
+// Integers must reach the container as plain digits; IEC strings and zero
+// must pass through; a null must emit no env var at all.
+func TestChartAttachmentQuotaRendersIntegersAsDigits(t *testing.T) {
+	helm, err := exec.LookPath("helm")
+	if err != nil {
+		t.Skip("helm is not installed")
+	}
+	render := func(t *testing.T, args ...string) string {
+		t.Helper()
+		full := append([]string{"template", "app-studio", "deploy/chart"}, args...)
+		output, err := exec.Command(helm, full...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("helm template %v: %v\n%s", args, err, output)
+		}
+		return string(output)
+	}
+	const envName = "name: APP_STUDIO_ATTACHMENT_WORKSPACE_QUOTA_BYTES"
+	envLine := func(value string) string {
+		return envName + "\n              value: " + value
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "shipped default", want: envLine(`"1073741824"`)},
+		{name: "large integer override", args: []string{"--set", "store.attachmentWorkspaceQuotaBytes=5368709120"}, want: envLine(`"5368709120"`)},
+		{name: "iec string override", args: []string{"--set-string", "store.attachmentWorkspaceQuotaBytes=1Gi"}, want: envLine(`"1Gi"`)},
+		{name: "zero disables the limit", args: []string{"--set", "store.attachmentWorkspaceQuotaBytes=0"}, want: envLine(`"0"`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rendered := render(t, tc.args...)
+			if !strings.Contains(rendered, tc.want) {
+				t.Fatalf("render %v lacks %q\n%s", tc.args, tc.want, excerpt(rendered, envName))
+			}
+			if strings.Contains(rendered, "e+") && strings.Contains(excerpt(rendered, envName), "e+") {
+				t.Fatalf("render %v emitted a float in scientific notation\n%s", tc.args, excerpt(rendered, envName))
+			}
+		})
+	}
+
+	for _, args := range [][]string{
+		{"--set", "store.attachmentWorkspaceQuotaBytes=null"},
+		{"--set-string", "store.attachmentWorkspaceQuotaBytes="},
+	} {
+		if rendered := render(t, args...); strings.Contains(rendered, envName) {
+			t.Fatalf("override %v emitted %s; an unset quota must leave the provider default in force\n%s", args, envName, excerpt(rendered, envName))
+		}
+	}
+}
+
+// excerpt returns the line containing marker plus the following line, so a
+// failure shows the rendered env var rather than the whole manifest.
+func excerpt(rendered, marker string) string {
+	lines := strings.Split(rendered, "\n")
+	for i, line := range lines {
+		if strings.Contains(line, marker) && i+1 < len(lines) {
+			return line + "\n" + lines[i+1]
+		}
+	}
+	return "(env var not rendered)"
+}

--- a/providers/app-studio/deploy/chart/templates/deployment.yaml
+++ b/providers/app-studio/deploy/chart/templates/deployment.yaml
@@ -205,9 +205,17 @@ spec:
             - name: APP_STUDIO_ATTACHMENT_DRAFT_RETENTION
               value: {{ .Values.store.attachmentDraftRetention | quote }}
             {{- end }}
-            {{- if ne (toString .Values.store.attachmentWorkspaceQuotaBytes) "" }}
+            {{- /* Helm decodes bare YAML integers as float64, so a byte count such
+                 as 1073741824 would render as "1.073741824e+09" and the provider
+                 refuses to start. Integers are rendered as plain digits; strings
+                 such as "1Gi" pass through untouched. */}}
+            {{- $attachmentQuota := .Values.store.attachmentWorkspaceQuotaBytes }}
+            {{- if or (kindIs "float64" $attachmentQuota) (kindIs "int64" $attachmentQuota) (kindIs "int" $attachmentQuota) }}
+            {{- $attachmentQuota = printf "%d" (int64 $attachmentQuota) }}
+            {{- end }}
+            {{- if and (not (kindIs "invalid" $attachmentQuota)) (ne (toString $attachmentQuota) "") }}
             - name: APP_STUDIO_ATTACHMENT_WORKSPACE_QUOTA_BYTES
-              value: {{ .Values.store.attachmentWorkspaceQuotaBytes | quote }}
+              value: {{ $attachmentQuota | quote }}
             {{- end }}
             {{- if .Values.store.messageEncryptionKeysSecretRef.name }}
             - name: APP_STUDIO_MESSAGE_ENCRYPTION_KEYS


### PR DESCRIPTION
## Problem

The app-studio provider chart 0.1.15 never deploys. The pod exits at startup with

```
attachment workspace quota: attachment quota must be a non-negative byte count or IEC value
```

`values.yaml` sets `store.attachmentWorkspaceQuotaBytes: 1073741824` as a bare integer. Helm decodes bare YAML integers as float64 and the template pipes it through `quote`, so the container receives `APP_STUDIO_ATTACHMENT_WORKSPACE_QUOTA_BYTES="1.073741824e+09"`. The parser only accepts digits or an IEC suffix. Every Flux upgrade in faros-dev timed out after 5 minutes and rolled back to 0.1.13; the HelmRelease is now stalled. The same default is on main, so 0.1.16 would fail identically.

## Fix

- `deployment.yaml`: numeric quota values render through `printf "%d" (int64 ...)`; strings such as `"1Gi"` pass through untouched; a null emits no env var instead of `"<nil>"`.
- `chart_attachment_quota_test.go`: renders the chart for the shipped default, a large integer, an IEC string, zero, null and empty, and asserts the env value. It fails on the previous template.

## Verification

```
helm template t providers/app-studio/deploy/chart | grep -A1 ATTACHMENT_WORKSPACE_QUOTA_BYTES
  value: "1073741824"
helm lint providers/app-studio/deploy/chart   # 0 failed
go test ./ -run TestChart                     # ok (providers/app-studio)
```

Operators on 0.1.15 can work around it today by setting the value as a string in their HelmRelease, e.g. `attachmentWorkspaceQuotaBytes: "1Gi"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)