### PR TITLE
fix(auth): unify sign-in and completion-page presentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,6 +399,27 @@ lint-app-studio-mcp-access: $(GOLANGCI_LINT) ## Lint the MCP authorization integ
 	$(GOLANGCI_LINT) run ./pkg/hub/mcpaggregate
 	cd providers/app-studio && $(CURDIR)/$(GOLANGCI_LINT) run ./controller/project ./hubmcp
 
+.PHONY: test-auth fmt-auth lint-auth
+test-auth: ## Verify standalone auth and status-page surfaces
+	go test -count=1 ./pkg/cli/auth ./pkg/hub/appauth
+	cd hack/dex && go test -count=1 ./...
+	cd provider-sdk && go test -count=1 ./statuspage
+	cd providers/agents && go test -count=1 ./api
+	cd providers/code && go test -count=1 ./oauthgithub
+
+fmt-auth: $(GOLANGCI_LINT) ## Format auth and status-page sources with the pinned formatter
+	$(GOLANGCI_LINT) fmt pkg/cli/auth/authenticator.go pkg/cli/auth/authenticator_test.go pkg/hub/appauth/appauth.go pkg/hub/appauth/appauth_test.go
+	cd hack/dex && $(CURDIR)/$(GOLANGCI_LINT) fmt web/web_test.go
+	cd provider-sdk && $(CURDIR)/$(GOLANGCI_LINT) fmt statuspage/statuspage.go statuspage/statuspage_test.go
+	cd providers/agents && $(CURDIR)/$(GOLANGCI_LINT) fmt api/oauth.go
+	cd providers/code && $(CURDIR)/$(GOLANGCI_LINT) fmt oauthgithub/oauth.go oauthgithub/oauth_test.go
+
+lint-auth: $(GOLANGCI_LINT) ## Lint auth and status-page sources with the pinned linter
+	$(GOLANGCI_LINT) run $(ARGS) ./pkg/cli/auth ./pkg/hub/appauth
+	cd provider-sdk && $(CURDIR)/$(GOLANGCI_LINT) run $(ARGS) ./statuspage
+	cd providers/agents && $(CURDIR)/$(GOLANGCI_LINT) run $(ARGS) ./api
+	cd providers/code && $(CURDIR)/$(GOLANGCI_LINT) run $(ARGS) ./oauthgithub
+
 .PHONY: test-code-provider test-code-provider-race lint-code-provider fix-lint-code-provider
 test-code-provider: ## Run standalone Code provider tests
 	cd providers/code && go test -count=1 ./...

--- a/hack/dex/web/static/faros-mark.svg
+++ b/hack/dex/web/static/faros-mark.svg
@@ -1,7 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-labelledby="title">
-  <title>Faros</title>
-  <rect width="32" height="32" rx="6" fill="#111320"/>
-  <path d="M8 7v18M8 16l12-9M8 16l12 9" fill="none" stroke="#a18aff" stroke-linecap="square" stroke-width="3"/>
-  <circle cx="23" cy="7" r="2" fill="#2fd6a0"/>
-  <circle cx="23" cy="25" r="2" fill="#8b6bff"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-labelledby="title">
+  <title id="title">Faros</title>
+  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" fill="none" stroke="#8b6bff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
 </svg>

--- a/hack/dex/web/static/main.css
+++ b/hack/dex/web/static/main.css
@@ -60,8 +60,8 @@
   --faros-danger-subtle: rgba(255, 93, 93, 0.12);
   --faros-text-primary: #e9e9f2;
   --faros-text-secondary: #8a8ca6;
-  --faros-text-muted: #5d5f78;
-  --faros-on-accent: #ffffff;
+  --faros-text-muted: #8587a1;
+  --faros-on-accent: #0a0b12;
   /* design.quality.exceptions: provider identity tiles keep the provider's brand-approved ground. */
   --faros-brand-tile-google: #ffffff;
   --faros-brand-tile-light: #f5f5f5;
