### PR TITLE
fix(app-studio): select the caller's workspace on data-plane calls

### DIFF
--- a/providers/app-studio/api/dataplane_client.go
+++ b/providers/app-studio/api/dataplane_client.go
@@ -98,6 +98,20 @@ func (s *Server) newDataPlaneRequest(ctx context.Context, method string, id iden
 	if token := strings.TrimSpace(id.token); token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
+	// The hub's provider proxy resolves the caller's scope from these headers
+	// exactly as it does for the portal. An org-owned (BYO) infrastructure
+	// provider is reached over the edge tunnel with a delegated token minted
+	// in the selected workspace, and the hub refuses that call with
+	// "a workspace selection (X-Faros-Workspace) is required" when the
+	// selection is missing. Without them every sandbox sync, exec, restart and
+	// log fetch against a tenant-hosted runtime fails with that 403 while the
+	// preview edge itself stays reachable.
+	if org := strings.TrimSpace(id.orgUUID); org != "" {
+		req.Header.Set("X-Faros-Org", org)
+	}
+	if ws := strings.TrimSpace(id.workspaceUUID); ws != "" {
+		req.Header.Set("X-Faros-Workspace", ws)
+	}
 	return req, nil
 }
 

--- a/providers/app-studio/api/dataplane_client_test.go
+++ b/providers/app-studio/api/dataplane_client_test.go
@@ -62,3 +62,44 @@ func TestNewDataPlaneRequestRequiresHubAndCluster(t *testing.T) {
 		t.Fatalf("Authorization = %q, want Bearer tok", got)
 	}
 }
+
+// The hub resolves a provider call's scope from X-Faros-Org and
+// X-Faros-Workspace. An org-owned infrastructure provider is reached with a
+// delegated token minted in that workspace, so a data-plane request without
+// the selection is refused with "a workspace selection (X-Faros-Workspace) is
+// required to reach provider: infrastructure" — which is exactly what every
+// sandbox sync, exec and restart returned once the infrastructure provider
+// moved into a tenant cluster.
+func TestNewDataPlaneRequestSelectsTheCallerWorkspace(t *testing.T) {
+	s := &Server{hubBase: "https://hub.example"}
+	ref := dataPlaneRef{Resource: "instances", Name: "pitch-dev", Component: "app"}
+	req, err := s.newDataPlaneRequest(context.Background(), http.MethodPost, identity{
+		clusterID:     "c1",
+		token:         "tok",
+		orgUUID:       " org-1 ",
+		workspaceUUID: "ws-1",
+	}, ref, dataPlaneVerbSync, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := req.Header.Get("X-Faros-Org"); got != "org-1" {
+		t.Errorf("X-Faros-Org = %q, want org-1", got)
+	}
+	if got := req.Header.Get("X-Faros-Workspace"); got != "ws-1" {
+		t.Errorf("X-Faros-Workspace = %q, want ws-1", got)
+	}
+
+	// An org-only identity sends no workspace header rather than an empty one:
+	// the hub treats a present-but-empty header as an org-scope selection too,
+	// but an absent header keeps the request identical to today's for callers
+	// that never had a workspace.
+	req, err = s.newDataPlaneRequest(context.Background(), http.MethodGet, identity{clusterID: "c1", token: "tok"}, ref, dataPlaneVerbLog, "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, header := range []string{"X-Faros-Org", "X-Faros-Workspace"} {
+		if _, present := req.Header[header]; present {
+			t.Errorf("%s set on an identity without a tenant scope", header)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Every development-sandbox call from App Studio to the BYO-hosted infrastructure provider fails. The assistant's `exec_command` on a fresh project today returned:

```
component app sync returned 403: a workspace selection (X-Faros-Workspace) is required to reach provider: infrastructure
```

The same 403 hits `restart_runtime`, log fetches and the post-mutation workspace sync, so the sandbox keeps serving the template scaffold while the workspace holds the assistant's edits. The preview edge stays reachable, which is why the assistant reports an unexplained "sync issue".

`pkg/hub/providers/proxy_edge.go` (`delegatedAuthorization`) requires a workspace selection to mint the delegated token for an org-owned provider. `newDataPlaneRequest` forwarded only the bearer; `provider_action_catalog.go` already sends `X-Faros-Org`/`X-Faros-Workspace` and works.

## Fix

`newDataPlaneRequest` sets `X-Faros-Org` and `X-Faros-Workspace` from the request identity when present, leaving org-only identities unchanged. Covers sync, exec, restart, env, process, proxy and log verbs since they all go through it.

## Tests

`TestNewDataPlaneRequestSelectsTheCallerWorkspace`: headers present and trimmed for a scoped identity, absent for an unscoped one.

Related: #673 (surface the failure), faroshq/ops#24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)