### PR TITLE
[AUTOMATED BOT PR] perf(kuery-portal): keep the Force topology layout off the main thread

### DIFF
--- a/providers/kuery/portal/src/components/TopologyView.vue
+++ b/providers/kuery/portal/src/components/TopologyView.vue
@@ -4,8 +4,8 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { FarosContext } from '../element'
 import type { ObjectResult, QuerySpec, QueryStatus } from '../api'
 import {
-  buildTopologyElements, deriveTopologyTree, graphKeyAction, IMPACT_RELATIONS, mountGraph, relationElements, themeStyle,
-  type GraphHandle,
+  buildTopologyElements, deriveTopologyTree, forceLayoutOptions, graphKeyAction, IMPACT_RELATIONS, mountGraph, relationElements, themeStyle,
+  type GraphHandle, type GraphHooks,
 } from '../graph'
 import { createKueryRequestContext, errorMessage, resourceLabel, useKueryApi } from '../kuery'
 import FormSelect from '../portalkit/FormSelect.vue'
@@ -31,6 +31,10 @@ const expansionFailure = ref<{ id: string | null; message: string } | null>(null
 const full = ref(false)
 const expandingAll = ref(false)
 const expansionStatus = ref('')
+// Force (cose) layout activity: it runs across animation frames on larger
+// graphs so the page stays interactive; the toolbar offers Stop while it runs.
+const layoutRunning = ref(false)
+const layoutNodeCount = ref(0)
 const responseWarnings = ref<string[]>([])
 const relationResponseTruncated = ref(false)
 const relationLimitReached = ref(false)
@@ -99,12 +103,18 @@ async function load(): Promise<void> {
   }
 }
 
