### PR TITLE
refactor(agents): clarify Activity and run detail UX

### DIFF
--- a/docs/design/ai/agents-autonomy-and-runs.md
+++ b/docs/design/ai/agents-autonomy-and-runs.md
@@ -1,5 +1,5 @@
 ---
-{"schema":1,"id":"design.ai.agents-autonomy-and-runs","title":"Agents autonomy and run transparency","kind":"journey","status":"active","authority":{"design":"normative","implementation":"canonical"},"implementation":{"state":"shipped","notes":"The Agents provider ships autonomy policy controls, separate interactive/background grants, and a live run detail with approval, step, source, failure, and child-run evidence."},"appliesTo":["agents","provider-portals","assistant"],"owner":"agents","canonicalSource":[{"path":"docs/design/ai/agents-autonomy-and-runs.md#agents-autonomy-and-run-transparency","role":"design"},{"path":"providers/agents/portal/src/views/AgentConfig.vue","role":"implementation"},{"path":"providers/agents/portal/src/views/RunDetail.vue","role":"implementation"},{"path":"providers/agents/portal/src/types.ts","role":"implementation"},{"path":"providers/agents/portal/src/test/config.test.ts","role":"reference"},{"path":"providers/agents/portal/src/test/activity.test.ts","role":"reference"}],"verification":{"state":"partial","checks":[{"kind":"command","ref":"make verify-design-docs","status":"passing","evidence":"The design knowledge-base metadata, IDs, sources, and links validate."},{"kind":"test","ref":"providers/agents/portal/src/test/config.test.ts","status":"not-run","evidence":"Portal dependencies are not installed in this worktree."},{"kind":"test","ref":"providers/agents/portal/src/test/activity.test.ts","status":"not-run","evidence":"Portal dependencies are not installed in this worktree."}]},"relatedDocuments":[{"id":"design.ai.app-studio-conversation","relation":"see-also"},{"id":"design.ai.evidence-and-status","relation":"see-also"},{"id":"design.patterns.navigation-and-feedback","relation":"see-also"}]}
+{"schema":1,"id":"design.ai.agents-autonomy-and-runs","title":"Agents autonomy and run transparency","kind":"journey","status":"active","authority":{"design":"normative","implementation":"canonical"},"implementation":{"state":"shipped","notes":"The Agents provider ships autonomy policy controls, separate interactive/background grants, and a live run detail with approval, step, source, failure, and child-run evidence."},"appliesTo":["agents","provider-portals","assistant"],"owner":"agents","canonicalSource":[{"path":"docs/design/ai/agents-autonomy-and-runs.md#agents-autonomy-and-run-transparency","role":"design"},{"path":"providers/agents/portal/src/views/AgentConfig.vue","role":"implementation"},{"path":"providers/agents/portal/src/views/RunDetail.vue","role":"implementation"},{"path":"providers/agents/portal/src/types.ts","role":"implementation"},{"path":"providers/agents/portal/src/test/config.test.ts","role":"reference"},{"path":"providers/agents/portal/src/test/activity.test.ts","role":"reference"}],"verification":{"state":"partial","checks":[{"kind":"command","ref":"make verify-design-docs","status":"passing","evidence":"The design knowledge-base metadata, IDs, sources, and links validate."},{"kind":"test","ref":"providers/agents/portal/src/test/config.test.ts","status":"passing","evidence":"make build-agents-provider-portal passed all 350 portal tests, typecheck, and Vite build on 2026-09-09."},{"kind":"test","ref":"providers/agents/portal/src/test/activity.test.ts","status":"passing","evidence":"make build-agents-provider-portal passed all 350 portal tests, typecheck, and Vite build on 2026-09-09."},{"kind":"browser","ref":"Agents Activity and run-detail rendered verification","status":"passing","evidence":"2026-09-09: production bundle with fixture API data in Chromium, 1440px and 390px, html.dark and html.light; 12 screenshots, approval interaction, child ResourceTable, and no page overflow. Evidence: /var/tmp/codex-build/agents-activity-proof/verification.json. No live-backend verification."}]},"relatedDocuments":[{"id":"design.ai.app-studio-conversation","relation":"see-also"},{"id":"design.ai.evidence-and-status","relation":"see-also"},{"id":"design.patterns.navigation-and-feedback","relation":"see-also"}]}
 ---
 
 # Agents autonomy and run transparency
@@ -50,6 +50,19 @@ stops live polling. **Cancel** is available only while live.
 An approval pause shows the tool and disclosed arguments with **Approve &
 resume** and **Deny**. A missing or malformed disclosure is a reason to stop
 and report, not a reason to reconstruct or guess the operation.
+
+Activity retains PortalKit's queryable `ResourceTable` for filters, cursor
+pagination, read states, and keyboard row navigation. The primary cell groups
+the input preview with the agent; phase, trigger/class, duration, usage, and
+creation time remain separate scan columns. Pending inbox actions retain their
+argument disclosure and approval/denial controls above the table.
+
+Run detail groups agent, trigger/class, elapsed duration, and usage in a compact
+summary. Approval and failure states precede the input/output and expandable
+tool trace. Session, start time, attempt, and parent navigation occupy a
+secondary details column that stacks below the trace in narrow containers.
+Child runs continue to use the shared simple `ResourceTable`. Output uses
+document styling, and sources remain available alongside partial failed output.
 
 The trace then makes the following evidence available when present:
 

