### PR TITLE
fix(code): prevent connection and repository action menu clipping

### DIFF
--- a/providers/code/portal/src/style.css
+++ b/providers/code/portal/src/style.css
@@ -283,10 +283,13 @@ faros-provider-code .repo-conditions__facts dd {
   color: var(--color-text-primary, #e9e9f2);
   font-size: 12px;
 }
-faros-provider-code .repo-detail__resource,
+/* Preserve component-owned widths for menus, controls, and tooltips. */
 faros-provider-code .repo-detail *,
 faros-provider-code .repo-detail *::before,
-faros-provider-code .repo-detail *::after,
+faros-provider-code .repo-detail *::after {
+  box-sizing: border-box;
+}
+faros-provider-code .repo-detail__resource,
 faros-provider-code .repo-section-card__facts,
 faros-provider-code .repo-integration-row,
 faros-provider-code .repo-integration-card__connection,
@@ -364,10 +367,13 @@ faros-provider-code .connection-detail__sections {
   flex-direction: column;
   gap: 14px;
 }
-faros-provider-code .connection-detail__resource,
+/* Preserve component-owned widths for menus, controls, and tooltips. */
 faros-provider-code .connection-detail *,
 faros-provider-code .connection-detail *::before,
-faros-provider-code .connection-detail *::after,
+faros-provider-code .connection-detail *::after {
+  box-sizing: border-box;
+}
+faros-provider-code .connection-detail__resource,
 faros-provider-code .connection-detail .props,
 faros-provider-code .connection-detail dl,
 faros-provider-code .connection-detail__facts,


### PR DESCRIPTION
Opening the overflow actions on Code connection and repository detail pages clipped the delete label to the trigger's width. The detail-page descendant reset overrode the shared menu's width rules when the host loaded PortalKit in its CSS component layer.

Keep border-box sizing for descendants, but limit min/max-width constraints to the existing page layout containers. This lets the shared ActionMenu retain its own panel, item, and tooltip sizing on both pages.

Validation:
- `make build-code-provider-portal`: 134 tests passed, TypeScript checking and production build passed.
- `make verify-design-docs`, `make verify-portalkit`, and `make verify-ui-conformance`: passed.
- Chromium checks of the actual detail components with fixture data and the host's CSS layer ordering: both themes at 390, 1440, and 3840 px; delete labels fit without horizontal menu overflow; Escape dismisses and restores trigger focus.
- Reapplying the original CSS reproduced the clipping on both pages (30 px panel content width); the fix restores a 180 px menu.

Browser validation used a local component fixture, not a deployed environment.