-function layoutConfig(): Record<string, unknown> {
+// layoutConfig builds the Cytoscape layout for the selected option. The
+// force layout is sized to the graph (see forceLayoutOptions): nodeCount is
+// the node total the layout will run over — the live graph's by default, or
+// the element count on first mount when there is no graph yet. incremental
+// (default) starts from the current positions; a fresh mount randomizes.
+function layoutConfig(options: { incremental?: boolean; nodeCount?: number } = {}): Record<string, unknown> {
   if (layout.value === 'concentric') return { name: 'concentric', concentric: (node: { data: (key: string) => unknown }) => node.data('tier') === 'cluster' ? 3 : node.data('tier') === 'namespace' ? 2 : 1, levelWidth: () => 1, minNodeSpacing: 30, padding: 20 }
   if (layout.value === 'circle') return { name: 'circle', padding: 20 }
-  if (layout.value === 'cose') return { name: 'cose', idealEdgeLength: 70, nodeRepulsion: 9000, padding: 20, animate: false }
+  if (layout.value === 'cose') return forceLayoutOptions(options.nodeCount ?? graph?.nodeCount() ?? 0, { incremental: options.incremental ?? true })
   return { name: 'breadthfirst', directed: true, spacingFactor: 1, padding: 20 }
 }
+function stopLayout(): void { graph?.stopLayout() }
 
 function destroyGraph(): void {
   graphGeneration += 1
@@ -121,6 +131,8 @@ function destroyGraph(): void {
   expansionBound.value = null
   expandingAll.value = false
   expansionStatus.value = ''
+  layoutRunning.value = false
+  layoutNodeCount.value = 0
 }
 
 async function mount(): Promise<void> {
@@ -130,8 +142,16 @@ async function mount(): Promise<void> {
   graphController = new AbortController()
   const built = buildTopologyElements(rows.value, { kind: kind.value, namespace: namespace.value })
   graphObjects = new Map(Object.entries(built.nodeIndex))
+  const nodeCount = built.elements.filter(element => !element.data?.source).length
+  const hooks: GraphHooks = {
+    onLayout: (running, nodes) => {
+      if (generation !== graphGeneration) return
+      layoutRunning.value = running
+      layoutNodeCount.value = nodes
+    },
+  }
   try {
-    const handle = await mountGraph(graphHost.value, built.elements, themeStyle(graphHost.value), id => { if (generation === graphGeneration) void expand(id) }, `${(context.value?.basePath || '').replace(/\/?$/, '/')}cytoscape.min.js`, layoutConfig())
+    const handle = await mountGraph(graphHost.value, built.elements, themeStyle(graphHost.value), id => { if (generation === graphGeneration) void expand(id) }, `${(context.value?.basePath || '').replace(/\/?$/, '/')}cytoscape.min.js`, layoutConfig({ incremental: false, nodeCount }), hooks)
     if (generation !== graphGeneration) return handle.destroy()
     graph = handle
     requestAnimationFrame(() => { if (generation === graphGeneration && graph === handle) handle.fit() })
@@ -195,7 +215,7 @@ async function expand(id: string): Promise<void> {
     }
     const built = relationElements(id, result.object); handle.add(built.elements)
     for (const [key, object] of Object.entries(built.nodeIndex)) graphObjects.set(key, object)
-    handle.relayout(layoutConfig())
+    void handle.relayout(layoutConfig())
   } catch (reason) {
     if (!isCurrent()) return
     handle.markExpanded(id, false)
@@ -234,15 +254,18 @@ async function expandAll(): Promise<void> {
       ids.forEach(id => handle.markExpanded(id, true))
       layoutDirty ||= added > 0
       expansionStatus.value = `Expansion round ${rounds + 1}: ${handle.nodeCount().toLocaleString()} graph nodes.`
-      if ((rounds + 1) % 3 === 0 && layoutDirty) {
-        handle.relayout(layoutConfig())
+      // Intermediate relayouts keep the discrete layouts readable as the
+      // graph grows. The force layout is a full simulation over every node,
+      // so it runs once, over the final graph, after expansion.
+      if ((rounds + 1) % 3 === 0 && layoutDirty && layout.value !== 'cose') {
+        void handle.relayout(layoutConfig())
         layoutDirty = false
       }
       if (added === 0) break
       await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
     }
     if (isCurrent()) {
-      if (layoutDirty) handle.relayout(layoutConfig())
+      if (layoutDirty) void handle.relayout(layoutConfig())
       if (handle.nodeCount() >= 4000) expansionBound.value = 'nodes'
       else if (rounds >= 30) expansionBound.value = 'rounds'
       expansionStatus.value = `Expansion complete: ${handle.nodeCount().toLocaleString()} graph nodes.`
@@ -265,7 +288,7 @@ function cancelExpandAll(): void {
   expandAllController = null
   expandingAll.value = false
   expansionStatus.value = `Expansion cancelled. ${graph?.nodeCount().toLocaleString() ?? 0} graph nodes remain available.`
-  graph?.relayout(layoutConfig())
+  void graph?.relayout(layoutConfig())
 }
 function retryExpansion(): void {
   const failure = expansionFailure.value
@@ -300,7 +323,7 @@ function graphKeydown(event: KeyboardEvent): void {
 
 watch(edge, () => void load())
 watch([rows, kind, namespace, representation], () => nextTick(() => void mount()), { deep: false })
-watch(layout, () => graph ? graph.relayout(layoutConfig()) : nextTick(() => void mount()))
+watch(layout, () => graph ? void graph.relayout(layoutConfig()) : nextTick(() => void mount()))
 watch(() => context.value?.theme, () => { if (graph && graphHost.value) graph.restyle(themeStyle(graphHost.value)) })
 watch(() => props.active, active => { if (active) requestAnimationFrame(() => graph?.fit()) })
 watch([api, requestContext], ([ready, current], [wasReady, previous]) => {
@@ -322,6 +345,7 @@ onBeforeUnmount(() => { loadGeneration += 1; fullscreenGeneration += 1; loadCont
       <label><span id="topology-namespace-label">Namespace</span><FormSelect v-model="namespace" :options="namespaceOptions" labelledby="topology-namespace-label" /></label>
       <button type="button" class="k-btn k-btn--ghost" :disabled="!graph || expandingAll" @click="expandAll">{{ expandingAll ? 'Expanding…' : 'Expand all' }}</button>
       <button v-if="expandingAll" type="button" class="k-btn k-btn--ghost" @click="cancelExpandAll">Cancel expansion</button>
+      <button v-if="layoutRunning" type="button" class="k-btn k-btn--ghost" @click="stopLayout">Stop layout</button>
       <button type="button" class="k-btn k-btn--ghost" :disabled="!graph" @click="resetGraph">Reset graph</button>
       <button type="button" class="k-btn k-btn--ghost" @click="toggleFullscreen">{{ full ? 'Exit full screen' : 'Full screen' }}</button>
     </div>
@@ -341,6 +365,7 @@ onBeforeUnmount(() => { loadGeneration += 1; fullscreenGeneration += 1; loadCont
         <div v-if="graphError" class="kuery-inline-error" role="alert">{{ graphError }} <button type="button" class="k-btn k-btn--ghost" @click="mount">Retry graph</button></div>
         <div v-if="expansionFailure" class="kuery-inline-error" role="alert"><span>{{ expansionFailure.message }}</span><button type="button" class="k-btn k-btn--ghost" @click="retryExpansion">Retry expansion</button></div>
         <p class="kuery-sr-only" role="status" aria-live="polite" aria-atomic="true">{{ expansionStatus }}</p>
+        <p v-if="layoutRunning" class="meta" role="status">Force layout is settling {{ layoutNodeCount.toLocaleString() }} nodes in the background; the graph stays interactive. Stop layout keeps the current positions.</p>
         <div ref="graphHost" class="kuery-graph" role="region" aria-label="Fleet topology visualization" aria-describedby="topology-help topology-bounds" tabindex="0" @keydown="graphKeydown" />
       </div>
     </div>

--- a/providers/kuery/portal/src/graph.ts
+++ b/providers/kuery/portal/src/graph.ts
@@ -459,6 +459,64 @@ export function themeStyle(host: Element): cytoscape.StylesheetStyle[] {
   return style
 }
 
+// Force layout (Cytoscape "cose") sizing. cose is a spring simulation that
+// costs O(nodes²) per iteration, and with animate:false Cytoscape runs every
+// iteration in one synchronous loop — on a 2,000-node fleet topology that
+// froze the tab for minutes (the portal looked "down"). With animate:true the
+// layout runs `refresh` iterations per animation frame, so the page stays
+// interactive and the layout can be stopped. forceLayoutOptions keeps the
+// total work bounded as the graph grows: fewer iterations on big graphs, a
+// cooling schedule that still converges within that budget, and few enough
+// iterations per frame to keep frames short.
+const FORCE_INITIAL_TEMP = 1000
+const FORCE_MIN_TEMP = 1
+// Pair evaluations (nodes² × iterations) the whole run may cost, and per
+// frame. 1.5e8 keeps a 500-node graph at 600 iterations and a 2,000-node one
+// at the 100-iteration floor; 1.6e7 per frame keeps a frame near the budget
+// of one 60 Hz tick on a laptop.
+const FORCE_RUN_BUDGET = 1.5e8
+const FORCE_FRAME_BUDGET = 1.6e7
+// Below this many nodes a synchronous run is cheap (well under 100 ms) and
+// gives a stable, jitter-free result immediately.
+export const FORCE_SYNC_NODE_LIMIT = 120
+
+export interface ForceLayoutSizing {
+  animate: boolean
+  numIter: number
+  refresh: number
+  coolingFactor: number
+}
+
+export function forceLayoutSizing(nodeCount: number): ForceLayoutSizing {
+  const n = Math.max(1, nodeCount)
+  const pairs = n * n
+  const numIter = Math.min(1000, Math.max(100, Math.round(FORCE_RUN_BUDGET / pairs)))
+  const refresh = Math.min(20, Math.max(1, Math.round(FORCE_FRAME_BUDGET / pairs)))
+  // Cool from initialTemp to minTemp over exactly numIter steps, so a
+  // shortened run still settles instead of being cut off while hot.
+  const coolingFactor = Math.pow(FORCE_MIN_TEMP / FORCE_INITIAL_TEMP, 1 / numIter)
+  return { animate: n > FORCE_SYNC_NODE_LIMIT, numIter, refresh, coolingFactor }
+}
+
+// forceLayoutOptions is the cose config for the topology "Force" layout.
+// incremental keeps existing positions as the starting point (relayout after
+// an expansion, or switching layouts); a fresh graph is randomized so the
+// simulation does not start with every node stacked at the origin.
+export function forceLayoutOptions(nodeCount: number, options: { incremental?: boolean } = {}): Record<string, unknown> {
+  const sizing = forceLayoutSizing(nodeCount)
+  return {
+    name: 'cose',
+    idealEdgeLength: 70,
+    nodeRepulsion: 9000,
+    padding: 20,
+    fit: true,
+    randomize: !(options.incremental ?? true),
+    initialTemp: FORCE_INITIAL_TEMP,
+    minTemp: FORCE_MIN_TEMP,
+    ...sizing,
+  }
+}
+
 export interface GraphHandle {
   destroy(): void
   // add merges new nodes/edges into the live graph, skipping ids already
@@ -472,8 +530,14 @@ export interface GraphHandle {
   markExpanded(id: string, expanded: boolean): void
   isExpanded(id: string): boolean
   collapseFrom(id: string): void
-  // relayout re-runs the layout after the graph grows/shrinks.
-  relayout(layout?: Record<string, unknown>): void
+  // relayout re-runs the layout after the graph grows/shrinks. A layout
+  // already running (an animated force layout) is stopped first. Resolves
+  // when the new layout has stopped — immediately for the discrete layouts.
+  relayout(layout?: Record<string, unknown>): Promise<void>
+  // stopLayout halts a running animated layout where it is; positions stay
+  // as last drawn.
+  stopLayout(): void
+  layoutRunning(): boolean
   // Viewport controls for keyboard nav / fullscreen.
   panBy(dx: number, dy: number): void
   zoomBy(factor: number): void
@@ -564,6 +628,13 @@ function loadCytoscape(libUrl: string): Promise<typeof cytoscape> {
 // into container. onNodeTap fires for non-anchor nodes (the anchor is already
 // centered) so the caller can re-anchor. Returns a handle whose destroy()
 // tears down the instance and its listeners.
+export interface GraphHooks {
+  // onLayout reports layout activity: true when a layout starts, false when
+  // it stops (finished or halted), with the node count it ran over. Discrete
+  // layouts report both within the same tick.
+  onLayout?: (running: boolean, nodeCount: number) => void
+}
+
 export async function mountGraph(
   container: HTMLElement,
   elements: cytoscape.ElementDefinition[],
@@ -573,22 +644,50 @@ export async function mountGraph(
   // Loose object so callers can pass any built-in layout config (tree, radial,
   // circle, force) without importing Cytoscape's layout union; cast below.
   layout?: Record<string, unknown>,
+  hooks?: GraphHooks,
 ): Promise<GraphHandle> {
   const cytoscape = await loadCytoscape(libUrl)
   const cy = cytoscape({
     container,
     elements,
     style,
-    layout: (layout ?? {
-      name: 'concentric',
-      concentric: (node: cytoscape.NodeSingular) => (node.data('anchor') === 'true' ? 2 : 1),
-      levelWidth: () => 1,
-      minNodeSpacing: 34,
-      padding: 16,
-    }) as unknown as cytoscape.LayoutOptions,
+    // No layout at construction: the initial layout goes through runLayout
+    // below so it is tracked (stoppable, reported) like every relayout.
+    layout: { name: 'preset' },
     // Allow zooming far out so a fully-expanded net still fits on screen.
     minZoom: 0.02,
     maxZoom: 3,
+  })
+
+  // One layout at a time. An animated cose layout keeps stepping in
+  // animation frames until it converges or is stopped; starting another on
+  // top of it would have two simulations fighting over the same positions.
+  let running: cytoscape.Layouts | null = null
+  const runLayout = (config: Record<string, unknown>): Promise<void> => {
+    running?.stop()
+    const next = cy.layout(config as unknown as cytoscape.LayoutOptions)
+    running = next
+    hooks?.onLayout?.(true, cy.nodes().length)
+    return new Promise<void>(resolve => {
+      // A stopped layout still emits layoutstop (on its next frame); the
+      // identity check keeps a superseded layout from reporting the new one
+      // as finished.
+      next.one('layoutstop', () => {
+        if (running === next) {
+          running = null
+          hooks?.onLayout?.(false, cy.nodes().length)
+        }
+        resolve()
+      })
+      next.run()
+    })
+  }
+  void runLayout(layout ?? {
+    name: 'concentric',
+    concentric: (node: cytoscape.NodeSingular) => (node.data('anchor') === 'true' ? 2 : 1),
+    levelWidth: () => 1,
+    minNodeSpacing: 34,
+    padding: 16,
   })
   // Every node is tappable; the caller decides what (if anything) to do — for
   // the explorer that's expand/collapse, for the impact view it re-anchors.
@@ -608,6 +707,8 @@ export async function mountGraph(
 
   return {
     destroy: () => {
+      running?.stop()
+      running = null
       resizeObserver?.disconnect()
       if (resizeObserver) cancelAnimationFrame(resizeFrame)
       container.removeEventListener('pointerdown', focusGraph)
@@ -671,9 +772,9 @@ export async function mountGraph(
       removeExclusiveChildren(id)
       root.data('expanded', 'false')
     },
-    relayout: (layout) => {
-      cy.layout((layout ?? { name: 'breadthfirst', directed: true, spacingFactor: 1.0, padding: 20 }) as unknown as cytoscape.LayoutOptions).run()
-    },
+    relayout: (layout) => runLayout(layout ?? { name: 'breadthfirst', directed: true, spacingFactor: 1.0, padding: 20 }),
+    stopLayout: () => { running?.stop() },
+    layoutRunning: () => running !== null,
     panBy: (dx, dy) => cy.panBy({ x: dx, y: dy }),
     zoomBy: (factor) => cy.zoom({ level: cy.zoom() * factor, renderedPosition: { x: cy.width() / 2, y: cy.height() / 2 } }),
     fit: () => {

--- a/providers/kuery/portal/topology.contract.test.mjs
+++ b/providers/kuery/portal/topology.contract.test.mjs
@@ -104,6 +104,12 @@ test('graph key actions and focus ownership are deterministic', () => {
   assert.equal(graphModule.graphOwnsFocus(graph, null), false)
 })
 
+// A discrete Cytoscape layout emits layoutstop synchronously inside run().
+const discreteLayoutStub = () => {
+  let onStop
+  return { one: (event, listener) => { if (event === 'layoutstop') onStop = listener }, run() { onStop?.() }, stop() {} }
+}
+
 test('mountGraph focuses the labeled container on pointer use and removes the listener on destroy', async () => {
   const previousWindow = globalThis.window
   let focusCount = 0
@@ -119,6 +125,8 @@ test('mountGraph focuses the labeled container on pointer use and removes the li
   const fakeCytoscape = () => ({
     on: () => {},
     destroy: () => { destroyed += 1 },
+    nodes: () => ({ length: 0 }),
+    layout: discreteLayoutStub,
   })
 
   try {
@@ -141,6 +149,7 @@ test('graph additions enforce a hard node limit while retaining parallel relatio
   const cy = {
     on: () => {},
     destroy: () => {},
+    layout: discreteLayoutStub,
     nodes: () => ({ length: [...stored.values()].filter(element => !element.data.source).length }),
     getElementById: id => ({ nonempty: () => stored.has(id), empty: () => !stored.has(id) }),
     add: elements => {
@@ -308,4 +317,126 @@ test('graph rendering provides theme contrast, relation labels, resize handling,
   assert.match(topologySource, /await new Promise<void>\(resolve => requestAnimationFrame/u)
   assert.match(topologySource, /\(rounds \+ 1\) % 3 === 0/u)
   assert.match(topologySource, /aria-live="polite" aria-atomic="true"/u)
+})
+
+test('force layout is sized to the graph and never runs a large graph synchronously', () => {
+  const small = graphModule.forceLayoutSizing(50)
+  assert.equal(small.animate, false, 'a small graph lays out synchronously for a stable, immediate result')
+  assert.equal(small.numIter, 1000)
+  assert.equal(small.refresh, 20)
+
+  const fleet = graphModule.forceLayoutSizing(2000)
+  assert.equal(fleet.animate, true, 'a fleet-sized graph must step across animation frames, not block the tab')
+  assert.ok(fleet.numIter >= 100 && fleet.numIter < small.numIter, `iterations shrink with size, got ${fleet.numIter}`)
+  assert.ok(fleet.refresh >= 1 && fleet.refresh <= 4, `few iterations per frame on 2,000 nodes, got ${fleet.refresh}`)
+
+  // Total work stays bounded: pair evaluations per run never exceed the budget
+  // by more than the iteration floor allows, and shrink monotonically.
+  let previous = Number.POSITIVE_INFINITY
+  for (const nodes of [100, 300, 500, 1000, 2000, 4000]) {
+    const sizing = graphModule.forceLayoutSizing(nodes)
+    assert.ok(sizing.numIter <= previous, `iterations must not grow with node count (${nodes})`)
+    assert.ok(sizing.refresh >= 1 && sizing.refresh <= 20)
+    // The cooling schedule reaches minTemp exactly at numIter, so a shortened
+    // run settles instead of being cut off hot.
+    const finalTemp = 1000 * Math.pow(sizing.coolingFactor, sizing.numIter)
+    assert.ok(Math.abs(finalTemp - 1) < 0.01, `cooling must reach minTemp at numIter (${nodes}: ${finalTemp})`)
+    previous = sizing.numIter
+  }
+  assert.equal(graphModule.forceLayoutSizing(graphModule.FORCE_SYNC_NODE_LIMIT + 1).animate, true)
+  assert.equal(graphModule.forceLayoutSizing(graphModule.FORCE_SYNC_NODE_LIMIT).animate, false)
+})
+
+test('force layout options randomize only a fresh graph and carry the sizing', () => {
+  const fresh = graphModule.forceLayoutOptions(800, { incremental: false })
+  assert.equal(fresh.name, 'cose')
+  assert.equal(fresh.randomize, true)
+  assert.equal(fresh.animate, true)
+  assert.equal(fresh.fit, true)
+  assert.equal(fresh.initialTemp, 1000)
+  assert.equal(fresh.minTemp, 1)
+  assert.deepEqual(
+    { numIter: fresh.numIter, refresh: fresh.refresh, coolingFactor: fresh.coolingFactor },
+    (({ numIter, refresh, coolingFactor }) => ({ numIter, refresh, coolingFactor }))(graphModule.forceLayoutSizing(800)),
+  )
+  assert.equal(graphModule.forceLayoutOptions(800).randomize, false, 'relayout keeps current positions as the start')
+})
+
+test('topology view keeps the force layout off the main thread and stoppable', () => {
+  const graphSource = readFileSync(new URL('./src/graph.ts', import.meta.url), 'utf8')
+  const topologySource = readFileSync(new URL('./src/components/TopologyView.vue', import.meta.url), 'utf8')
+
+  // The view never hands Cytoscape a synchronous cose config of its own.
+  assert.doesNotMatch(topologySource, /name: 'cose'/u)
+  assert.match(topologySource, /forceLayoutOptions\(/u)
+  assert.match(topologySource, /layoutConfig\(\{ incremental: false, nodeCount \}\)/u)
+  // Expand all runs the force layout once, over the final graph.
+  assert.match(topologySource, /\(rounds \+ 1\) % 3 === 0 && layoutDirty && layout\.value !== 'cose'/u)
+  // Users can stop a running layout and see that it is running.
+  assert.match(topologySource, /v-if="layoutRunning"[^>]*@click="stopLayout">Stop layout</u)
+  assert.match(topologySource, /Force layout is settling/u)
+  // The handle tracks one layout at a time, stops it before starting another
+  // or tearing down, and reports activity to the view.
+  assert.match(graphSource, /running\?\.stop\(\)\s+const next = cy\.layout\(/u)
+  assert.match(graphSource, /destroy: \(\) => \{\s+running\?\.stop\(\)/u)
+  assert.match(graphSource, /next\.one\('layoutstop'/u)
+  assert.match(graphSource, /layout: \{ name: 'preset' \}/u)
+  assert.match(graphSource, /hooks\?\.onLayout\?\.\(true, cy\.nodes\(\)\.length\)/u)
+})
+
+test('mountGraph runs one layout at a time, reports activity, and stops a running layout on relayout and destroy', async () => {
+  const previousWindow = globalThis.window
+  const layouts = []
+  // An animated layout: run() returns without emitting layoutstop; the test
+  // drives completion (or stop) by calling finish().
+  const animatedLayout = config => {
+    const layout = { config, runs: 0, stops: 0, onStop: undefined }
+    layout.one = (event, listener) => { if (event === 'layoutstop') layout.onStop = listener }
+    layout.run = () => { layout.runs += 1 }
+    layout.stop = () => { layout.stops += 1 }
+    layout.finish = () => layout.onStop?.()
+    layouts.push(layout)
+    return layout
+  }
+  const cy = { on: () => {}, destroy: () => {}, nodes: () => ({ length: 3 }), layout: animatedLayout }
+  const activity = []
+
+  try {
+    globalThis.window = { cytoscape: () => cy }
+    const handle = await graphModule.mountGraph(
+      { addEventListener: () => {}, removeEventListener: () => {} }, [], [], () => {}, '/cytoscape.min.js',
+      { name: 'cose', animate: true },
+      { onLayout: (running, nodes) => activity.push([running, nodes]) },
+    )
+    assert.equal(layouts.length, 1)
+    assert.equal(layouts[0].runs, 1)
+    assert.equal(handle.layoutRunning(), true)
+    assert.deepEqual(activity, [[true, 3]])
+
+    // A relayout while the first is still stepping stops the first; the
+    // first's late layoutstop must not be mistaken for the second finishing.
+    const second = handle.relayout({ name: 'cose', animate: true })
+    assert.equal(layouts[0].stops, 1)
+    assert.equal(layouts.length, 2)
+    layouts[0].finish()
+    assert.equal(handle.layoutRunning(), true, 'the superseded layout stopping does not end the current one')
+    assert.deepEqual(activity, [[true, 3], [true, 3]])
+
+    layouts[1].finish()
+    await second
+    assert.equal(handle.layoutRunning(), false)
+    assert.deepEqual(activity.at(-1), [false, 3])
+
+    // Stop halts the current layout where it is; teardown stops whatever runs.
+    void handle.relayout({ name: 'cose', animate: true })
+    handle.stopLayout()
+    assert.equal(layouts[2].stops, 1)
+    layouts[2].finish()
+    assert.equal(handle.layoutRunning(), false)
+    void handle.relayout({ name: 'cose', animate: true })
+    handle.destroy()
+    assert.equal(layouts[3].stops, 1)
+  } finally {
+    globalThis.window = previousWindow
+  }
 })


### PR DESCRIPTION
> **This pull request was prepared by an automated coding agent (Claude Code) on behalf of @mjudeikis. Review accordingly.**

## Symptom

Selecting **Layout → Force** in the kuery fleet topology view on console-dev froze the tab for minutes, then "came back". It looked like the provider had gone down.

## What actually happens

The provider is fine: every topology `/api/query` answered in ~80–100 ms and the pod never restarted (checked on kuery v0.1.18 with both edges engaged). The cost is entirely in the browser. "Force" is Cytoscape's `cose` layout, which the view ran with `animate: false`, so Cytoscape executes all 1,000 iterations — each O(nodes²) — in one synchronous loop on the main thread. With two edges × up to 1,000 members that is billions of pair evaluations with the UI blocked. Expand all made it worse by re-running cose every three rounds.

## Fix

- **`graph.ts` — `forceLayoutSizing` / `forceLayoutOptions`**: size cose to the graph.
  - `animate: true` above 120 nodes. Cytoscape's cose then runs `refresh` iterations per animation frame, so the page stays interactive and the layout is stoppable (it checks the stop flag every iteration).
  - Iterations shrink with size under a fixed pair-evaluation budget (1,000 at ≤ 387 nodes, 600 at 500, 150 at 1,000, floor 100 beyond ~1,200), with the cooling factor derived so the schedule still reaches `minTemp` exactly at `numIter` instead of being cut off hot.
  - Iterations per frame shrink too (20 down to 1 at 4,000 nodes) so individual frames stay short.
  - A fresh graph is randomized; relayouts keep current positions as the starting point.
- **`mountGraph` tracks one layout at a time.** The initial layout goes through the same path as relayouts (constructor gets `preset`), a relayout stops a still-running layout first, `destroy` stops it, `stopLayout()` / `layoutRunning()` are exposed, `relayout` resolves on `layoutstop`, and an `onLayout` hook reports activity to the view. A superseded layout's late `layoutstop` cannot mark the current one as finished.
- **`TopologyView.vue`**: uses the sized force layout (fresh on mount, incremental afterwards), shows "Force layout is settling N nodes in the background…" with a **Stop layout** button while it runs, and runs the force layout once after Expand all rather than every three rounds (discrete layouts keep their intermediate relayouts).

No new dependencies; still the vendored `cytoscape.min.js`.

## Tests

- `forceLayoutSizing`: sync below the threshold, animated above; iterations non-increasing with node count and within [100, 1000]; per-frame iterations within [1, 20]; cooling reaches `minTemp` at `numIter` for 100–4,000 nodes.
- `forceLayoutOptions`: randomize only when not incremental; carries the sizing.
- `mountGraph` with a stub animated layout: one layout at a time, stop-before-restart, superseded `layoutstop` ignored, activity hook, stop and destroy semantics.
- Source contract: the view never passes its own synchronous cose config, has the Stop control, and gates the Expand-all intermediate relayout on the non-force layouts.
- `npm run test` 47/47, `npm run typecheck` clean, `vite build` clean.

Not exercised in a real browser in this PR; the Playwright suite needs a browser install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