--- a/providers/agents/portal/src/activity.css
+++ b/providers/agents/portal/src/activity.css
@@ -1,0 +1,70 @@
+/* Activity composition. PortalKit owns tables, page chrome, badges and actions. */
+faros-provider-agents .agents-activity-title {
+  margin: 0;
+  font: 600 19px/1.3 var(--font-display);
+}
+faros-provider-agents .agents-activity-description { margin: 6px 0 0; color: var(--color-text-secondary); font-size: 13px; }
+faros-provider-agents .agents-run-cell { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+faros-provider-agents .agents-run-preview { font-weight: 500; }
+faros-provider-agents .agents-run-secondary { color: var(--color-text-secondary); font-size: 11px; overflow-wrap: anywhere; }
+faros-provider-agents .agents-approvals { display: flex; flex-direction: column; gap: 12px; }
+faros-provider-agents .agents-attention-title { display: flex; align-items: center; gap: 8px; margin: 0; font-size: 14px; font-weight: 600; }
+faros-provider-agents .agents-approval-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; padding: 16px; }
+faros-provider-agents .agents-approval-body { display: flex; flex-direction: column; gap: 10px; min-width: 0; flex: 1; }
+faros-provider-agents .agents-approval-prompt { font-size: 13px; overflow-wrap: anywhere; }
+faros-provider-agents .agents-approval-meta, faros-provider-agents .agents-approval-actions,
+faros-provider-agents .agents-detail-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+faros-provider-agents .agents-approval-meta { font-size: 11px; }
+faros-provider-agents .agents-approval-disclosure { min-width: 0; }
+faros-provider-agents .agents-approval-args { margin: 10px 0 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+faros-provider-agents .agents-run-layout { display: flex; flex-direction: column; gap: 24px; container-type: inline-size; }
+faros-provider-agents .agents-runmeta { display: grid; grid-template-columns: 1fr 1fr .7fr 1.5fr; gap: 20px; padding: 16px 0; border-block: 1px solid var(--color-border-subtle); }
+faros-provider-agents .agents-runmeta-cell { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+faros-provider-agents .agents-runmeta-k { font: 600 10px/1.4 var(--agents-mono); text-transform: uppercase; letter-spacing: .06em; color: var(--color-text-secondary); }
+faros-provider-agents .agents-runmeta-v { font: 12px/1.6 var(--agents-mono); overflow-wrap: anywhere; }
+faros-provider-agents .agents-elapsed { display: inline-flex; align-items: center; gap: 6px; }
+faros-provider-agents .agents-run-columns { display: grid; grid-template-columns: minmax(0, 1fr) 235px; gap: 24px; }
+faros-provider-agents .agents-run-main { display: flex; flex-direction: column; gap: 24px; min-width: 0; }
+faros-provider-agents .agents-run-aside { min-width: 0; padding-inline-start: 20px; border-inline-start: 1px solid var(--color-border-subtle); }
+faros-provider-agents .agents-run-facts { display: flex; flex-direction: column; gap: 18px; margin-top: 16px; }
+faros-provider-agents .agents-runinput h2, faros-provider-agents .agents-run-aside h2,
+faros-provider-agents .agents-run-steps h2, faros-provider-agents .agents-runsources h2,
+faros-provider-agents .agents-run-failure h2 { margin: 0; font-size: 14px; font-weight: 600; }
+faros-provider-agents .agents-runinput p { margin: 10px 0 0; white-space: pre-wrap; overflow-wrap: anywhere; font-size: 13px; max-width: 75ch; }
+faros-provider-agents .agents-run-approval { border-color: color-mix(in srgb, var(--color-warning) 35%, transparent); }
+faros-provider-agents .agents-run-approval-body { display: flex; flex-direction: column; gap: 16px; }
+faros-provider-agents .agents-run-failure { padding: 16px; background: var(--color-danger-subtle); border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent); border-radius: 6px; }
+faros-provider-agents .agents-run-failure h2 { color: var(--color-danger); }
+faros-provider-agents .agents-run-failure p { margin: 8px 0 0; overflow-wrap: anywhere; }
+faros-provider-agents .agents-run-main .agents-body { font-size: 13px; overflow-wrap: anywhere; }
+faros-provider-agents .agents-run-main pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+faros-provider-agents .agents-timeline { list-style: none; margin: 12px 0 0; padding: 0; border: 1px solid var(--color-border-subtle); border-radius: 6px; overflow: hidden; background: var(--color-surface-raised); }
+faros-provider-agents .agents-step + .agents-step { border-top: 1px solid var(--color-border-subtle); }
+faros-provider-agents .agents-step-head { display: flex; width: 100%; min-width: 0; align-items: center; gap: 12px; padding: 12px; text-align: left; border-radius: 0; }
+faros-provider-agents .agents-step-n { flex: none; color: var(--color-text-secondary); font: 11px var(--agents-mono); font-variant-numeric: tabular-nums; }
+faros-provider-agents .agents-step-name { flex: 1; min-width: 0; white-space: normal; overflow-wrap: anywhere; font-size: 12px; }
+faros-provider-agents .agents-step-meta { display: flex; align-items: center; gap: 14px; color: var(--color-text-secondary); font: 11px var(--agents-mono); font-variant-numeric: tabular-nums; }
+faros-provider-agents .agents-step-outcome.is-ok { color: var(--color-success); }
+faros-provider-agents .agents-step-outcome.is-err { color: var(--color-danger); }
+faros-provider-agents .agents-step-outcome.is-wait { color: var(--color-warning); }
+faros-provider-agents .agents-step-body { display: flex; flex-direction: column; gap: 12px; padding: 0 16px 16px 36px; }
+faros-provider-agents .agents-step-body pre { margin: 4px 0 0; }
+faros-provider-agents .agents-child-summary { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin: 0; font-size: 12px; }
+@container (max-width: 760px) {
+  faros-provider-agents .agents-runmeta { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  faros-provider-agents .agents-run-columns { grid-template-columns: minmax(0, 1fr); }
+  faros-provider-agents .agents-run-aside { padding: 16px 0 0; border-inline-start: 0; border-top: 1px solid var(--color-border-subtle); }
+  faros-provider-agents .agents-run-facts { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  faros-provider-agents .agents-step-head { flex-wrap: wrap; }
+  faros-provider-agents .agents-step-meta { flex-wrap: wrap; gap: 8px; }
+}
+@media (max-width: 640px) {
+  faros-provider-agents .agents-approval-row { flex-direction: column; }
+}
+/* Run output is a document, while the same body class in chat is a bubble. */
+faros-provider-agents .agents-run-main .agents-body { padding: 0; border-radius: 0; background: transparent; }
+faros-provider-agents .agents-run-main .agents-body ul { list-style: disc; }
+faros-provider-agents .agents-run-main .agents-body ol { list-style: decimal; }
+faros-provider-agents .agents-run-failure .agents-err { padding: 0; border: 0; background: transparent; }
+faros-provider-agents .agents-step-head { border: 0; background: transparent; }
+faros-provider-agents .agents-step-head:hover { background: var(--color-surface-hover); }

--- a/providers/agents/portal/src/main.ts
+++ b/providers/agents/portal/src/main.ts
@@ -7,6 +7,7 @@
 import { AgentsDashboardTileElement, AgentsElement } from './element'
 import { ensureFarosUIStyles } from './portalkit/styles'
 import styles from './style.css?raw'
+import activityStyles from './activity.css?raw'
 
 const TAG = 'faros-provider-agents'
 const TILE_TAG = 'faros-dashboard-tile-agents'
@@ -23,7 +24,7 @@ if (!customElements.get(TAG)) {
     s.id = styleId
     // PortalKit owns the tab and component recipes. Agents keeps only its
     // domain layout rules in this provider stylesheet.
-    s.textContent = styles
+    s.textContent = `${styles}\n${activityStyles}`
     document.head.appendChild(s)
   }
   customElements.define(TAG, AgentsElement)

--- a/providers/agents/portal/src/style.css
+++ b/providers/agents/portal/src/style.css
@@ -261,24 +261,6 @@ faros-provider-agents .agents-runsources a { font-size: 12px; overflow-wrap: any
 faros-provider-agents .agents-kv pre.err { color: var(--color-danger, #ff5d5d); }
 faros-provider-agents .agents-kv { display: flex; flex-direction: column; gap: 3px; }
 faros-provider-agents .agents-kv > span { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted, #5d5f78); }
-faros-provider-agents .agents-timeline { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
-faros-provider-agents .agents-step {
-  border-radius: 6px; overflow: hidden; border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.07));
-  background: var(--color-surface-raised, #111320);
-}
-faros-provider-agents .agents-step-head {
-  width: 100%; display: flex; align-items: center; gap: 10px; padding: 9px 12px; text-align: left;
-  background: transparent; color: inherit; font: inherit; font-weight: 500; border-radius: 0;
-}
-faros-provider-agents .agents-step-head:hover { background: var(--color-surface-hover, #1e2033); }
-faros-provider-agents .agents-step-n {
-  flex: none; width: 20px; height: 20px; border-radius: 6px; display: grid; place-items: center;
-  font-size: 10.5px; font-weight: 700; background: var(--color-surface-overlay, #171927); color: var(--color-text-muted, #5d5f78);
-}
-faros-provider-agents .agents-step-name { flex: 1; min-width: 0; font-size: 13px; overflow: hidden; text-overflow: ellipsis; }
-faros-provider-agents .agents-step-meta { font-size: 11.5px; color: var(--color-text-muted, #5d5f78); white-space: nowrap; }
-faros-provider-agents .agents-step-body { display: flex; flex-direction: column; gap: 9px; padding: 4px 12px 12px; }
-
 /* --- chat --- */
 faros-provider-agents .agents-chat {
   display: flex; flex-direction: column; gap: 8px;

--- a/providers/agents/portal/src/test/activity.test.ts
+++ b/providers/agents/portal/src/test/activity.test.ts
@@ -94,6 +94,8 @@ describe('Activity.vue', () => {
     expect(listRuns.mock.calls[0][0].since).toBeUndefined()
     expect(text(view.element.querySelector('.k-table__row'))).toContain('summarise the open PRs')
     expect(text(view.element.querySelector('.agents-phase'))).toContain('Succeeded')
+    expect(text(view.element.querySelector('td:first-child'))).toContain('scout')
+    expect(text(view.element.querySelector('td:first-child'))).toContain('summarise the open PRs')
 
     view.element.querySelector<HTMLElement>('.k-table__row')!.click()
     expect(view.navigations).toEqual([{ kind: 'run', id: 'r1' }])
@@ -332,8 +334,8 @@ describe('Activity.vue', () => {
     const view = await mount(Activity, { store, api })
 
     expect([...view.element.querySelectorAll('h1, h2, h3, h4, h5, h6')].map(heading => [heading.tagName, text(heading)])).toEqual([
-      ['H3', 'Activity'],
-      ['H4', 'Needs your attention (1)'],
+      ['H1', 'Activity'],
+      ['H2', 'Needs your attention (1)'],
     ])
     expect(text(view.element.querySelector('.agents-approval-disclosure'))).toContain('edges__pods_delete')
     expect(text(view.element.querySelector('.agents-approval-args'))).toBe('{}')
@@ -408,12 +410,14 @@ describe('RunDetail.vue', () => {
     const view = await mount(RunDetail, { store: makeStore(api), api, runId: 'r5' })
 
     expect(text(view.element.querySelector('.k-resource-page__title'))).toBe('Run')
-    expect(text(view.element.querySelector('.k-resource-page__kind'))).toBe('Run')
+    expect(view.element.querySelector('.k-resource-page__kind')).toBeNull()
     expect(text(view.element.querySelector('.k-resource-page__subtitle'))).toBe('r5')
     expect(view.element.querySelector<HTMLAnchorElement>('.k-back-action')?.getAttribute('href')).toBe('#/activity')
     expect(text(view.element.querySelector('.agents-runmeta'))).toContain('scout')
     expect(view.element.querySelectorAll('.agents-step')).toHaveLength(2)
-    expect(view.element.querySelectorAll('[data-k-resource-section-card]')).toHaveLength(3)
+    expect(text(view.element.querySelector('[data-k-resource-section-card] h2'))).toBe('Output')
+    expect(text(view.element.querySelector('#run-input-heading'))).toBe('Input')
+    expect(text(view.element.querySelector('#run-steps-heading'))).toBe('Tool steps (2)')
     expect(view.element.querySelector('.agents-panel.k-card')).toBeNull()
     expect(view.element.querySelectorAll('.agents-step')[1].className).toContain('is-err')
     buttonWithText(view.element.querySelector('.agents-step')!, 'edges__pods_list').click()
@@ -421,6 +425,17 @@ describe('RunDetail.vue', () => {
     expect(text(view.element.querySelector('.agents-step-body'))).toContain('"ns"')
     expect(view.element.querySelector('.agents-body strong')?.textContent).toBe('Answer')
     expect(view.element.querySelector<HTMLAnchorElement>('.agents-runsources a')?.rel).toContain('noopener')
+  })
+
+  it('keeps secondary metadata inspectable beside the trace', async () => {
+    const api = stubApi({ getRun: vi.fn().mockResolvedValue(detail({ sessionID: 'session-full-id', parentRunID: 'parent-run-id', attempt: 2 })) })
+    const view = await mount(RunDetail, { store: makeStore(api), api, runId: 'r5' })
+    const facts = view.element.querySelector('.agents-run-aside')!
+    expect(text(facts)).toContain('session-full-id')
+    expect([...facts.querySelectorAll('.agents-runmeta-cell')].map(cell => [...cell.children].map(child => text(child)))).toContainEqual(['attempt', '2'])
+    buttonWithText(facts, 'parent-r').click()
+    expect(view.navigations).toEqual([{ kind: 'run', id: 'parent-run-id' }])
+    expect(text(view.element.querySelector('.agents-runmeta'))).toContain('1.2k in')
   })
 
   it('keeps a loaded trace visible after a background refresh failure', async () => {
@@ -597,12 +612,14 @@ describe('RunDetail.vue', () => {
   })
 
   it('shows the error and partial output for a failed run', async () => {
-    const api = stubApi({ getRun: vi.fn().mockResolvedValue(detail({ phase: 'Failed', message: 'model unavailable', output: 'got this far' })) })
+    const api = stubApi({ getRun: vi.fn().mockResolvedValue(detail({ phase: 'Failed', message: 'model unavailable', output: 'got this far', sources: ['https://example.com/evidence'] })) })
     const view = await mount(RunDetail, { store: makeStore(api), api, runId: 'r5' })
 
     expect(text(view.element.querySelector('.agents-err'))).toContain('model unavailable')
     expect(text(view.element)).toContain('Partial output')
     expect(text(view.element.querySelector('.agents-body'))).toContain('got this far')
+    expect(view.element.querySelector('.agents-runsources a')?.getAttribute('href')).toBe('https://example.com/evidence')
+    expect(view.element.querySelector('.agents-run-failure')!.compareDocumentPosition(view.element.querySelector('.agents-body')!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
   it('summarizes running, queued, approval-gated, completed, and failed children', async () => {
@@ -661,7 +678,7 @@ describe('RunDetail.vue', () => {
     store.agents.data[0].spec.tools!.interactive!.families = ['core', 'spawn']
     store.dispatchEvent(new Event('change'))
     await settleVue()
-    expect(text(view.element)).toContain('answered this request directly')
+    expect(text(view.element)).toContain('this run answered directly')
   })
 })
 

--- a/providers/agents/portal/src/views/Activity.vue
+++ b/providers/agents/portal/src/views/Activity.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { Check, Clock, Inbox, MessageCircle, RefreshCw, X } from 'lucide-vue-next'
+import { Check, Inbox, RefreshCw, X } from 'lucide-vue-next'
 import type { ApiClient, RunFilter } from '../api'
 import type { AppStore, ServerEvent } from '../store'
 import { fmtDuration, fmtTime, fmtTokens, fmtUSD, type InboxItem, type RunPhase, type RunSummary } from '../types'
@@ -98,13 +98,12 @@ const filters = computed<TableFilterDefinition[]>(() => [
   },
 ])
 const columns = computed(() => [
-  ...(!props.agent ? [{ key: 'agent', label: 'Agent', primary: true }] : []),
-  { key: 'trigger', label: 'Trigger', primary: !!props.agent },
-  { key: 'input', label: 'Input' },
+  { key: 'input', label: props.agent ? 'Run' : 'Run / Agent', primary: true, fullValue: (row: Record<string, unknown>) => props.agent ? String(row.input) : `${row.input} · ${row.agent}` },
   { key: 'phase', label: 'Phase' },
-  { key: 'duration', label: 'Duration' },
-  { key: 'usage', label: 'Usage' },
-  { key: 'when', label: 'When' },
+  { key: 'trigger', label: 'Trigger / Class' },
+  { key: 'duration', label: 'Duration', align: 'end' as const },
+  { key: 'usage', label: 'Usage', align: 'end' as const },
+  { key: 'when', label: 'Created', align: 'end' as const },
 ])
 const tableRows = computed(() => runs.value.map(run => ({ ...run, input: run.inputPreview || '—', when: run.createdAt })))
 
@@ -240,9 +239,9 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="agents-panel k-card agents-route-panel agents-activity-panel">
+  <div class="agents-panel agents-activity-panel">
     <div class="agents-panel-head agents-activity-head">
-      <h3 v-if="!agent">Activity</h3>
+      <div v-if="!agent"><h1 class="agents-activity-title">Activity</h1><p class="agents-activity-description">Run history and actions waiting for your review.</p></div>
       <button
         class="k-btn k-btn--ghost secondary agents-filter-refresh"
         type="button"
@@ -266,15 +265,15 @@ onBeforeUnmount(() => {
         <button class="k-btn k-btn--ghost secondary" type="button" @click="store.load('inbox')">Retry</button>
       </div>
       <section v-if="pending.length" class="agents-approvals">
-        <component :is="agent ? 'h2' : 'h4'"><Inbox :stroke-width="1.75" aria-hidden="true" /> Needs your attention ({{ pending.length }})</component>
-        <div v-for="item in pending" :key="item.id" class="agents-approval-row">
+        <h2 class="agents-attention-title"><Inbox :stroke-width="1.75" aria-hidden="true" /> Needs your attention ({{ pending.length }})</h2>
+        <div v-for="item in pending" :key="item.id" class="agents-approval-row k-card">
           <div class="agents-approval-body">
             <div class="agents-approval-prompt">{{ item.prompt }}</div>
             <ApprovalDisclosure v-if="item.kind === 'approval'" :tool="item.payload?.tool" :args="item.payload?.args" />
             <div class="agents-approval-meta">
               <span class="k-badge agents-badge">{{ item.agentName }}</span>
               <span class="muted">{{ fmtTime(item.createdAt) }}</span>
-              <button v-if="item.runID" class="k-dashboard-action" type="button" @click="emit('navigate', { kind: 'run', id: item.runID! })">view run</button>
+              <button v-if="item.runID" class="k-dashboard-action" type="button" @click="emit('navigate', { kind: 'run', id: item.runID! })">View run</button>
             </div>
           </div>
           <div class="agents-approval-actions">
@@ -317,12 +316,21 @@ onBeforeUnmount(() => {
       @retry="reload('foreground')"
       @row-click="openRun"
     >
-      <template #agent="{ row }"><strong>{{ row.agent }}</strong></template>
-      <template #trigger="{ row }"><span class="k-badge agents-badge" :class="row.class === 'interactive' ? 'agents-cat-tool' : ''"><MessageCircle v-if="row.class === 'interactive'" :stroke-width="1.75" aria-hidden="true" /><Clock v-else :stroke-width="1.75" aria-hidden="true" /> {{ row.trigger }}</span> <span v-if="row.parentRunID" class="k-badge agents-badge k-badge--muted agents-badge-muted">delegated</span></template>
-      <template #input="{ row }"><span class="agents-cell-task muted">{{ row.input }}</span></template>
+      <template #input="{ row }">
+        <span class="agents-run-cell">
+          <strong class="agents-run-preview">{{ row.input }}</strong>
+          <span v-if="!agent" class="agents-run-secondary">{{ row.agent }}</span>
+        </span>
+      </template>
+      <template #trigger="{ row }">
+        <span class="agents-run-cell">
+          <span class="mono">{{ row.trigger }}</span>
+          <span class="agents-run-secondary">{{ row.class }}<template v-if="row.parentRunID"> · delegated</template></span>
+        </span>
+      </template>
       <template #phase="{ row }"><StatusBadge class="agents-phase" :class="`agents-phase-${phaseMeta(row.phase as RunPhase).cls}`" :status="phaseMeta(row.phase as RunPhase).label" :tone="phaseMeta(row.phase as RunPhase).tone" /> <span v-if="Number(row.attempt) > 1" class="k-badge agents-badge">try {{ row.attempt }}</span></template>
       <template #duration="{ row }"><span class="muted">{{ row.durationMS ? fmtDuration(Number(row.durationMS)) : '—' }}</span></template>
-      <template #usage="{ row }"><span class="muted mono">{{ fmtTokens(Number(row.inputTokens) + Number(row.outputTokens)) }}<template v-if="row.usdMicros"> · {{ fmtUSD(Number(row.usdMicros)) }}</template></span></template>
+      <template #usage="{ row }"><span class="agents-run-cell mono">{{ fmtTokens(Number(row.inputTokens) + Number(row.outputTokens)) }}<span class="agents-run-secondary">{{ fmtUSD(Number(row.usdMicros)) }}</span></span></template>
       <template #when="{ row }"><span class="muted">{{ fmtTime(String(row.when)) }}</span></template>
     </ResourceTable>
   </div>

--- a/providers/agents/portal/src/views/RunDetail.vue
+++ b/providers/agents/portal/src/views/RunDetail.vue
@@ -246,7 +246,7 @@ function attachCodeCopy(container: ParentNode | null): void {
 }
 
 function stepClass(step: RunStep): string {
-  return step.outcome === 'error' ? 'err' : step.outcome === 'pending_approval' ? 'wait' : 'ok'
+  return step.outcome === 'error' ? 'err' : step.outcome === 'pending_approval' ? 'wait' : step.outcome === 'ok' ? 'ok' : 'unknown'
 }
 
 function elapsed(current: Run): string {
@@ -288,7 +288,6 @@ onBeforeUnmount(() => {
     <ResourceBackLink :href="hashFor({ kind: 'menu', menu: 'activity' })" @back="emit('navigate', { kind: 'menu', menu: 'activity' })">Activity</ResourceBackLink>
     <ResourcePage
       title="Run"
-      kind="Run"
       :subtitle="runId"
       :loaded="!!run"
       :loading="loading"
@@ -308,75 +307,91 @@ onBeforeUnmount(() => {
         </div>
       </template>
       <template v-if="run" #body>
-      <ResourceSectionCard title="Run details">
-        <div class="agents-runmeta">
-          <div class="agents-runmeta-cell"><span class="agents-runmeta-k">agent</span><span class="agents-runmeta-v"><button class="k-dashboard-action" type="button" @click="emit('navigate', { kind: 'agent', name: run.agent, tab: 'config' })">{{ run.agent }}</button></span></div>
-          <div class="agents-runmeta-cell"><span class="agents-runmeta-k">trigger</span><span class="agents-runmeta-v"><span class="mono">{{ run.trigger }}</span> <span class="muted">({{ run.class }})</span></span></div>
-          <div v-if="run.sessionID" class="agents-runmeta-cell"><span class="agents-runmeta-k">session</span><span class="agents-runmeta-v mono">{{ run.sessionID }}</span></div>
-          <div class="agents-runmeta-cell"><span class="agents-runmeta-k">started</span><span class="agents-runmeta-v">{{ fmtTime(run.startedAt || run.createdAt) }}</span></div>
-          <div class="agents-runmeta-cell"><span class="agents-runmeta-k">duration</span><span class="agents-runmeta-v"><template v-if="run.durationMS">{{ fmtDuration(run.durationMS) }}</template><span v-else-if="LIVE_PHASES.has(run.phase)" class="agents-elapsed"><LoaderCircle class="k-spin" :size="13" :stroke-width="1.75" aria-hidden="true" />{{ elapsed(run) }}</span><template v-else>—</template></span></div>
-          <div class="agents-runmeta-cell"><span class="agents-runmeta-k">usage</span><span class="agents-runmeta-v">{{ fmtTokens(run.inputTokens) }} in · {{ fmtTokens(run.outputTokens) }} out · {{ fmtUSD(run.usdMicros) }}</span></div>
-          <div v-if="run.attempt && run.attempt > 1" class="agents-runmeta-cell"><span class="agents-runmeta-k">attempt</span><span class="agents-runmeta-v">{{ run.attempt }}</span></div>
-          <div v-if="run.parentRunID" class="agents-runmeta-cell"><span class="agents-runmeta-k">parent</span><span class="agents-runmeta-v"><button class="k-dashboard-action" type="button" @click="emit('navigate', { kind: 'run', id: run.parentRunID! })">{{ run.parentRunID.slice(0, 8) }}</button></span></div>
-        </div>
-        <div v-if="run.input" class="agents-runinput"><span class="agents-runmeta-k">input</span><pre>{{ run.input }}</pre></div>
-      </ResourceSectionCard>
-
-      <ResourceSectionCard v-if="run.phase === 'PendingApproval' && run.pending" title="Approval required">
-        <div class="agents-approval" role="group" aria-label="Tool approval required">
-          <ApprovalDisclosure :tool="run.pending.tool" :args="run.pending.args" paused />
-          <div class="agents-approval-actions">
-            <button class="k-btn k-btn--primary" type="button" :disabled="!!resolvingInboxID || !approvalDisclosureAvailable(run.pending.tool, run.pending.args)" :aria-busy="resolvingInboxID === run.pending.inboxID || undefined" @click="resolve(run.pending.inboxID, 'approve')"><Check :stroke-width="1.75" aria-hidden="true" /> {{ resolvingInboxID === run.pending.inboxID ? 'Resolving…' : 'Approve & resume' }}</button>
-            <button class="k-btn k-btn--ghost secondary" type="button" :disabled="!!resolvingInboxID" @click="resolve(run.pending.inboxID, 'deny')"><X :stroke-width="1.75" aria-hidden="true" /> Deny</button>
+        <div class="agents-run-layout">
+          <div class="agents-runmeta" aria-label="Run summary">
+            <div class="agents-runmeta-cell"><span class="agents-runmeta-k">agent</span><span class="agents-runmeta-v"><button class="k-dashboard-action" type="button" @click="emit('navigate', { kind: 'agent', name: run.agent, tab: 'config' })">{{ run.agent }}</button></span></div>
+            <div class="agents-runmeta-cell"><span class="agents-runmeta-k">trigger</span><span class="agents-runmeta-v"><span class="mono">{{ run.trigger }}</span> <span class="muted">({{ run.class }})</span></span></div>
+            <div class="agents-runmeta-cell"><span class="agents-runmeta-k">duration</span><span class="agents-runmeta-v"><template v-if="run.durationMS">{{ fmtDuration(run.durationMS) }}</template><span v-else-if="LIVE_PHASES.has(run.phase)" class="agents-elapsed"><LoaderCircle class="k-spin" :size="13" :stroke-width="1.75" aria-hidden="true" />{{ elapsed(run) }}</span><template v-else>—</template></span></div>
+            <div class="agents-runmeta-cell"><span class="agents-runmeta-k">usage</span><span class="agents-runmeta-v">{{ fmtTokens(run.inputTokens) }} in · {{ fmtTokens(run.outputTokens) }} out · {{ fmtUSD(run.usdMicros) }}</span></div>
           </div>
+        <ResourceSectionCard v-if="run.phase === 'PendingApproval' && run.pending" class="agents-run-approval" title="Approval required">
+          <div class="agents-run-approval-body" role="group" aria-label="Tool approval required">
+            <ApprovalDisclosure :tool="run.pending.tool" :args="run.pending.args" paused />
+            <div class="agents-approval-actions">
+              <button class="k-btn k-btn--primary" type="button" :disabled="!!resolvingInboxID || !approvalDisclosureAvailable(run.pending.tool, run.pending.args)" :aria-busy="resolvingInboxID === run.pending.inboxID || undefined" @click="resolve(run.pending.inboxID, 'approve')"><Check :stroke-width="1.75" aria-hidden="true" /> {{ resolvingInboxID === run.pending.inboxID ? 'Resolving…' : 'Approve & resume' }}</button>
+              <button class="k-btn k-btn--ghost secondary" type="button" :disabled="!!resolvingInboxID" @click="resolve(run.pending.inboxID, 'deny')"><X :stroke-width="1.75" aria-hidden="true" /> Deny</button>
+            </div>
+          </div>
+        </ResourceSectionCard>
+
+        <section v-if="(run.phase === 'Failed' || run.phase === 'Aborted') && run.message" class="agents-run-failure" aria-label="Run error">
+          <h2>{{ run.phase === 'Failed' ? 'Run failed' : 'Run aborted' }}</h2>
+          <p class="agents-err" role="alert">{{ run.message }}</p>
+        </section>
+        <div class="agents-run-columns">
+          <div class="agents-run-main">
+            <section v-if="run.input" class="agents-runinput" aria-labelledby="run-input-heading">
+              <h2 id="run-input-heading">Input</h2>
+              <p>{{ run.input }}</p>
+            </section>
+            <ResourceSectionCard v-if="run.output || (run.message && run.phase !== 'Failed' && run.phase !== 'Aborted')" :title="run.phase === 'Failed' || run.phase === 'Aborted' ? 'Partial output' : 'Output'">
+              <div class="agents-body" v-html="markdownHTML(run.output || run.message || '')"></div>
+            </ResourceSectionCard>
+            <p v-else-if="LIVE_PHASES.has(run.phase)" class="agents-hint">No output yet. {{ run.phase === 'PendingApproval' ? 'The run is waiting for approval.' : run.phase === 'Pending' ? 'The run is queued.' : 'The run is in progress.' }}</p>
+            <section v-if="run.sources?.length" class="agents-runsources" aria-labelledby="run-sources-heading">
+              <h2 id="run-sources-heading">Sources</h2>
+              <ul><li v-for="source in run.sources" :key="source"><a :href="source" target="_blank" rel="noopener noreferrer">{{ source }}</a></li></ul>
+            </section>
+
+        <section class="agents-run-steps" aria-labelledby="run-steps-heading">
+          <h2 id="run-steps-heading">Tool steps <span class="muted">({{ run.steps.length }})</span></h2>
+          <p v-if="!run.steps.length" class="agents-hint"><Wrench :stroke-width="1.75" aria-hidden="true" /> This run made no tool calls.</p>
+          <ol v-else class="agents-timeline">
+            <li v-for="(step, index) in run.steps" :key="step.id" class="agents-step" :class="`is-${stepClass(step)}`">
+              <button class="k-btn k-btn--ghost agents-step-head" type="button" :aria-expanded="expanded.has(step.id)" @click="toggle(step.id)">
+                <span class="agents-step-n">{{ index + 1 }}</span><span class="agents-step-name mono">{{ step.tool }}</span><span class="agents-step-meta"><span :class="`agents-step-outcome is-${stepClass(step)}`">{{ step.outcome === 'ok' ? 'Succeeded' : step.outcome === 'error' ? 'Failed' : step.outcome === 'pending_approval' ? 'Needs approval' : step.outcome }}</span><span>{{ step.durationMS != null ? fmtDuration(step.durationMS) : '—' }}</span></span><span class="agents-toolcard-chev" :class="{ open: expanded.has(step.id) }"><ChevronRight :stroke-width="1.75" aria-hidden="true" /></span>
+              </button>
+              <div v-if="expanded.has(step.id)" class="agents-step-body"><time class="agents-run-secondary mono" :datetime="step.at">{{ fmtTime(step.at) }}</time><div v-if="step.args" class="agents-kv"><span>Arguments</span><pre>{{ prettyJSON(step.args) }}</pre></div><div v-if="step.error" class="agents-kv"><span>Error</span><pre class="err">{{ step.error }}</pre></div><div v-if="step.result" class="agents-kv"><span>Result</span><pre>{{ prettyJSON(step.result) }}</pre></div></div>
+            </li>
+          </ol>
+        </section>
+          </div>
+          <aside class="agents-run-aside" aria-labelledby="run-details-heading">
+            <h2 id="run-details-heading">Run details</h2>
+            <div class="agents-run-facts">
+            <div v-if="run.sessionID" class="agents-runmeta-cell"><span class="agents-runmeta-k">session</span><span class="agents-runmeta-v mono">{{ run.sessionID }}</span></div>
+            <div class="agents-runmeta-cell"><span class="agents-runmeta-k">started</span><span class="agents-runmeta-v">{{ fmtTime(run.startedAt || run.createdAt) }}</span></div>
+            <div v-if="run.attempt && run.attempt > 1" class="agents-runmeta-cell"><span class="agents-runmeta-k">attempt</span><span class="agents-runmeta-v">{{ run.attempt }}</span></div>
+            <div v-if="run.parentRunID" class="agents-runmeta-cell"><span class="agents-runmeta-k">parent</span><span class="agents-runmeta-v"><button class="k-dashboard-action" type="button" @click="emit('navigate', { kind: 'run', id: run.parentRunID! })">{{ run.parentRunID.slice(0, 8) }}</button></span></div>
+            </div>
+          </aside>
         </div>
-      </ResourceSectionCard>
 
-      <ResourceSectionCard v-if="(run.phase === 'Failed' || run.phase === 'Aborted') && run.message" title="Error">
-        <div class="agents-err" role="alert">{{ run.message }}</div>
-        <template v-if="run.output"><h3>Partial output</h3><div class="agents-body" v-html="markdownHTML(run.output)"></div></template>
-      </ResourceSectionCard>
-      <ResourceSectionCard v-else-if="run.output || run.message" title="Output">
-        <div class="agents-body" v-html="markdownHTML(run.output || run.message || '')"></div>
-        <div v-if="run.sources?.length" class="agents-runsources"><span class="agents-runmeta-k">sources</span><ul><li v-for="source in run.sources" :key="source"><a :href="source" target="_blank" rel="noopener noreferrer">{{ source }}</a></li></ul></div>
-      </ResourceSectionCard>
-
-      <ResourceSectionCard :title="`Steps (${run.steps.length})`">
-        <p v-if="!run.steps.length" class="agents-hint"><Wrench :stroke-width="1.75" aria-hidden="true" /> This run made no tool calls.</p>
-        <ol v-else class="agents-timeline">
-          <li v-for="(step, index) in run.steps" :key="step.id" class="agents-step" :class="`is-${stepClass(step)}`">
-            <button class="k-btn k-btn--ghost agents-step-head" type="button" :aria-expanded="expanded.has(step.id)" @click="toggle(step.id)">
-              <span class="agents-step-n">{{ index + 1 }}</span><span class="agents-step-name mono">{{ step.tool }}</span><span class="agents-step-meta">{{ step.outcome }}<template v-if="step.durationMS"> · {{ fmtDuration(step.durationMS) }}</template> · {{ fmtTime(step.at) }}</span><span class="agents-toolcard-chev" :class="{ open: expanded.has(step.id) }"><ChevronRight :stroke-width="1.75" aria-hidden="true" /></span>
-            </button>
-            <div v-if="expanded.has(step.id)" class="agents-step-body"><div v-if="step.args" class="agents-kv"><span>args</span><pre>{{ prettyJSON(step.args) }}</pre></div><div v-if="step.error" class="agents-kv"><span>error</span><pre class="err">{{ step.error }}</pre></div><div v-if="step.result" class="agents-kv"><span>result</span><pre>{{ prettyJSON(step.result) }}</pre></div></div>
-          </li>
-        </ol>
-      </ResourceSectionCard>
-
-      <ResourceSectionCard v-if="!run.children?.length && fanOutGranted" title="Child runs (0)">
-        <p class="agents-hint"><Circle :stroke-width="1.75" aria-hidden="true" /><template v-if="run.steps.some(step => step.tool === 'spawn')"> This run called <span class="mono">spawn</span> but no worker runs were recorded — check the steps above for the error it came back with.</template><template v-else> Research fan-out is enabled and the agent was told how to use it, but it answered this request directly rather than splitting it up. That is the right call for a narrow question — a fan-out you do not need is just slower. For a request with genuinely independent parts, phrasing them explicitly ("compare X, Y and Z") makes the split obvious.</template></p>
-      </ResourceSectionCard>
-      <ResourceSectionCard v-else-if="run.children?.length" :title="`Child runs (${run.children.length})`" :description="childSummary.workers ? `${childSummary.workers} spawned worker${childSummary.workers === 1 ? '' : 's'}` : ''">
-        <p class="agents-child-summary" :class="{ 'is-live': childSummary.live }"><LoaderCircle v-if="childSummary.live" class="k-spin" :size="13" :stroke-width="1.75" aria-hidden="true" />{{ childSummary.text }} <span v-if="childSummary.live" class="muted">— this updates as they finish</span></p>
-        <ResourceTable
-          :columns="[{ key: 'agent', label: 'Agent', primary: true }, { key: 'kind', label: 'Kind' }, { key: 'input', label: 'Input' }, { key: 'phase', label: 'Phase' }, { key: 'duration', label: 'Duration' }, { key: 'usage', label: 'Usage' }]"
-          :rows="childRows"
-          row-key="id"
-          aria-label="Child runs"
-          variant="simple"
-          :loaded="true"
-          :interactive="true"
-          :row-aria-label="childAriaLabel"
-          @row-click="openChild(asChild($event))"
-        >
-          <template #agent="{ row }"><strong>{{ asChild(row).agent }}</strong></template>
-          <template #kind="{ row }"><span class="muted mono">{{ asChild(row).trigger === 'spawn' ? 'worker' : 'delegated' }}</span></template>
-          <template #input="{ row }"><span class="agents-cell-task muted">{{ asChild(row).inputPreview || '—' }}</span></template>
-          <template #phase="{ row }"><StatusBadge class="agents-phase" :class="`agents-phase-${phaseMeta[asChild(row).phase].cls}`" :status="phaseMeta[asChild(row).phase].label" :tone="phaseMeta[asChild(row).phase].tone" /></template>
-          <template #duration="{ row }"><span class="muted">{{ asChild(row).durationMS ? fmtDuration(asChild(row).durationMS) : '—' }}</span></template>
-          <template #usage="{ row }"><span class="muted mono">{{ fmtTokens(asChild(row).inputTokens + asChild(row).outputTokens) }} · {{ fmtUSD(asChild(row).usdMicros) }}</span></template>
-        </ResourceTable>
-      </ResourceSectionCard>
+        <ResourceSectionCard v-if="!run.children?.length && fanOutGranted" title="Child runs (0)">
+          <p class="agents-hint"><Circle :stroke-width="1.75" aria-hidden="true" /><template v-if="run.steps.some(step => step.tool === 'spawn')"> This run called <span class="mono">spawn</span> but no worker runs were recorded — check the steps above for the error it came back with.</template><template v-else-if="LIVE_PHASES.has(run.phase)"> No child runs have been recorded yet.</template><template v-else> No child runs were recorded. Fan-out is enabled, but this run answered directly.</template></p>
+        </ResourceSectionCard>
+        <ResourceSectionCard v-else-if="run.children?.length" :title="`Child runs (${run.children.length})`" :description="childSummary.workers ? `${childSummary.workers} spawned worker${childSummary.workers === 1 ? '' : 's'}` : ''">
+          <p class="agents-child-summary" :class="{ 'is-live': childSummary.live }"><LoaderCircle v-if="childSummary.live" class="k-spin" :size="13" :stroke-width="1.75" aria-hidden="true" />{{ childSummary.text }} <span v-if="childSummary.live" class="muted">— this updates as they finish</span></p>
+          <ResourceTable
+            :columns="[{ key: 'agent', label: 'Agent', primary: true }, { key: 'kind', label: 'Kind' }, { key: 'input', label: 'Input' }, { key: 'phase', label: 'Phase' }, { key: 'duration', label: 'Duration' }, { key: 'usage', label: 'Usage' }]"
+            :rows="childRows"
+            row-key="id"
+            aria-label="Child runs"
+            variant="simple"
+            :loaded="true"
+            :interactive="true"
+            :row-aria-label="childAriaLabel"
+            @row-click="openChild(asChild($event))"
+          >
+            <template #agent="{ row }"><strong>{{ asChild(row).agent }}</strong></template>
+            <template #kind="{ row }"><span class="muted mono">{{ asChild(row).trigger === 'spawn' ? 'worker' : 'delegated' }}</span></template>
+            <template #input="{ row }"><span class="agents-cell-task muted">{{ asChild(row).inputPreview || '—' }}</span></template>
+            <template #phase="{ row }"><StatusBadge class="agents-phase" :class="`agents-phase-${phaseMeta[asChild(row).phase].cls}`" :status="phaseMeta[asChild(row).phase].label" :tone="phaseMeta[asChild(row).phase].tone" /></template>
+            <template #duration="{ row }"><span class="muted">{{ asChild(row).durationMS ? fmtDuration(asChild(row).durationMS) : '—' }}</span></template>
+            <template #usage="{ row }"><span class="muted mono">{{ fmtTokens(asChild(row).inputTokens + asChild(row).outputTokens) }} · {{ fmtUSD(asChild(row).usdMicros) }}</span></template>
+          </ResourceTable>
+        </ResourceSectionCard>
+        </div>
       </template>
     </ResourcePage>
   </div>


### PR DESCRIPTION
Agents Activity and run detail lacked a clear visual hierarchy: metadata had missing layout rules, trace steps appeared as separate nested cards, and run output inherited chat-bubble styling. This change makes runs easier to scan and inspect while retaining PortalKit's standard ResourceTable.

- Activity groups input preview with agent identity and trigger with run class, aligns numeric columns, and retains shared filters, cursor pagination, read states, truncation disclosure, and keyboard row navigation. Pending actions keep their disclosed arguments and approval/denial controls.
- Run detail groups primary metadata in a compact summary, moves secondary facts into a responsive details column, and puts approval/failure states before the trace. Tool calls expand within one trace surface; output uses document styling. Failed runs retain partial output and source links.
- Child runs continue to use ResourceTable. Unknown step outcomes are no longer styled as success, and active runs with no children do not claim to have answered directly.
- Provider-specific composition lives in activity.css; canonical PortalKit files are unchanged. The design contract and focused regression coverage are updated.

Validation:

- `make build-agents-provider-portal`: 350 tests passed, Vue typecheck passed, production build passed.
- `make verify-design-docs`, `make verify-portalkit`, and `make verify-ui-conformance`: passed; UI conformance reported zero violations.
- `git diff --check`: passed.
- Chromium rendered the built custom element with controlled fixture API responses in dark/light themes at 1440px and 390px. Twelve screenshots cover Activity, successful/approval/failed run detail, and narrow layouts. Checked navigation, step expansion, approval submission, child table presence, and page overflow. Screenshots were supplied in the originating Codex task.

Browser evidence uses fixture data, not a live backend. The fixture event stream closes, which explains the reconnecting indicator in Activity screenshots. No backend behavior or shared table implementation changes are included.