@@ -156,10 +156,7 @@ body::before {
 }
 
 .brand-name {
-  background: linear-gradient(90deg, var(--faros-accent-hover), var(--faros-text-primary));
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--faros-text-primary);
 }
 
 .theme-panel {

--- a/hack/dex/web/templates/device.html
+++ b/hack/dex/web/templates/device.html
@@ -9,18 +9,18 @@
         <label for="user_code">Device code</label>
       </div>
       {{ if( .UserCode  )}}
-      <input tabindex="2" required id="user_code" name="user_code" type="text" class="theme-form-input" autocomplete="off" value="{{.UserCode}}" {{ if .Invalid }} autofocus {{ end }}/>
+      <input required id="user_code" name="user_code" type="text" class="theme-form-input" autocomplete="off" value="{{.UserCode}}" {{ if .Invalid }} autofocus aria-invalid="true" aria-describedby="login-error" aria-errormessage="login-error" {{ end }}/>
       {{ else }}
-      <input tabindex="2" required id="user_code" name="user_code" type="text" class="theme-form-input" placeholder="XXXX-XXXX" autocomplete="off"  {{ if .Invalid }} autofocus {{ end }}/>
+      <input required id="user_code" name="user_code" type="text" class="theme-form-input" placeholder="XXXX-XXXX" autocomplete="off"  {{ if .Invalid }} autofocus aria-invalid="true" aria-describedby="login-error" aria-errormessage="login-error" {{ end }}/>
       {{ end }}
     </div>
 
     {{ if .Invalid }}
-    <div id="login-error" class="dex-error-box">
+    <div id="login-error" class="dex-error-box" role="alert" aria-live="assertive" aria-atomic="true">
       That code is invalid or expired — check the value on your device and try again.
     </div>
     {{ end }}
-    <button tabindex="3" id="submit-login" type="submit" class="dex-btn theme-btn--primary">Continue</button>
+    <button id="submit-login" type="submit" class="dex-btn theme-btn--primary">Verify code</button>
   </form>
 </div>
 

--- a/hack/dex/web/templates/header.html
+++ b/hack/dex/web/templates/header.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -14,6 +14,6 @@
   <body class="theme-body">
     <div class="dex-container">
       <div class="brand" aria-label="Faros">
-        <span class="brand-mark" aria-hidden="true">K</span>
+        <img class="brand-mark" src="{{ url .ReqPath "static/faros-mark.svg" }}" alt="" aria-hidden="true">
         <span class="brand-name">Faros</span>
       </div>

--- a/hack/dex/web/templates/password.html
+++ b/hack/dex/web/templates/password.html
@@ -8,22 +8,22 @@
       <div class="theme-form-label">
         <label for="login">{{ .UsernamePrompt }}</label>
       </div>
-	  <input tabindex="1" required id="login" name="login" type="text" class="theme-form-input" autocomplete="username" placeholder="{{ .UsernamePrompt | lower }}" {{ if .Username }} value="{{ .Username }}" {{ else }} autofocus {{ end }}/>
+	  <input required id="login" name="login" type="text" class="theme-form-input" autocomplete="username" placeholder="{{ .UsernamePrompt | lower }}" {{ if .Username }} value="{{ .Username }}" {{ else }} autofocus {{ end }}{{ if .Invalid }} aria-invalid="true" aria-describedby="login-error" aria-errormessage="login-error" {{ end }}/>
     </div>
     <div class="theme-form-row">
       <div class="theme-form-label">
         <label for="password">Password</label>
       </div>
-	  <input tabindex="2" required id="password" name="password" type="password" class="theme-form-input" autocomplete="current-password" placeholder="Enter your password" {{ if .Invalid }} autofocus {{ end }}/>
+	  <input required id="password" name="password" type="password" class="theme-form-input" autocomplete="current-password" placeholder="Enter your password" {{ if .Invalid }} autofocus aria-invalid="true" aria-describedby="login-error" aria-errormessage="login-error" {{ end }}/>
     </div>
 
     {{ if .Invalid }}
-      <div id="login-error" class="dex-error-box">
+      <div id="login-error" class="dex-error-box" role="alert" aria-live="assertive" aria-atomic="true">
         Invalid credentials. Please check your {{ .UsernamePrompt | lower }} and password.
       </div>
     {{ end }}
 
-    <button tabindex="3" id="submit-login" type="submit" class="dex-btn theme-btn--primary">Sign in with Faros</button>
+    <button id="submit-login" type="submit" class="dex-btn theme-btn--primary">Sign in with Faros</button>
 
   </form>
   {{ if .BackLink }}

--- a/hack/dex/web/web_test.go
+++ b/hack/dex/web/web_test.go
@@ -55,8 +55,16 @@ func TestEmbeddedFarosWebAssetsKeepOIDCFrontendContract(t *testing.T) {
 	header := readEmbedded(t, assets, "templates/header.html")
 	if !strings.Contains(header, "<title>Faros — Sign in</title>") ||
 		!strings.Contains(header, "Sign in to Faros securely") ||
-		!strings.Contains(header, `static/faros-mark.svg`) {
+		!strings.Contains(header, `static/faros-mark.svg`) ||
+		!strings.Contains(header, `<html lang="en">`) ||
+		!strings.Contains(header, `class="brand-mark"`) {
 		t.Fatalf("header lost Faros title, description, or mark: %s", header)
+	}
+	mark := readEmbedded(t, assets, "static/faros-mark.svg")
+	if !strings.Contains(mark, `viewBox="0 0 24 24"`) ||
+		!strings.Contains(mark, `d="M21 16V8a2 2 0 0 0-1-1.73`) ||
+		strings.Contains(mark, `M8 7v18`) {
+		t.Fatalf("Faros mark is not the canonical Lucide Hexagon: %s", mark)
 	}
 
 	login := readEmbedded(t, assets, "templates/login.html")
@@ -64,8 +72,19 @@ func TestEmbeddedFarosWebAssetsKeepOIDCFrontendContract(t *testing.T) {
 		t.Fatalf("connector action copy is not Faros sign-in copy: %s", login)
 	}
 	password := readEmbedded(t, assets, "templates/password.html")
-	if !strings.Contains(password, "Sign in with Faros") {
+	if !strings.Contains(password, "Sign in with Faros") ||
+		strings.Contains(password, "tabindex=") ||
+		!strings.Contains(password, `aria-describedby="login-error"`) ||
+		!strings.Contains(password, `aria-errormessage="login-error"`) ||
+		!strings.Contains(password, `role="alert"`) {
 		t.Fatalf("password action does not identify Faros: %s", password)
+	}
+	device := readEmbedded(t, assets, "templates/device.html")
+	if strings.Contains(device, "tabindex=") ||
+		!strings.Contains(device, "Verify code") ||
+		!strings.Contains(device, `aria-describedby="login-error"`) ||
+		!strings.Contains(device, `role="alert"`) {
+		t.Fatalf("device form lost native order, error association, or action copy: %s", device)
 	}
 
 	var pages strings.Builder
@@ -90,6 +109,15 @@ func TestEmbeddedFarosWebAssetsKeepOIDCFrontendContract(t *testing.T) {
 		}
 	}
 	content := pages.String()
+	css := readEmbedded(t, assets, "static/main.css")
+	for _, want := range []string{
+		"--faros-text-muted: #8587a1",
+		"--faros-on-accent: #0a0b12",
+	} {
+		if !strings.Contains(css, want) {
+			t.Fatalf("Dex stylesheet is missing canonical dark token %q", want)
+		}
+	}
 	for _, forbidden := range []string{
 		"fonts.googleapis.com",
 		"fonts.gstatic.com",

--- a/pkg/cli/auth/authenticator.go
+++ b/pkg/cli/auth/authenticator.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/faroshq/provider-sdk/statuspage"
+
 	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
 )
 
@@ -129,7 +131,12 @@ func (a *LocalhostCallbackAuthenticator) callback(w http.ResponseWriter, r *http
 	a.response = resp
 
 	w.Header().Set("Content-Type", "text/html")
-	_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><body><h2>Login successful!</h2><p>You can close this tab and return to the terminal.</p></body></html>`)
+	_ = statuspage.Render(w, statuspage.Page{
+		Title:   "Login successful",
+		Heading: "Login successful",
+		Message: "You can close this tab and return to the terminal.",
+		State:   statuspage.Success,
+	})
 
 	a.once.Do(func() { close(a.done) })
 }

--- a/pkg/cli/auth/authenticator_test.go
+++ b/pkg/cli/auth/authenticator_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
+)
+
+func TestLocalhostCallbackRendersBrandedSuccessPage(t *testing.T) {
+	data, err := json.Marshal(tenancyv1alpha1.LoginResponse{UserID: "user-1", Email: "user@example.com"})
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	req := httptest.NewRequest("GET", "/callback?response="+url.QueryEscape(base64.URLEncoding.EncodeToString(data)), nil)
+	rec := httptest.NewRecorder()
+	a := NewLocalhostCallbackAuthenticator()
+	a.callback(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got, want := rec.Header().Get("Content-Type"), "text/html"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`<html lang="en">`,
+		`<meta name="viewport" content="width=device-width, initial-scale=1">`,
+		`role="status" aria-live="polite"`,
+		`<span>Faros</span>`,
+		`You can close this tab and return to the terminal.`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("callback page missing %q: %s", want, body)
+		}
+	}
+}

--- a/pkg/hub/appauth/appauth.go
+++ b/pkg/hub/appauth/appauth.go
@@ -58,6 +58,8 @@ import (
 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/klog/v2"
 
+	"github.com/faroshq/provider-sdk/statuspage"
+
 	"github.com/faroshq/faros/pkg/browsersession"
 )
 
@@ -603,16 +605,10 @@ func (h *Handler) renderError(w http.ResponseWriter, status int, title, detail s
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("Referrer-Policy", "no-referrer")
 	w.WriteHeader(status)
-	_, _ = fmt.Fprintf(w, `<!doctype html><html><head><meta charset="utf-8"><title>%s</title><style>
-body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0c0a14;color:#e8e6f0;font:16px/1.5 system-ui,sans-serif}
-main{max-width:26rem;padding:2rem;text-align:center}
-h1{font-size:1.15rem;margin:0 0 .6rem}
-p{margin:0;color:#a9a4bd;font-size:.92rem}
-</style></head><body><main><h1>%s</h1><p>%s</p></main></body></html>`,
-		htmlEscape(title), htmlEscape(title), htmlEscape(detail))
-}
-
-func htmlEscape(s string) string {
-	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&#39;")
-	return r.Replace(s)
+	_ = statuspage.Render(w, statuspage.Page{
+		Title:   title,
+		Heading: title,
+		Message: detail,
+		State:   statuspage.Error,
+	})
 }

--- a/pkg/hub/appauth/appauth_test.go
+++ b/pkg/hub/appauth/appauth_test.go
@@ -362,6 +362,42 @@ func TestAuthorizeDeniedRendersBrandedForbidden(t *testing.T) {
 	}
 }
 
+func TestRenderErrorPreservesSecurityHeadersAndEscapesDisplayText(t *testing.T) {
+	rec := httptest.NewRecorder()
+	(&Handler{}).renderError(rec, http.StatusForbidden, `Denied <title>`, `Reason <script>alert(1)</script>`)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if got, want := rec.Header().Get("Content-Type"), "text/html; charset=utf-8"; got != want {
+		t.Fatalf("Content-Type = %q, want %q", got, want)
+	}
+	for header, want := range map[string]string{
+		"Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'; form-action 'none'",
+		"X-Frame-Options":         "DENY",
+		"Referrer-Policy":         "no-referrer",
+	} {
+		if got := rec.Header().Get(header); got != want {
+			t.Errorf("%s = %q, want %q", header, got, want)
+		}
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`<html lang="en">`,
+		`<meta name="viewport" content="width=device-width, initial-scale=1">`,
+		`role="alert" aria-live="assertive"`,
+		`Denied &lt;title&gt;`,
+		`Reason &lt;script&gt;alert(1)&lt;/script&gt;`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("error page missing %q: %s", want, body)
+		}
+	}
+	if strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatalf("error detail was not escaped: %s", body)
+	}
+}
+
 func TestAuthorizePolicyOutageFailsClosed(t *testing.T) {
 	f := newFixture(t)
 	f.sarErr = http.ErrServerClosed

--- a/provider-sdk/statuspage/README.md
+++ b/provider-sdk/statuspage/README.md
@@ -1,0 +1,41 @@
+# statuspage
+
+`statuspage` renders the small Faros documents used when a browser flow ends
+outside the portal shell, such as an OAuth callback or an app-access result.
+The helper owns the complete self-contained HTML presentation. It does not own
+response headers, authentication, redirects, CSP, or callback behavior; the
+caller keeps those responsibilities.
+
+```go
+err := statuspage.Render(w, statuspage.Page{
+    Title:   "Connected",
+    Heading: "Connection complete",
+    Message: "You can return to the portal.",
+    State:   statuspage.Success,
+})
+```
+
+`Page.Title`, `Heading`, and `Message` are display strings and are escaped by
+the `html/template` renderer. `State` is `Success` or `Error`; unknown values
+are rendered as success. Error pages use `role="alert"` with assertive live
+announcements, while success pages use `role="status"` with polite
+announcements. The document has a viewport declaration, bounded and wrapping
+content, reduced-motion rules, and accessible heading/message relationships.
+
+`Script` is an optional `template.HTML` value for a trusted caller-owned script
+element. The helper inserts it after the status markup without inspecting or
+rewriting it. Callers must construct that value deliberately with
+`html/template`; arbitrary user or provider display text belongs in the normal
+escaped fields.
+
+The page is fixed dark and self-contained. Its inline stylesheet owns the
+current Faros surface, border, accent, success, danger, and text tokens and a
+small inline Hexagon mark. It uses a system-font fallback (`ui-sans-serif`,
+`system-ui`, and monospace fallbacks), contains no external font or other asset
+request, and makes no CSP change. The fixed-dark system-font choice is specific
+to this standalone status document; it is separate from Dex's standalone
+stylesheet, which embeds its actual Instrument Sans and IBM Plex Mono faces.
+
+The package is intentionally presentation-only so existing auth and browser
+flow contracts can adopt the same bounded status surface without giving the
+shared helper access to credentials or headers.

--- a/provider-sdk/statuspage/statuspage.go
+++ b/provider-sdk/statuspage/statuspage.go
@@ -1,0 +1,176 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Package statuspage renders small, self-contained Faros status documents for
+// browser flows that finish outside the portal shell.
+package statuspage
+
+import (
+	"html/template"
+	"io"
+)
+
+// State controls the semantic status role and the status color used by the
+// page. Callers should select Error when the document reports a failed action.
+type State string
+
+const (
+	// Success is a completed action.
+	Success State = "success"
+	// Error is a failed action that needs the user's attention.
+	Error State = "error"
+)
+
+// Page is the caller-owned content for a status document. Script is an
+// optional, trusted script element owned by the caller; it is inserted after
+// the status markup so the caller can preserve its own browser-flow behavior.
+// Callers should build it with html/template. Display strings are escaped by
+// the html/template renderer.
+type Page struct {
+	Title   string
+	Heading string
+	Message string
+	State   State
+	Script  template.HTML
+}
+
+// Render writes a bounded, branded status document. It only renders the
+// presentation; callers retain ownership of response headers, CSP, auth, and
+// callback behavior.
+func Render(w io.Writer, page Page) error {
+	page.State = normalizeState(page.State)
+	return pageTemplate.Execute(w, page)
+}
+
+func normalizeState(state State) State {
+	if state == Error {
+		return Error
+	}
+	return Success
+}
+
+var pageTemplate = template.Must(template.New("faros-status-page").Parse(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ .Title }}</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --faros-surface: #0a0b12;
+      --faros-surface-raised: #111320;
+      --faros-surface-overlay: #171927;
+      --faros-border-default: rgba(255, 255, 255, 0.11);
+      --faros-accent: #8b6bff;
+      --faros-accent-hover: #a18aff;
+      --faros-accent-subtle: rgba(139, 107, 255, 0.14);
+      --faros-success: #2fd6a0;
+      --faros-success-subtle: rgba(47, 214, 160, 0.12);
+      --faros-danger: #ff5d5d;
+      --faros-danger-subtle: rgba(255, 93, 93, 0.12);
+      --faros-text-primary: #e9e9f2;
+      --faros-text-secondary: #8a8ca6;
+      --faros-text-muted: #8587a1;
+      --faros-on-accent: #0a0b12;
+      --faros-font-sans: ui-sans-serif, system-ui, sans-serif;
+      --faros-font-mono: ui-monospace, "SFMono-Regular", Menlo, monospace;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { min-height: 100%; }
+    body {
+      min-width: 320px;
+      margin: 0;
+      background: var(--faros-surface);
+      color: var(--faros-text-primary);
+      font-family: var(--faros-font-sans);
+      font-size: 16px;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+    }
+    .faros-status {
+      display: grid;
+      min-height: 100vh;
+      align-content: center;
+      justify-items: center;
+      gap: 24px;
+      padding: 32px 20px;
+    }
+    .faros-status__brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      color: var(--faros-text-primary);
+      font-family: var(--faros-font-mono);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.20em;
+      line-height: 1;
+      text-transform: uppercase;
+    }
+    .faros-status__mark {
+      width: 28px;
+      height: 28px;
+      flex: 0 0 28px;
+      padding: 4px;
+      border: 1px solid var(--faros-border-default);
+      border-radius: 6px;
+      background: var(--faros-surface-overlay);
+    }
+    .faros-status__surface {
+      width: min(100%, 32rem);
+      padding: 32px;
+      border: 1px solid var(--faros-border-default);
+      border-radius: 6px;
+      background: var(--faros-surface-raised);
+      box-shadow: 0 1px 2px rgba(10, 11, 18, 0.40);
+      text-align: center;
+    }
+    h1 {
+      margin: 0;
+      color: var(--faros-text-primary);
+      font-size: clamp(22px, 5vw, 28px);
+      font-weight: 650;
+      letter-spacing: -0.02em;
+      line-height: 1.15;
+      overflow-wrap: anywhere;
+    }
+    p {
+      max-width: 60ch;
+      margin: 14px auto 0;
+      color: var(--faros-text-secondary);
+      overflow-wrap: anywhere;
+    }
+    .faros-status--success p { color: var(--faros-success); }
+    .faros-status--error p { color: var(--faros-danger); }
+    @media (max-width: 480px) {
+      .faros-status { padding: 24px 16px; }
+      .faros-status__surface { padding: 24px 20px; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+    }
+  </style>
+</head>
+<body>
+  <main class="faros-status faros-status--{{ .State }}">
+    <div class="faros-status__brand" aria-label="Faros">
+      <svg class="faros-status__mark" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" fill="none" stroke="#8b6bff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+      </svg>
+      <span>Faros</span>
+    </div>
+    <section class="faros-status__surface" {{ if eq .State "error" }}role="alert" aria-live="assertive"{{ else }}role="status" aria-live="polite"{{ end }} aria-labelledby="status-heading" aria-describedby="status-message">
+      <h1 id="status-heading">{{ .Heading }}</h1>
+      <p id="status-message">{{ .Message }}</p>
+    </section>
+  </main>
+  {{ if .Script }}{{ .Script }}{{ end }}
+</body>
+</html>`))

--- a/provider-sdk/statuspage/statuspage_test.go
+++ b/provider-sdk/statuspage/statuspage_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package statuspage
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+)
+
+func TestRenderEscapesDisplayTextAndProvidesAccessibleErrorState(t *testing.T) {
+	var out bytes.Buffer
+	if err := Render(&out, Page{
+		Title:   `<title><script>alert(1)</script>`,
+		Heading: `<heading>&"`,
+		Message: `<message>`,
+		State:   Error,
+	}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	body := out.String()
+	for _, raw := range []string{"<title><script>", `<heading>&"`, "<message>"} {
+		if strings.Contains(body, raw) {
+			t.Fatalf("unescaped display text %q in %s", raw, body)
+		}
+	}
+	for _, want := range []string{
+		`<html lang="en">`,
+		`<meta name="viewport" content="width=device-width, initial-scale=1">`,
+		`role="alert" aria-live="assertive"`,
+		`aria-labelledby="status-heading"`,
+		`aria-describedby="status-message"`,
+		`--faros-surface: #0a0b12`,
+		`--faros-text-secondary: #8a8ca6`,
+		`--faros-text-primary: #e9e9f2`,
+		`overflow-wrap: anywhere`,
+		`viewBox="0 0 24 24"`,
+		`d="M21 16V8a2 2 0 0 0-1-1.73`,
+		`<span>Faros</span>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("rendered page missing %q: %s", want, body)
+		}
+	}
+	if strings.Contains(body, `role="status"`) {
+		t.Fatalf("error page has success status role: %s", body)
+	}
+	if strings.Contains(body, `faros-status__surface::before`) || strings.Contains(body, `faros-accent-glow`) {
+		t.Fatalf("status page uses a decorative glow: %s", body)
+	}
+}
+
+func TestRenderUsesPoliteSuccessStateAndCallerScript(t *testing.T) {
+	var out bytes.Buffer
+	if err := Render(&out, Page{
+		Title:   "Complete",
+		Heading: "Connected",
+		Message: "Return to the portal.",
+		State:   Success,
+		Script:  template.HTML(`<script>document.title = "Connected";</script>`),
+	}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, `role="status" aria-live="polite"`) {
+		t.Fatalf("success page is not a polite status: %s", body)
+	}
+	if !strings.Contains(body, `<script>document.title = "Connected";</script>`) {
+		t.Fatalf("caller script was not preserved: %s", body)
+	}
+	if strings.Contains(body, "fonts.googleapis.com") || strings.Contains(body, "font-src") {
+		t.Fatalf("status page requests external fonts or CSP resources: %s", body)
+	}
+}

--- a/providers/agents/api/oauth.go
+++ b/providers/agents/api/oauth.go
@@ -38,6 +38,7 @@ import (
 	agentsv1alpha1 "github.com/faroshq/provider-agents/apis/v1alpha1"
 	agentsclient "github.com/faroshq/provider-agents/client"
 	"github.com/faroshq/provider-agents/llm"
+	"github.com/faroshq/provider-sdk/statuspage"
 )
 
 // oauthPreset holds a provider's endpoints and quirks.
@@ -306,9 +307,12 @@ func (s *Server) oauthCallback(w http.ResponseWriter, r *http.Request) {
 	_, _ = dyn.Resource(agentsclient.ConnectionGVR).UpdateStatus(r.Context(), obj, metav1.UpdateOptions{})
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, `<html><body style="font-family:sans-serif;text-align:center;margin-top:20vh">
-		<h2>✅ %s connected</h2><p>You can close this tab and return to faros.</p></body></html>`,
-		conn.Spec.OAuth.Provider)
+	_ = statuspage.Render(w, statuspage.Page{
+		Title:   "OAuth connection complete",
+		Heading: conn.Spec.OAuth.Provider + " connected",
+		Message: "You can close this tab and return to Faros.",
+		State:   statuspage.Success,
+	})
 }
 
 type oauthToken struct {

--- a/providers/code/oauthgithub/oauth.go
+++ b/providers/code/oauthgithub/oauth.go
@@ -35,6 +35,7 @@ You may obtain a copy of the License at
 package oauthgithub
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -45,6 +46,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/faroshq/provider-sdk/statuspage"
 	"golang.org/x/oauth2"
 	ghoauth "golang.org/x/oauth2/github"
 )
@@ -227,7 +229,7 @@ func fetchUser(ctx context.Context, token string) (login, scopes string, err err
 	if err != nil {
 		return "", "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	scopes = resp.Header.Get("X-OAuth-Scopes")
 	if resp.StatusCode != http.StatusOK {
 		return "", scopes, fmt.Errorf("github /user: %s", resp.Status)
@@ -264,7 +266,24 @@ func (h *Handler) renderResult(w http.ResponseWriter, res callbackResult) {
 			"error":  res.Error,
 		})),
 	}
-	_ = callbackTmpl.Execute(w, data)
+	var script bytes.Buffer
+	_ = callbackScriptTmpl.Execute(&script, data)
+
+	state := statuspage.Success
+	heading := "GitHub connected"
+	message := "Connected — you can close this window."
+	if res.Error != "" {
+		state = statuspage.Error
+		heading = "GitHub connection failed"
+		message = "GitHub could not be connected."
+	}
+	_ = statuspage.Render(w, statuspage.Page{
+		Title:   "GitHub connection",
+		Heading: heading,
+		Message: message,
+		State:   state,
+		Script:  template.HTML(script.String()),
+	})
 }
 
 func mustJSON(v any) string {
@@ -272,19 +291,17 @@ func mustJSON(v any) string {
 	return string(b)
 }
 
-var callbackTmpl = template.Must(template.New("cb").Parse(`<!doctype html>
-<html><head><meta charset="utf-8"><title>Connecting…</title></head>
-<body style="font-family:system-ui,sans-serif;background:#0d0d14;color:#eeeef3;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
-<p id="m">Completing GitHub connection…</p>
-<script>
+var callbackScriptTmpl = template.Must(template.New("cb-script").Parse(`<script>
 (function(){
   var payload = {{ .Payload }};
   try {
     // {{ .Origin }} is rendered by html/template as a quoted JS string literal.
     if (window.opener) { window.opener.postMessage(payload, {{ .Origin }}); }
   } catch (e) {}
-  document.getElementById('m').textContent = payload.error ? ('Failed: ' + payload.error) : 'Connected — you can close this window.';
+  var message = document.getElementById('status-message');
+  if (message) {
+    message.textContent = payload.error ? ('Failed: ' + payload.error) : 'Connected — you can close this window.';
+  }
   setTimeout(function(){ window.close(); }, payload.error ? 4000 : 600);
 })();
-</script>
-</body></html>`))
+</script>`))

--- a/providers/code/oauthgithub/oauth_test.go
+++ b/providers/code/oauthgithub/oauth_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package oauthgithub
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRenderResultPreservesOriginPayloadAndCloseTiming(t *testing.T) {
+	h := &Handler{cfg: Config{PortalOrigin: "https://portal.example"}}
+
+	t.Run("success", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		h.renderResult(rec, callbackResult{
+			State:  `state<&`,
+			Token:  `token<&`,
+			Login:  `octo-user`,
+			Scopes: `repo,workflow`,
+		})
+
+		body := rec.Body.String()
+		if got, want := rec.Header().Get("Content-Type"), "text/html; charset=utf-8"; got != want {
+			t.Fatalf("Content-Type = %q, want %q", got, want)
+		}
+		for _, want := range []string{
+			`<html lang="en">`,
+			`role="status" aria-live="polite"`,
+			`<h1 id="status-heading">GitHub connected</h1>`,
+			`postMessage(payload, "https://portal.example")`,
+			`"type":"faros-github-oauth"`,
+			`"state":"state\u003c\u0026"`,
+			`"token":"token\u003c\u0026"`,
+			`setTimeout(function(){ window.close(); }, payload.error ? 4000 : 600);`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("success callback missing %q: %s", want, body)
+			}
+		}
+		if strings.Contains(body, "Connecting to GitHub") {
+			t.Fatalf("success callback still presents an in-progress heading: %s", body)
+		}
+		if strings.Contains(body, `token<&`) {
+			t.Fatalf("token was inserted without JSON escaping: %s", body)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		h.renderResult(rec, callbackResult{State: "state", Error: `denied <script>`})
+
+		body := rec.Body.String()
+		for _, want := range []string{
+			`role="alert" aria-live="assertive"`,
+			`GitHub connection failed`,
+			`message.textContent = payload.error ? ('Failed: ' + payload.error)`,
+			`setTimeout(function(){ window.close(); }, payload.error ? 4000 : 600);`,
+			`"error":"denied \u003cscript\u003e"`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("error callback missing %q: %s", want, body)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Authentication completion/error pages and Dex sign-in screens used inconsistent presentation and feedback. Introduce one shared status-page renderer and align branding, labels, wrapping, and error presentation while retaining escaping, CSP, origin, and callback behavior.

Shared status-page package; CLI and hub auth pages; Agents/Code OAuth responses; Dex templates/styles; focused regressions and Makefile auth gates.

## Validation

make test-auth passed across CLI/hub auth, Dex, shared status pages, Agents API, and Code OAuth. Design/parity/conformance gates passed. Existing Agents API lint findings were previously reproduced on the base; lint-auth is not claimed as passing.

## Stack

Part 2 of 8. Merge in order; this PR targets the preceding branch.
1. [standardize shared menus, confirmations, and touch targets](https://github.com/faroshq/faros/pull/682)
2. [unify sign-in and completion-page presentation](https://github.com/faroshq/faros/pull/683) **(this PR)**
3. [make onboarding and form states honest and accessible](https://github.com/faroshq/faros/pull/684)
4. [align workspace reads, dashboard menus, and terminal controls](https://github.com/faroshq/faros/pull/685)
5. [align resource forms and validation across providers](https://github.com/faroshq/faros/pull/686)
6. [make configuration saves and connection states consistent](https://github.com/faroshq/faros/pull/687)
7. [align conversation controls and workbench feedback](https://github.com/faroshq/faros/pull/688)
8. [harden project flows and keep Share above workspace surfaces](https://github.com/faroshq/faros/pull/689)

The eight-PR stack excludes the audit findings and coverage ledger. Each implementation slice was checked independently; live browser evidence was collected on the complete audit branch.
