### PR TITLE
fix(portal): make onboarding and form states honest and accessible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: sync-portalkit verify-portalkit verify-agentkit verify-ui-conformance verify-design-docs verify-tilt-browser-deployment test-portal-settings-conformance test-create-flow-conformance serve-model-form-visual test-model-form-visual build-portal
+.PHONY: sync-portalkit verify-portalkit verify-agentkit verify-ui-conformance verify-design-docs verify-tilt-browser-deployment test-portal test-portal-settings-conformance test-create-flow-conformance serve-model-form-visual test-model-form-visual build-portal
 .PHONY: build-access-proxy docker-build-access-proxy
 .PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-hub-embedded-graphql run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-build-dev-agent load-dev-agent-image docker-build-universal-dev-image load-universal-dev-image docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal build-kuery-provider build-kuery-provider-portal run-provider-kuery kuery-db-up kuery-db-down install-provider-kuery init-provider-kuery uninstall-provider-kuery run-provider-quickstart install-provider-quickstart init-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-app-studio-provider build-app-studio-provider-portal codegen-app-studio-provider app-studio-preview-bridge-dev-key verify-app-studio-preview-bridge-dev-key verify-app-studio-eval app-studio-db-up app-studio-db-down run-provider-app-studio install-provider-app-studio init-provider-app-studio uninstall-provider-app-studio build-agents-provider build-agents-provider-portal codegen-agents-provider agents-db-up agents-db-down run-provider-agents install-provider-agents init-provider-agents uninstall-provider-agents build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code init-provider-code uninstall-provider-code build-databricks-provider build-databricks-provider-portal codegen-databricks-provider run-provider-databricks install-provider-databricks init-provider-databricks uninstall-provider-databricks test-databricks-provider-chart dev-kro-up dev-kro-down dev-kro-seed e2e-infrastructure e2e-provider e2e-provider-flags e2e-provider-all
 
@@ -481,8 +481,11 @@ verify-agentkit: ## Verify optional AgentKit style loading and conversation cont
 	@node --test provider-sdk/agentkit/styles.conformance.test.mjs
 	@node --test provider-sdk/agentkit-vue/conversation.conformance.test.mjs
 
+test-portal: ## Run the complete portal test suite
+	cd portal && npm test
+
 test-portal-settings-conformance: ## Verify portal shell and organization/workspace source contracts
-	@node --test portal/src/theme-bootstrap.test.mjs portal/src/pages/OrganizationsWorkspace.conformance.test.mjs
+	@node --test portal/src/theme-bootstrap.test.mjs portal/src/pages/OrganizationsWorkspace.conformance.test.mjs portal/src/pages/ProviderEnableDialog.deferred.test.mjs
 
 test-create-flow-conformance: ## Verify route-owned creation uses the canonical page skeleton
 	@node --test hack/create-flow-conformance.test.mjs

--- a/docs/design/foundations/typography.md
+++ b/docs/design/foundations/typography.md
@@ -1,5 +1,5 @@
 ---
-{"schema":1,"id":"design.foundations.typography","title":"Violet Circuit typography","kind":"token","status":"active","authority":{"design":"normative","implementation":"canonical"},"implementation":{"state":"shipped","notes":"Fonts are self-hosted in the host, while standalone fixed-dark Dex pages embed only their actual Instrument Sans and IBM Plex Mono faces."},"appliesTo":["portal","provider-portals","portalkit","dex"],"owner":"design-system","canonicalSource":[{"path":"docs/design/foundations/typography.md#typography","role":"design"},{"path":"portal/src/main.ts","role":"implementation"},{"path":"portal/src/assets/main.css","role":"implementation"},{"path":"hack/dex/web/static/main.css","role":"implementation"},{"path":"hack/dex/web/static/fonts","role":"implementation"}],"verification":{"state":"verified","checks":[{"kind":"command","ref":"make verify-ui-conformance","status":"passing"}]},"relatedDocuments":[]}
+{"schema":1,"id":"design.foundations.typography","title":"Violet Circuit typography","kind":"token","status":"active","authority":{"design":"normative","implementation":"canonical"},"implementation":{"state":"shipped","notes":"Fonts are self-hosted in the host, while standalone fixed-dark Dex pages embed only their actual Instrument Sans and IBM Plex Mono faces; status documents use a self-contained system-font fallback."},"appliesTo":["portal","provider-portals","portalkit","dex"],"owner":"design-system","canonicalSource":[{"path":"docs/design/foundations/typography.md#typography","role":"design"},{"path":"portal/src/main.ts","role":"implementation"},{"path":"portal/src/assets/main.css","role":"implementation"},{"path":"hack/dex/web/static/main.css","role":"implementation"},{"path":"hack/dex/web/static/fonts","role":"implementation"},{"path":"provider-sdk/statuspage/statuspage.go","role":"implementation"}],"verification":{"state":"verified","checks":[{"kind":"command","ref":"make verify-ui-conformance","status":"passing"}]},"relatedDocuments":[]}
 ---
 
 # Typography
@@ -18,6 +18,13 @@ Instrument Sans Variable (weight range 400–700) for sans copy and IBM Plex Mon
 (400, 600, and 700) for technical labels and values. Dex does not embed or
 declare Archivo, so the portal's `font-display` role does not apply there. No
 other faces and no CDN fonts are allowed.
+
+Standalone status documents rendered by `provider-sdk/statuspage` are a separate
+fixed-dark exception. They use the CSS system-font stack (`ui-sans-serif`,
+`system-ui`, and monospace fallbacks), with no embedded or external font assets;
+this keeps the self-contained auth/callback document usable under its caller's
+existing CSP. This exception does not change Dex's self-hosted Instrument Sans
+and IBM Plex Mono contract.
 
 The dense scale is explicit: `text-[9px]`–`text-[10px]` for eyebrows, section
 labels, and badges (uppercase, tracked, weight 600); `text-[11px]` for nav

