### PR TITLE
[AUTOMATED BOT PR] Serve org-owned provider UI bundles over the edge with hub-issued grants; fix infrastructure operator heartbeat credential

### DIFF
--- a/docs/byo-providers.md
+++ b/docs/byo-providers.md
@@ -630,21 +630,38 @@ in URL paths.
   cannot keep a platform provider of the same name looking alive. Org providers
   therefore never set `HeartbeatRequired`, leaving readiness resting on endpoint
   validity. An org-scoped heartbeat path is future work.
-- **The provider UI is not portable; the backend is.** `/services/providers/{name}`
-  now resolves in the caller's Org and routes an org-owned provider over its edge
-  tunnel. `/ui/providers/{name}` does not: it still resolves platform-only, so an
-  Org self-hosting a provider that ships a micro-frontend gets the PLATFORM's
-  bundle while its own copy serves the API — wrong rather than broken, which is
-  the harder failure to notice.
+- **The provider UI is portable, through a grant.** `/services/providers/{name}`
+  resolves in the caller's Org and routes an org-owned provider over its edge
+  tunnel. `/ui/providers/{name}` cannot do the same by itself: the bundle is
+  loaded with a plain `<script src>`
+  ([ProviderFrame.vue](../portal/src/pages/ProviderFrame.vue)), which carries
+  no `Authorization` header, so there is no identity on an asset GET to scope
+  by — and the platform edges provider refuses tunnel requests with no bearer,
+  so the hub cannot fetch the bundle anonymously either. Before this was
+  closed, an Org self-hosting a provider that ships a micro-frontend got the
+  PLATFORM's bundle (or its 503, when that copy was stale) while its own copy
+  served the API.
 
-  This is not the same change as the backend one. The bundle is loaded with a
-  plain `<script src="/ui/providers/{name}/main.js">`
-  ([ProviderFrame.vue](../portal/src/pages/ProviderFrame.vue)), so the request
-  carries no `Authorization` header, and `BrowserIdentity` — the hub's only way
-  to name a caller — requires one. There is no identity on an asset GET to scope
-  by. Closing it needs either the portal fetching the bundle with credentials
-  and injecting it as a blob, or the Org encoded in the asset path so no
-  identity is needed. Both are portal-visible changes; neither is a proxy tweak.
+  The portal now asks first: `POST /api/providers/{name}/ui-grant`, as the
+  user under the selected org/workspace (the same `TenantResolver` membership
+  check the backend proxy makes). The hub confirms the Org owns a copy of
+  `{name}` with a UI served by the same authority as its backend (the edge
+  route fronts that Service), hashes the bundle through the caller's own
+  delegated route for Subresource Integrity, and answers with
+  `/ui/providers/{name}/main.js?v=…&grant=…` plus the pin. The grant is a
+  sealed, five-minute, single-provider token naming `(user, org, workspace)`.
+  When the script tag fetches that URL, the UI proxy opens the grant, resolves
+  the ORG's copy, mints the delegated token for the tuple it names, and
+  forwards over the edge hop — the same hop and token swap as
+  `serveOverEdge`, so an asset fetch and an API call look identical at the
+  far end. A URL without a grant stays platform-scoped. See
+  [pkg/hub/providers/ui_grant.go](../pkg/hub/providers/ui_grant.go) and
+  [portal/src/providers/providerBundle.ts](../portal/src/providers/providerBundle.ts).
+
+  The bundle keeps its `/ui/providers/{name}/` shape on purpose: the
+  provider's vendored portalkit derives `/services/providers/{name}` from the
+  `basePath` the host passes, and the host's provider-fetch allow list is
+  unchanged, so a bundle built before this change loads as-is.
 
 - **No edge-driven install.** The Org installs the chart itself with the returned
   kubeconfig. One-click install onto a chosen edge needs credential projection

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -726,6 +726,16 @@ element. There is no iframe and no postMessage handshake. The shape:
    negotiate (it sends no `Access-Control-Allow-Origin`), so the script would
    fail to load. Without a pin it loads anyway and logs a warning. The `?v=`
    cache-buster does not interact with SRI, which hashes the response body.
+
+   An org-owned provider (`scope: "org"`) is loaded from the same path shape
+   but with a grant: the portal first `POST`s `/api/providers/{name}/ui-grant`
+   as the user (`providerBundle.ts`), and the hub answers with
+   `/ui/providers/{name}/main.js?v=…&grant=…` plus the bundle's pin, hashed
+   through the caller's delegated edge route. The UI proxy redeems the grant
+   into a delegated token and serves the bundle over the org's edge tunnel;
+   a grant-less URL stays platform-scoped. See
+   [byo-providers.md](./byo-providers.md) §"Known gaps" and
+   [pkg/hub/providers/ui_grant.go](../pkg/hub/providers/ui_grant.go).
 2. **Mount the element.** After `customElements.whenDefined('faros-provider-{name}')`
    the host appends `<faros-provider-{name}>` into its own DOM. The provider
    shares the portal stylesheet (CSS variables cascade in), so there is no
@@ -1112,7 +1122,10 @@ workspace by hand.
     swapped behind the URL after registration is refused by the browser
     until the hub re-admits it.
     Org-owned providers are served over the edge tunnel and never dialled by
