### PR TITLE
fix(app-studio): move Git option into project configuration

### DIFF
--- a/providers/app-studio/portal/src/App.vue
+++ b/providers/app-studio/portal/src/App.vue
@@ -8902,19 +8902,6 @@ function isMissingCodeConnectionError(value: string | null): boolean {
             </template>
 
             <template v-else-if="wizardOpen">
-              <div class="mb-4 grid gap-2 rounded-md border border-border-subtle bg-surface p-3 text-[12px]">
-                <label class="k-checkbox-hit flex items-center gap-2 text-text-primary">
-                  <input v-model="createWithGit" type="checkbox" class="app-studio-touch-target" :disabled="projectCreationPending || !reviewedGitConnection" />
-                  Create a private Git repository (recommended)
-                </label>
-                <p class="text-text-secondary">{{ createWithGit ? 'Project source will be saved to a new private repository.' : 'Start without Git. Connect a repository later in project settings.' }}</p>
-                <a v-if="!reviewedGitConnection" :href="CODE_CONNECTIONS_URL" target="_blank" rel="noopener noreferrer" class="app-studio-touch-target text-accent underline underline-offset-2">Connect GitHub</a>
-                <p v-if="createGitError" role="alert" class="text-danger">{{ createGitError }}</p>
-                <div v-if="createGitError || !reviewedGitConnection" class="flex gap-2">
-                  <button type="button" class="app-studio-touch-target k-btn k-btn--ghost" :disabled="projectCreationPending" @click="onWizardSetupRetry">Check again</button>
-                  <button type="button" class="app-studio-touch-target k-btn k-btn--ghost" :disabled="projectCreationPending" @click="createWithGit = false; createGitError = ''">Continue without Git</button>
-                </div>
-              </div>
               <NewProjectWizard
                 :ctx="props.ctx"
                 :initial-prompt="prompt"
@@ -8933,7 +8920,23 @@ function isMissingCodeConnectionError(value: string | null): boolean {
                 @retry-attachment="retryPreProjectAttachment"
                 @setup-action="onWizardSetupAction"
                 @retry-setup="onWizardSetupRetry"
-              />
+              >
+                <template #repository-options>
+                  <div class="grid min-w-0 gap-2 text-[12px]">
+                    <label class="k-checkbox-hit flex items-center gap-2 text-text-primary">
+                      <input v-model="createWithGit" type="checkbox" class="app-studio-touch-target" :disabled="projectCreationPending || !reviewedGitConnection" />
+                      Create a private Git repository (recommended)
+                    </label>
+                    <p class="text-text-secondary">{{ createWithGit ? 'Project source will be saved to a new private repository.' : 'Start without Git. Connect a repository later in project settings.' }}</p>
+                    <a v-if="!reviewedGitConnection" :href="CODE_CONNECTIONS_URL" target="_blank" rel="noopener noreferrer" class="app-studio-touch-target text-accent underline underline-offset-2">Connect GitHub</a>
+                    <p v-if="createGitError" role="alert" class="text-danger">{{ createGitError }}</p>
+                    <div v-if="createGitError || !reviewedGitConnection" class="flex flex-wrap gap-2">
+                      <button type="button" class="app-studio-touch-target k-btn k-btn--ghost" :disabled="projectCreationPending" @click="onWizardSetupRetry">Check again</button>
+                      <button type="button" class="app-studio-touch-target k-btn k-btn--ghost" :disabled="projectCreationPending" @click="createWithGit = false; createGitError = ''">Continue without Git</button>
+                    </div>
+                  </div>
+                </template>
+              </NewProjectWizard>
             </template>
 
             <template v-else>

--- a/providers/app-studio/portal/src/NewProjectWizard.vue
+++ b/providers/app-studio/portal/src/NewProjectWizard.vue
@@ -465,6 +465,8 @@ onMounted(async () => {
               </div>
             </label>
 
+            <slot name="repository-options" />
+
             <div id="template-impact" class="grid gap-3 border-t border-border-subtle pt-4">
               <div class="flex items-start gap-3">
                 <span class="mt-0.5 text-accent"><Package class="h-4 w-4" :stroke-width="1.75" /></span>


### PR DESCRIPTION
The private Git repository option appeared above the project creation wizard, separate from the configuration it controls. Move it into the confirmation form below Template, keeping its help text and recovery actions together.

A named wizard slot keeps Git state and creation behavior owned by App.vue. The field uses the existing form spacing, and recovery buttons wrap on narrow screens.

Validation passed:
- `make build-app-studio-provider-portal` (including bundle budgets)
- `make verify-design-docs`
- `make verify-portalkit`
- `make verify-ui-conformance`
- Local browser fixture using the real wizard and Git option markup: placement, selection retention after returning to the wizard, Git on/off creation handoff, and missing-connection recovery; desktop/mobile checks in light and dark themes with no horizontal overflow or page errors.
- `git diff --check`

Browser validation used a local component fixture with mocked project planning; it did not create a project or repository against the live deployment.