--- a/hack/ui-conformance-exceptions.json
+++ b/hack/ui-conformance-exceptions.json
@@ -400,7 +400,7 @@
     {
       "rule": "pill-radius",
       "path": "portal/src/components/ControlPlaneProvisioning.vue",
-      "line": 67,
+      "line": 61,
       "column": 77,
       "match": "rounded-full",
       "reference": "design.quality.exceptions",

--- a/portal/src/components/AppLayout.vue
+++ b/portal/src/components/AppLayout.vue
@@ -572,7 +572,7 @@ const contextStatus = computed<ContextStatus>(() => {
           @click="toggleNavGroup('cat:' + group.name)"
         >
           <component :is="categoryIcon(group.icon)" class="h-3 w-3 flex-shrink-0 text-text-secondary/80" :stroke-width="2" />
-          <span class="text-[9px] font-semibold uppercase tracking-wider text-text-secondary/80">{{ group.name }}</span>
+          <span class="text-[9px] font-semibold uppercase tracking-wider text-text-secondary">{{ group.name }}</span>
           <div class="h-px flex-1 bg-border-default/40" />
           <ChevronDown
             class="h-3 w-3 flex-shrink-0 text-text-secondary/80 transition-transform duration-200"
@@ -665,7 +665,7 @@ const contextStatus = computed<ContextStatus>(() => {
           @click="toggleNavGroup('uncat')"
         >
           <Puzzle class="h-3 w-3 flex-shrink-0 text-text-secondary/80" :stroke-width="2" />
-          <span class="text-[9px] font-semibold uppercase tracking-wider text-text-secondary/80">Other</span>
+          <span class="text-[9px] font-semibold uppercase tracking-wider text-text-secondary">Other</span>
           <div class="h-px flex-1 bg-border-default/40" />
           <ChevronDown
             class="h-3 w-3 flex-shrink-0 text-text-secondary/80 transition-transform duration-200"
@@ -750,7 +750,8 @@ const contextStatus = computed<ContextStatus>(() => {
       >
         <div class="flex items-center gap-1.5">
           <CircleAlert v-if="providerBindingRetryable" class="h-3 w-3 shrink-0 text-danger" :stroke-width="1.75" aria-hidden="true" />
-          <RefreshCw v-else class="h-3 w-3 shrink-0 text-accent" :class="providerBindingState === 'loading' ? 'animate-spin' : ''" :stroke-width="1.75" aria-hidden="true" />
+          <Loader2 v-else-if="providerBindingState === 'loading'" class="h-3 w-3 shrink-0 animate-spin text-accent" :stroke-width="1.75" aria-hidden="true" />
+          <RefreshCw v-else class="h-3 w-3 shrink-0 text-accent" :stroke-width="1.75" aria-hidden="true" />
           <span v-if="sidebarExpanded" class="min-w-0 flex-1 truncate">{{ providerBindingStatusLabel }}</span>
           <span v-else class="sr-only">{{ providerBindingStatusLabel }}</span>
           <button
@@ -761,7 +762,8 @@ const contextStatus = computed<ContextStatus>(() => {
             :title="providerBindingState === 'loading' ? 'Refreshing provider access' : 'Retry provider access'"
             @click="retryProviderBindings"
           >
-            <RefreshCw class="h-3 w-3" :class="providerBindingState === 'loading' ? 'animate-spin' : ''" :stroke-width="1.75" aria-hidden="true" />
+            <Loader2 v-if="providerBindingState === 'loading'" class="h-3 w-3 animate-spin" :stroke-width="1.75" aria-hidden="true" />
+            <RefreshCw v-else class="h-3 w-3" :stroke-width="1.75" aria-hidden="true" />
             <span v-if="sidebarExpanded" class="sr-only">{{ providerBindingState === 'loading' ? 'Refreshing' : 'Retry' }}</span>
           </button>
         </div>
@@ -898,7 +900,8 @@ const contextStatus = computed<ContextStatus>(() => {
         :title="providerBindingError || providerBindingStatusLabel"
       >
         <CircleAlert v-if="providerBindingRetryable" class="h-3 w-3 shrink-0 text-danger" :stroke-width="1.75" aria-hidden="true" />
-        <RefreshCw v-else class="h-3 w-3 shrink-0 text-accent" :class="providerBindingState === 'loading' ? 'animate-spin' : ''" :stroke-width="1.75" aria-hidden="true" />
+        <Loader2 v-else-if="providerBindingState === 'loading'" class="h-3 w-3 shrink-0 animate-spin text-accent" :stroke-width="1.75" aria-hidden="true" />
+        <RefreshCw v-else class="h-3 w-3 shrink-0 text-accent" :stroke-width="1.75" aria-hidden="true" />
         <span class="hidden xl:inline">{{ providerBindingStatusLabel }}</span>
         <button
           type="button"
@@ -908,7 +911,8 @@ const contextStatus = computed<ContextStatus>(() => {
           :title="providerBindingState === 'loading' ? 'Refreshing provider access' : 'Retry provider access'"
           @click="retryProviderBindings"
         >
-          <RefreshCw class="h-3 w-3" :class="providerBindingState === 'loading' ? 'animate-spin' : ''" :stroke-width="1.75" aria-hidden="true" />
+          <Loader2 v-if="providerBindingState === 'loading'" class="h-3 w-3 animate-spin" :stroke-width="1.75" aria-hidden="true" />
+          <RefreshCw v-else class="h-3 w-3" :stroke-width="1.75" aria-hidden="true" />
         </button>
       </div>
       <button
@@ -1092,7 +1096,8 @@ const contextStatus = computed<ContextStatus>(() => {
           :title="providerBindingError || providerBindingStatusLabel"
         >
           <CircleAlert v-if="providerBindingRetryable" class="h-3 w-3 shrink-0 text-danger" :stroke-width="1.75" aria-hidden="true" />
-          <RefreshCw v-else class="h-3 w-3 shrink-0 text-accent" :class="providerBindingState === 'loading' ? 'animate-spin' : ''" :stroke-width="1.75" aria-hidden="true" />
+          <Loader2 v-else-if="providerBindingState === 'loading'" class="h-3 w-3 shrink-0 animate-spin text-accent" :stroke-width="1.75" aria-hidden="true" />
+          <RefreshCw v-else class="h-3 w-3 shrink-0 text-accent" :stroke-width="1.75" aria-hidden="true" />
           <span class="hidden 2xl:inline">{{ providerBindingStatusLabel }}</span>
           <button
             type="button"
@@ -1102,7 +1107,8 @@ const contextStatus = computed<ContextStatus>(() => {
             :title="providerBindingState === 'loading' ? 'Refreshing provider access' : 'Retry provider access'"
             @click="retryProviderBindings"
           >
-            <RefreshCw class="h-3 w-3" :class="providerBindingState === 'loading' ? 'animate-spin' : ''" :stroke-width="1.75" aria-hidden="true" />
+            <Loader2 v-if="providerBindingState === 'loading'" class="h-3 w-3 animate-spin" :stroke-width="1.75" aria-hidden="true" />
+            <RefreshCw v-else class="h-3 w-3" :stroke-width="1.75" aria-hidden="true" />
           </button>
         </div>
         <button

--- a/portal/src/components/CliQuickstartModal.vue
+++ b/portal/src/components/CliQuickstartModal.vue
@@ -11,6 +11,9 @@ useEscapeKey(() => emit('close'))
 const dialogRef = ref<HTMLElement | null>(null)
 const closeButton = ref<HTMLButtonElement | null>(null)
 let previousFocus: HTMLElement | null = null
+const copiedField = ref<string | null>(null)
+const copyError = ref<string | null>(null)
+let copyResetTimer: ReturnType<typeof setTimeout> | null = null
 
 function onKeydown(event: KeyboardEvent) {
   if (event.key !== 'Tab') return
@@ -37,6 +40,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeydown)
+  if (copyResetTimer) clearTimeout(copyResetTimer)
   const target = previousFocus
   previousFocus = null
   nextTick(() => target?.isConnected && target.focus())
@@ -92,13 +96,19 @@ const verifySnippet = computed(
   () => `${cliBinary.value} edge list`,
 )
 
-const copiedField = ref<string | null>(null)
 async function copy(text: string, field: string) {
+  copyError.value = null
   try {
+    if (!navigator.clipboard?.writeText) throw new Error('clipboard unavailable')
     await navigator.clipboard.writeText(text)
     copiedField.value = field
-    setTimeout(() => (copiedField.value = null), 2000)
-  } catch {}
+    if (copyResetTimer) clearTimeout(copyResetTimer)
+    copyResetTimer = setTimeout(() => {
+      if (copiedField.value === field) copiedField.value = null
+    }, 2000)
+  } catch {
+    copyError.value = 'Copy failed. Select the command and copy it manually.'
+  }
 }
 
 const releasesURL = 'https://github.com/faroshq/faros/releases/latest'
@@ -143,6 +153,14 @@ const releasesURL = 'https://github.com/faroshq/faros/releases/latest'
               The <span class="font-mono text-text-secondary">faros</span> CLI talks to this hub at
               <span class="font-mono text-text-secondary">{{ hubURL }}</span>.
               Once installed, log in once and your kubeconfig will be updated automatically.
+            </p>
+            <p
+              v-if="copyError"
+              class="mt-3 rounded-lg border border-warning/30 bg-warning-subtle px-3 py-2 text-[11px] text-warning"
+              role="status"
+              aria-live="polite"
+            >
+              {{ copyError }}
             </p>
           </div>
 

--- a/portal/src/components/ControlPlaneProvisioning.vue
+++ b/portal/src/components/ControlPlaneProvisioning.vue
@@ -24,18 +24,17 @@ bootstrapState to 'ready'; until then App.vue mounts this full-screen
 overlay so the user sees "creating your control plane" instead of an
 empty, cluster-less shell that errors on every query.
 
-Purely presentational — the polling and state live in the tenant store.
-The step list is cosmetic, advancing off the poll-attempt count so the
-screen feels alive while the controller chain runs.
+Purely presentational — the polling and readiness state live in the tenant
+store. This surface does not infer progress from elapsed polls: until the
+store reports readiness, every setup item remains indeterminate.
 -->
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Hexagon, Check, Loader2, Building2, Boxes, KeyRound, Sparkles } from 'lucide-vue-next'
+import { Loader2, Building2, Boxes, KeyRound, Sparkles } from 'lucide-vue-next'
 
-// attempts = the tenant store's poll counter (~one every 2s). Used only
-// to walk the cosmetic step list and to surface a "taking longer than
-// usual" note once we pass the typical cold-start budget.
+// attempts = the tenant store's poll counter (~one every 2s). It may only
+// change the delay guidance; it is not evidence that any setup step completed.
 const props = withDefaults(defineProps<{ attempts?: number }>(), { attempts: 0 })
 
 interface Step {
@@ -49,11 +48,6 @@ const steps: Step[] = [
   { label: 'Finalizing control plane', icon: Sparkles },
 ]
 
-// Walk one step roughly every ~4s (2 polls). Clamp to the last step so
-// the final item keeps spinning until the store flips us to 'ready' and
-// App.vue unmounts the overlay.
-const activeStep = computed(() => Math.min(Math.floor(props.attempts / 2), steps.length - 1))
-
 // The hub's bootstrap chain is ~10-25s; past ~30s of polling we nudge
 // the user that it's taking longer than usual rather than leave them
 // staring at an indeterminate spinner.
@@ -61,7 +55,7 @@ const overBudget = computed(() => props.attempts >= 15)
 </script>
 
 <template>
-  <div class="contour-grid fixed inset-0 z-[200] flex items-center justify-center bg-surface">
+  <div class="contour-grid fixed inset-0 z-[200] flex items-center justify-center bg-surface" aria-busy="true">
     <!-- Ambient glow, matching the login / auth-callback takeovers -->
     <div class="pointer-events-none fixed inset-0 overflow-hidden">
       <div class="absolute -top-40 left-1/2 h-96 w-[500px] -translate-x-1/2 rounded-full bg-accent/5 blur-[160px]" />
@@ -69,52 +63,39 @@ const overBudget = computed(() => props.attempts >= 15)
     </div>
 
     <div class="relative flex w-full max-w-md flex-col items-center px-6">
-      <!-- Pulsing hex mark -->
+      <!-- Setup activity mark -->
       <div class="relative flex h-16 w-16 items-center justify-center">
         <div class="absolute inset-0 animate-pulse rounded-xl bg-accent/20 blur-lg" />
         <div class="relative flex h-16 w-16 items-center justify-center rounded-xl border border-accent/25 bg-surface-overlay">
-          <Hexagon class="h-8 w-8 animate-spin text-accent" style="animation-duration: 3s" :stroke-width="1.5" />
+          <Loader2 class="h-8 w-8 animate-spin text-accent" style="animation-duration: 3s" :stroke-width="1.5" aria-hidden="true" />
         </div>
       </div>
 
       <h1 class="mt-6 text-center text-[18px] font-bold tracking-tight text-text-primary">
         Creating your control plane
       </h1>
-      <p class="mt-1.5 text-center text-[12px] text-text-muted">
+      <p class="mt-1.5 text-center text-[12px] text-text-muted" role="status" aria-live="polite">
         Setting up your organization and first workspace. This is a one-time setup
         and usually takes a few seconds.
       </p>
 
-      <!-- Step list -->
+      <!-- Step list. These are the controller's work areas, not a progress
+           indicator. Completion is shown only when the tenant store unmounts
+           this overlay after an authoritative readiness result. -->
       <div class="mt-7 w-full rounded-xl border border-border-default shadow-sm">
         <ul class="space-y-1 rounded-xl border border-border-subtle bg-surface-raised/80 p-3 backdrop-blur">
           <li
-            v-for="(step, i) in steps"
+            v-for="step in steps"
             :key="step.label"
             class="flex items-center gap-3 rounded-xl px-3 py-2 transition-colors"
-            :class="i === activeStep ? 'bg-surface-overlay/60' : ''"
           >
-            <!-- State glyph: done / active / pending -->
+            <!-- No item is marked complete from timing alone. -->
             <span
-              class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border"
-              :class="i < activeStep
-                ? 'border-success/30 bg-success-subtle text-success'
-                : i === activeStep
-                  ? 'border-accent/30 bg-accent/10 text-accent'
-                  : 'border-border-default/40 bg-surface-overlay/40 text-text-muted/40'"
+              class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-border-default/40 bg-surface-overlay/40 text-text-secondary"
             >
-              <Check v-if="i < activeStep" class="h-3.5 w-3.5" :stroke-width="2.5" />
-              <Loader2 v-else-if="i === activeStep" class="h-3.5 w-3.5 animate-spin" :stroke-width="2" />
-              <component :is="step.icon" v-else class="h-3.5 w-3.5" :stroke-width="2" />
+              <component :is="step.icon" class="h-3.5 w-3.5" :stroke-width="2" />
             </span>
-            <span
-              class="text-[12px] font-medium"
-              :class="i < activeStep
-                ? 'text-text-secondary'
-                : i === activeStep
-                  ? 'text-text-primary'
-                  : 'text-text-muted/50'"
-            >
+            <span class="text-[12px] font-medium text-text-secondary">
               {{ step.label }}
             </span>
           </li>

--- a/portal/src/components/FirstWorkspaceWizard.vue
+++ b/portal/src/components/FirstWorkspaceWizard.vue
@@ -24,7 +24,7 @@ const trimmed = computed(() => name.value.trim())
 const canSubmit = computed(() => trimmed.value.length > 0 && !busy.value && !!tenant.orgUUID)
 
 async function handleCreate() {
-  if (!canSubmit.value || !tenant.orgUUID) return
+  if (!canSubmit.value || !tenant.orgUUID || busy.value) return
   busy.value = true
   error.value = null
   try {
@@ -68,48 +68,53 @@ async function handleCreate() {
       <div class="space-y-5 rounded-xl border border-border-subtle bg-surface-raised/80 p-6 backdrop-blur">
         <div
           v-if="error"
+          id="first-workspace-error"
           class="flex items-center gap-2 rounded-xl border border-danger/20 bg-danger-subtle p-3 text-[12px] text-danger"
+          role="alert"
+          aria-live="assertive"
         >
           <AlertCircle class="h-3.5 w-3.5 shrink-0" :stroke-width="1.75" />
           {{ error }}
         </div>
 
-        <div>
-          <label class="mb-1 block text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">
-            Workspace name
-          </label>
-          <input
-            v-model="name"
-            type="text"
-            placeholder="e.g. production"
-            class="k-input w-full py-2.5 font-mono text-[12px]"
-            autofocus
-            @keyup.enter="canSubmit && handleCreate()"
-          />
-          <p class="mt-1 text-[10px] text-text-muted">
-            A friendly name. The hub will allocate the underlying kcp cluster automatically.
-          </p>
-        </div>
+        <form class="space-y-5" @submit.prevent="handleCreate">
+          <div>
+            <label for="first-workspace-name" class="mb-1 block text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">
+              Workspace name
+            </label>
+            <input
+              id="first-workspace-name"
+              v-model="name"
+              type="text"
+              placeholder="e.g. production"
+              class="k-input w-full py-2.5 font-mono text-[12px]"
+              :aria-describedby="error ? 'first-workspace-error first-workspace-name-hint' : 'first-workspace-name-hint'"
+              autofocus
+            />
+            <p id="first-workspace-name-hint" class="mt-1 text-[10px] text-text-muted">
+              A friendly name. The hub will allocate the underlying kcp cluster automatically.
+            </p>
+          </div>
 
-        <div class="flex items-center justify-between gap-3 pt-2">
-          <router-link
-            to="/settings/workspaces"
-            class="flex items-center gap-1.5 text-[11px] font-medium text-text-muted transition-colors hover:text-text-secondary"
-          >
-            <Settings class="h-3 w-3" :stroke-width="2" />
-            Manage workspaces in settings
-          </router-link>
-          <button
-            type="button"
-            class="k-btn k-btn--primary group px-4 py-2.5 text-[12px] disabled:pointer-events-none disabled:opacity-40"
-            :disabled="!canSubmit"
-            @click="handleCreate"
-          >
-            <Loader2 v-if="busy" class="h-3.5 w-3.5 animate-spin" :stroke-width="2" />
-            <span>{{ busy ? 'Creating…' : 'Create workspace' }}</span>
-            <ArrowRight v-if="!busy" class="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" :stroke-width="2" />
-          </button>
-        </div>
+          <div class="flex items-center justify-between gap-3 pt-2">
+            <router-link
+              to="/settings/workspaces"
+              class="flex items-center gap-1.5 text-[11px] font-medium text-text-muted transition-colors hover:text-text-secondary"
+            >
+              <Settings class="h-3 w-3" :stroke-width="2" />
+              Manage workspaces in settings
+            </router-link>
+            <button
+              type="submit"
+              class="k-btn k-btn--primary group px-4 py-2.5 text-[12px] disabled:pointer-events-none disabled:opacity-40"
+              :disabled="!canSubmit"
+            >
+              <Loader2 v-if="busy" class="h-3.5 w-3.5 animate-spin" :stroke-width="2" />
+              <span>{{ busy ? 'Creating…' : 'Create workspace' }}</span>
+              <ArrowRight v-if="!busy" class="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" :stroke-width="2" />
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   </div>

--- a/portal/src/components/ProviderEnableDialog.vue
+++ b/portal/src/components/ProviderEnableDialog.vue
@@ -5,6 +5,11 @@ import type { ProviderDTO, PermissionClaim } from '@/stores/providers'
 
 const props = defineProps<{
   provider: ProviderDTO | null
+  // Enable is a caller-owned write. Keeping pending/error state in the page
+  // that owns the request means a failed write can remain retryable without
+  // leaving this modal permanently busy or hiding the error behind it.
+  busy?: boolean
+  error?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -16,10 +21,16 @@ const emit = defineEmits<{
 // to accepted; non-tenantScoped default to rejected so the user has to
 // explicitly opt-in to anything that escapes their workspace.
 const accepted = ref<Record<string, boolean>>({})
-const busy = ref(false)
 const dialogRef = ref<HTMLElement | null>(null)
 const closeButton = ref<HTMLButtonElement | null>(null)
 let previousFocus: HTMLElement | null = null
+
+const dismissLabel = computed(() => props.busy
+  ? 'Dismiss provider access dialog; request continues'
+  : 'Close provider access dialog')
+const dismissTitle = computed(() => props.busy
+  ? 'Dismiss dialog; request continues'
+  : 'Close dialog')
 
 const claimKey = (c: PermissionClaim) => `${c.group ?? ''}/${c.resource}`
 
@@ -32,7 +43,6 @@ watch(
       next[claimKey(c)] = !!c.tenantScoped
     }
     accepted.value = next
-    busy.value = false
   },
   { immediate: true },
 )
@@ -43,13 +53,13 @@ const hasUntrustedAccepted = computed(() =>
 )
 
 function toggle(c: PermissionClaim) {
+  if (props.busy) return
   const k = claimKey(c)
   accepted.value = { ...accepted.value, [k]: !accepted.value[k] }
 }
 
 function onConfirm() {
-  if (!props.provider) return
-  busy.value = true
+  if (!props.provider || props.busy) return
   const accept = claims.value.filter((c) => accepted.value[claimKey(c)])
   emit('confirm', accept)
 }
@@ -65,13 +75,18 @@ function onKeydown(event: KeyboardEvent) {
   const focusable = Array.from(dialogRef.value?.querySelectorAll<HTMLElement>(
     'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])',
   ) ?? [])
-  if (!focusable.length) return
+  if (!focusable.length) {
+    event.preventDefault()
+    dialogRef.value?.focus()
+    return
+  }
   const first = focusable[0]
   const last = focusable[focusable.length - 1]
-  if (event.shiftKey && document.activeElement === first) {
+  const activeIndex = focusable.indexOf(document.activeElement as HTMLElement)
+  if (event.shiftKey && activeIndex <= 0) {
     event.preventDefault()
     last.focus()
-  } else if (!event.shiftKey && document.activeElement === last) {
+  } else if (!event.shiftKey && (activeIndex < 0 || activeIndex >= focusable.length - 1)) {
     event.preventDefault()
     first.focus()
   }
@@ -91,6 +106,7 @@ watch(
       nextTick(() => target?.isConnected && target.focus())
     }
   },
+  { immediate: true },
 )
 
 onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
@@ -100,9 +116,18 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
   <div
     v-if="provider"
     class="k-modal-overlay"
-    @click.self="$emit('cancel')"
+    @click.self="!busy && $emit('cancel')"
   >
-    <div ref="dialogRef" class="k-modal w-full max-w-lg p-0" role="dialog" aria-modal="true" aria-labelledby="provider-enable-title" aria-describedby="provider-enable-description">
+    <div
+      ref="dialogRef"
+      class="k-modal w-full max-w-lg p-0"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      aria-labelledby="provider-enable-title"
+      :aria-describedby="error ? 'provider-enable-description provider-enable-error' : 'provider-enable-description'"
+      :aria-busy="busy"
+    >
       <div class="flex items-center justify-between border-b border-border-subtle px-4 py-3">
         <div>
           <h2 id="provider-enable-title" class="text-sm font-semibold text-text-primary">Enable {{ provider.displayName }}</h2>
@@ -110,15 +135,26 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
             Review what this provider will be able to access in your workspace.
           </p>
         </div>
-        <button ref="closeButton" type="button" class="k-btn k-btn--ghost p-1 text-text-muted hover:text-text-primary" aria-label="Close provider access dialog" @click="$emit('cancel')">
+        <button ref="closeButton" type="button" class="k-btn k-btn--ghost p-1 text-text-muted hover:text-text-primary" :aria-label="dismissLabel" :title="dismissTitle" @click="$emit('cancel')">
           <X class="h-4 w-4" :stroke-width="1.75" />
         </button>
       </div>
 
       <div class="max-h-[60vh] overflow-y-auto px-4 py-3">
+        <div
+          v-if="error"
+          id="provider-enable-error"
+          class="mb-3 flex items-start gap-2 rounded-lg border border-danger/30 bg-danger-subtle px-3 py-2 text-[11px] text-danger"
+          role="alert"
+          aria-live="assertive"
+        >
+          <ShieldAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" :stroke-width="2" />
+          <span>{{ error }}</span>
+        </div>
+
         <div v-if="claims.length === 0" class="rounded-lg border border-border-subtle bg-surface-overlay/50 px-3 py-4 text-center text-xs text-text-muted">
           This provider does not request access to any tenant resources.
-          Clicking Confirm will bind its APIs into your workspace.
+          Clicking Enable provider will bind its APIs into your workspace.
         </div>
 
         <ul v-else class="space-y-2">
@@ -128,11 +164,12 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
             class="rounded-lg border bg-surface-overlay/30 px-3 py-2"
             :class="c.tenantScoped ? 'border-border-subtle' : 'border-warning/30'"
           >
-            <label class="flex cursor-pointer items-start gap-3">
+            <label class="k-checkbox-hit flex cursor-pointer items-start gap-3">
               <input
                 type="checkbox"
                 class="k-checkbox mt-1"
                 :checked="!!accepted[claimKey(c)]"
+                :disabled="busy"
                 @change="toggle(c)"
               />
               <div class="min-w-0 flex-1">
@@ -181,6 +218,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
         <button
           type="button"
           class="k-btn k-btn--ghost px-3 py-1 text-[11px] text-text-muted transition-colors hover:text-text-primary"
+          :disabled="busy"
           @click="$emit('cancel')"
         >
           Cancel
@@ -192,7 +230,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
           @click="onConfirm"
         >
           <Loader2 v-if="busy" class="h-3 w-3 animate-spin" :stroke-width="2" />
-          Confirm &amp; Enable
+          {{ busy ? 'Enabling provider…' : 'Enable provider' }}
         </button>
       </div>
     </div>

--- a/portal/src/components/SelfHostInstructions.vue
+++ b/portal/src/components/SelfHostInstructions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import MarkdownIt from 'markdown-it'
 import { Copy, Check, Download, AlertTriangle, ExternalLink, ChevronRight, ArrowUpCircle } from 'lucide-vue-next'
 import type { OrgProviderRegistration } from '@/stores/orgProviders'
@@ -15,6 +15,20 @@ const props = defineProps<{ registration: OrgProviderRegistration }>()
 
 const revealed = ref(false)
 const copied = ref<string | null>(null)
+const copyError = ref<string | null>(null)
+const valuesDocOpen = ref(false)
+let copyResetTimer: ReturnType<typeof setTimeout> | null = null
+
+function resetTransientState() {
+  revealed.value = false
+  copied.value = null
+  copyError.value = null
+  valuesDocOpen.value = false
+  if (copyResetTimer) {
+    clearTimeout(copyResetTimer)
+    copyResetTimer = null
+  }
+}
 
 // The values the hub could not resolve — the only ones worth listing, since
 // everything else is already correct in the command above.
@@ -41,24 +55,41 @@ md.renderer.rules.link_open = (tokens, i, options, env, self) => {
   return defaultLinkOpen ? defaultLinkOpen(tokens, i, options, env, self) : self.renderToken(tokens, i, options)
 }
 
-const valuesDocOpen = ref(false)
 const valuesDocHTML = computed(() => {
   const doc = props.registration.instructions?.valuesDoc
   return doc ? md.render(doc) : ''
 })
 
+// Registration responses contain a one-time credential. Clear all transient
+// disclosure and copy state when the active registration is replaced so a
+// previous provider's credential cannot remain revealed or appear copied.
+watch(() => props.registration, resetTransientState)
+
 async function copy(key: string, value: string) {
+  const registration = props.registration
+  copyError.value = null
   try {
+    if (!navigator.clipboard?.writeText) throw new Error('clipboard unavailable')
     await navigator.clipboard.writeText(value)
+    if (props.registration !== registration) return
     copied.value = key
-    setTimeout(() => {
+    if (copyResetTimer) clearTimeout(copyResetTimer)
+    copyResetTimer = setTimeout(() => {
       if (copied.value === key) copied.value = null
     }, 1500)
   } catch {
-    // Clipboard can be blocked (insecure context, permissions). The text is
-    // on screen and selectable, so failing silently is better than an alert.
+    if (props.registration !== registration) return
+    // Clipboard can be blocked (insecure context, permissions). Keep the
+    // recovery action explicit without echoing the credential in the message.
+    copyError.value = key === 'kubeconfig'
+      ? 'Copy failed. Use Download, or choose Show and copy the credential manually.'
+      : 'Copy failed. Select the command and copy it manually.'
   }
 }
+
+onBeforeUnmount(() => {
+  if (copyResetTimer) clearTimeout(copyResetTimer)
+})
 
 function downloadKubeconfig() {
   const name = props.registration.instructions?.kubeconfigFilename
@@ -75,6 +106,16 @@ function downloadKubeconfig() {
 
 <template>
   <div class="space-y-4">
+    <p
+      v-if="copyError"
+      class="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning-subtle px-3 py-2 text-[11px] text-warning"
+      role="status"
+      aria-live="polite"
+    >
+      <AlertTriangle class="mt-0.5 h-3.5 w-3.5 shrink-0" :stroke-width="2" />
+      <span>{{ copyError }}</span>
+    </p>
+
     <!-- Upgrade, shown first and only when one is due. A running install needs
          none of the steps below — the namespace, credential Secret, and values
          all survive from the original install — so the one command is the whole
@@ -235,6 +276,8 @@ function downloadKubeconfig() {
         <button
           type="button"
           class="k-btn k-btn--ghost flex w-full items-center gap-2 rounded-none border-0 p-4 text-left"
+          aria-controls="self-host-values-doc"
+          :aria-expanded="valuesDocOpen"
           @click="valuesDocOpen = !valuesDocOpen"
         >
           <ChevronRight
@@ -251,7 +294,12 @@ function downloadKubeconfig() {
         </button>
         <!-- eslint-disable-next-line vue/no-v-html -- markdown-it runs with
              html:false, so the output contains no author-supplied markup. -->
-        <div v-if="valuesDocOpen" class="chart-doc px-4 pb-4" v-html="valuesDocHTML" />
+        <div
+          v-if="valuesDocOpen"
+          id="self-host-values-doc"
+          class="chart-doc px-4 pb-4"
+          v-html="valuesDocHTML"
+        />
       </section>
 
       <a

--- a/portal/src/components/TenantSwitcher.vue
+++ b/portal/src/components/TenantSwitcher.vue
@@ -67,12 +67,14 @@ function onWorkspaceChange(e: Event) {
 
 <template>
   <div class="tenant-switcher flex flex-col gap-1 px-2 py-2 border-b border-border-default/40">
-    <label class="text-[9px] font-semibold uppercase tracking-wider text-text-muted/70">
+    <label for="tenant-switcher-organization" class="text-[9px] font-semibold uppercase tracking-wider text-text-muted/70">
       Organization
     </label>
     <select
+      id="tenant-switcher-organization"
       class="k-input w-full px-2 py-1 text-[11px]"
       :value="tenant.orgUUID ?? ''"
+      :aria-describedby="tenant.error ? 'tenant-switcher-error' : undefined"
       :disabled="tenant.loading || tenant.orgs.length === 0"
       @change="onOrgChange"
     >
@@ -82,12 +84,14 @@ function onWorkspaceChange(e: Event) {
       </option>
     </select>
 
-    <label class="mt-2 text-[9px] font-semibold uppercase tracking-wider text-text-muted/70">
+    <label for="tenant-switcher-workspace" class="mt-2 text-[9px] font-semibold uppercase tracking-wider text-text-muted/70">
       Workspace
     </label>
     <select
+      id="tenant-switcher-workspace"
       class="k-input w-full px-2 py-1 text-[11px]"
       :value="tenant.workspaceUUID ?? ''"
+      :aria-describedby="tenant.error ? 'tenant-switcher-error' : undefined"
       :disabled="
         tenant.loading ||
         !tenant.orgUUID ||
@@ -112,7 +116,10 @@ function onWorkspaceChange(e: Event) {
 
     <p
       v-if="tenant.error"
+      id="tenant-switcher-error"
       class="mt-1 text-[10px] text-error"
+      role="alert"
+      aria-live="polite"
     >
       {{ tenant.error }}
     </p>

--- a/portal/src/components/WelcomeWizard.vue
+++ b/portal/src/components/WelcomeWizard.vue
@@ -19,7 +19,7 @@
 // one up says nothing about the next) and lives in localStorage — this is a
 // presentation preference, not state worth a round-trip to the hub.
 
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import {
   AlertCircle,
   ArrowLeft,
@@ -37,6 +37,7 @@ import {
   Sparkles,
 } from 'lucide-vue-next'
 import ProviderEnableDialog from '@/components/ProviderEnableDialog.vue'
+import { toast } from '@/portalkit/toast'
 import { useProvidersStore, type ProviderDTO, type PermissionClaim } from '@/stores/providers'
 import { useTenantStore } from '@/stores/tenant'
 import { categoryIcons, fallbackCategoryIcon } from '@/lib/categoryIcons'
@@ -90,6 +91,10 @@ const enabledCount = computed(() => catalog.value.filter((p) => providers.isEnab
 const busy = ref<Record<string, boolean>>({})
 const actionError = ref<string | null>(null)
 const dialogProvider = ref<ProviderDTO | null>(null)
+const dialogRevision = ref(0)
+const dialogScope = computed(
+  () => `${tenant.orgUUID ?? ''}/${tenant.workspaceUUID ?? ''}/${tenant.workspaceMode}`,
+)
 
 function categoryIcon(name: string | undefined): unknown {
   if (!name) return fallbackCategoryIcon
@@ -105,24 +110,52 @@ function dependencyNotice(p: ProviderDTO): string {
 }
 
 function openEnableDialog(p: ProviderDTO) {
+  if (busy.value[p.name]) return
   actionError.value = null
   if (providers.hasMissingDependencies(p)) {
     actionError.value = dependencyNotice(p)
     return
   }
+  dialogRevision.value += 1
   dialogProvider.value = p
 }
 
+function closeEnableDialog() {
+  dialogRevision.value += 1
+  dialogProvider.value = null
+  actionError.value = null
+}
+
+watch(dialogScope, () => {
+  // A workspace switch invalidates the visible consent decision. The store
+  // independently fences the in-flight write; this only prevents its result
+  // or error from changing the new workspace's dialog.
+  if (dialogProvider.value) closeEnableDialog()
+})
+
 async function onDialogConfirm(accept: PermissionClaim[]) {
   const p = dialogProvider.value
-  if (!p) return
+  const revision = dialogRevision.value
+  const scope = dialogScope.value
+  if (!p || busy.value[p.name]) return
   busy.value = { ...busy.value, [p.name]: true }
   actionError.value = null
   try {
     await providers.enable(p, accept)
-    dialogProvider.value = null
+    if (dialogRevision.value === revision && dialogProvider.value === p && dialogScope.value === scope) {
+      closeEnableDialog()
+    }
   } catch (e) {
-    actionError.value = e instanceof Error ? e.message : String(e)
+    const message = e instanceof Error ? e.message : String(e)
+    if (dialogRevision.value === revision && dialogProvider.value === p && dialogScope.value === scope) {
+      actionError.value = message
+    } else if (dialogScope.value === scope) {
+      toast('error', `Could not enable ${p.displayName}: ${message}`, {
+        scope,
+        source: 'provider-enable',
+        dedupeKey: `provider-enable:${p.name}`,
+      })
+    }
   } finally {
     const next = { ...busy.value }
     delete next[p.name]
@@ -339,14 +372,14 @@ const firstEnabled = computed(() => catalog.value.find((p) => providers.isEnable
                   <button
                     v-else
                     type="button"
-                    class="k-btn k-btn--primary inline-flex items-center gap-1 px-2.5 py-1 text-[11px] disabled:cursor-not-allowed disabled:opacity-50"
+                    class="k-btn k-btn--ghost inline-flex items-center gap-1 px-2.5 py-1 text-[11px] text-accent disabled:cursor-not-allowed disabled:opacity-50"
                     :disabled="!!busy[p.name] || providers.hasMissingDependencies(p)"
                     :title="dependencyNotice(p)"
                     @click="openEnableDialog(p)"
                   >
                     <Loader2 v-if="busy[p.name]" class="h-3 w-3 animate-spin" :stroke-width="2" />
                     <Plus v-else class="h-3 w-3" :stroke-width="2" />
-                    Enable
+                    {{ busy[p.name] ? 'Enabling provider…' : 'Enable provider' }}
                   </button>
                 </div>
               </div>
@@ -433,7 +466,9 @@ const firstEnabled = computed(() => catalog.value.find((p) => providers.isEnable
 
     <ProviderEnableDialog
       :provider="dialogProvider"
-      @cancel="dialogProvider = null"
+      :busy="dialogProvider ? !!busy[dialogProvider.name] : false"
+      :error="dialogProvider ? actionError : null"
+      @cancel="closeEnableDialog"
       @confirm="onDialogConfirm"
     />
   </div>

--- a/portal/src/components/WorkspaceSwitcher.vue
+++ b/portal/src/components/WorkspaceSwitcher.vue
@@ -22,6 +22,7 @@ import {
   Check,
   ChevronDown,
   FolderTree,
+  Loader2,
   RefreshCw,
   Search,
   Settings2,
@@ -560,7 +561,7 @@ onMounted(() => { void ensureContextLoaded() })
             </button>
           </div>
           <div v-if="orgRefreshing && hasCachedOrgRows" class="flex items-start gap-2 border-b border-border-subtle px-3 py-2 text-[10px] text-text-secondary" role="status" aria-live="polite">
-            <RefreshCw class="mt-px h-3 w-3 shrink-0 animate-spin text-accent" :stroke-width="1.75" aria-hidden="true" />
+            <Loader2 class="mt-px h-3 w-3 shrink-0 animate-spin text-accent" :stroke-width="1.75" aria-hidden="true" />
             <span>Refreshing organizations; workspace switching is paused until verification succeeds.</span>
           </div>
           <div v-if="orgRefreshFailed" class="flex flex-col items-center gap-2 border-b border-border-subtle px-3 py-3 text-center text-[10px] text-warning" role="alert" aria-live="assertive">

--- a/portal/src/components/YamlViewer.vue
+++ b/portal/src/components/YamlViewer.vue
@@ -129,7 +129,7 @@ const collapseAll = () => {
 
 <template>
   <div class="relative">
-    <div class="absolute right-2 top-2 z-10 flex gap-1">
+    <div class="mb-2 flex justify-end gap-1" role="toolbar" aria-label="YAML display controls">
       <button
         type="button"
         class="k-btn k-btn--ghost px-2 py-0.5 text-[10px] font-medium text-text-muted backdrop-blur transition-colors hover:text-text-primary"
@@ -156,7 +156,9 @@ const collapseAll = () => {
           type="button"
           class="k-btn k-btn--ghost mr-0.5 inline-flex h-[1.45em] w-4 shrink-0 items-center justify-center border-0 p-0 text-text-muted/50 transition-colors hover:text-accent"
           @click="toggle(item.idx)"
-          :title="collapsed.has(item.idx) ? 'Expand' : 'Collapse'"
+          :aria-expanded="!collapsed.has(item.idx)"
+          :aria-label="`${collapsed.has(item.idx) ? 'Expand' : 'Collapse'} ${item.line.key ?? 'section'}`"
+          :title="`${collapsed.has(item.idx) ? 'Expand' : 'Collapse'} ${item.line.key ?? 'section'}`"
         >
           <ChevronRight v-if="collapsed.has(item.idx)" class="h-3 w-3" :stroke-width="2.25" />
           <ChevronDown v-else class="h-3 w-3" :stroke-width="2.25" />

--- a/portal/src/pages/AuthCallback.vue
+++ b/portal/src/pages/AuthCallback.vue
@@ -5,7 +5,7 @@ import { useAuthStore } from '@/stores/auth'
 import { consumeAppAccessNext } from '@/auth/appAccessNext'
 import { parseClusterName } from '@/auth/token'
 import type { LoginResponse, StoredAuth } from '@/auth/types'
-import { AlertCircle, ArrowLeft, Hexagon } from 'lucide-vue-next'
+import { AlertCircle, ArrowLeft, Loader2 } from 'lucide-vue-next'
 
 const router = useRouter()
 const auth = useAuthStore()
@@ -63,12 +63,24 @@ onMounted(() => {
       <div class="absolute -top-40 left-1/2 h-96 w-[500px] -translate-x-1/2 rounded-full bg-accent/5 blur-[160px]" />
     </div>
 
-    <div v-if="error" class="relative rounded-xl border border-border-default shadow-sm">
-      <div class="rounded-xl border border-border-subtle bg-surface-raised/80 p-8 text-center backdrop-blur">
+    <div
+      v-if="error"
+      class="relative mx-4 w-full max-w-md rounded-xl border border-border-default shadow-sm"
+      role="alert"
+      aria-live="assertive"
+      aria-labelledby="auth-callback-error-title"
+      aria-describedby="auth-callback-error-detail"
+    >
+      <div class="rounded-xl border border-border-subtle bg-surface-raised/80 p-6 text-center backdrop-blur sm:p-8">
         <div class="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-danger/20 bg-danger-subtle">
           <AlertCircle class="h-5 w-5 text-danger" :stroke-width="1.75" />
         </div>
-        <p class="mt-3 text-[13px] text-text-secondary">{{ error }}</p>
+        <h1 id="auth-callback-error-title" class="mt-4 text-[15px] font-semibold text-text-primary">
+          Sign-in could not be completed
+        </h1>
+        <p id="auth-callback-error-detail" class="mt-3 max-h-48 overflow-y-auto break-words text-left text-[13px] text-text-secondary">
+          {{ error }}
+        </p>
         <router-link
           to="/login"
           class="mt-4 inline-flex items-center gap-1.5 text-[12px] font-medium text-accent transition-colors hover:text-accent-hover"
@@ -79,14 +91,12 @@ onMounted(() => {
       </div>
     </div>
 
-    <div v-else class="relative flex flex-col items-center gap-5">
-      <div class="relative flex h-16 w-16 items-center justify-center">
-        <div class="absolute inset-0 animate-pulse rounded-xl bg-accent/20 blur-lg" />
-        <div class="relative flex h-16 w-16 items-center justify-center rounded-xl border border-accent/25 bg-surface-overlay">
-          <Hexagon class="h-8 w-8 animate-spin text-accent" style="animation-duration: 3s" :stroke-width="1.5" />
-        </div>
+    <div v-else class="relative flex flex-col items-center gap-4" role="status" aria-live="polite" aria-busy="true">
+      <Loader2 class="h-7 w-7 animate-spin text-accent" :stroke-width="1.75" aria-hidden="true" />
+      <div class="text-center">
+        <h1 class="text-[15px] font-semibold text-text-primary">Completing sign in</h1>
+        <p class="mt-1 max-w-xs text-[12px] text-text-muted">Verifying your session and preparing your workspace.</p>
       </div>
-      <span class="text-[12px] text-text-muted">Completing sign in...</span>
     </div>
   </div>
 </template>

--- a/portal/src/pages/BonkersPage.vue
+++ b/portal/src/pages/BonkersPage.vue
@@ -103,8 +103,8 @@ function handleLogout() {
     </aside>
 
     <!-- Main content -->
-    <main class="min-w-0 flex-1 overflow-y-auto">
-      <div class="w-full px-8 py-5">
+    <main class="min-w-0 flex-1 overflow-y-auto" :aria-busy="admin.loading">
+      <div class="w-full px-4 py-5 sm:px-8">
         <header class="mb-6 flex items-center justify-between">
           <h1 class="flex items-center gap-2 text-[17px] font-bold">
             <ShieldAlert class="h-5 w-5 text-accent" :stroke-width="1.75" />
@@ -124,6 +124,8 @@ function handleLogout() {
         <div
           v-if="admin.forbidden"
           class="k-card flex items-start gap-2 border-danger/30 bg-danger-subtle px-4 py-3 text-[13px] text-danger"
+          role="alert"
+          aria-live="assertive"
         >
           <AlertCircle class="h-4 w-4 flex-shrink-0 mt-0.5" :stroke-width="1.75" />
           <span>Access denied. Your identity is not in the hub's <code>--admin-users</code> allowlist.</span>
@@ -132,7 +134,23 @@ function handleLogout() {
         <template v-else>
           <!-- Flat admin lists surface retry/stale state inside ResourceTable.
                Organizations remain grouped cards, so their read error stays at shell level. -->
-          <p v-if="admin.error && $route.name === 'bonkers-organizations'" class="mb-3 text-[13px] text-danger">{{ admin.error }}</p>
+          <div
+            v-if="admin.error && $route.name === 'bonkers-organizations'"
+            class="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-danger/30 bg-danger-subtle px-3 py-2 text-[13px] text-danger"
+            role="alert"
+            aria-live="assertive"
+          >
+            <span>{{ admin.loaded ? 'Could not refresh organizations. Showing the last loaded results.' : 'Could not load organizations.' }}</span>
+            <span class="text-[11px] text-danger">{{ admin.error }}</span>
+            <button
+              type="button"
+              class="k-btn k-btn--ghost px-2 py-0.5 text-[11px] text-danger"
+              :disabled="admin.loading"
+              @click="admin.refresh()"
+            >
+              Retry
+            </button>
+          </div>
           <router-view />
         </template>
       </div>

--- a/portal/src/pages/LoginPage.vue
+++ b/portal/src/pages/LoginPage.vue
@@ -61,6 +61,7 @@ function resumeAfterLogin() {
 }
 
 async function handleTokenLogin() {
+  if (!tokenInput.value || auth.loading) return
   loginError.value = null
   try {
     await auth.loginStatic(tokenInput.value)
@@ -147,7 +148,13 @@ function startOIDCLogin() {
             </div>
 
             <!-- Error -->
-            <div v-if="loginError" class="flex items-center gap-2 rounded-xl border border-danger/20 bg-danger-subtle p-3 text-[12px] text-danger">
+            <div
+              v-if="loginError"
+              id="login-error"
+              class="flex items-center gap-2 rounded-xl border border-danger/20 bg-danger-subtle p-3 text-[12px] text-danger"
+              role="alert"
+              aria-live="assertive"
+            >
               <AlertCircle class="h-3.5 w-3.5 shrink-0" :stroke-width="1.75" />
               {{ loginError }}
             </div>
@@ -184,7 +191,7 @@ function startOIDCLogin() {
             <!-- Token -->
             <form v-if="tokenFormVisible" @submit.prevent="handleTokenLogin" class="space-y-3">
               <div>
-                <label for="token" class="mb-1 block text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Bearer Token</label>
+                <label for="token" class="mb-1 block text-[10px] font-semibold uppercase tracking-[0.15em] text-text-muted">Bearer token</label>
                 <div
                   class="k-input flex items-center gap-2 px-3 py-2.5 transition-all duration-200"
                   :class="inputFocused ? 'border-accent ring-[3px] ring-accent/15' : 'border-border-default'"
@@ -196,6 +203,8 @@ function startOIDCLogin() {
                     type="password"
                     placeholder="Paste token here"
                     class="w-full bg-transparent font-mono text-[12px] text-text-primary placeholder-text-muted outline-none"
+                    :aria-describedby="loginError ? 'login-error' : undefined"
+                    :aria-invalid="loginError ? 'true' : undefined"
                     @focus="inputFocused = true"
                     @blur="inputFocused = false"
                   />
@@ -204,7 +213,8 @@ function startOIDCLogin() {
               <button
                 type="submit"
                 :disabled="!tokenInput || auth.loading"
-                class="k-btn k-btn--ghost group w-full px-4 py-2.5 text-[12px] active:scale-[0.98] disabled:pointer-events-none disabled:opacity-30"
+                class="k-btn group w-full px-4 py-2.5 text-[12px] active:scale-[0.98] disabled:pointer-events-none disabled:opacity-30"
+                :class="oidcAvailable ? 'k-btn--ghost' : 'k-btn--primary'"
               >
                 <Loader2
                   v-if="auth.loading"
@@ -216,7 +226,7 @@ function startOIDCLogin() {
                   class="h-3.5 w-3.5 text-text-muted group-hover:text-accent"
                   :stroke-width="1.75"
                 />
-                {{ auth.loading ? 'Signing in...' : 'Sign in with Token' }}
+                {{ auth.loading ? 'Signing in…' : 'Sign in with token' }}
               </button>
             </form>
           </div>

--- a/portal/src/pages/ProviderEnableDialog.deferred.test.mjs
+++ b/portal/src/pages/ProviderEnableDialog.deferred.test.mjs
@@ -1,0 +1,192 @@
+// Copyright 2026 The Faros Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import test from 'node:test'
+import ts from 'typescript'
+
+const portalRoot = path.resolve(new URL('../..', import.meta.url).pathname)
+
+function deferred() {
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function loadCaller(fileName) {
+  const source = await readFile(path.join(portalRoot, 'src', fileName), 'utf8')
+  const script = source.match(/<script setup[^>]*>([\s\S]*?)<\/script>/)?.[1]
+  assert.ok(script, `${fileName} should contain a setup script`)
+
+  // Compile the real caller script with deterministic doubles for Vue and its
+  // stores. This keeps the deferred request behavior under test without
+  // copying the caller's fencing logic into a second implementation.
+  const sourceWithoutImports = script.replace(/^import[\s\S]*?from ['"][^'"]+['"]\n/gm, '')
+  const harness = `
+const ref = (value) => ({ value })
+const computed = (getter) => ({ get value() { return getter() } })
+const watch = () => {}
+const onMounted = () => {}
+const defineEmits = () => () => {}
+const AlertCircle = {}
+const AlertTriangle = {}
+const ArrowLeft = {}
+const ArrowRight = {}
+const ArrowUpCircle = {}
+const Boxes = {}
+const Building2 = {}
+const Check = {}
+const CheckCircle2 = {}
+const ExternalLink = {}
+const FolderTree = {}
+const GripHorizontal = {}
+const GripVertical = {}
+const Hexagon = {}
+const LayoutDashboard = {}
+const Loader2 = {}
+const PanelLeftClose = {}
+const PanelLeftOpen = {}
+const Plus = {}
+const Puzzle = {}
+const RefreshCw = {}
+const Rocket = {}
+const Search = {}
+const Server = {}
+const Settings2 = {}
+const Sparkles = {}
+const X = {}
+const toastCalls = []
+const toast = (...args) => { toastCalls.push(args) }
+const confirmDialog = async () => false
+const categoryIcons = {}
+const fallbackCategoryIcon = null
+const providerBindingAction = () => null
+const providerStore = {
+  enableable: [],
+  selfHostable: [],
+  items: [],
+  categories: [],
+  enable: async () => undefined,
+  isEnabled: () => false,
+  isSelfHosted: () => false,
+  isSelfManaged: () => false,
+  missingDependencies: () => [],
+  hasMissingDependencies: () => false,
+  dependencyLabels: () => [],
+  byName: () => null,
+  load: () => undefined,
+}
+const orgProviderStore = {
+  supported: false,
+  items: [],
+  eligibleInstallTargets: [],
+  installTargetsEligible: false,
+  installTargetsReason: null,
+  installTargetsLoaded: false,
+  installTargetsLoading: false,
+  installTargetsError: null,
+  isSelfHosted: () => false,
+  load: () => undefined,
+  loadInstallTargets: () => undefined,
+  register: async () => null,
+  instructions: async () => null,
+  remove: async () => undefined,
+}
+const tenantStore = { orgUUID: 'org-a', workspaceUUID: 'workspace-a', workspaceMode: 'workspace' }
+const useProvidersStore = () => providerStore
+const useOrgProvidersStore = () => orgProviderStore
+const useTenantStore = () => tenantStore
+${sourceWithoutImports}
+export {
+  actionError,
+  busy,
+  closeEnableDialog,
+  dialogProvider,
+  dialogRevision,
+  onDialogConfirm,
+  providerStore,
+  tenantStore,
+  toastCalls,
+}
+`
+  const { outputText } = ts.transpileModule(harness, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+    },
+  })
+  return import(`data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`)
+}
+
+const callers = await Promise.all([
+  loadCaller('pages/ProvidersPage.vue'),
+  loadCaller('components/WelcomeWizard.vue'),
+])
+
+for (const [index, caller] of callers.entries()) {
+  const label = index === 0 ? 'ProvidersPage' : 'WelcomeWizard'
+
+  test(`${label} reports a dismissed same-scope deferred failure as a toast`, async () => {
+    caller.toastCalls.length = 0
+    caller.tenantStore.orgUUID = 'org-a'
+    caller.tenantStore.workspaceUUID = 'workspace-a'
+    const provider = { name: 'edges', displayName: 'Edges', permissionClaims: [] }
+    const pending = deferred()
+    caller.providerStore.enable = () => pending.promise
+    caller.dialogRevision.value += 1
+    caller.dialogProvider.value = provider
+
+    const request = caller.onDialogConfirm([])
+    await Promise.resolve()
+    assert.equal(caller.busy.value.edges, true)
+
+    caller.closeEnableDialog()
+    pending.reject(new Error('deferred gateway failure'))
+    await request
+
+    assert.equal(caller.actionError.value, null)
+    assert.equal(caller.toastCalls.length, 1)
+    assert.equal(caller.toastCalls[0][0], 'error')
+    assert.match(caller.toastCalls[0][1], /Could not enable Edges: deferred gateway failure/)
+    assert.equal(caller.toastCalls[0][2].scope, 'org-a/workspace-a/workspace')
+  })
+
+  test(`${label} drops a deferred failure after a scope change`, async () => {
+    caller.toastCalls.length = 0
+    caller.tenantStore.orgUUID = 'org-a'
+    caller.tenantStore.workspaceUUID = 'workspace-a'
+    const provider = { name: 'code', displayName: 'Code', permissionClaims: [] }
+    const pending = deferred()
+    caller.providerStore.enable = () => pending.promise
+    caller.dialogRevision.value += 1
+    caller.dialogProvider.value = provider
+
+    const request = caller.onDialogConfirm([])
+    await Promise.resolve()
+    caller.tenantStore.orgUUID = 'org-b'
+    pending.reject(new Error('old-scope failure'))
+    await request
+
+    assert.equal(caller.actionError.value, null)
+    assert.equal(caller.toastCalls.length, 0)
+    caller.tenantStore.orgUUID = 'org-a'
+    caller.dialogProvider.value = null
+  })
+}

--- a/portal/src/pages/ProvidersPage.vue
+++ b/portal/src/pages/ProvidersPage.vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import AppLayout from '@/components/AppLayout.vue'
 import ProviderEnableDialog from '@/components/ProviderEnableDialog.vue'
 import SelfHostInstructions from '@/components/SelfHostInstructions.vue'
 import { confirmDialog } from '@/portalkit/confirm'
+import { toast } from '@/portalkit/toast'
 import { useProvidersStore, type ProviderDTO, type PermissionClaim } from '@/stores/providers'
 import { useOrgProvidersStore, type OrgProviderRegistration } from '@/stores/orgProviders'
+import { useTenantStore } from '@/stores/tenant'
 import { categoryIcons, fallbackCategoryIcon } from '@/lib/categoryIcons'
 import { providerBindingAction } from '@/lib/providerBindingAction'
 import { Puzzle, ExternalLink, AlertCircle, AlertTriangle, ArrowUpCircle, Plus, X, Loader2, Search, Server, Trash2, RefreshCw } from 'lucide-vue-next'
 
 const providers = useProvidersStore()
 const orgProviders = useOrgProvidersStore()
+const tenant = useTenantStore()
 
 // Two views of the same catalog: what you can turn on ("Catalog"), and what you
 // can run yourself ("Self-Hosting"). They are separate tabs rather than one list
@@ -28,10 +31,12 @@ const tabs: { key: Tab; label: string }[] = [
 const activeRegistration = ref<OrgProviderRegistration | null>(null)
 const selfHostBusy = ref<Record<string, boolean>>({})
 const selfHostError = ref<string | null>(null)
+let selfHostRequestGeneration = 0
 
 // Which cluster a new self-hosted provider goes into. Keyed "workspace/name"
 // so it survives a reload of the target list by value rather than identity.
 const selectedEdgeKey = ref<string>('')
+const selfHostPending = computed(() => Object.values(selfHostBusy.value).some(Boolean))
 
 const eligibleEdges = computed(() => orgProviders.eligibleInstallTargets)
 
@@ -46,6 +51,10 @@ const selectedEdge = computed(() => {
 
 function edgeLabel(t: { workspace: string; workspaceDisplayName?: string; name: string }): string {
   return `${t.name} · ${t.workspaceDisplayName || t.workspace}`
+}
+
+function edgeKey(t: { workspace: string; name: string }): string {
+  return `${t.workspace}/${t.name}`
 }
 
 // canSelfHost is the single gate. A provider cannot be installed into a cluster
@@ -82,20 +91,42 @@ function bindingAction(p: ProviderDTO) {
 }
 
 async function selfHost(p: ProviderDTO) {
+  if (!canSelfHost.value) {
+    selfHostError.value = orgProviders.installTargetsReason ?? 'no connected cluster to install into'
+    return
+  }
   const edge = selectedEdge.value
   if (!edge) {
     selfHostError.value = orgProviders.installTargetsReason ?? 'no connected cluster to install into'
     return
   }
+  if (selfHostBusy.value[p.name]) return
+  const requestGeneration = ++selfHostRequestGeneration
+  const targetScope = dialogScope.value
+  const targetEdgeKey = edgeKey(edge)
   selfHostError.value = null
+  activeRegistration.value = null
   selfHostBusy.value = { ...selfHostBusy.value, [p.name]: true }
   try {
     // Same name as the platform provider: the chart registers its CatalogEntry
     // under its own name, and the org's copy shadows the platform one for this
     // org only.
-    activeRegistration.value = await orgProviders.register(p.name, p.name, edge)
+    const registration = await orgProviders.register(p.name, p.name, edge)
+    // The registration response belongs to the org and edge captured above.
+    // Ignore it when either changed while the hub was processing the request;
+    // otherwise an old credential/instructions panel can appear in the new
+    // context or after the user chose a different install target.
+    if (
+      requestGeneration === selfHostRequestGeneration &&
+      dialogScope.value === targetScope &&
+      selectedEdge.value && edgeKey(selectedEdge.value) === targetEdgeKey
+    ) {
+      activeRegistration.value = registration
+    }
   } catch (e) {
-    selfHostError.value = e instanceof Error ? e.message : String(e)
+    if (requestGeneration === selfHostRequestGeneration && dialogScope.value === targetScope) {
+      selfHostError.value = e instanceof Error ? e.message : String(e)
+    }
     // The hub is authoritative on eligibility and its answer may have changed
     // under us (an agent dropping between page load and click). Re-check so the
     // buttons reflect reality instead of failing the same way again.
@@ -106,31 +137,51 @@ async function selfHost(p: ProviderDTO) {
 }
 
 async function showInstructions(name: string) {
+  if (selfHostBusy.value[name]) return
+  const requestGeneration = ++selfHostRequestGeneration
+  const targetScope = dialogScope.value
   selfHostError.value = null
+  activeRegistration.value = null
   selfHostBusy.value = { ...selfHostBusy.value, [name]: true }
   try {
-    activeRegistration.value = await orgProviders.instructions(name)
+    const registration = await orgProviders.instructions(name)
+    if (requestGeneration === selfHostRequestGeneration && dialogScope.value === targetScope) {
+      activeRegistration.value = registration
+    }
   } catch (e) {
-    selfHostError.value = e instanceof Error ? e.message : String(e)
+    if (requestGeneration === selfHostRequestGeneration && dialogScope.value === targetScope) {
+      selfHostError.value = e instanceof Error ? e.message : String(e)
+    }
   } finally {
     selfHostBusy.value = { ...selfHostBusy.value, [name]: false }
   }
 }
 
 async function removeSelfHosted(name: string) {
+  const targetOrgUUID = tenant.orgUUID
+  const targetScope = dialogScope.value
   if (!(await confirmDialog({
     title: `Remove self-hosted "${name}"?`,
     message: 'This deletes its workspace and everything in it, including its API. Workspaces that enabled it will stop working until you disable it there.',
     confirmLabel: 'Remove',
     danger: true,
   }))) return
+  // Confirmation is asynchronous. Do not apply a destructive action to a
+  // same-named provider after the user has switched organizations or scope.
+  if (tenant.orgUUID !== targetOrgUUID || dialogScope.value !== targetScope) return
+  const requestGeneration = ++selfHostRequestGeneration
   selfHostError.value = null
+  if (activeRegistration.value?.provider.name === name) activeRegistration.value = null
   selfHostBusy.value = { ...selfHostBusy.value, [name]: true }
   try {
     await orgProviders.remove(name)
-    if (activeRegistration.value?.provider.name === name) activeRegistration.value = null
+    if (requestGeneration === selfHostRequestGeneration && dialogScope.value === targetScope && activeRegistration.value?.provider.name === name) {
+      activeRegistration.value = null
+    }
   } catch (e) {
-    selfHostError.value = e instanceof Error ? e.message : String(e)
+    if (requestGeneration === selfHostRequestGeneration && dialogScope.value === targetScope) {
+      selfHostError.value = e instanceof Error ? e.message : String(e)
+    }
   } finally {
     selfHostBusy.value = { ...selfHostBusy.value, [name]: false }
   }
@@ -267,6 +318,10 @@ const actionError = ref<string | null>(null)
 // when closed. The user reviews permission claims here before the APIBinding
 // is actually POSTed.
 const dialogProvider = ref<ProviderDTO | null>(null)
+const dialogRevision = ref(0)
+const dialogScope = computed(
+  () => `${tenant.orgUUID ?? ''}/${tenant.workspaceUUID ?? ''}/${tenant.workspaceMode}`,
+)
 
 // Always refetch on mount. The store's initial load happens at app boot
 // (App.vue), but new CatalogEntry installs are common while the portal is
@@ -282,25 +337,64 @@ onMounted(() => {
 })
 
 function openEnableDialog(p: ProviderDTO) {
+  if (busy.value[p.name]) return
   actionError.value = null
   const missing = providers.missingDependencies(p)
   if (missing.length > 0) {
     actionError.value = `${p.displayName} requires ${providers.dependencyLabels(missing).join(', ')} to be enabled first.`
     return
   }
+  dialogRevision.value += 1
   dialogProvider.value = p
 }
 
+function closeEnableDialog() {
+  dialogRevision.value += 1
+  dialogProvider.value = null
+  actionError.value = null
+}
+
+watch(dialogScope, () => {
+  // Provider enables are fenced by the store, but a context switch can happen
+  // while the request is waiting on the hub. Close the old consent surface so
+  // its eventual result cannot be applied to the new workspace.
+  if (dialogProvider.value) closeEnableDialog()
+  selfHostRequestGeneration += 1
+  activeRegistration.value = null
+  selfHostError.value = null
+})
+
+watch(selectedEdgeKey, () => {
+  // Install instructions are target-specific. Hide an old response as soon
+  // as the target changes and fence any request still in flight.
+  selfHostRequestGeneration += 1
+  activeRegistration.value = null
+  selfHostError.value = null
+})
+
 async function onDialogConfirm(accept: PermissionClaim[]) {
   const p = dialogProvider.value
-  if (!p) return
+  const revision = dialogRevision.value
+  const scope = dialogScope.value
+  if (!p || busy.value[p.name]) return
   busy.value = { ...busy.value, [p.name]: true }
   actionError.value = null
   try {
     await providers.enable(p, accept)
-    dialogProvider.value = null
+    if (dialogRevision.value === revision && dialogProvider.value === p && dialogScope.value === scope) {
+      closeEnableDialog()
+    }
   } catch (e) {
-    actionError.value = e instanceof Error ? e.message : String(e)
+    const message = e instanceof Error ? e.message : String(e)
+    if (dialogRevision.value === revision && dialogProvider.value === p && dialogScope.value === scope) {
+      actionError.value = message
+    } else if (dialogScope.value === scope) {
+      toast('error', `Could not enable ${p.displayName}: ${message}`, {
+        scope,
+        source: 'provider-enable',
+        dedupeKey: `provider-enable:${p.name}`,
+      })
+    }
   } finally {
     const next = { ...busy.value }
     delete next[p.name]
@@ -309,6 +403,7 @@ async function onDialogConfirm(accept: PermissionClaim[]) {
 }
 
 async function onDisable(p: ProviderDTO) {
+  if (busy.value[p.name]) return
   busy.value = { ...busy.value, [p.name]: true }
   actionError.value = null
   try {
@@ -402,6 +497,8 @@ function dependencyNotice(p: ProviderDTO): string {
         <div
           v-if="selfHostError"
           class="rounded-lg border border-danger/30 bg-danger-subtle px-3 py-2 text-sm text-danger flex items-start gap-2"
+          role="alert"
+          aria-live="assertive"
         >
           <AlertCircle class="h-4 w-4 flex-shrink-0 mt-0.5" :stroke-width="1.75" />
           <span>{{ selfHostError }}</span>
@@ -424,7 +521,8 @@ function dependencyNotice(p: ProviderDTO): string {
               :disabled="orgProviders.installTargetsLoading"
               @click="orgProviders.loadInstallTargets"
             >
-              <RefreshCw class="h-3 w-3" :class="{ 'animate-spin': orgProviders.installTargetsLoading }" :stroke-width="2" />
+              <Loader2 v-if="orgProviders.installTargetsLoading" class="h-3 w-3 animate-spin" :stroke-width="2" />
+              <RefreshCw v-else class="h-3 w-3" :stroke-width="2" />
               Retry check
             </button>
             <router-link
@@ -464,6 +562,7 @@ function dependencyNotice(p: ProviderDTO): string {
             id="self-host-edge"
             v-model="selectedEdgeKey"
             class="k-input w-auto px-2 py-1 text-[11px]"
+            :disabled="selfHostPending"
           >
             <option v-for="t in eligibleEdges" :key="`${t.workspace}/${t.name}`" :value="`${t.workspace}/${t.name}`">
               {{ edgeLabel(t) }}
@@ -667,17 +766,21 @@ function dependencyNotice(p: ProviderDTO): string {
         <div class="mb-4 flex flex-wrap items-center gap-3">
           <div class="relative w-full sm:w-80 sm:max-w-full">
             <Search class="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" :stroke-width="1.75" />
+            <label for="provider-catalog-search" class="sr-only">Search providers</label>
             <input
+              id="provider-catalog-search"
               v-model="search"
               type="search"
+              aria-label="Search providers"
               placeholder="Search providers…"
               class="k-input w-full bg-surface-raised/60 py-1.5 pl-8 pr-3 text-sm"
             />
           </div>
-          <div class="flex flex-wrap items-center gap-1.5">
+          <div class="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter providers by category">
             <button
               type="button"
               class="k-btn k-btn--ghost rounded-sm px-2.5 py-1 text-[11px] font-medium transition-colors"
+              :aria-pressed="selectedCategory === null"
               :class="
                 selectedCategory === null
                   ? 'border-accent/40 bg-accent/10 text-accent'
@@ -692,6 +795,7 @@ function dependencyNotice(p: ProviderDTO): string {
               :key="chip.name"
               type="button"
               class="k-btn k-btn--ghost inline-flex items-center gap-1 rounded-sm px-2.5 py-1 text-[11px] font-medium transition-colors"
+              :aria-pressed="selectedCategory === chip.name"
               :class="
                 selectedCategory === chip.name
                   ? 'border-accent/40 bg-accent/10 text-accent'
@@ -921,7 +1025,9 @@ function dependencyNotice(p: ProviderDTO): string {
 
     <ProviderEnableDialog
       :provider="dialogProvider"
-      @cancel="dialogProvider = null"
+      :busy="dialogProvider ? !!busy[dialogProvider.name] : false"
+      :error="dialogProvider ? actionError : null"
+      @cancel="closeEnableDialog"
       @confirm="onDialogConfirm"
     />
   </AppLayout>

--- a/portal/src/pages/bonkers/OrgsSection.vue
+++ b/portal/src/pages/bonkers/OrgsSection.vue
@@ -1,7 +1,32 @@
 <script setup lang="ts">
-import { useAdminStore } from '@/stores/admin'
+import ResourceTable from '@/portalkit/ResourceTable.vue'
+import { useAdminStore, type AdminOrg } from '@/stores/admin'
 
 const admin = useAdminStore()
+
+const workspaceColumns = [
+  { key: 'displayName', label: 'Workspace', primary: true },
+  { key: 'uuid', label: 'UUID' },
+  { key: 'clusterName', label: 'Cluster' },
+  { key: 'providers', label: 'Providers' },
+]
+
+const workspaceRows = (org: AdminOrg): Array<Record<string, unknown>> => org.workspaces.map((workspace) => ({
+  ...workspace,
+  displayName: workspace.displayName || '—',
+  clusterName: workspace.clusterName || '—',
+  providers: workspace.providers ?? [],
+}))
+
+function providerNames(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((provider): provider is string => typeof provider === 'string')
+    : []
+}
+
+async function refresh() {
+  await admin.refresh()
+}
 </script>
 
 <template>
@@ -11,17 +36,20 @@ const admin = useAdminStore()
       All organizations registered on the hub, with their workspaces and enabled providers.
     </p>
 
-    <div v-if="!admin.orgs.length && !admin.loading" class="text-sm text-text-muted">
+    <div v-if="admin.loading && !admin.loaded" class="text-sm text-text-muted" role="status" aria-live="polite">
+      Loading organizations…
+    </div>
+
+    <div v-else-if="admin.loaded && !admin.orgs.length" class="text-sm text-text-muted" role="status" aria-live="polite">
       No organizations found.
     </div>
 
-    <div class="space-y-4">
+    <div v-if="admin.loaded" class="space-y-4">
       <div
         v-for="o in admin.orgs"
         :key="o.name"
         class="k-card p-4"
       >
-        <!-- Org header -->
         <div class="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
           <span class="text-sm font-semibold text-text-primary">{{ o.displayName || '—' }}</span>
           <span class="font-mono text-[11px] text-text-muted">{{ o.name }}</span>
@@ -30,55 +58,46 @@ const admin = useAdminStore()
           </span>
         </div>
 
-        <!-- Workspaces -->
-        <div class="k-table">
-          <table class="w-full text-sm">
-          <thead class="text-left text-[11px] uppercase text-text-muted">
-            <tr>
-              <th class="py-1 pr-4">Workspace</th>
-              <th class="py-1 pr-4">UUID</th>
-              <th class="py-1 pr-4">Cluster</th>
-              <th class="py-1">Providers</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="ws in o.workspaces"
-              :key="ws.uuid"
-              class="border-t border-border-subtle/40"
-              :class="{ 'opacity-50': ws.deletionRequestedAt }"
+        <ResourceTable
+          :columns="workspaceColumns"
+          :rows="workspaceRows(o)"
+          :aria-label="`Workspaces for ${o.displayName || o.name}`"
+          row-key="uuid"
+          variant="simple"
+          :interactive="false"
+          :loaded="admin.loaded"
+          :loading="admin.loading"
+          empty-text="No workspaces."
+          @retry="refresh"
+        >
+          <template #displayName="{ row }">
+            <span class="text-text-primary">{{ row.displayName || '—' }}</span>
+            <span
+              v-if="row.deletionRequestedAt"
+              class="k-badge k-badge--danger ml-1"
             >
-              <td class="py-1.5 pr-4 text-text-primary">
-                {{ ws.displayName || '—' }}
-                <span
-                  v-if="ws.deletionRequestedAt"
-                  class="k-badge k-badge--danger ml-1"
-                  >deleting</span
-                >
-              </td>
-              <td class="py-1.5 pr-4 font-mono text-[11px] text-text-muted">{{ ws.uuid }}</td>
-              <td class="py-1.5 pr-4 font-mono text-[11px] text-text-muted">
-                {{ ws.clusterName || '—' }}
-              </td>
-              <td class="py-1.5">
-                <div v-if="ws.providers.length" class="flex flex-wrap gap-1">
-                  <span
-                    v-for="p in ws.providers"
-                    :key="p"
-                    class="k-badge k-badge--muted normal-case"
-                  >
-                    {{ p }}
-                  </span>
-                </div>
-                <span v-else class="text-[11px] text-text-muted">—</span>
-              </td>
-            </tr>
-            <tr v-if="!o.workspaces.length">
-              <td colspan="4" class="py-2 text-[11px] text-text-muted">No workspaces.</td>
-            </tr>
-          </tbody>
-          </table>
-        </div>
+              deleting
+            </span>
+          </template>
+          <template #uuid="{ value }">
+            <span class="font-mono text-[11px] text-text-muted">{{ value || '—' }}</span>
+          </template>
+          <template #clusterName="{ value }">
+            <span class="font-mono text-[11px] text-text-muted">{{ value || '—' }}</span>
+          </template>
+          <template #providers="{ value }">
+            <div v-if="providerNames(value).length" class="flex flex-wrap gap-1">
+              <span
+                v-for="provider in providerNames(value)"
+                :key="provider"
+                class="k-badge k-badge--muted normal-case"
+              >
+                {{ provider }}
+              </span>
+            </div>
+            <span v-else class="text-[11px] text-text-muted">—</span>
+          </template>
+        </ResourceTable>
       </div>
     </div>
   </section>

--- a/portal/src/pages/bonkers/ProvidersSection.vue
+++ b/portal/src/pages/bonkers/ProvidersSection.vue
@@ -55,7 +55,7 @@ async function refresh() {
 
 async function create() {
   const name = newName.value.trim()
-  if (!name) return
+  if (!name || busy.value) return
   busy.value = true
   actionError.value = null
   try {
@@ -124,36 +124,36 @@ async function remove(name: string) {
       Secret. Deleting it triggers full teardown.
     </p>
 
-    <div class="mb-4 flex flex-wrap items-end gap-2">
+    <form class="mb-4 flex flex-wrap items-end gap-2" @submit.prevent="create">
       <div>
-        <label class="block text-[11px] text-text-muted">Name</label>
+        <label for="admin-provider-name" class="block text-[11px] text-text-muted">Name</label>
         <input
+          id="admin-provider-name"
           v-model="newName"
           placeholder="e.g. code"
           class="k-input mt-1 w-48 font-mono text-sm"
-          @keyup.enter="create"
+          required
         />
       </div>
       <div>
-        <label class="block text-[11px] text-text-muted">Display name (optional)</label>
+        <label for="admin-provider-display-name" class="block text-[11px] text-text-muted">Display name (optional)</label>
         <input
+          id="admin-provider-display-name"
           v-model="newDisplayName"
           placeholder="e.g. Code"
           class="k-input mt-1 w-56 text-sm"
-          @keyup.enter="create"
         />
       </div>
       <button
-        type="button"
+        type="submit"
         class="k-btn k-btn--primary px-3 py-1.5 text-sm disabled:opacity-50"
         :disabled="busy || !newName.trim()"
-        @click="create"
       >
         <Plus class="h-4 w-4" :stroke-width="1.75" />
-        Create Provider
+        {{ busy ? 'Creating provider…' : 'Create provider' }}
       </button>
-    </div>
-    <p v-if="actionError" class="mb-2 text-sm text-danger">{{ actionError }}</p>
+    </form>
+    <p v-if="actionError" class="mb-2 text-sm text-danger" role="alert" aria-live="assertive">{{ actionError }}</p>
 
     <ResourceTable
       :columns="columns"


### PR DESCRIPTION
Provisioning inferred completed steps from polling, and a failed provider Enable could remain busy with its error behind the dialog. Use authoritative loading/error states and recoverable Enable feedback; align sign-in, setup forms, labels, and self-host credential handling.

Host onboarding, provider enablement/catalog, organization/workspace setup, login/callback, self-host instructions, YAML/CLI help, and their matching checks. Includes the corresponding exception line update.

## Validation

Host tests, onboarding/settings conformance, host production build, and design/parity/UI-conformance gates passed on this slice.

## Stack

Part 3 of 8. Merge in order; this PR targets the preceding branch.
1. [standardize shared menus, confirmations, and touch targets](https://github.com/faroshq/faros/pull/682)
2. [unify sign-in and completion-page presentation](https://github.com/faroshq/faros/pull/683)
3. [make onboarding and form states honest and accessible](https://github.com/faroshq/faros/pull/684) **(this PR)**
4. [align workspace reads, dashboard menus, and terminal controls](https://github.com/faroshq/faros/pull/685)
5. [align resource forms and validation across providers](https://github.com/faroshq/faros/pull/686)
6. [make configuration saves and connection states consistent](https://github.com/faroshq/faros/pull/687)
7. [align conversation controls and workbench feedback](https://github.com/faroshq/faros/pull/688)
8. [harden project flows and keep Share above workspace surfaces](https://github.com/faroshq/faros/pull/689)

The eight-PR stack excludes the audit findings and coverage ledger. Each implementation slice was checked independently; live browser evidence was collected on the complete audit branch.