-    the hub, so they currently load unpinned (the loader logs a warning).
+    the reconciler; their pin is computed at grant time instead
+    (`POST /api/providers/{name}/ui-grant` hashes the bundle through the
+    caller's delegated route, `pkg/hub/providers/ui_grant.go`) and returned
+    with the bundle URL, so they load pinned too.
   - **Host fetch, no raw token.** The host hands the bundle
     `farosContext.fetch` (Authorization + tenant headers injected by the host,
     same-origin allow list) instead of the user's id token. `token` is still

--- a/pkg/hub/providers/api.go
+++ b/pkg/hub/providers/api.go
@@ -77,8 +77,10 @@ type providerDTO struct {
 	// /ui/providers/{name}/main.js. The portal sets it as the script's
 	// integrity attribute so the browser refuses a bundle that differs from
 	// the one the hub hashed at registration. Empty when the hub has no pin
-	// (org-owned providers, builtin routes, or a failed hash fetch); the
-	// portal then loads the bundle unpinned and logs a warning.
+	// (builtin routes or a failed hash fetch); the portal then loads the
+	// bundle unpinned and logs a warning. Always empty for an org-owned
+	// provider: its bundle URL and pin are issued per load by
+	// POST /api/providers/{name}/ui-grant (ui_grant.go).
 	MainJSIntegrity string `json:"mainJSIntegrity,omitempty"`
 	// BuiltinRoute, when set, tells the portal to render the named Vue
 	// route inside its own SPA instead of loading /main.js as a custom

--- a/pkg/hub/providers/proxy.go
+++ b/pkg/hub/providers/proxy.go
@@ -34,6 +34,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/faroshq/faros/pkg/apiurl"
+	"github.com/faroshq/faros/pkg/hub/serviceaccounts"
 )
 
 // NewUIProxy returns an http.Handler serving /ui/providers/{name}/* by reverse
@@ -270,6 +271,11 @@ type ProviderProxy struct {
 	// SetDelegationPolicy.
 	delegation DelegationPolicy
 
+	// uiGrantKeys opens the grants that let the UI proxy serve an org-owned
+	// provider's bundle over its edge (ui_grant.go). Only the UI proxy sets
+	// it; nil means grant-bearing requests are refused.
+	uiGrantKeys serviceaccounts.ProofKeySource
+
 	// denyHubOnlyEndpoints reserves the hub-only path prefixes on a
 	// provider's backend origin. Provider action routes (/actions/*) are a
 	// public data-plane surface and ride this proxy like any other verb —
@@ -326,12 +332,19 @@ func (p *ProviderProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// missing feature but a wrong answer: it silently served the platform
 	// provider to a tenant who had deliberately replaced it.
 	//
-	// UI proxy stays platform-scoped: it serves static assets, and an org's
-	// bundle is not something the hub hosts.
+	// The UI proxy cannot resolve by caller: a <script src> carries no
+	// bearer. An org-owned bundle is instead addressed by a grant the portal
+	// obtained while authenticated (ui_grant.go), which names the org; a
+	// request without one is platform-scoped, as before.
 	//
 	// Resolve the caller once here; resolveProvider, the delegated-token
 	// path, and setHeaders all read the memo (see resolveCaller).
-	if !p.fallbackForSPA {
+	if p.fallbackForSPA {
+		if grant := r.URL.Query().Get(UIGrantQueryParam); grant != "" {
+			p.serveOrgUIAsset(w, r, name, rest, grant)
+			return
+		}
+	} else {
 		r = p.withResolvedCaller(r)
 	}
 	prov, found := p.resolveProvider(r, name)

--- a/pkg/hub/providers/ui_grant.go
+++ b/pkg/hub/providers/ui_grant.go
@@ -1,0 +1,588 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+// UI bundles of org-owned providers.
+//
+// A platform provider's micro-frontend is served by the UI proxy from a URL
+// the hub dials directly, and the request that fetches it carries no identity:
+// the portal loads /ui/providers/{name}/main.js with a plain <script src>, and
+// a script tag sends no Authorization header. That is fine for a platform
+// bundle, which is the same for everyone.
+//
+// An org-owned provider's bundle lives in the tenant's own cluster, behind the
+// edge tunnel. Two things follow. The hub cannot tell from an anonymous asset
+// GET WHICH org's copy is meant, and the platform edges provider refuses every
+// tunnel request that carries no bearer (providers/edges
+// edges_proxy_builder.go step 1), so the hub has to attach a delegated token
+// exactly as the backend proxy does for /services/providers/{name} — and a
+// delegated token needs a verified (user, org, workspace) to be minted for.
+//
+// The grant closes that gap in two steps:
+//
+//  1. The portal, authenticated as the user with its X-Faros-Org /
+//     X-Faros-Workspace selection, POSTs /api/providers/{name}/ui-grant. The
+//     hub resolves the caller the way the backend proxy does (membership is
+//     verified by the TenantResolver), checks that the caller's org owns a
+//     copy of {name} with a UI, and answers with a bundle URL that carries a
+//     short-lived sealed grant naming that (user, org, workspace, provider).
+//  2. The portal injects <script src="/ui/providers/{name}/main.js?grant=…">.
+//     The UI proxy opens the grant, resolves the ORG's copy of the provider,
+//     mints the delegated token for the tuple the grant names, and forwards
+//     the asset request over the edge hop — the same hop and the same token
+//     swap as serveOverEdge, so the tenant's cluster never sees anything but
+//     a delegated identity.
+//
+// The grant is sealed (AES-256-GCM under a subkey HKDF-derived from the hub's
+// cross-replica secret) rather than signed: it rides in a URL that lands in
+// browser history and hub access logs, and the user name inside it is not
+// something those should carry in the clear. Any replica opens what any
+// replica minted. It is bound to one provider and expires in minutes; it is
+// not a credential at the far end — the delegated token is, and that is minted
+// afresh on redemption, never embedded.
+//
+// The bundle is also hashed for Subresource Integrity at grant time, fetched
+// through the same route on the caller's behalf, so an org-owned bundle is
+// pinned in the portal document exactly as a platform one is.
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/faroshq/faros/pkg/apiurl"
+	"github.com/faroshq/faros/pkg/hub/serviceaccounts"
+)
+
+const (
+	// PathProviderUIGrant is the gorilla/mux pattern of the grant endpoint. It
+	// must be registered BEFORE the heartbeat PathPrefix route on the same
+	// /api/providers prefix, or every POST there is claimed by the heartbeat
+	// handler first.
+	PathProviderUIGrant = PathListProviders + "/{name}/ui-grant"
+
+	// UIGrantQueryParam is the query parameter the UI proxy reads the grant
+	// from. It sits in the query rather than the path so the bundle URL keeps
+	// the /ui/providers/{name}/ shape the provider's own portalkit derives its
+	// service base from, and so the portal's provider-fetch allow list is
+	// unchanged.
+	UIGrantQueryParam = "grant"
+
+	// uiGrantPrefix marks a grant so a stray app token or bearer pasted into
+	// the query is refused before any cryptography runs.
+	uiGrantPrefix = "fpui_"
+
+	// uiGrantTTL bounds a grant's lifetime. The portal requests one immediately
+	// before injecting the script and the loader gives up after 15s, so the
+	// grant only needs to outlive a slow first byte over the tunnel.
+	uiGrantTTL = 5 * time.Minute
+
+	// uiGrantKeyInfo domain-separates the grant key from every other subkey
+	// derived from the hub secret (app access tokens, delegated-identity
+	// proofs). uiGrantAAD binds the ciphertext to this construction.
+	uiGrantKeyInfo = "faros.sh/provider-ui-grant/aes-256-gcm/v1"
+	uiGrantAAD     = "faros.sh/provider-ui-grant/v1"
+	uiGrantVersion = 1
+	uiGrantIDBytes = 16
+	uiGrantMinKey  = 32
+)
+
+// errUIGrantInvalid is every reason a presented grant is not usable. The UI
+// proxy answers 401 and logs the wrapped detail.
+var errUIGrantInvalid = errors.New("invalid provider UI grant")
+
+// uiGrantClaims is the sealed content of a grant: the tuple the delegated
+// token is minted for on redemption, the provider the grant is bound to, and
+// its validity window.
+type uiGrantClaims struct {
+	Version       int    `json:"v"`
+	ID            string `json:"jti"`
+	OrgUUID       string `json:"o"`
+	WorkspaceUUID string `json:"w"`
+	User          string `json:"u"`
+	Provider      string `json:"p"`
+	IssuedAt      int64  `json:"iat"`
+	ExpiresAt     int64  `json:"exp"`
+}
+
+func (c uiGrantClaims) caller() DelegatedCaller {
+	return DelegatedCaller{User: c.User, OrgUUID: c.OrgUUID, WorkspaceUUID: c.WorkspaceUUID}
+}
+
+func uiGrantAEAD(secret []byte) (cipher.AEAD, error) {
+	if len(secret) < uiGrantMinKey {
+		return nil, fmt.Errorf("provider UI grant key is too short")
+	}
+	key, err := hkdf.Key(sha256.New, secret, nil, uiGrantKeyInfo, 32)
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+// sealUIGrant mints a grant for claims. random supplies the nonce and ID.
+func sealUIGrant(secret []byte, random io.Reader, claims uiGrantClaims) (string, error) {
+	aead, err := uiGrantAEAD(secret)
+	if err != nil {
+		return "", err
+	}
+	id := make([]byte, uiGrantIDBytes)
+	if _, err := io.ReadFull(random, id); err != nil {
+		return "", err
+	}
+	claims.Version = uiGrantVersion
+	claims.ID = base64.RawURLEncoding.EncodeToString(id)
+	plaintext, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(random, nonce); err != nil {
+		return "", err
+	}
+	sealed := aead.Seal(nonce, nonce, plaintext, []byte(uiGrantAAD))
+	return uiGrantPrefix + base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+// openUIGrant authenticates and decodes grant and checks its validity window
+// against now. It does NOT check the provider binding; the redeeming request
+// does that against the path it arrived on.
+func openUIGrant(secret []byte, grant string, now time.Time) (uiGrantClaims, error) {
+	if !strings.HasPrefix(grant, uiGrantPrefix) {
+		return uiGrantClaims{}, fmt.Errorf("%w: not a provider UI grant", errUIGrantInvalid)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(grant, uiGrantPrefix))
+	if err != nil {
+		return uiGrantClaims{}, fmt.Errorf("%w: malformed encoding", errUIGrantInvalid)
+	}
+	aead, err := uiGrantAEAD(secret)
+	if err != nil {
+		return uiGrantClaims{}, err
+	}
+	if len(raw) < aead.NonceSize()+aead.Overhead() {
+		return uiGrantClaims{}, fmt.Errorf("%w: truncated", errUIGrantInvalid)
+	}
+	nonce, sealed := raw[:aead.NonceSize()], raw[aead.NonceSize():]
+	plaintext, err := aead.Open(nil, nonce, sealed, []byte(uiGrantAAD))
+	if err != nil {
+		return uiGrantClaims{}, fmt.Errorf("%w: not issued by this hub", errUIGrantInvalid)
+	}
+	var claims uiGrantClaims
+	if err := json.Unmarshal(plaintext, &claims); err != nil {
+		return uiGrantClaims{}, fmt.Errorf("%w: unreadable claims", errUIGrantInvalid)
+	}
+	if claims.Version != uiGrantVersion || claims.OrgUUID == "" || claims.WorkspaceUUID == "" ||
+		claims.User == "" || claims.Provider == "" || claims.ExpiresAt == 0 {
+		return uiGrantClaims{}, fmt.Errorf("%w: incomplete claims", errUIGrantInvalid)
+	}
+	if !now.Before(time.Unix(claims.ExpiresAt, 0)) {
+		return uiGrantClaims{}, fmt.Errorf("%w: expired", errUIGrantInvalid)
+	}
+	return claims, nil
+}
+
+// SetUIGrantKeys installs the secret the UI proxy opens grants with. The same
+// source mints them (UIGrantHandler reads it through the proxy), so every
+// replica agrees. Without one the proxy refuses every grant-bearing request
+// rather than serving an org bundle unscoped.
+func (p *ProviderProxy) SetUIGrantKeys(keys serviceaccounts.ProofKeySource) {
+	p.uiGrantKeys = keys
+}
+
+// orgUIOverEdge reports whether prov's UI can be carried by its edge route.
+// The route fronts the Service the provider published as its backend, so the
+// UI has to be served by that same authority: a spec.ui.url on another host
+// has nothing to land on. Path prefixes may differ (they are appended per
+// request); only scheme and host must match.
+func orgUIOverEdge(prov Provider) bool {
+	return prov.OrgUUID != "" && prov.UIURL != nil && prov.BackendURL != nil &&
+		prov.UIURL.Scheme == prov.BackendURL.Scheme && prov.UIURL.Host == prov.BackendURL.Host
+}
+
+// orgUIAssetPath is the provider-relative path of one UI asset: the
+// spec.ui.url path prefix, then the path after /ui/providers/{name} — the same
+// join the direct UI proxy makes for a platform provider.
+func orgUIAssetPath(prov Provider, rest string) string {
+	return singleJoiningSlash(prov.UIURL.Path, rest)
+}
+
+// serveOrgUIAsset redeems grant for one asset of the org-owned provider name
+// and forwards the request over the provider's edge hop.
+func (p *ProviderProxy) serveOrgUIAsset(w http.ResponseWriter, r *http.Request, name, rest, grant string) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if p.uiGrantKeys == nil {
+		p.log.Info("refusing provider UI grant: no grant key source wired", "provider", name)
+		http.Error(w, "provider UI grants are not available", http.StatusServiceUnavailable)
+		return
+	}
+	secret, err := p.uiGrantKeys.DelegatedProofKey(r.Context())
+	if err != nil {
+		p.log.Error(err, "loading provider UI grant key", "provider", name)
+		http.Error(w, "provider UI grants are not available", http.StatusServiceUnavailable)
+		return
+	}
+	claims, err := openUIGrant(secret, grant, time.Now())
+	if err != nil {
+		p.log.V(1).Info("refusing provider UI grant", "provider", name, "reason", err.Error())
+		http.Error(w, "invalid or expired provider UI grant", http.StatusUnauthorized)
+		return
+	}
+	if claims.Provider != name {
+		// A grant for one provider must not fetch another's bundle, even
+		// within the same org.
+		p.log.V(1).Info("refusing provider UI grant", "provider", name, "reason", "grant is bound to another provider", "grantProvider", claims.Provider)
+		http.Error(w, "invalid or expired provider UI grant", http.StatusUnauthorized)
+		return
+	}
+	// The grant names the org, so resolution is in THAT org — never the
+	// platform record, which is what a grant-less request reaches. GetForOrg
+	// falls back to the platform copy when the org has none; refuse that
+	// rather than serve a platform bundle under an org grant.
+	prov, found := p.reg.GetForOrg(claims.OrgUUID, name)
+	if !found || prov.OrgUUID != claims.OrgUUID || !orgUIOverEdge(prov) {
+		http.Error(w, "provider has no org-owned UI bundle: "+name, http.StatusNotFound)
+		return
+	}
+	if !prov.Ready() {
+		http.Error(w, "provider not ready: "+name, http.StatusServiceUnavailable)
+		return
+	}
+	hop, err := resolveEdgeHop(p.reg, prov)
+	switch {
+	case errors.Is(err, errEdgeRouteUnusable):
+		p.log.Info("org-owned provider has no usable edge route yet", "provider", prov.Name, "org", prov.OrgUUID)
+		http.Error(w, "provider backend is not routable yet: "+name, http.StatusServiceUnavailable)
+		return
+	case err != nil:
+		p.log.Info("edge transport unavailable: the platform edges provider has no backend", "provider", prov.Name, "org", prov.OrgUUID)
+		http.Error(w, "edge transport unavailable for provider: "+name, http.StatusServiceUnavailable)
+		return
+	}
+	// Same decision point as the backend proxy and OrgProviderRoute: the far
+	// end receives a delegated token for the tuple the grant names, minted on
+	// the hub's authority, and nothing else.
+	token, refusal := issueDelegatedToken(r.Context(), p.delegatedIssuer, prov, claims.caller())
+	if refusal != nil {
+		if refusal.err != nil {
+			p.log.Error(refusal.err, "issuing delegated user token for provider UI asset",
+				"provider", prov.Name, "org", prov.OrgUUID, "workspace", claims.WorkspaceUUID, "user", claims.User)
+		} else {
+			p.log.Info("refusing provider UI asset: "+refusal.reason, "provider", prov.Name, "org", prov.OrgUUID)
+		}
+		http.Error(w, refusal.message, refusal.status)
+		return
+	}
+
+	dst := hop.url(orgUIAssetPath(prov, rest))
+	basePath := p.pathPrefix + "/" + prov.Name
+	query := r.URL.Query()
+	query.Del(UIGrantQueryParam)
+	rawQuery := query.Encode()
+
+	rp := &httputil.ReverseProxy{
+		FlushInterval: -1,
+		Director: func(req *http.Request) {
+			req.URL.Scheme = dst.Scheme
+			req.URL.Host = dst.Host
+			req.URL.Path = dst.Path
+			req.URL.RawPath = ""
+			// The grant stops here: the tenant's cluster has no use for it
+			// and must not be handed something it could replay at the hub.
+			req.URL.RawQuery = rawQuery
+			req.Host = dst.Host
+			// Identity under the ORG provider's name, as the backend proxy
+			// does (E-6): the headers describe who is fetching the bundle.
+			req.Header.Del("X-Faros-User")
+			req.Header.Del("X-Faros-Tenant")
+			req.Header.Del("X-Faros-Cluster")
+			req.Header.Set("X-Faros-User", claims.User)
+			p.setHeaders(req, prov.Name, basePath)
+			setDelegatedAuthorization(req.Header, token)
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			// The URL carries a grant, so a shared cache must never keep this
+			// response: after expiry the cached copy would answer a URL the
+			// hub no longer would.
+			resp.Header.Set("Cache-Control", "private, no-store")
+			return nil
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			p.log.Error(err, "edge upstream error serving provider UI asset",
+				"provider", prov.Name, "org", prov.OrgUUID, "edge", hop.route.EdgeName, "service", hop.route.ServiceName)
+			http.Error(w, "provider upstream error", http.StatusBadGateway)
+		},
+	}
+	p.log.V(4).Info("forwarding provider UI asset over edge",
+		"provider", prov.Name, "org", prov.OrgUUID, "edge", hop.route.EdgeName, "path", dst.Path)
+	rp.ServeHTTP(w, r)
+}
+
+// UIGrantHandler serves POST /api/providers/{name}/ui-grant. It is built
+// early (so it can be registered ahead of the heartbeat prefix route) and
+// configured once the auth stack exists, like the proxies.
+type UIGrantHandler struct {
+	reg   *Registry
+	proxy *ProviderProxy // the UI proxy: shares its grant keys and delegated issuer
+	log   logr.Logger
+	now   func() time.Time
+	rand  io.Reader
+
+	mu       sync.RWMutex
+	resolver TenantResolver
+
+	// uiIntegrity caches the SRI pin per org provider and version, on the
+	// same terms as the catalog reconciler's cache for platform bundles.
+	uiIntegrityMu sync.Mutex
+	uiIntegrity   map[providerKey]uiIntegrityRecord
+	// uiClient overrides the transport-bound client built per grant; tests
+	// only.
+	uiFetchTimeout time.Duration
+}
+
+// NewUIGrantHandler builds the grant endpoint over reg, minting with the keys
+// and issuer installed on uiProxy (SetUIGrantKeys, SetDelegatedTokenIssuer).
+func NewUIGrantHandler(reg *Registry, uiProxy *ProviderProxy, log logr.Logger) *UIGrantHandler {
+	return &UIGrantHandler{
+		reg:            reg,
+		proxy:          uiProxy,
+		log:            log.WithName("ui-grant"),
+		now:            time.Now,
+		rand:           rand.Reader,
+		uiFetchTimeout: uiIntegrityFetchTimeout,
+	}
+}
+
+// SetTenantResolver installs the resolver that names the caller. It is the
+// same resolver the backend proxy uses, so the membership checks behind
+// X-Faros-Org / X-Faros-Workspace are the same ones. Until one is installed
+// every request is refused.
+func (h *UIGrantHandler) SetTenantResolver(r TenantResolver) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.resolver = r
+}
+
+// uiGrantResponse is the wire shape of a minted grant.
+type uiGrantResponse struct {
+	// URL is the bundle URL to load, grant included. Same-origin; the portal
+	// injects it as a classic <script src> exactly like a platform bundle.
+	URL string `json:"url"`
+	// Integrity is the SRI pin for that bundle, hashed through the same
+	// route. Empty when the hash fetch failed; the portal then loads unpinned
+	// and logs it, as it does for a platform bundle the hub could not hash.
+	Integrity string `json:"integrity,omitempty"`
+	// ExpiresAt is when the grant stops being redeemable.
+	ExpiresAt time.Time `json:"expiresAt"`
+}
+
+func (h *UIGrantHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	name, ok := parseUIGrantPath(r.URL.Path)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	h.mu.RLock()
+	resolver := h.resolver
+	h.mu.RUnlock()
+	if resolver == nil || h.proxy.uiGrantKeys == nil {
+		h.log.Info("refusing provider UI grant request: grants are not configured", "provider", name)
+		http.Error(w, "provider UI grants are not available", http.StatusServiceUnavailable)
+		return
+	}
+	user, tenantPath, err := resolver.Resolve(r)
+	if err != nil || user == "" {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	orgUUID, wsUUID := splitTenantPath(tenantPath)
+	if orgUUID == "" {
+		http.Error(w, "caller has no tenant workspace", http.StatusForbidden)
+		return
+	}
+	if wsUUID == "" {
+		// The delegated token the asset fetch is made with lives in a team
+		// workspace; an org-scope selection has nowhere to mint it. Say so
+		// here rather than at redemption, where the browser only sees a
+		// failed script.
+		http.Error(w, "a workspace selection (X-Faros-Workspace) is required to load provider: "+name, http.StatusForbidden)
+		return
+	}
+	prov, found := h.reg.GetForOrg(orgUUID, name)
+	if !found || prov.OrgUUID != orgUUID || prov.UIURL == nil {
+		// Platform bundles need no grant, and a provider without a UI has
+		// nothing to grant; both are "not found" for this endpoint.
+		http.Error(w, "provider has no org-owned UI bundle: "+name, http.StatusNotFound)
+		return
+	}
+	if !orgUIOverEdge(prov) {
+		h.log.Info("org-owned provider UI is not served by its backend authority; the edge route cannot carry it",
+			"provider", name, "org", orgUUID, "ui", urlString(prov.UIURL), "backend", urlString(prov.BackendURL))
+		http.Error(w, "provider UI is not reachable over its edge route: "+name, http.StatusNotFound)
+		return
+	}
+	if !prov.Ready() {
+		http.Error(w, "provider not ready: "+name, http.StatusServiceUnavailable)
+		return
+	}
+
+	secret, err := h.proxy.uiGrantKeys.DelegatedProofKey(r.Context())
+	if err != nil {
+		h.log.Error(err, "loading provider UI grant key", "provider", name)
+		http.Error(w, "provider UI grants are not available", http.StatusServiceUnavailable)
+		return
+	}
+	now := h.now()
+	claims := uiGrantClaims{
+		OrgUUID:       orgUUID,
+		WorkspaceUUID: wsUUID,
+		User:          user,
+		Provider:      name,
+		IssuedAt:      now.Unix(),
+		ExpiresAt:     now.Add(uiGrantTTL).Unix(),
+	}
+	grant, err := sealUIGrant(secret, h.rand, claims)
+	if err != nil {
+		h.log.Error(err, "sealing provider UI grant", "provider", name)
+		http.Error(w, "provider UI grants are not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	integrity := h.pinOrgUIIntegrity(r.Context(), prov, claims.caller())
+
+	bundle := url.URL{
+		Path:     apiurl.PathPrefixProvidersUI + "/" + prov.Name + "/main.js",
+		RawQuery: url.Values{"v": {prov.Version}, UIGrantQueryParam: {grant}}.Encode(),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(uiGrantResponse{
+		URL:       bundle.String(),
+		Integrity: integrity,
+		ExpiresAt: time.Unix(claims.ExpiresAt, 0).UTC(),
+	})
+}
+
+// parseUIGrantPath extracts the provider name from
+// /api/providers/{name}/ui-grant. Returns ("", false) on mismatch.
+func parseUIGrantPath(p string) (string, bool) {
+	const prefix = PathListProviders + "/"
+	const suffix = "/ui-grant"
+	rest := strings.TrimPrefix(p, prefix)
+	if rest == p || !strings.HasSuffix(rest, suffix) {
+		return "", false
+	}
+	name := strings.TrimSuffix(rest, suffix)
+	if name == "" || strings.Contains(name, "/") {
+		return "", false
+	}
+	return name, true
+}
+
+// pinOrgUIIntegrity returns the SRI pin for prov's bundle, fetching it through
+// the caller's own delegated route when no fresh pin is cached for the running
+// version. A fetch failure keeps a cached pin for the same version and
+// otherwise yields "" (unpinned), logged — the same policy as
+// CatalogReconciler.pinUIIntegrity for platform bundles.
+func (h *UIGrantHandler) pinOrgUIIntegrity(ctx context.Context, prov Provider, caller DelegatedCaller) string {
+	version := uiIntegrityVersion(prov.Version, prov.ReportedVersion)
+	key := providerKey{Org: prov.OrgUUID, Name: prov.Name}
+	now := h.now()
+
+	h.uiIntegrityMu.Lock()
+	cached, ok := h.uiIntegrity[key]
+	h.uiIntegrityMu.Unlock()
+	if ok && cached.version == version && now.Sub(cached.hashedAt) < UIIntegrityResync {
+		return cached.integrity
+	}
+
+	integrity, err := h.hashOrgProviderMainJS(ctx, prov, caller)
+	if err != nil {
+		h.log.Info("WARNING could not pin org-owned provider UI bundle; portal loads it unpinned",
+			"provider", prov.Name, "org", prov.OrgUUID, "version", version, "err", err.Error())
+		if ok && cached.version == version {
+			return cached.integrity
+		}
+		return ""
+	}
+	h.uiIntegrityMu.Lock()
+	if h.uiIntegrity == nil {
+		h.uiIntegrity = map[providerKey]uiIntegrityRecord{}
+	}
+	h.uiIntegrity[key] = uiIntegrityRecord{version: version, integrity: integrity, hashedAt: now}
+	h.uiIntegrityMu.Unlock()
+	if !ok || cached.integrity != integrity {
+		h.log.Info("Pinned org-owned provider UI bundle", "provider", prov.Name, "org", prov.OrgUUID, "version", version, "integrity", integrity)
+	}
+	return integrity
+}
+
+// hashOrgProviderMainJS GETs the bundle over the provider's edge hop as
+// caller — OrgProviderRoute, the one hub-originated path to an org-owned
+// provider — and returns its SRI metadata. It reads exactly the bytes the UI
+// proxy will later forward for the same path.
+func (h *UIGrantHandler) hashOrgProviderMainJS(ctx context.Context, prov Provider, caller DelegatedCaller) (string, error) {
+	route, err := h.proxy.OrgProviderRoute(ctx, prov, caller)
+	if err != nil {
+		return "", err
+	}
+	base, err := url.Parse(route.BaseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse org provider route: %w", err)
+	}
+	ui := *base
+	ui.Path = singleJoiningSlash(base.Path, strings.TrimSuffix(prov.UIURL.Path, "/"))
+	client := &http.Client{
+		Transport: route.Transport,
+		Timeout:   h.uiFetchTimeout,
+		// As for platform bundles: a provider-controlled redirect cannot move
+		// the fetch elsewhere. The transport would refuse the destination
+		// anyway; this keeps the failure legible.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	data, err := fetchProviderMainJS(ctx, client, &ui)
+	if err != nil {
+		return "", err
+	}
+	return sriSHA384(data), nil
+}

--- a/pkg/hub/providers/ui_grant_test.go
+++ b/pkg/hub/providers/ui_grant_test.go
@@ -12,6 +12,7 @@ package providers
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"errors"
@@ -309,7 +310,7 @@ func TestUIGrantPinIsCachedPerVersion(t *testing.T) {
 
 func mintTestGrant(t *testing.T, claims uiGrantClaims) string {
 	t.Helper()
-	secret, _ := uiGrantTestKey.DelegatedProofKey(nil)
+	secret, _ := uiGrantTestKey.DelegatedProofKey(context.Background())
 	grant, err := sealUIGrant(secret, rand.Reader, claims)
 	if err != nil {
 		t.Fatal(err)
@@ -339,7 +340,7 @@ func TestUIProxyRefusesBadGrants(t *testing.T) {
 		{
 			name: "another hub's key",
 			grant: func(t *testing.T) string {
-				secret, _ := otherKey.DelegatedProofKey(nil)
+				secret, _ := otherKey.DelegatedProofKey(context.Background())
 				g, err := sealUIGrant(secret, rand.Reader, validClaims())
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/hub/providers/ui_grant_test.go
+++ b/pkg/hub/providers/ui_grant_test.go
@@ -1,0 +1,502 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package providers
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/faroshq/faros/pkg/hub/serviceaccounts"
+)
+
+const orgBundleBody = "customElements.define('faros-provider-infrastructure', class extends HTMLElement {})"
+
+var uiGrantTestKey = serviceaccounts.StaticProofKeySource(bytes.Repeat([]byte{7}, 32))
+
+// uiGrantFixture is a UI proxy plus grant endpoint in front of a fake platform
+// edges provider that serves the org's bundle at the edge-proxy path of the
+// org provider's Service.
+type uiGrantFixture struct {
+	ui      *ProviderProxy
+	grants  *UIGrantHandler
+	reg     *Registry
+	issuer  *recordingIssuer
+	edge    *edgeUpstream
+	edgeURL *url.URL
+	// edgeStatus lets a test make the edge answer something other than 200.
+	edgeStatus int
+}
+
+func newUIGrantFixture(t *testing.T, orgOfCaller, wsOfCaller string) *uiGrantFixture {
+	t.Helper()
+	f := &uiGrantFixture{edge: &edgeUpstream{}, edgeStatus: http.StatusOK, issuer: &recordingIssuer{}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.edge.hit = true
+		f.edge.path = r.URL.Path
+		f.edge.user = r.Header.Get("X-Faros-User")
+		f.edge.tenant = r.Header.Get("X-Faros-Tenant")
+		f.edge.authorization = r.Header.Get("Authorization")
+		if r.URL.Query().Get(UIGrantQueryParam) != "" {
+			t.Errorf("the grant reached the tenant's cluster: query %q", r.URL.RawQuery)
+		}
+		if f.edgeStatus != http.StatusOK {
+			http.Error(w, "edge says no", f.edgeStatus)
+			return
+		}
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		_, _ = w.Write([]byte(orgBundleBody))
+	}))
+	t.Cleanup(srv.Close)
+	edgesURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse upstream: %v", err)
+	}
+	f.edgeURL = edgesURL
+
+	f.reg = NewRegistry()
+	f.reg.Upsert(Provider{Name: EdgesProviderName, BackendURL: edgesURL, EndpointsValid: true})
+	// A platform copy that is NOT ready, so a request that silently resolved
+	// platform-scope would 503 and be caught.
+	platformURL, _ := url.Parse("http://platform.invalid")
+	f.reg.Upsert(Provider{Name: "infrastructure", UIURL: platformURL, BackendURL: platformURL, EndpointsValid: true, HeartbeatRequired: true, HeartbeatStale: true})
+	orgURL, _ := url.Parse("http://infrastructure.faros-infrastructure-provider.svc.cluster.local:8081")
+	f.reg.Upsert(Provider{
+		Name: "infrastructure", OrgUUID: testOrg, Version: "v0.1.20", EndpointsValid: true,
+		UIURL: orgURL, BackendURL: orgURL,
+		EdgeRoute: &EdgeRoute{WorkspaceUUID: testWS, Cluster: testCluster, EdgeName: "prod-eu", ServiceName: "provider-infrastructure"},
+	})
+
+	f.ui = NewUIProxy(f.reg, logr.Discard())
+	f.ui.SetUIGrantKeys(uiGrantTestKey)
+	f.ui.SetDelegatedTokenIssuer(f.issuer)
+	f.grants = NewUIGrantHandler(f.reg, f.ui, logr.Discard())
+	f.grants.SetTenantResolver(TenantResolverFunc(func(*http.Request) (string, string, error) {
+		if orgOfCaller == "" {
+			return "", "", errors.New("anonymous caller")
+		}
+		path := "root:faros:tenants:" + orgOfCaller
+		if wsOfCaller != "" {
+			path += ":" + wsOfCaller
+		}
+		return "alice", path, nil
+	}))
+	return f
+}
+
+func (f *uiGrantFixture) requestGrant(t *testing.T, name string) (*httptest.ResponseRecorder, uiGrantResponse) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/providers/"+name+"/ui-grant", nil)
+	r.Header.Set("Authorization", "Bearer "+callerBearer)
+	f.grants.ServeHTTP(w, r)
+	var body uiGrantResponse
+	if w.Code == http.StatusOK {
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode grant response: %v", err)
+		}
+	}
+	return w, body
+}
+
+func (f *uiGrantFixture) fetchBundle(rawURL string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	// A <script src> carries no Authorization; nothing else identifies it.
+	r := httptest.NewRequest(http.MethodGet, rawURL, nil)
+	f.ui.ServeHTTP(w, r)
+	return w
+}
+
+// The whole path, end to end: an org member obtains a grant, the URL it names
+// loads the ORG's bundle over the org's edge with a delegated token, and the
+// pin the grant carried matches those bytes.
+func TestUIGrantLoadsOrgBundleOverItsEdge(t *testing.T) {
+	f := newUIGrantFixture(t, testOrg, testWS)
+
+	w, grant := f.requestGrant(t, "infrastructure")
+	if w.Code != http.StatusOK {
+		t.Fatalf("grant status = %d, want 200 (body %q)", w.Code, w.Body.String())
+	}
+	wantPin := wantSRI(t, orgBundleBody)
+	if grant.Integrity != wantPin {
+		t.Errorf("integrity = %q, want %q (the pin must be computed from the bytes the proxy serves)", grant.Integrity, wantPin)
+	}
+	if !strings.HasPrefix(grant.URL, "/ui/providers/infrastructure/main.js?") {
+		t.Fatalf("url = %q, want the same-origin bundle path", grant.URL)
+	}
+	u, err := url.Parse(grant.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := u.Query().Get("v"); got != "v0.1.20" {
+		t.Errorf("?v = %q, want the catalog version", got)
+	}
+	if !strings.HasPrefix(u.Query().Get(UIGrantQueryParam), uiGrantPrefix) {
+		t.Errorf("grant = %q, want a %s-prefixed grant", u.Query().Get(UIGrantQueryParam), uiGrantPrefix)
+	}
+	if grant.ExpiresAt.Before(time.Now().Add(uiGrantTTL-time.Minute)) || grant.ExpiresAt.After(time.Now().Add(uiGrantTTL+time.Minute)) {
+		t.Errorf("expiresAt = %v, want about %v from now", grant.ExpiresAt, uiGrantTTL)
+	}
+	// The hash fetch went over the edge as alice with the delegated token.
+	if !f.edge.hit || f.edge.authorization != "Bearer "+delegatedToken || f.edge.user != "alice" {
+		t.Fatalf("hash fetch: hit=%v authorization=%q user=%q", f.edge.hit, f.edge.authorization, f.edge.user)
+	}
+	*f.edge = edgeUpstream{}
+	f.issuer.calls = 0
+
+	got := f.fetchBundle(grant.URL)
+	if got.Code != http.StatusOK {
+		t.Fatalf("bundle status = %d, want 200 (body %q)", got.Code, got.Body.String())
+	}
+	if got.Body.String() != orgBundleBody {
+		t.Errorf("bundle body = %q, want the org's bundle", got.Body.String())
+	}
+	wantPath := "/edgeproxy/clusters/" + testCluster + "/apis/edges.faros.sh/v1alpha1/services/provider-infrastructure/proxy/main.js"
+	if f.edge.path != wantPath {
+		t.Errorf("edges provider saw path %q, want %q", f.edge.path, wantPath)
+	}
+	if f.edge.authorization != "Bearer "+delegatedToken {
+		t.Errorf("Authorization at the edge = %q, want the delegated token", f.edge.authorization)
+	}
+	if f.edge.user != "alice" {
+		t.Errorf("X-Faros-User at the edge = %q, want the grant's user", f.edge.user)
+	}
+	if f.issuer.calls != 1 || f.issuer.org != testOrg || f.issuer.ws != testWS || f.issuer.user != "alice" || f.issuer.provider != "infrastructure" {
+		t.Errorf("delegated token minted for (%s,%s,%s,%s) x%d, want (org,ws,alice,infrastructure) once",
+			f.issuer.org, f.issuer.ws, f.issuer.user, f.issuer.provider, f.issuer.calls)
+	}
+	if cc := got.Header().Get("Cache-Control"); cc != "private, no-store" {
+		t.Errorf("Cache-Control = %q, want private, no-store (the URL carries a grant)", cc)
+	}
+	if !strings.HasPrefix(got.Header().Get("Content-Type"), "application/javascript") {
+		t.Errorf("Content-Type = %q, want the provider's", got.Header().Get("Content-Type"))
+	}
+}
+
+// Without a grant the UI proxy is what it always was: platform-scoped. The
+// platform copy in the fixture is stale, so that is a 503 — never the org's
+// bundle.
+func TestUIProxyWithoutGrantStaysPlatformScoped(t *testing.T) {
+	f := newUIGrantFixture(t, testOrg, testWS)
+	got := f.fetchBundle("/ui/providers/infrastructure/main.js?v=v0.1.20")
+	if got.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 for the stale platform copy (body %q)", got.Code, got.Body.String())
+	}
+	if f.edge.hit {
+		t.Fatal("a grant-less request reached the org's edge")
+	}
+}
+
+func TestUIGrantRefusals(t *testing.T) {
+	cases := []struct {
+		name       string
+		org, ws    string
+		provider   string
+		prepare    func(f *uiGrantFixture)
+		wantStatus int
+	}{
+		{name: "anonymous", org: "", ws: "", provider: "infrastructure", wantStatus: http.StatusUnauthorized},
+		{name: "org scope selection cannot mint", org: testOrg, ws: "", provider: "infrastructure", wantStatus: http.StatusForbidden},
+		{name: "another org gets the platform copy, no grant", org: "other-org", ws: testWS, provider: "infrastructure", wantStatus: http.StatusNotFound},
+		{name: "unknown provider", org: testOrg, ws: testWS, provider: "nope", wantStatus: http.StatusNotFound},
+		{name: "platform provider needs no grant", org: testOrg, ws: testWS, provider: EdgesProviderName, wantStatus: http.StatusNotFound},
+		{
+			name: "org provider without a UI", org: testOrg, ws: testWS, provider: "infrastructure",
+			prepare: func(f *uiGrantFixture) {
+				p, _ := f.reg.GetForOrg(testOrg, "infrastructure")
+				p.UIURL = nil
+				f.reg.Upsert(p)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "org UI on another host cannot ride the edge", org: testOrg, ws: testWS, provider: "infrastructure",
+			prepare: func(f *uiGrantFixture) {
+				p, _ := f.reg.GetForOrg(testOrg, "infrastructure")
+				p.UIURL, _ = url.Parse("http://ui-elsewhere.svc:8080")
+				f.reg.Upsert(p)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "org provider not ready", org: testOrg, ws: testWS, provider: "infrastructure",
+			prepare: func(f *uiGrantFixture) {
+				p, _ := f.reg.GetForOrg(testOrg, "infrastructure")
+				p.EdgeRoute = nil
+				f.reg.Upsert(p)
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name: "grants not configured", org: testOrg, ws: testWS, provider: "infrastructure",
+			prepare:    func(f *uiGrantFixture) { f.ui.SetUIGrantKeys(nil) },
+			wantStatus: http.StatusServiceUnavailable,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newUIGrantFixture(t, tc.org, tc.ws)
+			if tc.prepare != nil {
+				tc.prepare(f)
+			}
+			w, _ := f.requestGrant(t, tc.provider)
+			if w.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body %q)", w.Code, tc.wantStatus, w.Body.String())
+			}
+			if f.edge.hit {
+				t.Error("a refused grant request still reached the edge")
+			}
+		})
+	}
+}
+
+// A failed hash fetch must not fail the grant: the bundle loads unpinned, as
+// a platform bundle the hub could not hash does.
+func TestUIGrantSurvivesFailedHash(t *testing.T) {
+	f := newUIGrantFixture(t, testOrg, testWS)
+	f.edgeStatus = http.StatusBadGateway
+	w, grant := f.requestGrant(t, "infrastructure")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", w.Code, w.Body.String())
+	}
+	if grant.Integrity != "" {
+		t.Errorf("integrity = %q, want none after a failed fetch", grant.Integrity)
+	}
+	if grant.URL == "" {
+		t.Error("no bundle URL")
+	}
+}
+
+func TestUIGrantPinIsCachedPerVersion(t *testing.T) {
+	f := newUIGrantFixture(t, testOrg, testWS)
+	if _, first := f.requestGrant(t, "infrastructure"); first.Integrity == "" {
+		t.Fatal("first grant carried no pin")
+	}
+	*f.edge = edgeUpstream{}
+	if _, second := f.requestGrant(t, "infrastructure"); second.Integrity != wantSRI(t, orgBundleBody) {
+		t.Fatalf("second grant pin = %q", second.Integrity)
+	}
+	if f.edge.hit {
+		t.Error("second grant re-fetched the bundle within the resync window")
+	}
+	// A new running version invalidates the pin.
+	p, _ := f.reg.GetForOrg(testOrg, "infrastructure")
+	p.ReportedVersion = "v0.1.21"
+	f.reg.Upsert(p)
+	f.requestGrant(t, "infrastructure")
+	if !f.edge.hit {
+		t.Error("a version change did not re-hash the bundle")
+	}
+}
+
+func mintTestGrant(t *testing.T, claims uiGrantClaims) string {
+	t.Helper()
+	secret, _ := uiGrantTestKey.DelegatedProofKey(nil)
+	grant, err := sealUIGrant(secret, rand.Reader, claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return grant
+}
+
+func validClaims() uiGrantClaims {
+	now := time.Now()
+	return uiGrantClaims{
+		OrgUUID: testOrg, WorkspaceUUID: testWS, User: "alice", Provider: "infrastructure",
+		IssuedAt: now.Unix(), ExpiresAt: now.Add(uiGrantTTL).Unix(),
+	}
+}
+
+func TestUIProxyRefusesBadGrants(t *testing.T) {
+	otherKey := serviceaccounts.StaticProofKeySource(bytes.Repeat([]byte{9}, 32))
+	cases := []struct {
+		name       string
+		grant      func(t *testing.T) string
+		path       string
+		prepare    func(f *uiGrantFixture)
+		wantStatus int
+	}{
+		{name: "garbage", grant: func(*testing.T) string { return "fpui_not-a-grant" }, wantStatus: http.StatusUnauthorized},
+		{name: "wrong prefix", grant: func(*testing.T) string { return "fapp_" + strings.Repeat("A", 64) }, wantStatus: http.StatusUnauthorized},
+		{
+			name: "another hub's key",
+			grant: func(t *testing.T) string {
+				secret, _ := otherKey.DelegatedProofKey(nil)
+				g, err := sealUIGrant(secret, rand.Reader, validClaims())
+				if err != nil {
+					t.Fatal(err)
+				}
+				return g
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "expired",
+			grant: func(t *testing.T) string {
+				c := validClaims()
+				c.ExpiresAt = time.Now().Add(-time.Second).Unix()
+				return mintTestGrant(t, c)
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "bound to another provider",
+			grant: func(t *testing.T) string {
+				c := validClaims()
+				c.Provider = "kuery"
+				return mintTestGrant(t, c)
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "org without a copy falls to nothing, not the platform",
+			grant: func(t *testing.T) string {
+				c := validClaims()
+				c.OrgUUID = "other-org"
+				return mintTestGrant(t, c)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:  "issuer refuses",
+			grant: func(t *testing.T) string { return mintTestGrant(t, validClaims()) },
+			prepare: func(f *uiGrantFixture) {
+				f.issuer.err = errors.New("kcp down")
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:  "no issuer wired",
+			grant: func(t *testing.T) string { return mintTestGrant(t, validClaims()) },
+			prepare: func(f *uiGrantFixture) {
+				f.ui.SetDelegatedTokenIssuer(nil)
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:  "no keys wired",
+			grant: func(t *testing.T) string { return mintTestGrant(t, validClaims()) },
+			prepare: func(f *uiGrantFixture) {
+				f.ui.SetUIGrantKeys(nil)
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "non-asset path is not a bundle",
+			grant:      func(t *testing.T) string { return mintTestGrant(t, validClaims()) },
+			path:       "/ui/providers/infrastructure/some-route",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newUIGrantFixture(t, testOrg, testWS)
+			if tc.prepare != nil {
+				tc.prepare(f)
+			}
+			path := tc.path
+			if path == "" {
+				path = "/ui/providers/infrastructure/main.js"
+			}
+			got := f.fetchBundle(path + "?v=1&" + UIGrantQueryParam + "=" + url.QueryEscape(tc.grant(t)))
+			if got.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body %q)", got.Code, tc.wantStatus, got.Body.String())
+			}
+			if f.edge.hit {
+				t.Error("a refused request still reached the edge")
+			}
+		})
+	}
+}
+
+// A grant redeems any asset under the provider's UI, with the spec.ui.url path
+// prefix applied as the direct proxy would.
+func TestUIGrantCarriesUIPathPrefix(t *testing.T) {
+	f := newUIGrantFixture(t, testOrg, testWS)
+	p, _ := f.reg.GetForOrg(testOrg, "infrastructure")
+	p.UIURL, _ = url.Parse("http://infrastructure.faros-infrastructure-provider.svc.cluster.local:8081/ui")
+	f.reg.Upsert(p)
+
+	_, grant := f.requestGrant(t, "infrastructure")
+	wantHash := "/edgeproxy/clusters/" + testCluster + "/apis/edges.faros.sh/v1alpha1/services/provider-infrastructure/proxy/ui/main.js"
+	if f.edge.path != wantHash {
+		t.Errorf("hash fetch path %q, want %q", f.edge.path, wantHash)
+	}
+	u, _ := url.Parse(grant.URL)
+	got := f.fetchBundle("/ui/providers/infrastructure/icon.svg?" + UIGrantQueryParam + "=" + url.QueryEscape(u.Query().Get(UIGrantQueryParam)))
+	if got.Code != http.StatusOK {
+		t.Fatalf("status = %d (body %q)", got.Code, got.Body.String())
+	}
+	wantIcon := "/edgeproxy/clusters/" + testCluster + "/apis/edges.faros.sh/v1alpha1/services/provider-infrastructure/proxy/ui/icon.svg"
+	if f.edge.path != wantIcon {
+		t.Errorf("asset path %q, want %q", f.edge.path, wantIcon)
+	}
+}
+
+func TestUIGrantSealRoundTrip(t *testing.T) {
+	secret := bytes.Repeat([]byte{1}, 32)
+	claims := validClaims()
+	grant, err := sealUIGrant(secret, rand.Reader, claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(grant, uiGrantPrefix) {
+		t.Fatalf("grant %q lacks the %s prefix", grant, uiGrantPrefix)
+	}
+	if strings.Contains(grant, "alice") || strings.Contains(grant, testOrg) {
+		t.Fatal("grant is not sealed: claims are readable in the URL")
+	}
+	got, err := openUIGrant(secret, grant, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.User != "alice" || got.OrgUUID != testOrg || got.WorkspaceUUID != testWS || got.Provider != "infrastructure" || got.ID == "" {
+		t.Errorf("claims = %+v", got)
+	}
+	// One flipped byte in the ciphertext is refused, not decoded.
+	raw := []byte(grant)
+	raw[len(raw)-3] ^= 0x01
+	if _, err := openUIGrant(secret, string(raw), time.Now()); !errors.Is(err, errUIGrantInvalid) {
+		t.Errorf("tampered grant opened: %v", err)
+	}
+	if _, err := openUIGrant(bytes.Repeat([]byte{2}, 16), grant, time.Now()); err == nil {
+		t.Error("a short key was accepted")
+	}
+}
+
+func TestParseUIGrantPath(t *testing.T) {
+	cases := map[string]struct {
+		name string
+		ok   bool
+	}{
+		"/api/providers/infrastructure/ui-grant":  {"infrastructure", true},
+		"/api/providers//ui-grant":                {"", false},
+		"/api/providers/a/b/ui-grant":             {"", false},
+		"/api/providers/infrastructure/heartbeat": {"", false},
+		"/api/providers/ui-grant":                 {"", false},
+	}
+	for path, want := range cases {
+		name, ok := parseUIGrantPath(path)
+		if name != want.name || ok != want.ok {
+			t.Errorf("%s → (%q,%v), want (%q,%v)", path, name, ok, want.name, want.ok)
+		}
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -448,6 +448,14 @@ func (s *Server) Run(ctx context.Context) error {
 	// own providers are folded in for callers who present a verified Org.
 	providerListHandler := providers.NewListHandler(providerRegistry)
 	router.Handle(providers.PathListProviders, providerListHandler).Methods("GET")
+	// Bundle grants for org-owned providers: the portal cannot load an
+	// org's bundle with an anonymous <script src>, so it asks here, as the
+	// user, for a short-lived grant the UI proxy redeems over the edge
+	// (pkg/hub/providers/ui_grant.go). Registered ahead of the heartbeat
+	// PathPrefix route below, which would otherwise claim every POST under
+	// /api/providers/. Configured with the auth stack further down.
+	providerUIGrantHandler := providers.NewUIGrantHandler(providerRegistry, uiProxy, logger)
+	router.Handle(providers.PathProviderUIGrant, providerUIGrantHandler).Methods("POST")
 	// Heartbeat endpoint matches /api/providers/{name}/heartbeat. The
 	// parsing happens inside the handler; gorilla/mux just needs the prefix.
 	// A heartbeat lands on exactly one replica but every replica routes provider
@@ -732,7 +740,16 @@ func (s *Server) Run(ctx context.Context) error {
 				tenant.OptionalOrgMiddleware(userResolver, membershipLookup),
 				catalogWorkloads.resolveWorkloadServiceAccount,
 			))
-			backendProxy.SetTenantResolver(newKCPTenantResolver(kcpProxy, userClient, bootstrapper, delegatedProofKeys))
+			providerTenantResolver := newKCPTenantResolver(kcpProxy, userClient, bootstrapper, delegatedProofKeys)
+			backendProxy.SetTenantResolver(providerTenantResolver)
+			// The UI proxy serves an org-owned bundle only against a grant the
+			// portal obtained as the user. Minting and redemption share the
+			// cross-replica secret and the delegated issuer with the backend
+			// proxy, so the tenant's cluster sees the same delegated identity
+			// for an asset fetch as for an API call.
+			providerUIGrantHandler.SetTenantResolver(providerTenantResolver)
+			uiProxy.SetUIGrantKeys(delegatedProofKeys)
+			uiProxy.SetDelegatedTokenIssuer(serviceaccounts.NewManager(bootstrapper, delegatedProofKeys))
 			// Inject X-Faros-Cluster (the resolved tenant's logical-cluster
 			// ID) so providers can address per-workspace surfaces that key on
 			// the ID — notably the kcp proxy at /clusters/{id}.

--- a/portal/src/components/DashboardTile.conformance.test.mjs
+++ b/portal/src/components/DashboardTile.conformance.test.mjs
@@ -29,7 +29,11 @@ test('dashboard tile load failures offer recovery without leaking raw transport 
   assert.match(tile, /canReloadProviderScriptInDocument,[\s\S]*invalidateProviderScript,[\s\S]*loadProviderScript,[\s\S]*from '@\/providers\/providerScriptLoader'/)
   assert.match(tile, /props\.provider\.name, props\.provider\.version, props\.provider\.ready/)
   assert.match(tile, /const generation = loadGeneration\.begin\(\)/)
-  assert.match(tile, /await loadProviderScript\(name, version, document, undefined, \{\s*integrity: props\.provider\.mainJSIntegrity,\s*\}\)[\s\S]*if \(!isCurrentLoad\(generation, name, version\)\) return/)
+  // The bundle (URL + SRI pin) is resolved first — an org-owned provider's
+  // comes from a hub-issued grant — and the generation is re-checked after
+  // that await before the shared loader runs.
+  assert.match(tile, /import \{ resolveProviderBundle \} from '@\/providers\/providerBundle'/)
+  assert.match(tile, /const bundle = await resolveProviderBundle\(props\.provider, authFetch\)\s*if \(!isCurrentLoad\(generation, name, version\)\) return\s*await loadProviderScript\(name, version, document, undefined, bundle\)[\s\S]*if \(!isCurrentLoad\(generation, name, version\)\) return/)
   assert.match(tile, /await nextTick\(\)[\s\S]*if \(!isCurrentLoad\(generation, name, version\) \|\| !mountRef\.value\) return/)
   assert.match(tile, /function retryLoad\(\)[\s\S]*if \(!canRetryInDocument\.value\)[\s\S]*window\.location\.reload\(\)/)
   assert.match(tile, /addEventListener\('faros-provider-bootstrap-retry', onProviderBootstrapRetry\)/)

--- a/portal/src/components/DashboardTile.vue
+++ b/portal/src/components/DashboardTile.vue
@@ -14,6 +14,8 @@ import {
   loadProviderScript,
 } from '@/providers/providerScriptLoader'
 import { createProviderContext } from '@/providers/providerContext'
+import { resolveProviderBundle } from '@/providers/providerBundle'
+import { authFetch } from '@/auth/session'
 import type { ProviderDTO } from '@/stores/providers'
 import ActionMenu, { type ActionMenuItem } from '@/portalkit/ActionMenu.vue'
 import {
@@ -144,9 +146,11 @@ async function loadAndMount(name: string, version: string | undefined, generatio
     // Pass the catalog version even when the element is already defined. App
     // Studio uses the bootstrap reload to refresh its lazy-loader registry;
     // page and dashboard callers coalesce through the shared loader.
-    await loadProviderScript(name, version, document, undefined, {
-      integrity: props.provider.mainJSIntegrity,
-    })
+    // Org-owned providers load through a hub-issued grant over their edge;
+    // platform providers use the loader's fixed URL (providerBundle.ts).
+    const bundle = await resolveProviderBundle(props.provider, authFetch)
+    if (!isCurrentLoad(generation, name, version)) return
+    await loadProviderScript(name, version, document, undefined, bundle)
   } catch {
     if (isCurrentLoad(generation, name, version)) loadState.value = 'error'
     return

--- a/portal/src/components/ProviderNavigation.conformance.test.mjs
+++ b/portal/src/components/ProviderNavigation.conformance.test.mjs
@@ -17,7 +17,12 @@ test('provider host consumers honor replace navigation while preserving push by 
 test('provider page and dashboard consumers coordinate versioned bootstrap reloads', () => {
   for (const source of [frame, tile]) {
     assert.match(source, /loadProviderScript,[\s\S]*from '@\/providers\/providerScriptLoader'/)
-    assert.match(source, /await loadProviderScript\(name, version, document, undefined, \{\s*integrity: (?:entry\.value\?|props\.provider)\.mainJSIntegrity,\s*\}\)/)
+    // Both consumers resolve the bundle (URL + SRI pin; a grant for an
+    // org-owned provider) through the shared resolver as the user, then hand
+    // it to the shared loader — neither builds the script URL itself.
+    assert.match(source, /import \{ resolveProviderBundle \} from '@\/providers\/providerBundle'/)
+    assert.match(source, /await resolveProviderBundle\((?:entry\.value|props\.provider), authFetch\)/)
+    assert.match(source, /await loadProviderScript\(name, version, document, undefined, bundle\)/)
     assert.doesNotMatch(source, /document\.createElement\('script'\)/)
   }
   assert.match(frame, /invalidateProviderScript\(name, version\)/)

--- a/portal/src/pages/ProviderFrame.vue
+++ b/portal/src/pages/ProviderFrame.vue
@@ -3,6 +3,8 @@ import { computed, onBeforeUnmount, onMounted, ref, watch, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import AppLayout from '@/components/AppLayout.vue'
 import { useProvidersStore } from '@/stores/providers'
+import { resolveProviderBundle } from '@/providers/providerBundle'
+import { authFetch } from '@/auth/session'
 import { useAuthStore } from '@/stores/auth'
 import { useTenantStore } from '@/stores/tenant'
 import { useThemeStore } from '@/stores/theme'
@@ -321,9 +323,14 @@ async function loadAndMount(name: string, version: string | undefined, mount: HT
   const ready = customElements.whenDefined(tag)
 
   try {
-    await loadProviderScript(name, version, document, undefined, {
-      integrity: entry.value?.mainJSIntegrity,
-    })
+    // An org-owned provider's bundle is fetched through its edge tunnel
+    // against a grant the hub issues to this user; a platform bundle is the
+    // fixed URL the loader derives. See providers/providerBundle.ts.
+    const bundle = entry.value
+      ? await resolveProviderBundle(entry.value, authFetch)
+      : {}
+    if (!isCurrentMount(generation, name)) return
+    await loadProviderScript(name, version, document, undefined, bundle)
 
     // 5s timeout so a script that loaded but never called customElements.define
     // doesn't hang the loader forever.

--- a/portal/src/providers/providerBundle.test.mjs
+++ b/portal/src/providers/providerBundle.test.mjs
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { createServer } from 'vite'
+
+const vite = await createServer({
+  appType: 'custom',
+  cacheDir: join(tmpdir(), 'faros-vite-provider-bundle'),
+  configFile: false,
+  optimizeDeps: { noDiscovery: true },
+  root: new URL('../../', import.meta.url).pathname,
+  server: { middlewareMode: true, hmr: false },
+})
+const { ProviderBundleGrantError, resolveProviderBundle } = await vite.ssrLoadModule('/src/providers/providerBundle.ts')
+test.after(() => vite.close())
+
+function fakeFetch(handler) {
+  const calls = []
+  const fetchImpl = async (path, init) => {
+    calls.push({ path, init })
+    return handler(path, init)
+  }
+  return { calls, fetchImpl }
+}
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  }
+}
+
+test('a platform provider keeps the loader default and its catalog pin', async () => {
+  const { calls, fetchImpl } = fakeFetch(() => {
+    throw new Error('platform providers must not request a grant')
+  })
+  const bundle = await resolveProviderBundle(
+    { name: 'kuery', scope: 'global', mainJSIntegrity: 'sha384-abc' },
+    fetchImpl,
+  )
+  assert.deepEqual(bundle, { integrity: 'sha384-abc' })
+  assert.equal(calls.length, 0)
+})
+
+test('an org-owned provider loads the granted URL and pin as the user', async () => {
+  const { calls, fetchImpl } = fakeFetch(() =>
+    jsonResponse(200, {
+      url: '/ui/providers/infrastructure/main.js?v=v0.1.20&grant=fpui_sealed',
+      integrity: 'sha384-org',
+      expiresAt: '2026-09-11T10:00:00Z',
+    }),
+  )
+  const bundle = await resolveProviderBundle(
+    { name: 'infrastructure', scope: 'org', ownerOrg: 'org-1', mainJSIntegrity: undefined },
+    fetchImpl,
+  )
+  assert.deepEqual(bundle, {
+    src: '/ui/providers/infrastructure/main.js?v=v0.1.20&grant=fpui_sealed',
+    integrity: 'sha384-org',
+  })
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].path, '/api/providers/infrastructure/ui-grant')
+  assert.equal(calls[0].init.method, 'POST')
+  // The grant is minted for the selected org/workspace: the tenant headers
+  // are what the hub verifies membership against.
+  assert.equal(calls[0].init.tenant, true)
+})
+
+test('a refused grant fails the load rather than falling back to the platform bundle', async () => {
+  const { fetchImpl } = fakeFetch(() => jsonResponse(503, 'provider not ready: infrastructure'))
+  await assert.rejects(
+    resolveProviderBundle({ name: 'infrastructure', scope: 'org', ownerOrg: 'org-1' }, fetchImpl),
+    (err) => {
+      assert.ok(err instanceof ProviderBundleGrantError)
+      assert.equal(err.status, 503)
+      assert.match(err.message, /provider not ready/)
+      return true
+    },
+  )
+})
+
+test('a grant response that is not a same-origin path is refused', async () => {
+  for (const url of ['https://evil.example/main.js', '//evil.example/main.js', '', undefined]) {
+    const { fetchImpl } = fakeFetch(() => jsonResponse(200, { url }))
+    await assert.rejects(
+      resolveProviderBundle({ name: 'infrastructure', scope: 'org', ownerOrg: 'org-1' }, fetchImpl),
+      ProviderBundleGrantError,
+    )
+  }
+})
+
+test('an unpinned grant loads the bundle without an integrity attribute', async () => {
+  const { fetchImpl } = fakeFetch(() =>
+    jsonResponse(200, { url: '/ui/providers/infrastructure/main.js?grant=fpui_sealed' }),
+  )
+  const bundle = await resolveProviderBundle({ name: 'infrastructure', scope: 'org' }, fetchImpl)
+  assert.deepEqual(bundle, { src: '/ui/providers/infrastructure/main.js?grant=fpui_sealed', integrity: undefined })
+})

--- a/portal/src/providers/providerBundle.ts
+++ b/portal/src/providers/providerBundle.ts
@@ -1,0 +1,89 @@
+import type { ProviderDTO } from '@/stores/providers'
+
+// GrantFetch is the authenticated transport the grant request goes through:
+// auth/session authFetch, which injects the bearer and, with tenant: true,
+// the X-Faros-Org / X-Faros-Workspace selection the hub verifies membership
+// against. Passed in rather than imported so this module stays free of
+// browser session state and testable on its own, like providerFetch.ts.
+export type GrantFetch = (
+  path: string,
+  init?: RequestInit & { tenant?: boolean },
+) => Promise<Response>
+
+// Where a provider's bundle is loaded from, and how it is pinned.
+//
+// A platform provider's bundle is a fixed same-origin URL the loader derives
+// from the name and catalog version, pinned with the SRI hash the hub computed
+// at registration (catalog mainJSIntegrity). An org-owned ("bring your own")
+// provider runs in the organization's own cluster behind its edge tunnel, and
+// the hub cannot serve that bundle to an anonymous <script src>: the platform
+// edges provider refuses tunnel requests without a bearer, and the hub has no
+// identity on an asset GET to mint one for. So the portal first asks the hub,
+// as the user and under the selected org/workspace, for a short-lived grant
+// (POST /api/providers/<name>/ui-grant). The hub answers with a same-origin
+// bundle URL carrying that grant and the bundle's SRI hash, computed through
+// the same route; the UI proxy redeems the grant into a delegated token when
+// the script tag fetches it.
+
+export interface ProviderBundle {
+  // Explicit bundle URL, or undefined for the loader's default.
+  src?: string
+  // SRI pin, or undefined to load unpinned (the loader logs a warning).
+  integrity?: string
+}
+
+interface UIGrantResponse {
+  url?: string
+  integrity?: string
+}
+
+export class ProviderBundleGrantError extends Error {
+  readonly code = 'PROVIDER_BUNDLE_GRANT_FAILED'
+  readonly status: number
+
+  constructor(name: string, status: number, detail: string) {
+    super(`provider "${name}" bundle grant failed: ${status} ${detail}`.trim())
+    this.name = 'ProviderBundleGrantError'
+    this.status = status
+  }
+}
+
+export function isOrgOwnedProvider(entry: Pick<ProviderDTO, 'scope' | 'ownerOrg'>): boolean {
+  return entry.scope === 'org' || !!entry.ownerOrg
+}
+
+// resolveProviderBundle returns what loadProviderScript needs for entry. It
+// never falls back from an org-owned provider to the platform URL: that URL
+// resolves platform-only at the hub, so it would load the PLATFORM's bundle
+// against the organization's own backend — wrong rather than broken, which
+// is the harder failure to notice.
+export async function resolveProviderBundle(
+  entry: Pick<ProviderDTO, 'name' | 'scope' | 'ownerOrg' | 'mainJSIntegrity'>,
+  fetchImpl: GrantFetch,
+): Promise<ProviderBundle> {
+  if (!isOrgOwnedProvider(entry)) {
+    return { integrity: entry.mainJSIntegrity || undefined }
+  }
+  const res = await fetchImpl(`/api/providers/${encodeURIComponent(entry.name)}/ui-grant`, {
+    method: 'POST',
+    tenant: true,
+  })
+  if (!res.ok) {
+    let detail = ''
+    try {
+      detail = (await res.text()).trim()
+    } catch {
+      detail = ''
+    }
+    throw new ProviderBundleGrantError(entry.name, res.status, detail || res.statusText)
+  }
+  const body = (await res.json()) as UIGrantResponse
+  const src = typeof body.url === 'string' ? body.url : ''
+  // Same-origin only: the loader sets no crossorigin attribute, and a bundle
+  // executes as trusted code in this document. The hub only ever returns a
+  // path, so anything else is a malformed answer, not a redirect to honour.
+  if (!src.startsWith('/') || src.startsWith('//')) {
+    throw new ProviderBundleGrantError(entry.name, res.status, 'grant response carried no same-origin bundle URL')
+  }
+  return { src, integrity: body.integrity || undefined }
+}

--- a/portal/src/providers/providerScriptLoader.test.mjs
+++ b/portal/src/providers/providerScriptLoader.test.mjs
@@ -232,6 +232,23 @@ test('pins the bundle with subresource integrity when the catalog carries a hash
   await load
 })
 
+test('loads an org-owned bundle from the granted URL the hub returned', async () => {
+  const doc = providerDocument()
+  const integrity = 'sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb'
+  const src = '/ui/providers/infrastructure/main.js?v=v0.1.20&grant=fpui_sealed'
+  const load = loadProviderScript('infrastructure', 'v0.1.20', doc, 15_000, { integrity, src })
+  await Promise.resolve()
+  assert.equal(doc.appended.length, 1)
+  const script = doc.appended[0]
+  // The grant rides in the URL; the loader must use it verbatim rather than
+  // rebuilding the platform path from name and version.
+  assert.equal(script.src, src)
+  assert.equal(script.integrity, integrity)
+  assert.equal(script.crossOrigin, undefined)
+  script.onload()
+  await load
+})
+
 test('loads an unpinned bundle with a warning when the catalog carries no hash', async () => {
   const doc = providerDocument()
   const warnings = []

--- a/portal/src/providers/providerScriptLoader.ts
+++ b/portal/src/providers/providerScriptLoader.ts
@@ -88,6 +88,15 @@ export interface ProviderScriptOptions {
   // URL. When absent the bundle loads unpinned, which is logged: a provider
   // bundle executes as trusted code in this document.
   integrity?: string | null
+  // Bundle URL to load instead of the default /ui/providers/<name>/main.js.
+  // An org-owned ("bring your own") provider's bundle lives behind the
+  // tenant's edge tunnel, and a <script src> carries no identity the hub could
+  // scope by; the hub therefore hands the portal a same-origin URL carrying a
+  // short-lived grant (POST /api/providers/<name>/ui-grant, see
+  // stores/providers.ts resolveBundle). Must stay same-origin: the loader sets
+  // no crossorigin attribute, so a cross-origin URL would load unpinned and
+  // untrusted.
+  src?: string | null
 }
 
 function injectProviderScript(
@@ -97,6 +106,7 @@ function injectProviderScript(
   bootstrapGeneration: string,
   timeoutMs: number,
   integrity: string | null,
+  bundleSrc: string | null,
 ): ProviderScriptAttempt {
   const scriptID = `faros-provider-script-${name}`
   const current = doc.getElementById(scriptID) as HTMLScriptElement | null
@@ -108,7 +118,7 @@ function injectProviderScript(
   }
 
   current?.remove()
-  const src = `/ui/providers/${name}/main.js?v=${encodeURIComponent(version)}`
+  const src = bundleSrc || `/ui/providers/${name}/main.js?v=${encodeURIComponent(version)}`
   let cancel = (_reason?: Error) => {}
   const promise = new Promise<void>((resolve, reject) => {
     const script = doc.createElement('script')
@@ -183,6 +193,7 @@ export function loadProviderScript(
 ): Promise<void> {
   const requestedVersion = version ?? '0'
   const integrity = options.integrity || null
+  const bundleSrc = options.src || null
   const loads = documentLoads(doc)
   const current = loads.get(name)
   if (current?.version === requestedVersion) return current.promise
@@ -212,7 +223,7 @@ export function loadProviderScript(
     bootstrapGeneration,
     promise: predecessor.then(() => {
       if (cancelled) throw cancelled
-      attempt = injectProviderScript(doc, name, requestedVersion, bootstrapGeneration, timeoutMs, integrity)
+      attempt = injectProviderScript(doc, name, requestedVersion, bootstrapGeneration, timeoutMs, integrity, bundleSrc)
       return attempt.promise
     }),
     cancel: (reason = new Error(`cancelled provider "${name}" version ${requestedVersion}`)) => {

--- a/portal/src/stores/providers.ts
+++ b/portal/src/stores/providers.ts
@@ -36,8 +36,10 @@ export interface ProviderDTO {
   iconURL?: string
   // Subresource Integrity pin ("sha384-...") the hub computed for
   // /ui/providers/{name}/main.js at registration. The loader sets it as the
-  // script's integrity attribute; absent (older hub, org-owned provider, or a
-  // failed hash fetch) means the bundle loads unpinned with a console warning.
+  // script's integrity attribute; absent (older hub or a failed hash fetch)
+  // means the bundle loads unpinned with a console warning. Always absent for
+  // an org-owned provider: its bundle URL and pin come from the grant the
+  // portal requests at load time (providers/providerBundle.ts).
   mainJSIntegrity?: string
   // True when the provider requests background access to the workspace's
   // edge clusters (verb "proxy" on edges) on Enable. Rendered in the

--- a/providers/infrastructure/operator/serve.go
+++ b/providers/infrastructure/operator/serve.go
@@ -82,6 +82,13 @@ func EnsureProviderServe(
 		{Name: "PORT", Value: fmt.Sprintf("%d", port)},
 		{Name: "FAROS_PROVIDER_NAME", Value: "infrastructure"},
 		{Name: "INFRASTRUCTURE_KUBECONFIG", Value: providerKubeconfigMount},
+		// The hub-minted provider kubeconfig is also the heartbeat credential:
+		// the SDK resolves its bearer from FAROS_HUB_TOKEN, else from the
+		// kubeconfig at FAROS_PROVIDER_KUBECONFIG (provider-sdk/hubclient
+		// token.go). Every Helm-installed provider sets the latter; without it
+		// serve beats unauthenticated, a hub enforcing heartbeat auth answers
+		// 401, and the provider is marked stale within a few minutes.
+		{Name: "FAROS_PROVIDER_KUBECONFIG", Value: providerKubeconfigMount},
 	}
 	if cr.Spec.ProviderWorkspace != "" {
 		// The mounted kubeconfig may be root-scoped (the supplied-admin flow,

--- a/providers/infrastructure/operator/serve_test.go
+++ b/providers/infrastructure/operator/serve_test.go
@@ -188,6 +188,44 @@ func TestEnsureProviderServeBindsServeRoleFromEnv(t *testing.T) {
 	}
 }
 
+// The provider kubeconfig the operator mounts is also the heartbeat bearer:
+// the SDK reads it from FAROS_PROVIDER_KUBECONFIG. Without that variable serve
+// beat unauthenticated, an enforcing hub answered 401, and the provider went
+// stale — which took every consumer of /ui/providers/infrastructure down with
+// it.
+func TestEnsureProviderServeWiresHeartbeatCredential(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	provider := &v1alpha1.InfrastructureProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-infrastructure"},
+		Spec: v1alpha1.InfrastructureProviderSpec{
+			Hub: v1alpha1.HubSpec{URL: "https://heartbeat-hub.internal"},
+			Provider: v1alpha1.ProviderServeSpec{
+				Image: v1alpha1.ImageSpec{Repository: "example.test/infrastructure", Tag: "test"},
+			},
+		},
+	}
+	if err := EnsureProviderServe(context.Background(), client, provider, []byte("provider-kubeconfig"), nil, nil); err != nil {
+		t.Fatalf("EnsureProviderServe: %v", err)
+	}
+	deployment, err := client.AppsV1().Deployments(ServeNamespace).Get(context.Background(), provider.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{}
+	for _, variable := range deployment.Spec.Template.Spec.Containers[0].Env {
+		env[variable.Name] = variable.Value
+	}
+	if env["FAROS_PROVIDER_KUBECONFIG"] != providerKubeconfigMount {
+		t.Errorf("FAROS_PROVIDER_KUBECONFIG = %q, want %q", env["FAROS_PROVIDER_KUBECONFIG"], providerKubeconfigMount)
+	}
+	if env["INFRASTRUCTURE_KUBECONFIG"] != providerKubeconfigMount {
+		t.Errorf("INFRASTRUCTURE_KUBECONFIG = %q, want %q", env["INFRASTRUCTURE_KUBECONFIG"], providerKubeconfigMount)
+	}
+	if _, set := env["FAROS_HUB_TOKEN"]; set {
+		t.Errorf("FAROS_HUB_TOKEN set without spec.hub.tokenSecret")
+	}
+}
+
 func TestEnsureProviderServePropagatesPlatformPublishingConfig(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	provider := &v1alpha1.InfrastructureProvider{


### PR DESCRIPTION
> **This pull request was prepared by an automated coding agent (Claude Code) on behalf of @mjudeikis. Review accordingly.**

Fixes "Failed to load provider bundle: failed to load /ui/providers/infrastructure/main.js?v=v0.1.20" for BYO (org-owned) infrastructure providers. Third of three: #693 and #694 are merged; this is rebased on top.

## Root causes (observed in prod: hub v0.1.26, infrastructure provider v0.1.20 on both the platform cluster and the tenant's `minis` edge)

1. **Operator rendered the serve pod without a heartbeat credential.** `providers/infrastructure/operator/serve.go` set `INFRASTRUCTURE_KUBECONFIG` only; the SDK resolves the heartbeat bearer from `FAROS_HUB_TOKEN`, else `FAROS_PROVIDER_KUBECONFIG`. With `--provider-heartbeat-auth=enforce` every beat got 401, the platform record went `HeartbeatStale`, and the UI proxy answered 503 for the bundle.
2. **The UI proxy was platform-scoped by design.** A `<script src>` carries no bearer, so `/ui/providers/{name}` always resolved the platform copy. The org catalog showed the BYO entry as ready, the portal injected the script, and it hit the stale platform record. Even with a healthy platform copy an org would have run the platform's bundle against its own backend. `docs/byo-providers.md` listed this as a known gap.

## Changes

**Operator**
- Serve deployment now sets `FAROS_PROVIDER_KUBECONFIG` to the mounted provider kubeconfig (same as every Helm-installed provider). Test: `TestEnsureProviderServeWiresHeartbeatCredential`.

**Hub** (`pkg/hub/providers/ui_grant.go`, `proxy.go`, `server.go`)
- New `POST /api/providers/{name}/ui-grant`. The caller is resolved by the same `TenantResolver` the backend proxy uses (bearer + verified `X-Faros-Org` / `X-Faros-Workspace`). The hub checks the org owns a copy of `{name}` whose UI is served by the same authority as its backend (the edge route fronts that Service), hashes the bundle through the caller's delegated `OrgProviderRoute` for SRI, and returns `/ui/providers/{name}/main.js?v=…&grant=…` plus the pin and expiry.
- The grant is an AES-256-GCM sealed token (HKDF subkey of the hub's cross-replica secret, distinct info label; same construction as app access tokens), five minutes, bound to one provider, naming `(user, org, workspace)`. Sealed rather than signed because it rides in a URL that lands in history and access logs.
- The UI proxy redeems `?grant=`: opens it, resolves the org's copy (never falling back to the platform record), mints the delegated token for the tuple the grant names via the existing `issueDelegatedToken` decision point, and forwards over the edge hop like `serveOverEdge`. The grant is stripped before the tunnel; responses are `Cache-Control: private, no-store`. A grant-less URL stays platform-scoped exactly as before.
- Route is registered ahead of the heartbeat `PathPrefix` route, which would otherwise claim every POST under `/api/providers/`.
- Refusals: anonymous → 401, org-scope selection (no workspace to mint in) → 403, no org-owned UI / UI on a different host → 404, provider not ready or no edge route or issuer failure → 503, bad/expired/other-provider grant → 401.

**Portal**
- `providers/providerBundle.ts` resolves `{src, integrity}` per catalog entry: platform providers keep the loader default and catalog pin; org providers POST for a grant. Never falls back from org to platform.
- `providerScriptLoader.ts` accepts an explicit `src`. `ProviderFrame.vue` and `DashboardTile.vue` use it.
- The URL keeps the `/ui/providers/{name}/` shape, so the provider's vendored portalkit `serviceBase` and the host's provider-fetch allow list are unchanged; the v0.1.20 bundle loads as-is.

**Docs**: `byo-providers.md` known-gap entry replaced with the design; `providers.md` loader and SRI notes updated.

## Tests
- Go: `ui_grant_test.go` (end-to-end grant → edge fetch with delegated token and matching SRI pin, platform-scoped without grant, grant refusals, proxy refusals, pin caching per version, seal round-trip and tamper), operator env test. `pkg/hub`, `pkg/hub/providers`, and the operator package pass after the rebase.
- Portal: `providerBundle.test.mjs` and loader `src` case; 24/24 pass, `vue-tsc` clean.

## Rollout
Both prod infrastructure installs are still v0.1.20 and will keep beating 401 until the operator release with this change is rolled out (or `spec.hub.tokenSecret` is set on the `InfrastructureProvider` CR). The BYO copy's beats are still refused after that because the heartbeat endpoint is platform-only by design; org readiness does not depend on it.