### PR TITLE
Stage 2: add durable local coding runners over Edges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: sync-portalkit verify-portalkit verify-agentkit verify-ui-conformance verify-design-docs verify-tilt-browser-deployment test-portal test-portal-settings-conformance test-create-flow-conformance serve-model-form-visual test-model-form-visual build-portal test-macos-agent test-edges-provider test-edges-portal build-macos-agent build-macos-agent-arm64 build-macos-agent-amd64 build-macos-stub build-macos-stub-native build-macos-stub-arm64 build-macos-stub-amd64 verify-macos-edges
 .PHONY: build-access-proxy docker-build-access-proxy
+.PHONY: test-runner lint-runner fix-lint-runner build-runner build-runner-darwin
 .PHONY: dev-edge-create dev-run-edge build test lint fix-lint codegen crds clean certs dev-setup run-dex run-hub run-hub-static run-hub-embedded run-hub-embedded-static run-hub-standalone run-kcp dev-login dev-login-static dev-create-workload dev dev-infra dev-run-kcp path boilerplate verify-boilerplate verify-codegen ldflags tools docker-build docker-build-hub docker-build-agent docker-build-dex docker-build-dev-agent load-dev-agent-image docker-build-universal-dev-image load-universal-dev-image docker-push-dex verify help-dev dev-status dev-clean-hooks helm-build-local helm-push-local helm-clean build-quickstart-provider build-quickstart-provider-portal build-kuery-provider build-kuery-provider-portal run-provider-kuery kuery-db-up kuery-db-down install-provider-kuery init-provider-kuery uninstall-provider-kuery run-provider-quickstart install-provider-quickstart init-provider-quickstart uninstall-provider-quickstart build-infrastructure-provider build-infrastructure-provider-portal codegen-infrastructure-provider run-provider-infrastructure install-provider-infrastructure init-provider-infrastructure uninstall-provider-infrastructure build-app-studio-provider build-app-studio-provider-portal codegen-app-studio-provider app-studio-preview-bridge-dev-key verify-app-studio-preview-bridge-dev-key verify-app-studio-eval app-studio-db-up app-studio-db-down run-provider-app-studio install-provider-app-studio init-provider-app-studio uninstall-provider-app-studio build-agents-provider build-agents-provider-portal codegen-agents-provider agents-db-up agents-db-down run-provider-agents install-provider-agents init-provider-agents uninstall-provider-agents build-code-provider build-code-provider-portal codegen-code-provider run-provider-code install-provider-code init-provider-code uninstall-provider-code build-databricks-provider build-databricks-provider-portal codegen-databricks-provider run-provider-databricks install-provider-databricks init-provider-databricks uninstall-provider-databricks test-databricks-provider-chart dev-kro-up dev-kro-down dev-kro-seed e2e-infrastructure e2e-provider e2e-provider-flags e2e-provider-all
 
 BINDIR ?= bin
@@ -67,6 +68,24 @@ build-release: ## Build the release-tagging helper (release <component|all>)
 
 build-hub:
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BINDIR)/faros-hub ./cmd/faros-hub/
+
+test-runner: ## Run focused generic runner and harness tests
+	go test -count=1 ./pkg/runner/...
+
+lint-runner: $(GOLANGCI_LINT) ## Lint the standalone runner and adapters
+	$(GOLANGCI_LINT) run ./pkg/runner/... ./cmd/faros-runner/...
+
+fix-lint-runner: $(GOLANGCI_LINT) ## Format and auto-fix the standalone runner
+	$(GOLANGCI_LINT) run --fix ./pkg/runner/... ./cmd/faros-runner/...
+
+build-runner: ## Build the standalone loopback runner binary
+	mkdir -p $(BINDIR)
+	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BINDIR)/faros-runner ./cmd/faros-runner/
+
+build-runner-darwin: ## Build the standalone runner for Darwin arm64 and amd64
+	mkdir -p $(BINDIR)
+	GOOS=darwin GOARCH=arm64 go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BINDIR)/faros-runner-darwin-arm64 ./cmd/faros-runner/
+	GOOS=darwin GOARCH=amd64 go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BINDIR)/faros-runner-darwin-amd64 ./cmd/faros-runner/
 
 build-hub-portal: build-portal ## Build hub with embedded portal
 	mkdir -p pkg/hub/portal

--- a/Tiltfile
+++ b/Tiltfile
@@ -82,6 +82,9 @@ go build -o bin/faros-hub ./cmd/faros-hub
         # absent at first boot — see pkg/hub/server.go.
         '.faros-kro.kubeconfig',
     ],
+    # The standalone generic runner is reached through its enrolled Edge
+    # Service and is not a hub dependency; runner edits must not restart KCP.
+    ignore=['pkg/runner'],
     resource_deps=['portal'],
     labels=['hub'],
 )

--- a/cmd/faros-runner/main.go
+++ b/cmd/faros-runner/main.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command faros-runner serves the loopback-only generic runner protocol.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/faroshq/faros/pkg/runner"
+	"github.com/faroshq/faros/pkg/runner/harness/codex"
+	"github.com/faroshq/faros/pkg/version"
+)
+
+type options struct {
+	config      string
+	stateDir    string
+	listen      string
+	tokenFile   string
+	codexHome   string
+	codexBinary string
+	versionPin  string
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "faros-runner:", err)
+		os.Exit(1)
+	}
+}
+
+func run() (runErr error) {
+	var opts options
+	flags := flag.NewFlagSet("faros-runner", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	flags.StringVar(&opts.config, "config", "", "path to the JSON runner enrollment/configuration file")
+	flags.StringVar(&opts.stateDir, "state-dir", "", "durable runner state directory")
+	flags.StringVar(&opts.listen, "listen", "", "loopback listen address (default 127.0.0.1:8787)")
+	flags.StringVar(&opts.tokenFile, "token-file", "", "file containing the runner bearer token")
+	flags.StringVar(&opts.codexHome, "codex-home", "", "runner-owned CODEX_HOME directory")
+	flags.StringVar(&opts.codexBinary, "codex-binary", "codex", "Codex executable")
+	flags.StringVar(&opts.versionPin, "version-pin", "0.147.0", "expected Codex version")
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		return err
+	}
+	if os.Geteuid() == 0 {
+		return errors.New("faros-runner must run as a non-root user")
+	}
+	cfg, err := runner.LoadConfig(opts.config)
+	if err != nil {
+		return err
+	}
+	if opts.stateDir != "" {
+		cfg.StateDir = opts.stateDir
+	}
+	if opts.listen != "" {
+		cfg.Listen = opts.listen
+	}
+	if opts.tokenFile != "" {
+		cfg.TokenFile = opts.tokenFile
+		cfg.Token = ""
+	}
+	if cfg.StateDir == "" {
+		base, resolveErr := os.UserConfigDir()
+		if resolveErr != nil {
+			return resolveErr
+		}
+		cfg.StateDir = filepath.Join(base, "faros-runner")
+	}
+	if opts.codexHome == "" {
+		opts.codexHome = filepath.Join(cfg.StateDir, "codex-home")
+	}
+	adapter := codex.New(codex.Config{
+		Binary:          opts.codexBinary,
+		Home:            opts.codexHome,
+		ExpectedVersion: opts.versionPin,
+	})
+	r, err := runner.New(cfg, adapter)
+	if err != nil {
+		return err
+	}
+	defer func() { runErr = errors.Join(runErr, r.Close()) }()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := r.ListenAndServe(ctx); err != nil {
+		return fmt.Errorf("serve runner version %s: %w", version.Get(), err)
+	}
+	return nil
+}

--- a/cmd/faros-runner/main.go
+++ b/cmd/faros-runner/main.go
@@ -90,9 +90,14 @@ func run() (runErr error) {
 	if opts.codexHome == "" {
 		opts.codexHome = filepath.Join(cfg.StateDir, "codex-home")
 	}
+	stateRoot, err := filepath.Abs(cfg.StateDir)
+	if err != nil {
+		return fmt.Errorf("resolve runner state directory: %w", err)
+	}
 	adapter := codex.New(codex.Config{
 		Binary:          opts.codexBinary,
 		Home:            opts.codexHome,
+		WorktreeRoot:    filepath.Join(stateRoot, "worktrees"),
 		ExpectedVersion: opts.versionPin,
 	})
 	r, err := runner.New(cfg, adapter)

--- a/docs/local-runner.md
+++ b/docs/local-runner.md
@@ -216,10 +216,13 @@ receipt with `Inspect` and replayable server-sent events. Events have ordered
 cursors; a cursor gap or `cursor_expired` response requires inspecting the
 receipt before continuing. Progress is an observation, not proof of completion.
 
-Cancellation has two states. A cancel request first returns `cancelling`; it is
-complete only after the harness exits and the receipt or event reports
-`cancelled`. A process shutdown also cancels active child processes, but it is
-not a substitute for observing the attempt's terminal receipt.
+Cancellation has two states. An explicit cancel request first returns
+`cancelling`; it is complete only after the harness exits and the receipt or
+event reports `cancelled`. That cancellation remains terminal across process
+shutdown. A graceful shutdown drains active child processes and persists a
+shutdown interruption as `needs_input`, retaining the recorded session and
+worktree for same-session recovery. Adapter failures and approved output or
+duration limits retain failure precedence when shutdown overlaps them.
 
 Interactive approval, authentication, a missing Codex session, or another
 operator decision moves an attempt to `needs_input`. Resume requires the same
@@ -238,6 +241,14 @@ reconciliation blocker. Inspect the receipt, verify that the enrolled source,
 approved commit, worktree, and session still exist, then resume only when the
 same session can be recovered. If that evidence is unavailable, leave the
 attempt in `needs_input` with its blocker instead of claiming recovery.
+
+When loading a v1 journal, the runner upgrades it to v2. The migration reopens
+only the old shutdown receipt that was recorded as `cancelled` with the exact
+legacy shutdown blocker, a valid session ID, and no `CancelPending`, cancel
+operation, durable error, or limit-exceeded marker. It changes that receipt to
+`needs_input` and records no execution; all other cancelled receipts remain
+terminal. A v1 runner rejects the upgraded v2 journal, so do not downgrade the
+binary over an upgraded state directory.
 
 Do not copy the state directory to another machine or assume raw Codex session
 files are portable. Cross-machine continuation, migration, scheduling, and

--- a/docs/local-runner.md
+++ b/docs/local-runner.md
@@ -1,0 +1,261 @@
+# Local runner runbook
+
+`faros-runner` is a single-execution runner for a host that is already enrolled
+by its operator. It exposes the `runner/v1` protocol on a loopback-only HTTP
+listener and uses a bearer token for every request. The default listener is
+`127.0.0.1:8787`; the listener cannot be configured to a non-loopback address.
+
+The runner is an explicit operations surface. It has no scheduler, automatic
+cross-machine migration, Git publication, or deployment/publishing workflow.
+The caller must provide an approved task envelope and must observe the durable
+receipt and events for its outcome.
+
+## Prepare the host
+
+Run the binary as the dedicated non-root account that owns the runner state.
+The command refuses to start as root. Build the runner for the host with:
+
+```sh
+make build-runner
+```
+
+For Darwin hosts, build both supported architectures and install the matching
+binary:
+
+```sh
+make build-runner-darwin
+# bin/faros-runner-darwin-arm64
+# bin/faros-runner-darwin-amd64
+```
+
+For a disposable Mac acceptance check, place the matching binary under the name
+`faros-runner` beside [setup-macos.sh](../hack/runner-acceptance/setup-macos.sh)
+and run `sh setup-macos.sh`. It creates a tiny local Git source, token, and
+configuration below `~/.faros-runner-preview`, then prints login and launch
+commands. It requires Git, OpenSSL, Python 3, and Codex. It does not enroll a
+Service, send credentials, or start a coding task. Its setup can be repeated
+without replacing the token or resetting the fixture repository.
+
+Install the Codex executable for this dedicated account. Create the runner's
+Codex home as a new owner-only directory, then use the supported Codex login
+flow with `CODEX_HOME` set to that directory. Do not copy an interactive
+developer home into it. The runner's default expected Codex version is
+`0.147.0`; override it only when the installed harness is intentionally pinned
+to another version:
+
+```sh
+./bin/faros-runner --version-pin <codex-version> --help
+```
+
+The runner probes the executable and its app-server authentication state during
+startup without making a model call. A failed version or authentication probe
+leaves capabilities unready, so a start request cannot be accepted until the
+host is repaired.
+
+Generate one local bearer value, register that value with the tenant's existing
+Service credential flow, and provide the same value to the runner through an
+owner-only file. The tenant stores the Service credential in its auth Secret.
+Do not put the token in the JSON configuration, a command-line argument, a
+checked-in file, request instructions, or logs.
+
+```sh
+install -m 600 /path/to/locally-generated-token /path/to/runner-token
+```
+
+The exact Secret retrieval and mounting mechanism belongs to the tenant
+deployment. The local binary only reads the token file and compares the
+presented `Authorization: Bearer` value with it. The local runner has no
+bootstrap endpoint for creating this credential.
+
+## Enroll configuration
+
+Use an absolute, private state directory and an absolute token-file path. A
+configuration can enroll several named local Git sources, but each source must
+be explicitly allowlisted. `baseCommit`, when set, further restricts that
+source to one commit.
+
+```json
+{
+  "protocolVersion": "runner/v1",
+  "runnerID": "<runner-id>",
+  "stateDir": "<absolute-private-state-directory>",
+  "tokenFile": "<absolute-private-token-file>",
+  "toolchains": ["<toolchain-name>"],
+  "environment": ["<approved-environment-capability>"],
+  "verificationCapabilities": ["<verification-capability>"],
+  "maximumCapacity": 1,
+  "repositories": {
+    "<repository-id>": {
+      "source": "<absolute-local-git-source>",
+      "baseCommit": "<40-character-commit>"
+    }
+  },
+  "resources": {
+    "<resource-name>": {
+      "kind": "<preconfigured-resource-kind>",
+      "capacity": 1
+    }
+  }
+}
+```
+
+`runnerID` and map keys use the identifier form accepted by the protocol. The
+runner defaults `runnerID` to a platform-qualified value, `stateDir` to the
+user configuration directory followed by `faros-runner`, and `maximumCapacity`
+to one. It rejects a capacity greater than one. The source path is resolved at
+startup; the source directory must exist and contain the requested full commit.
+
+The runner stores durable state as a protected file below `stateDir`, takes a
+single-process lock for that directory, and places task workspaces below
+`stateDir/worktrees/<taskID>/<attemptID>`. Keep this directory on durable
+storage on the same machine. Do not share one state directory between runner
+instances.
+
+## Start the runner
+
+```sh
+./bin/faros-runner \
+  --config <absolute-runner-config.json> \
+  --codex-binary <codex-executable>
+```
+
+The command also accepts `--state-dir`, `--listen`, `--token-file`, and
+`--codex-home`. If `--codex-home` is omitted, it is
+`<stateDir>/codex-home`. The Codex home is created with owner-only permissions
+and must be dedicated to the runner account. The adapter rejects symlinks and
+interactive configuration entries in that home. It runs Codex with a sanitized
+environment: the runner-owned home is used for `HOME`, `CODEX_HOME`, and XDG
+directories, while GitHub tokens, API keys, SSH-agent settings, and global Git
+configuration are removed.
+
+These boundaries isolate configuration and task workspaces, not the operating
+system account or all filesystem reads. Use an appropriate worker account or
+host boundary for production execution.
+
+Check readiness through an authenticated loopback request:
+
+```text
+GET http://127.0.0.1:8787/runner/v1/capabilities
+Authorization: Bearer <runner-token>
+```
+
+The response reports the protocol version, runner identity, OS and
+architecture, harness readiness and version, configured capabilities, capacity,
+and readiness reasons. A readiness response does not mean a task has completed.
+
+## Run an operation
+
+All JSON requests use `protocolVersion: "runner/v1"`. Mutation requests carry a
+`requestID`, `taskID`, `attemptID`, and positive `attemptEpoch`. A repeated
+request with the same identity and content returns the durable prior result; a
+reused request ID with different content is an idempotency conflict. An older
+attempt epoch is stale and cannot mutate the newer attempt.
+
+| Operation | Request |
+| --- | --- |
+| Discover | `GET /runner/v1/capabilities` |
+| Start | `POST /runner/v1/attempts` |
+| Inspect | `GET /runner/v1/attempts/<attempt-id>` |
+| Events | `GET /runner/v1/attempts/<attempt-id>/events?after=<cursor>` |
+| Cancel | `POST /runner/v1/attempts/<attempt-id>/cancel` |
+| Resume | `POST /runner/v1/attempts/<attempt-id>/resume` |
+| Artifact | `GET /runner/v1/attempts/<attempt-id>/artifacts/<artifact-id>` |
+
+A start request must include the enrolled `repositoryID`, the full 40-character
+`baseCommit`, non-empty instructions, and a non-empty JSON `approvedInput`
+object containing `provenance`, `manualAuthorization`, or `authorization`.
+The base commit must resolve exactly in the enrolled local source. The runner
+clones that source with fixed, non-interactive Git settings into the task-owned
+worktree and checks out the commit detached. It does not use `git worktree add`
+and does not modify the enrolled source checkout.
+
+The request may additionally require configured capabilities, toolchains,
+environment entries, a named ready harness, verification names or commands,
+named resources, execution limits, and logical artifact paths. Resource values
+are names only. A configured resource reserves capacity; the runner does not
+provision ports, containers, clusters, or other infrastructure.
+
+For a local fixture, use a repository enrolled by absolute path and authorize
+one explicit start request. Keep the commit equal to the enrolled commit:
+
+```json
+{
+  "protocolVersion": "runner/v1",
+  "requestID": "<request-id>",
+  "taskID": "<task-id>",
+  "attemptID": "<attempt-id>",
+  "attemptEpoch": 1,
+  "repositoryID": "<repository-id>",
+  "baseCommit": "<same-40-character-commit-as-config>",
+  "instructions": "<task instructions>",
+  "approvedInput": {
+    "manualAuthorization": {
+      "operator": "<operator-reference>",
+      "scope": "<approved-task-scope>"
+    }
+  },
+  "limits": {"maxTurns": 1},
+  "verification": {"names": ["<verification-name>"]}
+}
+```
+
+This example is an authorization envelope for a local fixture. It does not
+activate a scheduler, create a publication, or grant the harness credentials
+to another system.
+
+The Codex adapter starts one app-server process, one thread, and one turn per
+execution. Its turn runs with workspace-write access restricted to the task
+worktree and with network access disabled. The runner's single execution slot
+and any configured resource reservations are released when the attempt reaches
+a terminal phase.
+
+## Observe, cancel, and resume
+
+`Start` durably persists an accepted receipt before returning. Follow the
+receipt with `Inspect` and replayable server-sent events. Events have ordered
+cursors; a cursor gap or `cursor_expired` response requires inspecting the
+receipt before continuing. Progress is an observation, not proof of completion.
+
+Cancellation has two states. A cancel request first returns `cancelling`; it is
+complete only after the harness exits and the receipt or event reports
+`cancelled`. A process shutdown also cancels active child processes, but it is
+not a substitute for observing the attempt's terminal receipt.
+
+Interactive approval, authentication, a missing Codex session, or another
+operator decision moves an attempt to `needs_input`. Resume requires the same
+attempt epoch, the same session ID and task worktree, and an explicit
+resolution. It cannot amend the approved input or instructions. A missing or
+unrecoverable checkpoint is a blocker; the runner never silently starts a new
+session as a substitute.
+
+## Restart and recovery
+
+The state journal, task worktree, and Codex home are same-machine state. On
+startup the runner loads the journal and verifies its harness without a model
+call. It does not automatically rerun an in-flight attempt. Attempts that were
+active when the process stopped are reported as `needs_input` with a restart
+reconciliation blocker. Inspect the receipt, verify that the enrolled source,
+approved commit, worktree, and session still exist, then resume only when the
+same session can be recovered. If that evidence is unavailable, leave the
+attempt in `needs_input` with its blocker instead of claiming recovery.
+
+Do not copy the state directory to another machine or assume raw Codex session
+files are portable. Cross-machine continuation, migration, scheduling, and
+publication are outside this runner contract.
+
+## Limits and verification boundary
+
+The default bounds are 256 retained events per attempt, 64 KiB per event
+payload, 2 MiB per JSON request body, and 32 MiB per artifact. Configuration
+can lower or raise these limits within the implementation's accepted values;
+callers should use the advertised protocol response and error code as the
+authority. The runner supports at most one harness turn per execution and one
+simultaneous execution by default.
+
+Focused runner tests, race and vet checks, native builds, Darwin arm64 and
+amd64 builds, and two no-model Codex `0.147.0` authentication probes have
+passed for the current implementation. These checks establish protocol,
+process, and harness contracts. They do not establish that a real Mac has
+successfully completed a coding task. A real-Mac acceptance still needs an
+actual enrolled host, approved local repository, start/observe path,
+interruption, restart, and same-session resume evidence.

--- a/docs/local-runner.md
+++ b/docs/local-runner.md
@@ -123,7 +123,16 @@ The command also accepts `--state-dir`, `--listen`, `--token-file`, and
 `--codex-home`. If `--codex-home` is omitted, it is
 `<stateDir>/codex-home`. The Codex home is created with owner-only permissions
 and must be dedicated to the runner account. The adapter rejects symlinks and
-interactive configuration entries in that home. It runs Codex with a sanitized
+interactive configuration entries in that home. The CLI permits a bounded
+`config.toml` containing only project `trust_level` records (`trusted` or
+`untrusted`) for existing task/attempt directories under its managed
+`stateDir/worktrees` root. Parent paths, symlinks, and additional settings are
+rejected. When this configuration exists, a launch also rejects `.codex`
+entries from the managed worktree root through the task checkout, preventing
+project trust from enabling local configuration or hooks. Library consumers
+must explicitly supply `codex.Config.WorktreeRoot` to enable this exception.
+The runner preserves the trust file and existing authentication/session state.
+It runs Codex with a sanitized
 environment: the runner-owned home is used for `HOME`, `CODEX_HOME`, and XDG
 directories, while GitHub tokens, API keys, SSH-agent settings, and global Git
 configuration are removed.

--- a/docs/local-runner.md
+++ b/docs/local-runner.md
@@ -132,6 +132,10 @@ entries from the managed worktree root through the task checkout, preventing
 project trust from enabling local configuration or hooks. Library consumers
 must explicitly supply `codex.Config.WorktreeRoot` to enable this exception.
 The runner preserves the trust file and existing authentication/session state.
+Codex-owned `plugins` cache and staging directories may remain in the dedicated
+home. Every app-server launch explicitly disables apps, plugins, and hooks,
+including readiness probes and resumed sessions. A symlink or non-directory
+`plugins` entry is rejected; the runner does not remove cache files.
 It runs Codex with a sanitized
 environment: the runner-owned home is used for `HOME`, `CODEX_HOME`, and XDG
 directories, while GitHub tokens, API keys, SSH-agent settings, and global Git

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.8
 replace github.com/faroshq/provider-sdk => ./provider-sdk
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/coreos/go-oidc v2.5.0+incompatible
@@ -98,7 +99,6 @@ require (
 	cyphar.com/go-pathrs v0.2.2 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect

--- a/hack/runner-acceptance/setup-macos.sh
+++ b/hack/runner-acceptance/setup-macos.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Copyright 2026 The Faros Authors.
+# Disposable, local-only acceptance fixture. No credentials leave this script.
+set -eu
+
+if [ "$(uname -s)" != Darwin ]; then
+  echo 'This fixture setup is for macOS.' >&2
+  exit 1
+fi
+command -v git >/dev/null
+command -v openssl >/dev/null
+command -v codex >/dev/null
+command -v python3 >/dev/null
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY
+unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS
+export GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+runner_binary="$script_dir/faros-runner"
+if [ ! -x "$runner_binary" ]; then
+  echo 'Place setup-macos.sh beside the matching faros-runner binary.' >&2
+  exit 1
+fi
+
+fixture_root="${FAROS_RUNNER_FIXTURE_ROOT:-$HOME/.faros-runner-preview}"
+umask 077
+mkdir -p "$fixture_root"
+fixture_root=$(CDPATH='' cd -- "$fixture_root" && pwd)
+if [ ! -f "$fixture_root/token" ]; then
+  openssl rand -hex 32 > "$fixture_root/token"
+fi
+chmod 600 "$fixture_root/token"
+mkdir -p "$fixture_root/source" "$fixture_root/codex-home" "$fixture_root/state"
+if [ ! -d "$fixture_root/source/.git" ]; then
+  printf '#!/bin/sh\nprintf "TODO\\n"\n' > "$fixture_root/source/greet.sh"
+  cat > "$fixture_root/source/verify.sh" <<'EOF'
+#!/bin/sh
+set -eu
+test "$(sh ./greet.sh)" = 'Hello from the runner.'
+printf 'fixture check passed\n'
+EOF
+  git -C "$fixture_root/source" -c init.defaultBranch=main init --quiet
+  git -C "$fixture_root/source" add greet.sh verify.sh
+  git -C "$fixture_root/source" -c user.name='Runner Fixture' \
+    -c user.email='fixture@localhost' -c core.hooksPath=/dev/null \
+    -c commit.gpgSign=false commit --quiet -m 'Add disposable runner fixture'
+fi
+base_commit=$(git -C "$fixture_root/source" rev-parse HEAD)
+python3 - "$fixture_root" "$base_commit" <<'PY'
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+config = {
+    'protocolVersion': 'runner/v1',
+    'runnerID': 'macos-acceptance-runner',
+    'stateDir': str(root / 'state'),
+    'tokenFile': str(root / 'token'),
+    'toolchains': ['git', 'sh'],
+    'verificationCapabilities': ['fixture-shell'],
+    'repositories': {'acceptance-fixture': {
+        'source': str(root / 'source'), 'baseCommit': sys.argv[2]}},
+}
+(root / 'runner.json').write_text(json.dumps(config, indent=2) + '\n')
+PY
+
+printf 'Fixture base commit: %s\n' "$base_commit"
+printf 'Runner token file (keep private): %s/token\n' "$fixture_root"
+printf 'Copy the token locally into your Faros Service credential field. Do not send it in chat.\n'
+printf 'If the dedicated Codex home is not signed in, run:\n'
+printf '  CODEX_HOME="%s/codex-home" codex login\n' "$fixture_root"
+printf 'Then start or restart the runner with:\n'
+printf '  "%s" --config "%s/runner.json" --codex-home "%s/codex-home"\n' "$runner_binary" "$fixture_root" "$fixture_root"

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package runner provides a durable, authenticated local execution service.
+package runner
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+const (
+	defaultMaxEvents       = 256
+	defaultMaxEventBytes   = 64 << 10
+	defaultMaxBodyBytes    = 2 << 20
+	defaultMaxArtifactSize = 32 << 20
+)
+
+var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+
+// RepositoryConfig enrolls one local Git source. The source is read-only from
+// the runner's point of view; attempts are cloned into task-owned worktrees.
+type RepositoryConfig struct {
+	Source     string `json:"source"`
+	BaseCommit string `json:"baseCommit,omitempty"`
+}
+
+// ResourceConfig names a preconfigured shared resource. Capacity is a count
+// of simultaneous reservations; it does not cause the runner to provision the
+// resource.
+type ResourceConfig struct {
+	Kind     string            `json:"kind,omitempty"`
+	Capacity int               `json:"capacity,omitempty"`
+	Labels   map[string]string `json:"labels,omitempty"`
+}
+
+// Config contains local runner identity, enrollment, persistence, and
+// capability settings. It is intentionally independent of the Codex adapter.
+type Config struct {
+	ProtocolVersion string                      `json:"protocolVersion,omitempty"`
+	RunnerID        string                      `json:"runnerID"`
+	Version         string                      `json:"version,omitempty"`
+	Listen          string                      `json:"listen,omitempty"`
+	StateDir        string                      `json:"stateDir"`
+	TokenFile       string                      `json:"tokenFile"`
+	Token           string                      `json:"-"`
+	Toolchains      []string                    `json:"toolchains,omitempty"`
+	Environment     []string                    `json:"environment,omitempty"`
+	Verification    []string                    `json:"verificationCapabilities,omitempty"`
+	MaximumCapacity int                         `json:"maximumCapacity,omitempty"`
+	MaxEvents       int                         `json:"maxEvents,omitempty"`
+	MaxEventBytes   int                         `json:"maxEventBytes,omitempty"`
+	MaxBodyBytes    int                         `json:"maxBodyBytes,omitempty"`
+	MaxArtifactSize int64                       `json:"maxArtifactSize,omitempty"`
+	Repositories    map[string]RepositoryConfig `json:"repositories,omitempty"`
+	Resources       map[string]ResourceConfig   `json:"resources,omitempty"`
+}
+
+// LoadConfig reads a JSON runner configuration. A missing path is equivalent
+// to an empty configuration and is useful for callers that supply Config
+// directly; the CLI requires a path when --config is set.
+func LoadConfig(path string) (Config, error) {
+	if strings.TrimSpace(path) == "" {
+		return Config{}, nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("read runner config: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return Config{}, fmt.Errorf("decode runner config: %w", err)
+	}
+	return cfg, nil
+}
+
+func (c *Config) applyDefaults() error {
+	if c.ProtocolVersion == "" {
+		c.ProtocolVersion = ProtocolVersion
+	}
+	if c.ProtocolVersion != ProtocolVersion {
+		return fmt.Errorf("unsupported runner protocol version %q", c.ProtocolVersion)
+	}
+	if c.RunnerID == "" {
+		c.RunnerID = "faros-runner-" + runtime.GOOS + "-" + runtime.GOARCH
+	}
+	if c.Version == "" {
+		c.Version = "dev"
+	}
+	if c.Listen == "" {
+		c.Listen = "127.0.0.1:8787"
+	}
+	if c.StateDir == "" {
+		base, err := os.UserConfigDir()
+		if err != nil {
+			return fmt.Errorf("resolve default runner state directory: %w", err)
+		}
+		c.StateDir = filepath.Join(base, "faros-runner")
+	}
+	abs, err := filepath.Abs(c.StateDir)
+	if err != nil {
+		return fmt.Errorf("resolve runner state directory: %w", err)
+	}
+	c.StateDir = abs
+	if c.MaximumCapacity <= 0 {
+		c.MaximumCapacity = 1
+	} else if c.MaximumCapacity > 1 {
+		return errors.New("runner maximumCapacity must be 1 for the single-execution runner")
+	}
+	if c.MaxEvents <= 0 {
+		c.MaxEvents = defaultMaxEvents
+	}
+	if c.MaxEventBytes <= 0 {
+		c.MaxEventBytes = defaultMaxEventBytes
+	}
+	if c.MaxBodyBytes <= 0 {
+		c.MaxBodyBytes = defaultMaxBodyBytes
+	}
+	if c.MaxArtifactSize <= 0 {
+		c.MaxArtifactSize = defaultMaxArtifactSize
+	}
+	if c.TokenFile != "" {
+		b, err := os.ReadFile(c.TokenFile)
+		if err != nil {
+			return fmt.Errorf("read runner token file: %w", err)
+		}
+		c.Token = strings.TrimSpace(string(b))
+	}
+	if c.Token == "" {
+		return errors.New("runner bearer token is empty")
+	}
+	if len(c.Token) > 4096 || strings.ContainsAny(c.Token, "\r\n \t") {
+		return errors.New("runner bearer token contains invalid whitespace or is too long")
+	}
+	if !identifierPattern.MatchString(c.RunnerID) {
+		return fmt.Errorf("runner ID %q is invalid", c.RunnerID)
+	}
+	if !isLoopbackListenAddress(c.Listen) {
+		return fmt.Errorf("runner listen address %q is not loopback-only", c.Listen)
+	}
+	for id, repo := range c.Repositories {
+		if !identifierPattern.MatchString(id) {
+			return fmt.Errorf("repository ID %q is invalid", id)
+		}
+		if strings.TrimSpace(repo.Source) == "" {
+			return fmt.Errorf("repository %q has an empty source", id)
+		}
+		if abs, err := filepath.Abs(repo.Source); err == nil {
+			repo.Source = abs
+			c.Repositories[id] = repo
+		} else {
+			return fmt.Errorf("resolve repository %q source: %w", id, err)
+		}
+	}
+	for name, resource := range c.Resources {
+		if !identifierPattern.MatchString(name) {
+			return fmt.Errorf("resource name %q is invalid", name)
+		}
+		if resource.Capacity < 0 {
+			return fmt.Errorf("resource %q has negative capacity", name)
+		}
+		if resource.Capacity == 0 {
+			resource.Capacity = 1
+			c.Resources[name] = resource
+		}
+	}
+	return nil
+}
+
+func isLoopbackListenAddress(address string) bool {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil || host == "" {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func tokenEqual(expected, presented string) bool {
+	if len(expected) != len(presented) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(presented)) == 1
+}

--- a/pkg/runner/harness/codex/codex.go
+++ b/pkg/runner/harness/codex/codex.go
@@ -1,0 +1,1030 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package codex adapts the Codex app-server protocol to the runner harness.
+package codex
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+const (
+	defaultBinary          = "codex"
+	defaultExpectedVersion = "0.147.0"
+	maxEventData           = 64 << 10
+	maxWireLine            = 2 << 20
+	processStopGrace       = 750 * time.Millisecond
+	processStopTimeout     = 2 * time.Second
+	interruptTimeout       = 1500 * time.Millisecond
+)
+
+// Codex creates its worker skills directory during the first probe, so skills
+// is deliberately absent; interactive config, MCP, plugin, and hook entries
+// remain rejected.
+var unsafeHomeEntries = map[string]struct{}{ //nolint:gochecknoglobals // immutable worker-home policy
+	".codex":      {},
+	".mcp.json":   {},
+	".mcp.toml":   {},
+	"config":      {},
+	"config.json": {},
+	"config.toml": {},
+	"hooks":       {},
+	"mcp":         {},
+	"mcp.json":    {},
+	"mcp.toml":    {},
+	"plugins":     {},
+	"prompts":     {},
+}
+
+var versionPattern = regexp.MustCompile(`(?:codex-cli\s+)?v?([0-9]+\.[0-9]+\.[0-9]+)`) //nolint:gochecknoglobals
+
+// Config selects the Codex executable and its isolated worker home.
+type Config struct {
+	Binary string
+	// Home is a runner-owned CODEX_HOME. It must be separate from an
+	// interactive user's Codex home and independently signed in by the worker.
+	Home            string
+	Model           string
+	ExpectedVersion string
+}
+
+// Adapter is the Codex implementation of harness.Adapter.
+type Adapter struct {
+	cfg Config
+}
+
+var _ harness.Adapter = (*Adapter)(nil)
+
+// New constructs a Codex harness adapter. The returned adapter starts no
+// process until Probe or Run is called.
+func New(cfg Config) harness.Adapter {
+	if strings.TrimSpace(cfg.Binary) == "" {
+		cfg.Binary = defaultBinary
+	}
+	if strings.TrimSpace(cfg.ExpectedVersion) == "" {
+		cfg.ExpectedVersion = defaultExpectedVersion
+	}
+	return &Adapter{cfg: cfg}
+}
+
+// Probe checks the binary version and app-server authentication state without
+// starting a model thread or turn.
+func (a *Adapter) Probe(ctx context.Context) (harness.Info, error) {
+	info := harness.Info{Name: "codex"}
+	if err := a.ensureHome(); err != nil {
+		return info, err
+	}
+	version, err := a.probeVersion(ctx)
+	if err != nil {
+		return info, err
+	}
+	info.Version = version
+	if a.cfg.ExpectedVersion != "" && version != a.cfg.ExpectedVersion {
+		info.Reasons = append(info.Reasons, fmt.Sprintf("expected Codex %s, found %s", a.cfg.ExpectedVersion, version))
+	}
+
+	proc, err := a.startServer(ctx, "")
+	if err != nil {
+		return info, err
+	}
+	defer func() { _ = proc.stop() }()
+	conn := proc.conn
+
+	handler := func(msg wireMessage) error {
+		if isInteractiveRequest(msg.Method) || isAuthNotification(msg.Method) {
+			return &needsInputError{method: msg.Method, data: boundedData(msg.Params), message: "Codex requires user input"}
+		}
+		return nil
+	}
+	if _, err := conn.call(ctx, "initialize", initializeParams(), handler); err != nil {
+		if needsInput(err) || isAuthRPCError(err) {
+			info.Reasons = append(info.Reasons, "Codex authentication requires user input")
+			return infoWithReady(info), nil
+		}
+		return info, err
+	}
+	if err := conn.notify("initialized", map[string]any{}); err != nil {
+		return info, err
+	}
+	account, err := conn.call(ctx, "account/read", map[string]any{"refreshToken": false}, handler)
+	if err != nil {
+		if needsInput(err) || isAuthRPCError(err) {
+			info.Reasons = append(info.Reasons, "Codex authentication requires user input")
+			return infoWithReady(info), nil
+		}
+		return info, err
+	}
+	var accountResult struct {
+		Account            json.RawMessage `json:"account"`
+		RequiresOpenAIAuth bool            `json:"requiresOpenaiAuth"`
+	}
+	if err := json.Unmarshal(account.Result, &accountResult); err != nil {
+		return info, fmt.Errorf("decoding Codex account/read response: %w", err)
+	}
+	if accountResult.RequiresOpenAIAuth {
+		info.Reasons = append(info.Reasons, "Codex authentication is not configured")
+	}
+	return infoWithReady(info), nil
+}
+
+func infoWithReady(info harness.Info) harness.Info {
+	info.Ready = len(info.Reasons) == 0
+	return info
+}
+
+func (a *Adapter) probeVersion(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, a.cfg.Binary, "--version")
+	cmd.Env = safeEnv(a.cfg.Home)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("running Codex version probe: %w: %s", err, trimOutput(output))
+	}
+	match := versionPattern.FindSubmatch(output)
+	if len(match) != 2 {
+		return "", fmt.Errorf("parsing Codex version from %q", trimOutput(output))
+	}
+	return string(match[1]), nil
+}
+
+// Run starts one dedicated app-server process, creates or resumes exactly one
+// thread, starts one turn, forwards events, and stops the process before it
+// returns. A resumed session is never silently replaced with a new thread.
+func (a *Adapter) Run(ctx context.Context, launch harness.Launch, emit harness.Emit) (result harness.Result, err error) {
+	if err := a.ensureHome(); err != nil {
+		return result, err
+	}
+	if err := validateLaunch(launch); err != nil {
+		return result, err
+	}
+	proc, err := a.startServer(ctx, launch.Workdir)
+	if err != nil {
+		return result, err
+	}
+	defer func() {
+		stopErr := proc.stop()
+		if stopErr != nil {
+			if err == nil {
+				err = stopErr
+			} else {
+				err = errors.Join(err, stopErr)
+			}
+		}
+		if ctx.Err() != nil && err == nil {
+			result.Phase = "cancelled"
+		}
+	}()
+
+	state := &runState{emit: emit, sessionID: launch.SessionID}
+	conn := proc.conn
+	if _, callErr := conn.call(ctx, "initialize", initializeParams(), state.handle); callErr != nil {
+		return resultForError(callErr, state), normalizeContextError(ctx, callErr)
+	}
+	if callErr := conn.notify("initialized", map[string]any{}); callErr != nil {
+		return result, callErr
+	}
+
+	threadMethod := "thread/start"
+	threadParams := a.threadStartParams(launch)
+	if launch.SessionID != "" {
+		threadMethod = "thread/resume"
+		threadParams = a.threadResumeParams(launch)
+	}
+	threadResponse, callErr := conn.call(ctx, threadMethod, threadParams, state.handle)
+	if callErr != nil {
+		if needsInput(callErr) {
+			return needsInputResult(state, callErr), nil
+		}
+		if isAuthRPCError(callErr) {
+			return authResult(state, callErr, emit), nil
+		}
+		if launch.SessionID != "" && isMissingThreadError(callErr) {
+			return missingSessionResult(state, callErr, emit), nil
+		}
+		return resultForError(callErr, state), normalizeContextError(ctx, callErr)
+	}
+	responseSessionID := threadID(threadResponse.Result)
+	if responseSessionID == "" {
+		return resultForError(errors.New("codex thread response did not include an id"), state), nil
+	}
+	if state.sessionID != "" && state.sessionID != responseSessionID {
+		return resultForError(fmt.Errorf("codex thread response referenced foreign session %q", responseSessionID), state), nil
+	}
+	state.sessionID = responseSessionID
+	if err := state.emitEvent(harness.Event{
+		Type:      "session",
+		SessionID: state.sessionID,
+		Message:   "Codex session ready",
+		Data:      boundedData(threadResponse.Result),
+	}); err != nil {
+		return result, err
+	}
+
+	turnParams := a.turnStartParams(launch, state.sessionID)
+	turnResponse, callErr := conn.call(ctx, "turn/start", turnParams, state.handle)
+	if callErr != nil {
+		if needsInput(callErr) {
+			return needsInputResult(state, callErr), nil
+		}
+		if isAuthRPCError(callErr) {
+			return authResult(state, callErr, emit), nil
+		}
+		return resultForError(callErr, state), normalizeContextError(ctx, callErr)
+	}
+	if state.turnID == "" {
+		state.turnID = turnID(turnResponse.Result)
+	}
+	if state.done {
+		return state.result(), nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			if state.turnID != "" {
+				interruptCtx, cancel := context.WithTimeout(context.Background(), interruptTimeout)
+				_, _ = conn.call(interruptCtx, "turn/interrupt", map[string]any{
+					"threadId": state.sessionID,
+					"turnId":   state.turnID,
+				}, state.handle)
+				cancel()
+			}
+			result = harness.Result{Phase: "cancelled", SessionID: state.sessionID}
+			return result, nil
+		case msg := <-conn.messages:
+			if handleErr := state.handle(msg); handleErr != nil {
+				if needsInput(handleErr) {
+					return needsInputResult(state, handleErr), nil
+				}
+				return resultForError(handleErr, state), nil
+			}
+			if state.done {
+				return state.result(), nil
+			}
+		case readErr := <-conn.errors:
+			if readErr == nil {
+				readErr = io.EOF
+			}
+			return resultForError(fmt.Errorf("reading Codex app-server: %w", readErr), state), normalizeContextError(ctx, readErr)
+		}
+	}
+}
+
+func (a *Adapter) ensureHome() error {
+	home := strings.TrimSpace(a.cfg.Home)
+	if home == "" {
+		return errors.New("codex runner home is required and must be dedicated to the worker")
+	}
+	if !filepath.IsAbs(home) {
+		return fmt.Errorf("codex runner home must be absolute: %q", home)
+	}
+	if info, err := os.Lstat(home); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("codex runner home must not be a symlink: %q", home)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect codex runner home: %w", err)
+	}
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		return fmt.Errorf("creating codex runner home: %w", err)
+	}
+	if err := os.Chmod(home, 0o700); err != nil {
+		return fmt.Errorf("protecting codex runner home: %w", err)
+	}
+	entries, err := os.ReadDir(home)
+	if err != nil {
+		return fmt.Errorf("reading codex runner home: %w", err)
+	}
+	for _, entry := range entries {
+		name := strings.ToLower(entry.Name())
+		if _, unsafe := unsafeHomeEntries[name]; unsafe {
+			return fmt.Errorf("codex runner home contains interactive configuration %q; use a dedicated worker home", entry.Name())
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("codex runner home contains symlink %q; use a dedicated worker home", entry.Name())
+		}
+	}
+	return nil
+}
+
+func validateLaunch(launch harness.Launch) error {
+	if strings.TrimSpace(launch.Workdir) == "" {
+		return errors.New("codex launch workdir is required")
+	}
+	if strings.TrimSpace(launch.Instructions) == "" {
+		return errors.New("codex launch instructions are required")
+	}
+	return nil
+}
+
+func normalizeContextError(ctx context.Context, err error) error {
+	if ctx.Err() != nil {
+		return nil
+	}
+	return err
+}
+
+func (a *Adapter) threadStartParams(launch harness.Launch) map[string]any {
+	params := map[string]any{
+		"approvalPolicy": "on-request",
+		"cwd":            launch.Workdir,
+		"sandbox":        "workspace-write",
+	}
+	if model := a.model(launch); model != "" {
+		params["model"] = model
+	}
+	return params
+}
+
+func (a *Adapter) threadResumeParams(launch harness.Launch) map[string]any {
+	params := map[string]any{
+		"approvalPolicy": "on-request",
+		"cwd":            launch.Workdir,
+		"sandbox":        "workspace-write",
+		"threadId":       launch.SessionID,
+	}
+	if model := a.model(launch); model != "" {
+		params["model"] = model
+	}
+	return params
+}
+
+func (a *Adapter) turnStartParams(launch harness.Launch, sessionID string) map[string]any {
+	params := map[string]any{
+		"approvalPolicy": "on-request",
+		"cwd":            launch.Workdir,
+		"input": []map[string]string{{
+			"type": "text",
+			"text": launch.Instructions,
+		}},
+		"sandboxPolicy": map[string]any{
+			"networkAccess": false,
+			"type":          "workspaceWrite",
+			"writableRoots": []string{launch.Workdir},
+		},
+		"threadId": sessionID,
+	}
+	if model := a.model(launch); model != "" {
+		params["model"] = model
+	}
+	return params
+}
+
+func (a *Adapter) model(launch harness.Launch) string {
+	if strings.TrimSpace(launch.Model) != "" {
+		return launch.Model
+	}
+	return a.cfg.Model
+}
+
+func initializeParams() map[string]any {
+	return map[string]any{
+		"clientInfo": map[string]string{
+			"name":    "faros-runner",
+			"title":   "Faros Runner",
+			"version": "0.1.0",
+		},
+	}
+}
+
+func safeEnv(home string) []string {
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, item := range os.Environ() {
+		key, _, ok := strings.Cut(item, "=")
+		if !ok {
+			continue
+		}
+		upper := strings.ToUpper(key)
+		if blockedEnvKey(upper) {
+			continue
+		}
+		env = append(env, item)
+	}
+	if strings.TrimSpace(home) != "" {
+		cacheHome := filepath.Join(home, "cache")
+		env = append(env, "HOME="+home)
+		env = append(env, "CODEX_HOME="+home)
+		env = append(env, "XDG_CONFIG_HOME="+home)
+		env = append(env, "XDG_DATA_HOME="+home)
+		env = append(env, "XDG_CACHE_HOME="+cacheHome)
+		env = append(env, "GIT_CONFIG_GLOBAL="+os.DevNull)
+		env = append(env, "GIT_CONFIG_SYSTEM="+os.DevNull)
+		env = append(env, "GIT_CONFIG_NOSYSTEM=1")
+	}
+	return env
+}
+
+func blockedEnvKey(key string) bool {
+	if key == "HOME" || key == "CODEX_HOME" || strings.HasPrefix(key, "XDG_") {
+		return true
+	}
+	if key == "GH_TOKEN" || strings.HasPrefix(key, "GH_") || key == "GITHUB_TOKEN" || strings.HasPrefix(key, "GITHUB_") {
+		return true
+	}
+	if key == "GIT_CONFIG_GLOBAL" || key == "GIT_CONFIG_SYSTEM" || key == "GIT_CONFIG_NOSYSTEM" || strings.HasPrefix(key, "GIT_CONFIG_") {
+		return true
+	}
+	if key == "GIT_SSH" || key == "GIT_SSH_COMMAND" || key == "GIT_ASKPASS" || key == "SSH_AUTH_SOCK" || key == "SSH_AGENT_PID" {
+		return true
+	}
+	return key == "OPENAI_API_KEY" || key == "CODEX_API_KEY" || key == "CHATGPT_API_KEY"
+}
+
+type serverProcess struct {
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	conn    *rpcConn
+	done    chan error
+	stopMu  sync.Mutex
+	stopped bool
+}
+
+func (a *Adapter) startServer(ctx context.Context, workdir string) (*serverProcess, error) {
+	cmd := exec.Command(a.cfg.Binary, "app-server", "--listen", "stdio://")
+	cmd.Env = safeEnv(a.cfg.Home)
+	if workdir != "" {
+		cmd.Dir = workdir
+	}
+	configureProcess(cmd)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("opening codex app-server stdout: %w", err)
+	}
+	cmd.Stderr = &limitedBuffer{limit: 32 << 10}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("opening codex app-server stdin: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("starting codex app-server: %w", err)
+	}
+	proc := &serverProcess{cmd: cmd, stdin: stdin, done: make(chan error, 1)}
+	proc.conn = newRPCConn(stdin, stdout)
+	go func() { proc.done <- cmd.Wait() }()
+	if ctx.Err() != nil {
+		_ = proc.stop()
+		return nil, ctx.Err()
+	}
+	return proc, nil
+}
+
+func (p *serverProcess) stop() error {
+	p.stopMu.Lock()
+	defer p.stopMu.Unlock()
+	if p.stopped {
+		return nil
+	}
+	p.stopped = true
+	closeErr := p.stdin.Close()
+	select {
+	case waitErr := <-p.done:
+		return errors.Join(closeErr, waitErr)
+	case <-time.After(processStopGrace):
+	}
+	killErr := killProcessGroup(p.cmd)
+	select {
+	case waitErr := <-p.done:
+		// A process-group kill is expected to report an interrupted wait. The
+		// cleanup itself succeeded when the group was signalled and the child
+		// exited within the bounded wait below.
+		if killErr == nil {
+			return closeErr
+		}
+		return errors.Join(closeErr, killErr, waitErr)
+	case <-time.After(processStopTimeout):
+		return errors.Join(closeErr, killErr, errors.New("timed out stopping codex app-server process"))
+	}
+}
+
+type limitedBuffer struct {
+	buf   bytes.Buffer
+	limit int
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.buf.Len()
+	if remaining > 0 {
+		_, _ = b.buf.Write(p[:min(len(p), remaining)])
+	}
+	return len(p), nil
+}
+
+type wireMessage struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+}
+
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *rpcError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("codex app-server error %d: %s", e.Code, e.Message)
+}
+
+type rpcConn struct {
+	stdin    io.Writer
+	writeMu  sync.Mutex
+	nextID   uint64
+	messages chan wireMessage
+	errors   chan error
+}
+
+func newRPCConn(stdin io.Writer, stdout io.Reader) *rpcConn {
+	c := &rpcConn{
+		stdin:    stdin,
+		messages: make(chan wireMessage, 64),
+		errors:   make(chan error, 1),
+	}
+	go c.read(stdout)
+	return c
+}
+
+func (c *rpcConn) read(stdout io.Reader) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 4096), maxWireLine)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var msg wireMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			c.errors <- fmt.Errorf("decoding Codex app-server message: %w", err)
+			return
+		}
+		c.messages <- msg
+	}
+	if err := scanner.Err(); err != nil {
+		c.errors <- err
+		return
+	}
+	c.errors <- io.EOF
+}
+
+func (c *rpcConn) notify(method string, params any) error {
+	return c.send(map[string]any{"method": method, "params": params})
+}
+
+func (c *rpcConn) call(ctx context.Context, method string, params any, handle func(wireMessage) error) (wireMessage, error) {
+	c.nextID++
+	id := c.nextID
+	if err := c.send(map[string]any{"id": id, "method": method, "params": params}); err != nil {
+		return wireMessage{}, err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return wireMessage{}, ctx.Err()
+		case msg := <-c.messages:
+			if hasID(msg.ID) && string(bytes.TrimSpace(msg.ID)) == strconv.FormatUint(id, 10) {
+				if msg.Error != nil {
+					return msg, msg.Error
+				}
+				return msg, nil
+			}
+			if msg.Method != "" && handle != nil {
+				if err := handle(msg); err != nil {
+					return wireMessage{}, err
+				}
+			}
+		case err := <-c.errors:
+			if err == nil {
+				err = io.EOF
+			}
+			return wireMessage{}, err
+		}
+	}
+}
+
+func (c *rpcConn) send(value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	_, err = c.stdin.Write(data)
+	return err
+}
+
+func hasID(id json.RawMessage) bool {
+	id = bytes.TrimSpace(id)
+	return len(id) > 0 && !bytes.Equal(id, []byte("null"))
+}
+
+type needsInputError struct {
+	method  string
+	data    json.RawMessage
+	message string
+}
+
+func (e *needsInputError) Error() string {
+	if e.message != "" {
+		return e.message
+	}
+	return "codex requires user input"
+}
+
+func needsInput(err error) bool {
+	var target *needsInputError
+	return errors.As(err, &target)
+}
+
+type runState struct {
+	emit      harness.Emit
+	sessionID string
+	turnID    string
+	phase     string
+	blocker   string
+	done      bool
+}
+
+func (s *runState) handle(msg wireMessage) error {
+	if msg.Method == "" {
+		return nil
+	}
+	if isInteractiveRequest(msg.Method) {
+		if err := s.observeSessionID(threadIDFromParams(msg.Params)); err != nil {
+			return err
+		}
+		if err := s.emitEvent(harness.Event{
+			Type:      msg.Method,
+			SessionID: s.sessionID,
+			TurnID:    turnIDFromParams(msg.Params, s.turnID),
+			Message:   interactiveMessage(msg.Method, msg.Params),
+			Data:      boundedData(msg.Params),
+		}); err != nil {
+			return err
+		}
+		return &needsInputError{method: msg.Method, data: boundedData(msg.Params), message: "Codex requires user input"}
+	}
+	if isAuthNotification(msg.Method) {
+		if err := s.observeSessionID(threadIDFromParams(msg.Params)); err != nil {
+			return err
+		}
+		if err := s.emitEvent(harness.Event{
+			Type:      "auth_failure",
+			SessionID: s.sessionID,
+			TurnID:    turnIDFromParams(msg.Params, s.turnID),
+			Message:   "Codex authentication requires user input",
+			Data:      boundedData(msg.Params),
+		}); err != nil {
+			return err
+		}
+		return &needsInputError{method: msg.Method, data: boundedData(msg.Params), message: "Codex authentication requires user input"}
+	}
+
+	switch msg.Method {
+	case "thread/started":
+		if err := s.observeSessionID(threadID(msg.Params)); err != nil {
+			return err
+		}
+	case "turn/started":
+		if err := s.observeSessionID(threadIDFromParams(msg.Params)); err != nil {
+			return err
+		}
+		if id := turnID(msg.Params); id != "" {
+			s.turnID = id
+		}
+		if err := s.emitEvent(harness.Event{
+			Type:      "turn_started",
+			SessionID: s.sessionID,
+			TurnID:    s.turnID,
+			Data:      boundedData(msg.Params),
+		}); err != nil {
+			return err
+		}
+	case "item/agentMessage/delta":
+		var params struct {
+			Delta    string `json:"delta"`
+			ThreadID string `json:"threadId"`
+			TurnID   string `json:"turnId"`
+		}
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return fmt.Errorf("decoding Codex message delta: %w", err)
+		}
+		if err := s.observeSessionID(params.ThreadID); err != nil {
+			return err
+		}
+		if err := s.emitEvent(harness.Event{
+			Type:      "message",
+			SessionID: s.sessionID,
+			TurnID:    firstNonEmpty(params.TurnID, s.turnID),
+			Message:   params.Delta,
+			Data:      boundedData(msg.Params),
+		}); err != nil {
+			return err
+		}
+	case "error":
+		if err := s.observeSessionID(threadIDFromParams(msg.Params)); err != nil {
+			return err
+		}
+		if authData(msg.Params) {
+			if err := s.emitEvent(harness.Event{
+				Type:      "auth_failure",
+				SessionID: s.sessionID,
+				TurnID:    turnIDFromParams(msg.Params, s.turnID),
+				Message:   "Codex authentication requires user input",
+				Data:      boundedData(msg.Params),
+			}); err != nil {
+				return err
+			}
+			return &needsInputError{method: msg.Method, data: boundedData(msg.Params), message: "Codex authentication requires user input"}
+		}
+		if err := s.emitEvent(harness.Event{
+			Type:      msg.Method,
+			SessionID: s.sessionID,
+			TurnID:    turnIDFromParams(msg.Params, s.turnID),
+			Data:      boundedData(msg.Params),
+		}); err != nil {
+			return err
+		}
+	case "turn/completed":
+		var params struct {
+			ThreadID string `json:"threadId"`
+			Turn     struct {
+				ID     string          `json:"id"`
+				Status string          `json:"status"`
+				Error  json.RawMessage `json:"error"`
+			} `json:"turn"`
+		}
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return fmt.Errorf("decoding Codex turn completion: %w", err)
+		}
+		if err := s.observeSessionID(params.ThreadID); err != nil {
+			return err
+		}
+		s.done = true
+		if params.Turn.ID != "" {
+			s.turnID = params.Turn.ID
+		}
+		s.phase = "completed"
+		if params.Turn.Status == "failed" || len(bytes.TrimSpace(params.Turn.Error)) > 0 && !bytes.Equal(bytes.TrimSpace(params.Turn.Error), []byte("null")) {
+			s.phase = "failed"
+			s.blocker = "Codex turn failed"
+			if authData(params.Turn.Error) {
+				s.phase = "needs_input"
+				s.blocker = "Codex authentication requires user input"
+			}
+		} else if params.Turn.Status == "interrupted" {
+			s.phase = "cancelled"
+		}
+		if err := s.emitEvent(harness.Event{
+			Type:      "turn_completed",
+			SessionID: s.sessionID,
+			TurnID:    s.turnID,
+			Message:   s.phase,
+			Data:      boundedData(msg.Params),
+		}); err != nil {
+			return err
+		}
+	default:
+		if err := s.observeSessionID(threadIDFromParams(msg.Params)); err != nil {
+			return err
+		}
+		if err := s.emitEvent(harness.Event{
+			Type:      msg.Method,
+			SessionID: s.sessionID,
+			TurnID:    turnIDFromParams(msg.Params, s.turnID),
+			Data:      boundedData(msg.Params),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *runState) emitEvent(event harness.Event) error {
+	if s.emit == nil {
+		return nil
+	}
+	return s.emit(event)
+}
+
+func (s *runState) observeSessionID(sessionID string) error {
+	if sessionID == "" {
+		return nil
+	}
+	if s.sessionID == "" {
+		s.sessionID = sessionID
+		return nil
+	}
+	if s.sessionID != sessionID {
+		return fmt.Errorf("codex event referenced foreign session %q", sessionID)
+	}
+	return nil
+}
+
+func (s *runState) result() harness.Result {
+	phase := s.phase
+	if phase == "" {
+		phase = "completed"
+	}
+	return harness.Result{Phase: phase, SessionID: s.sessionID, Blocker: s.blocker}
+}
+
+func resultForError(err error, state *runState) harness.Result {
+	result := state.result()
+	result.Phase = "failed"
+	if result.Blocker == "" {
+		result.Blocker = err.Error()
+	}
+	return result
+}
+
+func needsInputResult(state *runState, err error) harness.Result {
+	result := state.result()
+	result.Phase = "needs_input"
+	var target *needsInputError
+	if errors.As(err, &target) && target.message != "" {
+		result.Blocker = target.message
+	} else {
+		result.Blocker = "Codex requires user input"
+	}
+	return result
+}
+
+func authResult(state *runState, err error, emit harness.Emit) harness.Result {
+	data := json.RawMessage(nil)
+	var target *rpcError
+	if errors.As(err, &target) {
+		data = boundedData(target.Data)
+	}
+	if emit != nil {
+		_ = emit(harness.Event{
+			Type:      "auth_failure",
+			SessionID: state.sessionID,
+			TurnID:    state.turnID,
+			Message:   "Codex authentication requires user input",
+			Data:      data,
+		})
+	}
+	return harness.Result{Phase: "needs_input", SessionID: state.sessionID, Blocker: "Codex authentication requires user input"}
+}
+
+func missingSessionResult(state *runState, err error, emit harness.Emit) harness.Result {
+	data := json.RawMessage(nil)
+	var target *rpcError
+	if errors.As(err, &target) {
+		data = boundedData(target.Data)
+	}
+	if emit != nil {
+		_ = emit(harness.Event{
+			Type:      "session_error",
+			SessionID: state.sessionID,
+			Message:   "Codex session was not found",
+			Data:      data,
+		})
+	}
+	return harness.Result{Phase: "needs_input", SessionID: state.sessionID, Blocker: "Codex session was not found"}
+}
+
+func isInteractiveRequest(method string) bool {
+	method = strings.ToLower(method)
+	return strings.Contains(method, "requestapproval") || strings.Contains(method, "requestuserinput") || strings.Contains(method, "request_user_input") || strings.Contains(method, "approval")
+}
+
+func isAuthNotification(method string) bool {
+	method = strings.ToLower(method)
+	if strings.Contains(method, "login") || strings.Contains(method, "reauth") {
+		return true
+	}
+	if strings.Contains(method, "auth") {
+		return strings.Contains(method, "refresh") || strings.Contains(method, "recovery") || strings.Contains(method, "required") || strings.Contains(method, "failure") || strings.Contains(method, "error")
+	}
+	return false
+}
+
+func isAuthRPCError(err error) bool {
+	var target *rpcError
+	if !errors.As(err, &target) {
+		return false
+	}
+	message := strings.ToLower(target.Message)
+	return target.Code == 401 || target.Code == 403 || strings.Contains(message, "auth") || strings.Contains(message, "unauthorized") || strings.Contains(message, "login") || strings.Contains(message, "credential")
+}
+
+func isMissingThreadError(err error) bool {
+	var target *rpcError
+	if !errors.As(err, &target) {
+		return false
+	}
+	message := strings.ToLower(target.Message)
+	return strings.Contains(message, "thread") && (strings.Contains(message, "not found") || strings.Contains(message, "unknown") || strings.Contains(message, "missing") || strings.Contains(message, "invalid session"))
+}
+
+func authData(data json.RawMessage) bool {
+	message := strings.ToLower(string(data))
+	return strings.Contains(message, "auth") || strings.Contains(message, "unauthorized") || strings.Contains(message, "credential") || strings.Contains(message, "login")
+}
+
+func interactiveMessage(method string, params json.RawMessage) string {
+	if len(params) == 0 || bytes.Equal(bytes.TrimSpace(params), []byte("null")) {
+		return method
+	}
+	return method + " requires a user decision"
+}
+
+func boundedData(data json.RawMessage) json.RawMessage {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+	if len(data) <= maxEventData {
+		return append(json.RawMessage(nil), data...)
+	}
+	return json.RawMessage(fmt.Sprintf(`{"truncated":true,"bytes":%d}`, len(data)))
+}
+
+func threadID(data json.RawMessage) string {
+	var value struct {
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+	}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return ""
+	}
+	return value.Thread.ID
+}
+
+func threadIDFromParams(data json.RawMessage) string {
+	var value struct {
+		ThreadID string `json:"threadId"`
+	}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return ""
+	}
+	return value.ThreadID
+}
+
+func turnID(data json.RawMessage) string {
+	var value struct {
+		Turn struct {
+			ID string `json:"id"`
+		} `json:"turn"`
+	}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return ""
+	}
+	return value.Turn.ID
+}
+
+func turnIDFromParams(data json.RawMessage, fallback string) string {
+	var value struct {
+		TurnID string `json:"turnId"`
+	}
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fallback
+	}
+	return firstNonEmpty(value.TurnID, fallback)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func trimOutput(data []byte) string {
+	return strings.TrimSpace(string(bytes.TrimSpace(data)))
+}

--- a/pkg/runner/harness/codex/codex.go
+++ b/pkg/runner/harness/codex/codex.go
@@ -145,15 +145,62 @@ func (a *Adapter) Probe(ctx context.Context) (harness.Info, error) {
 	}
 	var accountResult struct {
 		Account            json.RawMessage `json:"account"`
-		RequiresOpenAIAuth bool            `json:"requiresOpenaiAuth"`
+		RequiresOpenAIAuth json.RawMessage `json:"requiresOpenaiAuth"`
 	}
 	if err := json.Unmarshal(account.Result, &accountResult); err != nil {
 		return info, fmt.Errorf("decoding Codex account/read response: %w", err)
 	}
-	if accountResult.RequiresOpenAIAuth {
+	requiresOpenAIAuth, validAuthRequirement := parseAuthRequirement(accountResult.RequiresOpenAIAuth)
+	accountType, validAccount := parseAccountType(accountResult.Account)
+	if !validAuthRequirement || !validAccount {
+		info.Reasons = append(info.Reasons, "Codex authentication state is unavailable")
+	} else if requiresOpenAIAuth && !isAuthenticatedAccountType(accountType) {
 		info.Reasons = append(info.Reasons, "Codex authentication is not configured")
 	}
 	return infoWithReady(info), nil
+}
+
+func parseAuthRequirement(raw json.RawMessage) (bool, bool) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return false, false
+	}
+
+	var required bool
+	if err := json.Unmarshal(raw, &required); err != nil {
+		return false, false
+	}
+	return required, true
+}
+
+func parseAccountType(raw json.RawMessage) (string, bool) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return "", true
+	}
+
+	var account map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &account); err != nil || account == nil {
+		return "", false
+	}
+	typeRaw, ok := account["type"]
+	if !ok {
+		return "", false
+	}
+	var accountType string
+	if err := json.Unmarshal(typeRaw, &accountType); err != nil || accountType == "" {
+		return "", false
+	}
+	return accountType, true
+}
+
+func isAuthenticatedAccountType(accountType string) bool {
+	switch accountType {
+	case "apiKey", "chatgpt":
+		return true
+	default:
+		return false
+	}
 }
 
 func infoWithReady(info harness.Info) harness.Info {

--- a/pkg/runner/harness/codex/codex.go
+++ b/pkg/runner/harness/codex/codex.go
@@ -72,7 +72,9 @@ type Config struct {
 	Binary string
 	// Home is a runner-owned CODEX_HOME. It must be separate from an
 	// interactive user's Codex home and independently signed in by the worker.
-	Home            string
+	Home string
+	// WorktreeRoot permits trust-only configuration for managed task checkouts.
+	WorktreeRoot    string
 	Model           string
 	ExpectedVersion string
 }
@@ -232,6 +234,9 @@ func (a *Adapter) Run(ctx context.Context, launch harness.Launch, emit harness.E
 	if err := validateLaunch(launch); err != nil {
 		return result, err
 	}
+	if err := a.validateLaunchConfiguration(launch.Workdir); err != nil {
+		return result, err
+	}
 	proc, err := a.startServer(ctx, launch.Workdir)
 	if err != nil {
 		return result, err
@@ -370,6 +375,12 @@ func (a *Adapter) ensureHome() error {
 	}
 	for _, entry := range entries {
 		name := strings.ToLower(entry.Name())
+		if name == codexConfigName && entry.Name() == codexConfigName {
+			if _, err := validateCodexConfig(home, a.cfg.WorktreeRoot); err != nil {
+				return err
+			}
+			continue
+		}
 		if _, unsafe := unsafeHomeEntries[name]; unsafe {
 			return fmt.Errorf("codex runner home contains interactive configuration %q; use a dedicated worker home", entry.Name())
 		}

--- a/pkg/runner/harness/codex/codex.go
+++ b/pkg/runner/harness/codex/codex.go
@@ -47,9 +47,9 @@ const (
 	interruptTimeout       = 1500 * time.Millisecond
 )
 
-// Codex creates its worker skills directory during the first probe, so skills
-// is deliberately absent; interactive config, MCP, plugin, and hook entries
-// remain rejected.
+// Codex creates skills and plugin cache directories in its own home. Plugin
+// caches are permitted below, but extensions are explicitly disabled for every
+// app-server process. Interactive config, MCP, and hook entries remain rejected.
 var unsafeHomeEntries = map[string]struct{}{ //nolint:gochecknoglobals // immutable worker-home policy
 	".codex":      {},
 	".mcp.json":   {},
@@ -375,6 +375,9 @@ func (a *Adapter) ensureHome() error {
 	}
 	for _, entry := range entries {
 		name := strings.ToLower(entry.Name())
+		if entry.Name() == "plugins" && entry.IsDir() && entry.Type()&os.ModeSymlink == 0 {
+			continue
+		}
 		if name == codexConfigName && entry.Name() == codexConfigName {
 			if _, err := validateCodexConfig(home, a.cfg.WorktreeRoot); err != nil {
 				return err
@@ -524,7 +527,10 @@ type serverProcess struct {
 }
 
 func (a *Adapter) startServer(ctx context.Context, workdir string) (*serverProcess, error) {
-	cmd := exec.Command(a.cfg.Binary, "app-server", "--listen", "stdio://")
+	// Keep extension execution policy independent of whether Codex has created
+	// its cache directories. Apply it to probes, new sessions, and resumed ones.
+	cmd := exec.Command(a.cfg.Binary, "app-server", "--listen", "stdio://",
+		"--disable", "apps", "--disable", "plugins", "--disable", "hooks")
 	cmd.Env = safeEnv(a.cfg.Home)
 	if workdir != "" {
 		cmd.Dir = workdir

--- a/pkg/runner/harness/codex/codex_auth_state_verify_test.go
+++ b/pkg/runner/harness/codex/codex_auth_state_verify_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProbeAllowsMissingAccountWhenOpenAIAuthIsNotRequired(t *testing.T) {
+	binary := fakeCodexBinaryMissingAccount(t)
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+
+	info, err := adapter.Probe(context.Background())
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if !info.Ready || len(info.Reasons) != 0 {
+		t.Fatalf("probe rejected optional account for an unauthenticated provider: %+v", info)
+	}
+}
+
+func fakeCodexBinaryMissingAccount(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "codex")
+	content := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo codex-cli 0.147.0; exit 0; fi\nFAROS_FAKE_MISSING_ACCOUNT_CHILD=1 exec %q -test.run=TestFakeMissingAccountAppServerProcess\n", os.Args[0])
+	if err := os.WriteFile(script, []byte(content), 0700); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestFakeMissingAccountAppServerProcess(t *testing.T) {
+	if os.Getenv("FAROS_FAKE_MISSING_ACCOUNT_CHILD") != "1" {
+		return
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		var request map[string]any
+		if json.Unmarshal(scanner.Bytes(), &request) != nil {
+			continue
+		}
+		method, _ := request["method"].(string)
+		switch method {
+		case "initialize":
+			writeResponse(map[string]any{"id": request["id"], "result": map[string]any{"userAgent": "fake", "codexHome": os.Getenv("CODEX_HOME"), "platformFamily": "unix", "platformOs": "linux"}})
+		case "account/read":
+			writeResponse(map[string]any{"id": request["id"], "result": map[string]any{"requiresOpenaiAuth": false}})
+		}
+	}
+	os.Exit(0)
+}

--- a/pkg/runner/harness/codex/codex_contract_test.go
+++ b/pkg/runner/harness/codex/codex_contract_test.go
@@ -138,7 +138,7 @@ func TestRunRejectsForeignResumeResponseAndCompletion(t *testing.T) {
 }
 
 func TestEnsureHomeRejectsInteractiveConfiguration(t *testing.T) {
-	for _, name := range []string{"config.toml", "mcp.json", "plugins", "hooks"} {
+	for _, name := range []string{"config.toml", "mcp.json", "hooks"} {
 		t.Run(name, func(t *testing.T) {
 			home := t.TempDir()
 			path := filepath.Join(home, name)
@@ -347,5 +347,92 @@ func TestFakeCleanupAppServerProcess(t *testing.T) {
 	}
 	for {
 		time.Sleep(time.Hour)
+	}
+}
+
+func TestPluginCacheDoesNotEnableExtensions(t *testing.T) {
+	binary := fakeCodexBinary(t, "success")
+	home := t.TempDir()
+	for _, name := range []string{"cache", ".remote-plugin-install-staging"} {
+		if err := os.MkdirAll(filepath.Join(home, "plugins", name), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	marker := filepath.Join(home, "plugins", "cache", "fixture.txt")
+	if err := os.WriteFile(marker, []byte("preserve cache"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	adapter := New(Config{Home: home, Binary: binary, ExpectedVersion: "0.147.0"})
+	checkArgs := func() {
+		t.Helper()
+		raw, err := os.ReadFile(filepath.Join(filepath.Dir(binary), "argv"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		args := strings.Split(strings.TrimSpace(string(raw)), "\n")
+		for _, feature := range []string{"apps", "plugins", "hooks"} {
+			found := false
+			for i := 0; i+1 < len(args); i++ {
+				if args[i] == "--disable" && args[i+1] == feature {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("%s not disabled: %v", feature, args)
+			}
+		}
+	}
+	for range 2 {
+		info, err := adapter.Probe(context.Background())
+		if err != nil || !info.Ready {
+			t.Fatalf("probe=%+v err=%v", info, err)
+		}
+		checkArgs()
+	}
+	for _, method := range readMethods(t, filepath.Join(filepath.Dir(binary), "methods")) {
+		if method == "thread/start" || method == "thread/resume" || method == "turn/start" {
+			t.Fatal("probe started model")
+		}
+	}
+	for _, session := range []string{"", "original-session"} {
+		result, err := adapter.Run(context.Background(), harness.Launch{Workdir: t.TempDir(), Instructions: "approved", SessionID: session}, nil)
+		if err != nil || result.Phase != "completed" {
+			t.Fatalf("run=%+v err=%v", result, err)
+		}
+		if session != "" && result.SessionID != session {
+			t.Fatal("resume replaced session")
+		}
+		checkArgs()
+	}
+	raw, err := os.ReadFile(marker)
+	if err != nil || string(raw) != "preserve cache" {
+		t.Fatal("cache changed")
+	}
+}
+
+func TestPluginCacheRejectsUnsafeHomeEntries(t *testing.T) {
+	for _, kind := range []string{"file", "symlink", "case-variant"} {
+		t.Run(kind, func(t *testing.T) {
+			home := t.TempDir()
+			path := filepath.Join(home, "plugins")
+			switch kind {
+			case "file":
+				if err := os.WriteFile(path, []byte("not a cache directory"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "symlink":
+				if err := os.Symlink(t.TempDir(), path); err != nil {
+					t.Fatal(err)
+				}
+			case "case-variant":
+				if err := os.Mkdir(filepath.Join(home, "Plugins"), 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			a := &Adapter{cfg: Config{Home: home}}
+			if err := a.ensureHome(); err == nil {
+				t.Fatal("unsafe plugin entry accepted")
+			}
+		})
 	}
 }

--- a/pkg/runner/harness/codex/codex_contract_test.go
+++ b/pkg/runner/harness/codex/codex_contract_test.go
@@ -1,0 +1,351 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+func TestNewUsesContractDefaultVersionPin(t *testing.T) {
+	adapter, ok := New(Config{Home: t.TempDir()}).(*Adapter)
+	if !ok {
+		t.Fatal("New did not return the Codex adapter")
+	}
+	if adapter.cfg.ExpectedVersion != "0.147.0" {
+		t.Fatalf("default expected Codex version = %q, want 0.147.0", adapter.cfg.ExpectedVersion)
+	}
+}
+
+func TestProbeAuthenticationNeedsInputWithoutStartingModelWork(t *testing.T) {
+	binary := fakeCodexBinary(t, "auth")
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+
+	info, err := adapter.Probe(context.Background())
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if info.Ready {
+		t.Fatalf("auth-required probe reported ready: %+v", info)
+	}
+	if len(info.Reasons) == 0 || !strings.Contains(strings.ToLower(strings.Join(info.Reasons, " ")), "authentication") {
+		t.Fatalf("auth-required probe reasons = %v", info.Reasons)
+	}
+	methods := readMethods(t, filepath.Join(filepath.Dir(binary), "methods"))
+	if strings.Contains(strings.Join(methods, ","), "thread/start") || strings.Contains(strings.Join(methods, ","), "turn/start") {
+		t.Fatalf("auth probe started model work: %v", methods)
+	}
+}
+
+func TestRunResumeUsesExactExistingSession(t *testing.T) {
+	binary := fakeCodexBinary(t, "success")
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+	result, err := adapter.Run(context.Background(), harness.Launch{
+		AttemptID:    "attempt-resume",
+		Workdir:      t.TempDir(),
+		SessionID:    "thread-existing",
+		Instructions: "continue the existing session",
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Phase != "completed" || result.SessionID != "thread-existing" {
+		t.Fatalf("resume result = %+v", result)
+	}
+	methods := readMethods(t, filepath.Join(filepath.Dir(binary), "methods"))
+	if strings.Contains(strings.Join(methods, ","), "thread/start") {
+		t.Fatalf("resume started a new thread: %v", methods)
+	}
+	requests := readJSONLines(t, filepath.Join(filepath.Dir(binary), "requests"))
+	if len(requests) < 4 || requests[2]["method"] != "thread/resume" {
+		t.Fatalf("resume requests = %v", requests)
+	}
+	threadParams, ok := requests[2]["params"].(map[string]any)
+	if !ok || threadParams["threadId"] != "thread-existing" {
+		t.Fatalf("resume thread params = %v", requests[2]["params"])
+	}
+	turnParams, ok := requests[3]["params"].(map[string]any)
+	if !ok || turnParams["threadId"] != "thread-existing" {
+		t.Fatalf("resume turn params = %v", requests[3]["params"])
+	}
+}
+
+func TestRunRejectsForeignResumeResponseAndCompletion(t *testing.T) {
+	t.Run("resume response", func(t *testing.T) {
+		binary := fakeCodexBinary(t, "foreign-resume")
+		adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+		result, err := adapter.Run(context.Background(), harness.Launch{
+			AttemptID:    "attempt-foreign-resume",
+			Workdir:      t.TempDir(),
+			SessionID:    "thread-existing",
+			Instructions: "continue the approved session",
+		}, nil)
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if result.Phase != "failed" {
+			t.Fatalf("foreign resume result = %+v, want failed", result)
+		}
+		methods := readMethods(t, filepath.Join(filepath.Dir(binary), "methods"))
+		if strings.Contains(strings.Join(methods, ","), "turn/start") {
+			t.Fatalf("foreign resume started a turn: %v", methods)
+		}
+	})
+
+	t.Run("completion event", func(t *testing.T) {
+		binary := fakeCodexBinary(t, "foreign-completion")
+		adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+		result, err := adapter.Run(context.Background(), harness.Launch{
+			AttemptID:    "attempt-foreign-completion",
+			Workdir:      t.TempDir(),
+			Instructions: "run the approved turn",
+		}, nil)
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if result.Phase != "failed" {
+			t.Fatalf("foreign completion result = %+v, want failed", result)
+		}
+	})
+}
+
+func TestEnsureHomeRejectsInteractiveConfiguration(t *testing.T) {
+	for _, name := range []string{"config.toml", "mcp.json", "plugins", "hooks"} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			path := filepath.Join(home, name)
+			if filepath.Ext(name) != "" {
+				if err := os.WriteFile(path, []byte("interactive"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.Mkdir(path, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			adapter, ok := New(Config{Home: home}).(*Adapter)
+			if !ok {
+				t.Fatal("New did not return the Codex adapter")
+			}
+			if err := adapter.ensureHome(); err == nil {
+				t.Fatalf("ensureHome accepted unsafe entry %q", name)
+			}
+		})
+	}
+}
+
+func TestSafeEnvDropsAllInteractiveCredentialsAndGlobalConfiguration(t *testing.T) {
+	secrets := map[string]string{
+		"HOME":                "/interactive/home",
+		"CODEX_HOME":          "/interactive/codex",
+		"XDG_CONFIG_HOME":     "/interactive/config",
+		"XDG_DATA_HOME":       "/interactive/data",
+		"XDG_CACHE_HOME":      "/interactive/cache",
+		"GIT_CONFIG_GLOBAL":   "/interactive/gitconfig",
+		"GIT_CONFIG_SYSTEM":   "/interactive/system-gitconfig",
+		"GIT_CONFIG_NOSYSTEM": "0",
+		"GIT_CONFIG_COUNT":    "1",
+		"GIT_SSH":             "/interactive/ssh",
+		"GIT_SSH_COMMAND":     "ssh -i /interactive/key",
+		"GIT_ASKPASS":         "/interactive/askpass",
+		"GH_TOKEN":            "gh-secret",
+		"GH_ENTERPRISE_TOKEN": "gh-enterprise-secret",
+		"GITHUB_TOKEN":        "github-secret",
+		"GITHUB_ACTIONS":      "true",
+		"OPENAI_API_KEY":      "openai-secret",
+		"CODEX_API_KEY":       "codex-secret",
+		"CHATGPT_API_KEY":     "chatgpt-secret",
+		"SSH_AUTH_SOCK":       "/interactive/agent.sock",
+		"SSH_AGENT_PID":       "1234",
+	}
+	for key, value := range secrets {
+		t.Setenv(key, value)
+	}
+
+	runnerHome := filepath.Join(t.TempDir(), "codex-home")
+	env := safeEnv(runnerHome)
+	values := map[string][]string{}
+	for _, item := range env {
+		key, value, ok := strings.Cut(item, "=")
+		if ok {
+			values[key] = append(values[key], value)
+		}
+	}
+	for key := range secrets {
+		if key == "HOME" || key == "CODEX_HOME" || strings.HasPrefix(key, "XDG_") || key == "GIT_CONFIG_GLOBAL" || key == "GIT_CONFIG_SYSTEM" || key == "GIT_CONFIG_NOSYSTEM" {
+			continue
+		}
+		if got := values[key]; len(got) != 0 {
+			t.Fatalf("blocked environment key %s leaked values %q", key, got)
+		}
+	}
+	for _, key := range []string{"GH_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_TOKEN", "GITHUB_ACTIONS", "OPENAI_API_KEY", "CODEX_API_KEY", "CHATGPT_API_KEY", "SSH_AUTH_SOCK", "SSH_AGENT_PID", "GIT_SSH", "GIT_SSH_COMMAND", "GIT_ASKPASS", "GIT_CONFIG_COUNT"} {
+		if got := values[key]; len(got) != 0 {
+			t.Fatalf("interactive credential/config key %s leaked values %q", key, got)
+		}
+	}
+	for key, want := range map[string]string{
+		"HOME":                runnerHome,
+		"CODEX_HOME":          runnerHome,
+		"XDG_CONFIG_HOME":     runnerHome,
+		"XDG_DATA_HOME":       runnerHome,
+		"XDG_CACHE_HOME":      filepath.Join(runnerHome, "cache"),
+		"GIT_CONFIG_GLOBAL":   os.DevNull,
+		"GIT_CONFIG_SYSTEM":   os.DevNull,
+		"GIT_CONFIG_NOSYSTEM": "1",
+	} {
+		if got := values[key]; len(got) != 1 || got[0] != want {
+			t.Fatalf("isolated %s = %q, want [%q]", key, got, want)
+		}
+	}
+}
+
+func TestRunCancellationKillsProcessGroupDescendants(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process groups use the Unix implementation")
+	}
+	pidFile := filepath.Join(t.TempDir(), "descendant.pid")
+	logFile := filepath.Join(t.TempDir(), "cleanup.log")
+	binary := fakeCleanupCodexBinary(t, pidFile, logFile)
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.153.4"})
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	resultCh := make(chan harness.Result, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := adapter.Run(ctx, harness.Launch{AttemptID: "attempt-cleanup", Workdir: t.TempDir(), Instructions: "wait"}, func(event harness.Event) error {
+			if event.Type == "turn_started" {
+				close(started)
+			}
+			return nil
+		})
+		resultCh <- result
+		errCh <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("cleanup harness did not start a turn")
+	}
+	var descendantPID int
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidFile)
+		if err == nil {
+			if descendantPID, err = strconv.Atoi(strings.TrimSpace(string(data))); err == nil && descendantPID > 0 {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if descendantPID == 0 {
+		t.Fatal("cleanup harness did not publish descendant pid")
+	}
+	cancel()
+	select {
+	case result := <-resultCh:
+		if result.Phase != "cancelled" {
+			t.Fatalf("cancellation result = %+v", result)
+		}
+		if err := <-errCh; err != nil {
+			log, _ := os.ReadFile(logFile)
+			t.Fatalf("Run: %v (child log=%q)", err, log)
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("Run did not stop after cancellation")
+	}
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(descendantPID, 0); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("descendant process %d survived Codex process-group cleanup", descendantPID)
+}
+
+func fakeCleanupCodexBinary(t *testing.T, pidFile, logFile string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "codex")
+	content := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo codex-cli 0.153.4; exit 0; fi\nFAROS_FAKE_CLEANUP_CHILD=1 FAROS_FAKE_CLEANUP_PID=%q FAROS_FAKE_CLEANUP_LOG=%q exec %q -test.run=TestFakeCleanupAppServerProcess\n", pidFile, logFile, os.Args[0])
+	if err := os.WriteFile(script, []byte(content), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestFakeCleanupAppServerProcess(t *testing.T) {
+	if os.Getenv("FAROS_FAKE_CLEANUP_CHILD") != "1" {
+		return
+	}
+	logFile := os.Getenv("FAROS_FAKE_CLEANUP_LOG")
+	log := func(message string) {
+		_ = os.WriteFile(logFile, []byte(message), 0o600)
+	}
+	child := exec.Command("sh", "-c", "sleep 60")
+	if err := child.Start(); err != nil {
+		log("child start: " + err.Error())
+		os.Exit(2)
+	}
+	if err := os.WriteFile(os.Getenv("FAROS_FAKE_CLEANUP_PID"), []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+		log("pid write: " + err.Error())
+		os.Exit(2)
+	}
+	log("ready")
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		var request map[string]any
+		if json.Unmarshal(scanner.Bytes(), &request) != nil {
+			continue
+		}
+		method, _ := request["method"].(string)
+		id := request["id"]
+		switch method {
+		case "initialize":
+			writeResponse(map[string]any{"id": id, "result": map[string]any{}})
+		case "thread/start":
+			writeResponse(map[string]any{"id": id, "result": map[string]any{"thread": map[string]any{"id": "thread-cleanup"}}})
+		case "turn/start":
+			writeResponse(map[string]any{"id": id, "result": map[string]any{"turn": map[string]any{"id": "turn-cleanup", "status": "inProgress"}}})
+			writeNotification("turn/started", map[string]any{"threadId": "thread-cleanup", "turn": map[string]any{"id": "turn-cleanup", "status": "inProgress"}})
+		case "turn/interrupt":
+			// Keep the app-server alive until the adapter's process-group kill.
+		default:
+			if id != nil {
+				writeResponse(map[string]any{"id": id, "result": map[string]any{}})
+			}
+		}
+	}
+	for {
+		time.Sleep(time.Hour)
+	}
+}

--- a/pkg/runner/harness/codex/codex_test.go
+++ b/pkg/runner/harness/codex/codex_test.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+func TestProbeUsesVersionAndAccountReadWithoutModelCall(t *testing.T) {
+	binary := fakeCodexBinary(t, "probe")
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+
+	info, err := adapter.Probe(context.Background())
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if !info.Ready || info.Version != "0.147.0" {
+		t.Fatalf("unexpected probe info: %+v", info)
+	}
+	methods := readMethods(t, filepath.Join(filepath.Dir(binary), "methods"))
+	want := []string{"initialize", "initialized", "account/read"}
+	if strings.Join(methods, ",") != strings.Join(want, ",") {
+		t.Fatalf("probe methods = %v, want %v", methods, want)
+	}
+	for _, method := range methods {
+		if method == "thread/start" || method == "thread/resume" || method == "turn/start" {
+			t.Fatalf("probe unexpectedly called model method %q", method)
+		}
+	}
+}
+
+func TestRunLifecycleStartsSessionBeforeTurnAndSanitizesEnvironment(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), "env.json")
+	binary := fakeCodexBinaryWithEnvFile(t, "success", envFile)
+	oldGH := os.Getenv("GITHUB_TOKEN")
+	oldGitHub := os.Getenv("GITHUB_ACTIONS")
+	t.Setenv("GITHUB_TOKEN", "secret-github-token")
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GIT_CONFIG_GLOBAL", "/tmp/shared-gitconfig")
+	t.Setenv("SSH_AUTH_SOCK", "/tmp/shared-agent.sock")
+	t.Cleanup(func() {
+		_ = os.Setenv("GITHUB_TOKEN", oldGH)
+		_ = os.Setenv("GITHUB_ACTIONS", oldGitHub)
+	})
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), Model: "model-147", ExpectedVersion: "0.147.0"})
+	var events []harness.Event
+	result, err := adapter.Run(context.Background(), harness.Launch{
+		AttemptID:    "attempt-1",
+		Workdir:      t.TempDir(),
+		Instructions: "say hello",
+	}, func(event harness.Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Phase != "completed" || result.SessionID != "thread-1" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if len(events) < 3 || events[0].Type != "session" || events[1].Type != "message" || events[2].Type != "turn_completed" {
+		t.Fatalf("unexpected event order: %+v", events)
+	}
+	if events[1].Message != "hello" {
+		t.Fatalf("message event = %+v", events[1])
+	}
+	envData := readJSONFile(t, envFile)
+	if envData["GITHUB_TOKEN"] != "" || envData["GITHUB_ACTIONS"] != "" {
+		t.Fatalf("github credentials leaked into app-server environment: %v", envData)
+	}
+	if got, _ := envData["CODEX_HOME"].(string); got == "" {
+		t.Fatalf("CODEX_HOME was not set: %v", envData)
+	}
+	if envData["HOME"] != envData["CODEX_HOME"] || envData["XDG_CONFIG_HOME"] != envData["CODEX_HOME"] {
+		t.Fatalf("worker home was not isolated: %v", envData)
+	}
+	if envData["GIT_CONFIG_GLOBAL"] == "" || envData["SSH_AUTH_SOCK"] != "" {
+		t.Fatalf("git/ssh configuration was not sanitized: %v", envData)
+	}
+	methods := readMethods(t, filepath.Join(filepath.Dir(binary), "methods"))
+	if strings.Join(methods, ",") != "initialize,initialized,thread/start,turn/start" {
+		t.Fatalf("run methods = %v", methods)
+	}
+	requests := readJSONLines(t, filepath.Join(filepath.Dir(binary), "requests"))
+	thread := requests[2]
+	if thread["method"] != "thread/start" {
+		t.Fatalf("thread request = %v", thread)
+	}
+	threadParams := thread["params"].(map[string]any)
+	if threadParams["sandbox"] != "workspace-write" || threadParams["cwd"] == nil {
+		t.Fatalf("unsafe thread params = %v", threadParams)
+	}
+	turn := requests[3]
+	turnParams := turn["params"].(map[string]any)
+	policy := turnParams["sandboxPolicy"].(map[string]any)
+	if policy["type"] != "workspaceWrite" || policy["networkAccess"] != false {
+		t.Fatalf("unsafe turn policy = %v", policy)
+	}
+}
+
+func TestRunResumeMissingThreadNeedsInputWithoutStartingNewThread(t *testing.T) {
+	binary := fakeCodexBinary(t, "missing-resume")
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+	result, err := adapter.Run(context.Background(), harness.Launch{
+		Workdir:      t.TempDir(),
+		SessionID:    "missing-thread",
+		Instructions: "continue",
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Phase != "needs_input" || !strings.Contains(result.Blocker, "not found") {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	methods := readMethods(t, filepath.Join(filepath.Dir(binary), "methods"))
+	if strings.Contains(strings.Join(methods, ","), "thread/start") {
+		t.Fatalf("resume fallback started a new thread: %v", methods)
+	}
+}
+
+func TestRunApprovalRequestNeedsInputWithoutAutoApproval(t *testing.T) {
+	decisionFile := filepath.Join(t.TempDir(), "decision")
+	binary := fakeCodexBinaryWithDecisionFile(t, "approval", decisionFile)
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+	var events []harness.Event
+	result, err := adapter.Run(context.Background(), harness.Launch{
+		Workdir:      t.TempDir(),
+		Instructions: "run command",
+	}, func(event harness.Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Phase != "needs_input" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if len(events) != 2 || events[1].Type != "item/commandExecution/requestApproval" {
+		t.Fatalf("approval events = %+v", events)
+	}
+	var approval map[string]any
+	if err := json.Unmarshal(events[1].Data, &approval); err != nil {
+		t.Fatalf("decode approval data: %v", err)
+	}
+	wantApproval := map[string]any{"itemId": "item-1", "threadId": "thread-1", "turnId": "turn-1", "command": "uname"}
+	if !reflect.DeepEqual(approval, wantApproval) {
+		t.Fatalf("approval data = %s", events[1].Data)
+	}
+	if data, err := os.ReadFile(decisionFile); err == nil && len(data) != 0 {
+		t.Fatalf("adapter auto-approved request: %q", data)
+	}
+}
+
+func TestRunAuthRequestNeedsInputWithoutAnswering(t *testing.T) {
+	binary := fakeCodexBinary(t, "auth-request")
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+	var events []harness.Event
+	result, err := adapter.Run(context.Background(), harness.Launch{
+		Workdir:      t.TempDir(),
+		Instructions: "authenticate",
+	}, func(event harness.Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Phase != "needs_input" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if len(events) != 2 || events[1].Type != "auth_failure" {
+		t.Fatalf("auth events = %+v", events)
+	}
+	var params map[string]any
+	if err := json.Unmarshal(events[1].Data, &params); err != nil || params["reason"] != "expired" {
+		t.Fatalf("auth data = %s", events[1].Data)
+	}
+}
+
+func TestRunCancellationInterruptsAndStopsProcess(t *testing.T) {
+	binary := fakeCodexBinary(t, "cancel")
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{})
+	resultCh := make(chan harness.Result, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := adapter.Run(ctx, harness.Launch{
+			Workdir:      t.TempDir(),
+			Instructions: "wait",
+		}, func(event harness.Event) error {
+			if event.Type == "turn_started" {
+				close(started)
+			}
+			return nil
+		})
+		resultCh <- result
+		errCh <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session did not start")
+	}
+	cancel()
+	select {
+	case result := <-resultCh:
+		if result.Phase != "cancelled" {
+			t.Fatalf("result = %+v", result)
+		}
+		if err := <-errCh; err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("Run did not stop after cancellation")
+	}
+	methods := readMethods(t, filepath.Join(filepath.Dir(binary), "methods"))
+	if !strings.Contains(strings.Join(methods, ","), "turn/interrupt") {
+		t.Fatalf("methods = %v, want turn/interrupt", methods)
+	}
+}
+
+func fakeCodexBinary(t *testing.T, scenario string) string {
+	return fakeCodexBinaryWithEnvFile(t, scenario, "")
+}
+
+func fakeCodexBinaryWithDecisionFile(t *testing.T, scenario, decisionFile string) string {
+	binary := fakeCodexBinary(t, scenario)
+	t.Setenv("FAROS_FAKE_CODEX_DECISION_FILE", decisionFile)
+	return binary
+}
+
+func fakeCodexBinaryWithEnvFile(t *testing.T, scenario, envFile string) string {
+	t.Helper()
+	dir := t.TempDir()
+	methodsFile := filepath.Join(dir, "methods")
+	requestsFile := filepath.Join(dir, "requests")
+	script := filepath.Join(dir, "codex")
+	content := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo codex-cli 0.147.0; exit 0; fi\nFAROS_FAKE_CODEX_CHILD=1 exec %q -test.run=TestFakeAppServerProcess\n", os.Args[0])
+	if err := os.WriteFile(script, []byte(content), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FAROS_FAKE_CODEX_SCENARIO", scenario)
+	t.Setenv("FAROS_FAKE_CODEX_METHODS", methodsFile)
+	t.Setenv("FAROS_FAKE_CODEX_REQUESTS", requestsFile)
+	if envFile != "" {
+		t.Setenv("FAROS_FAKE_CODEX_ENV_FILE", envFile)
+	} else {
+		t.Setenv("FAROS_FAKE_CODEX_ENV_FILE", "")
+	}
+	t.Setenv("FAROS_FAKE_CODEX_DECISION_FILE", "")
+	return script
+}
+
+func TestFakeAppServerProcess(t *testing.T) {
+	if os.Getenv("FAROS_FAKE_CODEX_CHILD") != "1" {
+		return
+	}
+	scenario := os.Getenv("FAROS_FAKE_CODEX_SCENARIO")
+	methodsFile := os.Getenv("FAROS_FAKE_CODEX_METHODS")
+	requestsFile := os.Getenv("FAROS_FAKE_CODEX_REQUESTS")
+	if envFile := os.Getenv("FAROS_FAKE_CODEX_ENV_FILE"); envFile != "" {
+		env := map[string]string{}
+		for _, name := range []string{"GITHUB_TOKEN", "GITHUB_ACTIONS", "CODEX_HOME", "HOME", "XDG_CONFIG_HOME", "GIT_CONFIG_GLOBAL", "SSH_AUTH_SOCK"} {
+			env[name] = os.Getenv(name)
+		}
+		writeJSONFile(envFile, env)
+	}
+	methods, methodsErr := os.OpenFile(methodsFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	requests, requestsErr := os.OpenFile(requestsFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if methodsErr != nil || requestsErr != nil {
+		os.Exit(2)
+	}
+	defer func() { _ = methods.Close() }()
+	defer func() { _ = requests.Close() }()
+	scanner := bufio.NewScanner(os.Stdin)
+	approvalPending := false
+	sawApprovalDecision := false
+	for scanner.Scan() {
+		var request map[string]any
+		if json.Unmarshal(scanner.Bytes(), &request) != nil {
+			continue
+		}
+		method, _ := request["method"].(string)
+		if approvalPending {
+			sawApprovalDecision = true
+		}
+		_, _ = fmt.Fprintln(methods, method)
+		writeJSONLine(requests, request)
+		id := request["id"]
+		switch method {
+		case "initialize":
+			writeResponse(map[string]any{"id": id, "result": map[string]any{"userAgent": "fake", "codexHome": os.Getenv("CODEX_HOME"), "platformFamily": "unix", "platformOs": "linux"}})
+		case "account/read":
+			if scenario == "auth" {
+				writeResponse(map[string]any{"id": id, "error": map[string]any{"code": 401, "message": "authentication required"}})
+			} else {
+				writeResponse(map[string]any{"id": id, "result": map[string]any{"account": nil, "requiresOpenaiAuth": false}})
+			}
+		case "thread/start":
+			writeResponse(map[string]any{"id": id, "result": map[string]any{"thread": map[string]any{"id": "thread-1"}}})
+		case "thread/resume":
+			if scenario == "missing-resume" {
+				writeResponse(map[string]any{"id": id, "error": map[string]any{"code": -32602, "message": "thread not found"}})
+			} else {
+				params, _ := request["params"].(map[string]any)
+				resumeID, _ := params["threadId"].(string)
+				if scenario == "foreign-resume" {
+					resumeID = "thread-foreign"
+				}
+				writeResponse(map[string]any{"id": id, "result": map[string]any{"thread": map[string]any{"id": resumeID}}})
+			}
+		case "turn/start":
+			writeResponse(map[string]any{"id": id, "result": map[string]any{"turn": map[string]any{"id": "turn-1", "status": "inProgress"}}})
+			params, _ := request["params"].(map[string]any)
+			threadID, _ := params["threadId"].(string)
+			if threadID == "" {
+				threadID = "thread-1"
+			}
+			switch scenario {
+			case "success", "foreign-completion":
+				writeNotification("item/agentMessage/delta", map[string]any{"threadId": threadID, "turnId": "turn-1", "itemId": "item-1", "delta": "hello"})
+				completionThreadID := threadID
+				if scenario == "foreign-completion" {
+					completionThreadID = "thread-foreign"
+				}
+				writeNotification("turn/completed", map[string]any{"threadId": completionThreadID, "turn": map[string]any{"id": "turn-1", "status": "completed", "error": nil}})
+			case "approval":
+				writeRequest("item/commandExecution/requestApproval", "approval-1", map[string]any{"itemId": "item-1", "threadId": "thread-1", "turnId": "turn-1", "command": "uname"})
+				approvalPending = true
+			case "auth-request":
+				writeRequest("account/chatgptAuthTokens/refresh", "auth-1", map[string]any{"reason": "expired"})
+			case "cancel":
+				writeNotification("turn/started", map[string]any{"threadId": threadID, "turn": map[string]any{"id": "turn-1", "status": "inProgress"}})
+			}
+		case "turn/interrupt":
+			writeResponse(map[string]any{"id": id, "result": map[string]any{}})
+			writeNotification("turn/completed", map[string]any{"threadId": "thread-1", "turn": map[string]any{"id": "turn-1", "status": "interrupted", "error": nil}})
+		default:
+			if id != nil {
+				writeResponse(map[string]any{"id": id, "result": map[string]any{}})
+			}
+		}
+	}
+	if scenario == "approval" && sawApprovalDecision {
+		// Any response after the approval request proves the adapter auto-approved it.
+		_ = os.WriteFile(os.Getenv("FAROS_FAKE_CODEX_DECISION_FILE"), []byte("decision"), 0600)
+	}
+	os.Exit(0)
+}
+
+var fakeWriteMu sync.Mutex
+
+func writeResponse(value map[string]any) {
+	writeJSONLine(os.Stdout, value)
+}
+
+func writeNotification(method string, params map[string]any) {
+	writeJSONLine(os.Stdout, map[string]any{"method": method, "params": params})
+}
+
+func writeRequest(method, id string, params map[string]any) {
+	writeJSONLine(os.Stdout, map[string]any{"id": id, "method": method, "params": params})
+}
+
+func writeJSONLine(w interface{ Write([]byte) (int, error) }, value any) {
+	fakeWriteMu.Lock()
+	defer fakeWriteMu.Unlock()
+	data, _ := json.Marshal(value)
+	_, _ = w.Write(append(data, '\n'))
+}
+
+func writeJSONFile(path string, value any) {
+	data, _ := json.Marshal(value)
+	_ = os.WriteFile(path, data, 0600)
+}
+
+func readMethods(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read methods: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return nil
+	}
+	return lines
+}
+
+func readJSONLines(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read requests: %v", err)
+	}
+	var result []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var value map[string]any
+		if err := json.Unmarshal([]byte(line), &value); err != nil {
+			t.Fatalf("decode request %q: %v", line, err)
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func readJSONFile(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read json file: %v", err)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		t.Fatalf("decode json file: %v", err)
+	}
+	return value
+}

--- a/pkg/runner/harness/codex/codex_test.go
+++ b/pkg/runner/harness/codex/codex_test.go
@@ -308,7 +308,7 @@ func fakeCodexBinaryWithEnvFile(t *testing.T, scenario, envFile string) string {
 	methodsFile := filepath.Join(dir, "methods")
 	requestsFile := filepath.Join(dir, "requests")
 	script := filepath.Join(dir, "codex")
-	content := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo codex-cli 0.147.0; exit 0; fi\nFAROS_FAKE_CODEX_CHILD=1 exec %q -test.run=TestFakeAppServerProcess\n", os.Args[0])
+	content := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo codex-cli 0.147.0; exit 0; fi\nprintf '%%s\\n' \"$@\" > %q\nFAROS_FAKE_CODEX_CHILD=1 exec %q -test.run=TestFakeAppServerProcess\n", filepath.Join(dir, "argv"), os.Args[0])
 	if err := os.WriteFile(script, []byte(content), 0700); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/runner/harness/codex/codex_test.go
+++ b/pkg/runner/harness/codex/codex_test.go
@@ -55,6 +55,50 @@ func TestProbeUsesVersionAndAccountReadWithoutModelCall(t *testing.T) {
 	}
 }
 
+func TestProbeAccountReadAuthenticationState(t *testing.T) {
+	tests := []struct {
+		name       string
+		scenario   string
+		wantReady  bool
+		wantReason bool
+	}{
+		{name: "chatgpt account", scenario: "auth-chatgpt", wantReady: true},
+		{name: "api key account", scenario: "auth-api-key", wantReady: true},
+		{name: "missing account", scenario: "auth-missing", wantReason: true},
+		{name: "null account", scenario: "auth-null", wantReason: true},
+		{name: "malformed account", scenario: "auth-malformed", wantReason: true},
+		{name: "malformed account without auth requirement", scenario: "auth-malformed-noauth", wantReason: true},
+		{name: "missing auth requirement", scenario: "auth-missing-flag", wantReason: true},
+		{name: "malformed auth requirement", scenario: "auth-wrong-type-flag", wantReason: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			binary := fakeCodexBinary(t, tc.scenario)
+			adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+
+			info, err := adapter.Probe(context.Background())
+			if err != nil {
+				t.Fatalf("Probe: %v", err)
+			}
+			if info.Ready != tc.wantReady {
+				t.Fatalf("ready = %v, want %v (info = %+v)", info.Ready, tc.wantReady, info)
+			}
+			if (len(info.Reasons) > 0) != tc.wantReason {
+				t.Fatalf("reasons = %v, want reason presence %v", info.Reasons, tc.wantReason)
+			}
+			infoData, err := json.Marshal(info)
+			if err != nil {
+				t.Fatalf("marshal probe info: %v", err)
+			}
+			for _, secret := range []string{"user@example.com", "sk-test-secret", "access-token-secret"} {
+				if strings.Contains(string(infoData), secret) {
+					t.Fatalf("probe info exposed account data %q: %+v", secret, info)
+				}
+			}
+		})
+	}
+}
+
 func TestRunLifecycleStartsSessionBeforeTurnAndSanitizesEnvironment(t *testing.T) {
 	envFile := filepath.Join(t.TempDir(), "env.json")
 	binary := fakeCodexBinaryWithEnvFile(t, "success", envFile)
@@ -320,9 +364,43 @@ func TestFakeAppServerProcess(t *testing.T) {
 		case "initialize":
 			writeResponse(map[string]any{"id": id, "result": map[string]any{"userAgent": "fake", "codexHome": os.Getenv("CODEX_HOME"), "platformFamily": "unix", "platformOs": "linux"}})
 		case "account/read":
-			if scenario == "auth" {
+			switch scenario {
+			case "auth":
 				writeResponse(map[string]any{"id": id, "error": map[string]any{"code": 401, "message": "authentication required"}})
-			} else {
+			case "auth-chatgpt":
+				writeResponse(map[string]any{"id": id, "result": map[string]any{
+					"account":            map[string]any{"type": "chatgpt", "email": "user@example.com", "planType": "pro"},
+					"requiresOpenaiAuth": true,
+				}})
+			case "auth-api-key":
+				writeResponse(map[string]any{"id": id, "result": map[string]any{
+					"account":            map[string]any{"type": "apiKey"},
+					"requiresOpenaiAuth": true,
+				}})
+			case "auth-missing":
+				writeResponse(map[string]any{"id": id, "result": map[string]any{"requiresOpenaiAuth": true}})
+			case "auth-null":
+				writeResponse(map[string]any{"id": id, "result": map[string]any{"account": nil, "requiresOpenaiAuth": true}})
+			case "auth-malformed":
+				writeResponse(map[string]any{"id": id, "result": map[string]any{
+					"account":            map[string]any{"type": []string{"chatgpt"}, "token": "access-token-secret", "apiKey": "sk-test-secret"},
+					"requiresOpenaiAuth": true,
+				}})
+			case "auth-missing-flag":
+				writeResponse(map[string]any{"id": id, "result": map[string]any{
+					"account": map[string]any{"type": "chatgpt", "email": "user@example.com"},
+				}})
+			case "auth-wrong-type-flag":
+				writeResponse(map[string]any{"id": id, "result": map[string]any{
+					"account":            map[string]any{"type": "chatgpt", "email": "user@example.com"},
+					"requiresOpenaiAuth": "true",
+				}})
+			case "auth-malformed-noauth":
+				writeResponse(map[string]any{"id": id, "result": map[string]any{
+					"account":            []string{"not-an-account"},
+					"requiresOpenaiAuth": false,
+				}})
+			default:
 				writeResponse(map[string]any{"id": id, "result": map[string]any{"account": nil, "requiresOpenaiAuth": false}})
 			}
 		case "thread/start":

--- a/pkg/runner/harness/codex/config.go
+++ b/pkg/runner/harness/codex/config.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codex
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+const (
+	codexConfigName     = "config.toml"
+	maxCodexConfigBytes = 64 << 10
+)
+
+var errCodexConfigRejected = errors.New("codex config.toml is not an approved runner configuration")
+
+type codexProjectConfig struct {
+	TrustLevel string `toml:"trust_level"`
+}
+
+type codexConfig struct {
+	Projects map[string]codexProjectConfig `toml:"projects"`
+}
+
+// validateCodexConfig validates the only project configuration that a worker
+// home may contain. Multiple managed checkout entries are permitted; the
+// launch path is checked separately before starting a model process.
+func validateCodexConfig(home, worktreeRoot string) (bool, error) {
+	path := filepath.Join(home, codexConfigName)
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return true, errCodexConfigRejected
+	}
+	root, err := normalizeWorktreeRoot(worktreeRoot)
+	if err != nil {
+		return true, errCodexConfigRejected
+	}
+	if info.Size() < 0 || info.Size() > maxCodexConfigBytes {
+		return true, errCodexConfigRejected
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return true, errCodexConfigRejected
+	}
+	defer func() { _ = f.Close() }()
+	openedInfo, err := f.Stat()
+	if err != nil || !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		return true, errCodexConfigRejected
+	}
+	contents, err := io.ReadAll(io.LimitReader(f, maxCodexConfigBytes+1))
+	if err != nil || len(contents) > maxCodexConfigBytes {
+		return true, errCodexConfigRejected
+	}
+
+	var parsed codexConfig
+	metadata, err := toml.Decode(string(contents), &parsed)
+	if err != nil || len(metadata.Undecoded()) != 0 || len(parsed.Projects) == 0 {
+		return true, errCodexConfigRejected
+	}
+	for projectPath, project := range parsed.Projects {
+		if project.TrustLevel != "trusted" && project.TrustLevel != "untrusted" {
+			return true, errCodexConfigRejected
+		}
+		if err := validateTrustProjectPath(root, projectPath); err != nil {
+			return true, errCodexConfigRejected
+		}
+	}
+	return true, nil
+}
+
+func normalizeWorktreeRoot(worktreeRoot string) (string, error) {
+	if strings.TrimSpace(worktreeRoot) == "" || !filepath.IsAbs(worktreeRoot) {
+		return "", errCodexConfigRejected
+	}
+	root := filepath.Clean(worktreeRoot)
+	info, err := os.Lstat(root)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return "", errCodexConfigRejected
+		}
+	} else {
+		return "", errCodexConfigRejected
+	}
+	return root, nil
+}
+
+func validateTrustProjectPath(root, projectPath string) error {
+	if !filepath.IsAbs(projectPath) || filepath.Clean(projectPath) != projectPath {
+		return errCodexConfigRejected
+	}
+	rel, err := filepath.Rel(root, projectPath)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return errCodexConfigRejected
+	}
+	parts := splitPath(rel)
+	if len(parts) != 2 {
+		return errCodexConfigRejected
+	}
+	return validateNoSymlinkComponents(root, projectPath)
+}
+
+func validateManagedWorktree(root, workdir string) error {
+	if !filepath.IsAbs(workdir) || filepath.Clean(workdir) != workdir {
+		return errCodexConfigRejected
+	}
+	if err := validateTrustProjectPath(root, workdir); err != nil {
+		return err
+	}
+	info, err := os.Lstat(workdir)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return errCodexConfigRejected
+	}
+	return nil
+}
+
+func validateNoSymlinkComponents(root, candidate string) error {
+	rootInfo, err := os.Lstat(root)
+	if err == nil {
+		if rootInfo.Mode()&os.ModeSymlink != 0 || !rootInfo.IsDir() {
+			return errCodexConfigRejected
+		}
+	} else {
+		return errCodexConfigRejected
+	}
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return errCodexConfigRejected
+	}
+	current := root
+	for _, part := range splitPath(rel) {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return errCodexConfigRejected
+		}
+	}
+	return nil
+}
+
+func splitPath(path string) []string {
+	parts := strings.FieldsFunc(path, func(r rune) bool { return r == rune(filepath.Separator) })
+	return parts
+}
+
+func (a *Adapter) validateLaunchConfiguration(workdir string) error {
+	present, err := validateCodexConfig(a.cfg.Home, a.cfg.WorktreeRoot)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return nil
+	}
+	root, err := normalizeWorktreeRoot(a.cfg.WorktreeRoot)
+	if err != nil {
+		return errCodexConfigRejected
+	}
+	if err := validateManagedWorktree(root, workdir); err != nil {
+		return errCodexConfigRejected
+	}
+	return rejectLocalCodexConfiguration(root, workdir)
+}
+
+func rejectLocalCodexConfiguration(root, workdir string) error {
+	current := workdir
+	for {
+		candidate := filepath.Join(current, ".codex")
+		if _, err := os.Lstat(candidate); err == nil {
+			return errCodexConfigRejected
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return errCodexConfigRejected
+		}
+		if current == root {
+			return nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return errCodexConfigRejected
+		}
+		current = parent
+	}
+}

--- a/pkg/runner/harness/codex/config_test.go
+++ b/pkg/runner/harness/codex/config_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codex
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+func TestManagedTrustConfiguration(t *testing.T) {
+	for _, tc := range []struct {
+		name, extra, level string
+		invalid            bool
+	}{
+		{name: "trusted", level: "trusted"}, {name: "untrusted", level: "untrusted"},
+		{name: "extra-project-key", level: "trusted", extra: "model = \"secret-marker\"", invalid: true},
+		{name: "extra-table", level: "trusted", extra: "[mcp_servers.secret]\ncommand = \"secret-marker\"", invalid: true},
+		{name: "empty-extra-table", level: "trusted", extra: "[hooks]", invalid: true},
+		{name: "invalid-level", level: "secret-marker", invalid: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home, root, work := trustFixture(t)
+			writeTrustConfig(t, home, fmt.Sprintf("[projects.%q]\ntrust_level = %q\n%s\n", work, tc.level, tc.extra))
+			a := &Adapter{cfg: Config{Home: home, WorktreeRoot: root}}
+			err := a.ensureHome()
+			if (err != nil) != tc.invalid {
+				t.Fatalf("ensureHome error=%v invalid=%v", err, tc.invalid)
+			}
+			if err != nil && strings.Contains(err.Error(), "secret-marker") {
+				t.Fatal("configuration contents leaked")
+			}
+			if !tc.invalid {
+				if err := a.validateLaunchConfiguration(work); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func TestManagedTrustRejectsUnsafeScope(t *testing.T) {
+	for _, kind := range []string{"parent", "root", "outside", "relative", "unclean", "missing", "symlink", "no-root", "malformed", "oversize", "file-symlink", "directory"} {
+		t.Run(kind, func(t *testing.T) {
+			home, root, work := trustFixture(t)
+			target := work
+			switch kind {
+			case "parent":
+				target = filepath.Dir(work)
+			case "root":
+				target = root
+			case "outside":
+				target = t.TempDir()
+			case "relative":
+				target = "task/attempt"
+			case "unclean":
+				target = work + "/../attempt"
+			case "missing":
+				target = filepath.Join(root, "absent", "attempt")
+			case "symlink":
+				target = filepath.Join(root, "task", "alias")
+				if err := os.Symlink(work, target); err != nil {
+					t.Fatal(err)
+				}
+			}
+			content := fmt.Sprintf("[projects.%q]\ntrust_level = \"trusted\"\n", target)
+			if kind == "malformed" {
+				content = "invalid = secret-marker"
+			}
+			if kind == "oversize" {
+				content = strings.Repeat(" ", maxCodexConfigBytes+1)
+			}
+			writeTrustConfig(t, home, content)
+			path := filepath.Join(home, codexConfigName)
+			if kind == "file-symlink" || kind == "directory" {
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if kind == "directory" {
+					if err := os.Mkdir(path, 0700); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					other := filepath.Join(t.TempDir(), "config")
+					if err := os.WriteFile(other, []byte(content), 0600); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.Symlink(other, path); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			if kind == "no-root" {
+				root = ""
+			}
+			a := &Adapter{cfg: Config{Home: home, WorktreeRoot: root}}
+			if err := a.ensureHome(); err == nil {
+				t.Fatal("unsafe config accepted")
+			}
+		})
+	}
+}
+
+func TestManagedTrustProbeAndLaunchIsolation(t *testing.T) {
+	home, root, work := trustFixture(t)
+	second := filepath.Join(root, "next", "attempt")
+	if err := os.MkdirAll(second, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeTrustConfig(t, home, fmt.Sprintf("[projects.%q]\ntrust_level = \"trusted\"\n[projects.%q]\ntrust_level = \"trusted\"\n", work, second))
+	binary := fakeCodexBinary(t, "probe")
+	a := &Adapter{cfg: Config{Home: home, WorktreeRoot: root, Binary: binary, ExpectedVersion: "0.147.0"}}
+	for range 2 {
+		info, err := a.Probe(context.Background())
+		if err != nil || !info.Ready {
+			t.Fatalf("probe=%+v err=%v", info, err)
+		}
+	}
+	for _, method := range readMethods(t, filepath.Join(filepath.Dir(binary), "methods")) {
+		if method == "thread/start" || method == "thread/resume" || method == "turn/start" {
+			t.Fatal("probe started model")
+		}
+	}
+	for _, path := range []string{work, second} {
+		if err := a.validateLaunchConfiguration(path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := a.validateLaunchConfiguration(t.TempDir()); err == nil {
+		t.Fatal("foreign launch allowed")
+	}
+	for _, base := range []string{root, filepath.Dir(work), work} {
+		local := filepath.Join(base, ".codex")
+		if err := os.Mkdir(local, 0700); err != nil {
+			t.Fatal(err)
+		}
+		_, err := a.Run(context.Background(), harness.Launch{Workdir: work, Instructions: "approved", SessionID: "original"}, nil)
+		if err == nil {
+			t.Fatal("trusted local config reached harness")
+		}
+		if err := os.Remove(local); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func trustFixture(t *testing.T) (string, string, string) {
+	t.Helper()
+	home := t.TempDir()
+	root := filepath.Join(t.TempDir(), "worktrees")
+	work := filepath.Join(root, "task", "attempt")
+	if err := os.MkdirAll(work, 0700); err != nil {
+		t.Fatal(err)
+	}
+	return home, root, work
+}
+func writeTrustConfig(t *testing.T, home, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(home, codexConfigName), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/runner/harness/codex/process_unix.go
+++ b/pkg/runner/harness/codex/process_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codex
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+func configureProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func killProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return errors.Join(err, cmd.Process.Kill())
+	}
+	return nil
+}

--- a/pkg/runner/harness/codex/process_windows.go
+++ b/pkg/runner/harness/codex/process_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codex
+
+import "os/exec"
+
+func configureProcess(_ *exec.Cmd) {}
+
+func killProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/pkg/runner/harness/harness.go
+++ b/pkg/runner/harness/harness.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package harness defines the public execution seam for runner adapters.
+package harness
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Info describes an adapter's executable and readiness state.
+type Info struct {
+	Name    string   `json:"name"`
+	Version string   `json:"version"`
+	Ready   bool     `json:"ready"`
+	Reasons []string `json:"reasons,omitempty"`
+}
+
+// Launch identifies one worker attempt and the thread turn it should execute.
+type Launch struct {
+	AttemptID    string `json:"attemptID"`
+	Workdir      string `json:"workdir"`
+	SessionID    string `json:"sessionID,omitempty"`
+	Instructions string `json:"instructions"`
+	Model        string `json:"model,omitempty"`
+}
+
+// Event is a bounded adapter event forwarded to the runner state engine.
+type Event struct {
+	Type      string          `json:"type"`
+	SessionID string          `json:"sessionID,omitempty"`
+	TurnID    string          `json:"turnID,omitempty"`
+	Message   string          `json:"message,omitempty"`
+	Data      json.RawMessage `json:"data,omitempty"`
+}
+
+// Result is the terminal state of one adapter launch.
+type Result struct {
+	Phase     string `json:"phase"`
+	SessionID string `json:"sessionID,omitempty"`
+	Blocker   string `json:"blocker,omitempty"`
+}
+
+// Emit receives adapter events. Implementations must treat an error as a
+// terminal failure and stop producing events for the launch.
+type Emit func(Event) error
+
+// Adapter probes its executable and runs one isolated agent turn.
+type Adapter interface {
+	Probe(context.Context) (Info, error)
+	Run(context.Context, Launch, Emit) (Result, error)
+}

--- a/pkg/runner/http.go
+++ b/pkg/runner/http.go
@@ -1,0 +1,390 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func (r *Runner) serveHTTP(w http.ResponseWriter, request *http.Request) {
+	if !r.authorized(request) {
+		writeHTTPError(w, http.StatusUnauthorized, protocolError(ErrorUnauthorized, false, "runner bearer authentication required", nil))
+		return
+	}
+	path := strings.TrimSuffix(request.URL.Path, "/")
+	switch {
+	case request.Method == http.MethodGet && path == "/runner/v1/capabilities":
+		writeJSON(w, http.StatusOK, r.Capabilities())
+	case request.Method == http.MethodPost && path == "/runner/v1/attempts":
+		var body StartRequest
+		if err := decodeJSONBody(request, &body, r.cfg.MaxBodyBytes); err != nil {
+			writeHTTPError(w, http.StatusBadRequest, protocolError(ErrorInvalidRequest, false, err.Error(), nil))
+			return
+		}
+		receipt, err := r.Start(request.Context(), body)
+		if err != nil {
+			writeRunnerError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, receipt)
+	case request.Method == http.MethodGet && strings.HasPrefix(path, "/runner/v1/attempts/"):
+		r.serveAttemptGet(w, request, path)
+	case request.Method == http.MethodPost && strings.HasPrefix(path, "/runner/v1/attempts/"):
+		r.serveAttemptMutation(w, request, path)
+	default:
+		writeHTTPError(w, http.StatusNotFound, protocolError(ErrorUnavailable, false, "runner route not found", nil))
+	}
+}
+
+func (r *Runner) authorized(request *http.Request) bool {
+	value := request.Header.Get("Authorization")
+	parts := strings.Fields(value)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return false
+	}
+	return tokenEqual(r.cfg.Token, parts[1])
+}
+
+func (r *Runner) serveAttemptGet(w http.ResponseWriter, request *http.Request, path string) {
+	parts := strings.Split(strings.TrimPrefix(path, "/runner/v1/attempts/"), "/")
+	if len(parts) == 1 && parts[0] != "" {
+		receipt, err := r.Inspect(request.Context(), parts[0])
+		if err != nil {
+			writeRunnerError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, receipt)
+		return
+	}
+	if len(parts) == 2 && parts[0] != "" && parts[1] == "events" {
+		r.serveEvents(w, request, parts[0])
+		return
+	}
+	if len(parts) == 3 && parts[0] != "" && parts[1] == "artifacts" && parts[2] != "" {
+		r.serveArtifact(w, request, parts[0], parts[2])
+		return
+	}
+	writeHTTPError(w, http.StatusNotFound, protocolError(ErrorUnavailable, false, "runner route not found", nil))
+}
+
+func (r *Runner) serveAttemptMutation(w http.ResponseWriter, request *http.Request, path string) {
+	parts := strings.Split(strings.TrimPrefix(path, "/runner/v1/attempts/"), "/")
+	if len(parts) != 2 || parts[0] == "" {
+		writeHTTPError(w, http.StatusNotFound, protocolError(ErrorUnavailable, false, "runner route not found", nil))
+		return
+	}
+	var (
+		receipt Receipt
+		err     error
+	)
+	switch parts[1] {
+	case "cancel":
+		var body CancelRequest
+		if decodeErr := decodeJSONBody(request, &body, r.cfg.MaxBodyBytes); decodeErr != nil {
+			writeHTTPError(w, http.StatusBadRequest, protocolError(ErrorInvalidRequest, false, decodeErr.Error(), nil))
+			return
+		}
+		if body.AttemptID != parts[0] {
+			writeHTTPError(w, http.StatusBadRequest, protocolError(ErrorInvalidRequest, false, "attemptID must match the URL", nil))
+			return
+		}
+		receipt, err = r.Cancel(request.Context(), body)
+	case "resume":
+		var body ResumeRequest
+		if decodeErr := decodeJSONBody(request, &body, r.cfg.MaxBodyBytes); decodeErr != nil {
+			writeHTTPError(w, http.StatusBadRequest, protocolError(ErrorInvalidRequest, false, decodeErr.Error(), nil))
+			return
+		}
+		if body.AttemptID != parts[0] {
+			writeHTTPError(w, http.StatusBadRequest, protocolError(ErrorInvalidRequest, false, "attemptID must match the URL", nil))
+			return
+		}
+		receipt, err = r.Resume(request.Context(), body)
+	default:
+		writeHTTPError(w, http.StatusNotFound, protocolError(ErrorUnavailable, false, "runner route not found", nil))
+		return
+	}
+	if err != nil {
+		writeRunnerError(w, err)
+		return
+	}
+	status := http.StatusAccepted
+	if receipt.Phase.IsTerminal() {
+		status = http.StatusOK
+	}
+	writeJSON(w, status, receipt)
+}
+
+func (r *Runner) serveEvents(w http.ResponseWriter, request *http.Request, attemptID string) {
+	after, err := parseCursor(request.URL.Query().Get("after"))
+	if err != nil {
+		writeHTTPError(w, http.StatusBadRequest, protocolError(ErrorInvalidRequest, false, err.Error(), nil))
+		return
+	}
+	r.mu.Lock()
+	attempt, ok := r.state.Attempts[attemptID]
+	if !ok {
+		r.mu.Unlock()
+		writeHTTPError(w, http.StatusNotFound, protocolError(ErrorUnavailable, false, "attempt not found", nil))
+		return
+	}
+	events := append([]Event(nil), r.state.Events[attemptID]...)
+	if err := cursorGap(events, after); err != nil {
+		receipt := receiptForResponse(attempt.Receipt)
+		r.mu.Unlock()
+		err.Receipt = &receipt
+		status := statusForCode(err.Code)
+		if err.Code == ErrorCursorExpired {
+			err.SnapshotRequired = true
+		}
+		writeHTTPError(w, status, err)
+		return
+	}
+	updates := make(chan Event, 64)
+	if r.subscribers[attemptID] == nil {
+		r.subscribers[attemptID] = map[chan Event]struct{}{}
+	}
+	r.subscribers[attemptID][updates] = struct{}{}
+	terminal := attempt.Receipt.Phase.IsTerminal()
+	r.mu.Unlock()
+	defer func() {
+		r.mu.Lock()
+		delete(r.subscribers[attemptID], updates)
+		r.mu.Unlock()
+	}()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher, _ := w.(http.Flusher)
+	last := after
+	for _, event := range events {
+		if event.Cursor <= after {
+			continue
+		}
+		if err := writeSSE(w, event); err != nil {
+			return
+		}
+		last = event.Cursor
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	if terminal {
+		return
+	}
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case <-request.Context().Done():
+			return
+		case <-timer.C:
+			return
+		case event := <-updates:
+			if event.Cursor <= last {
+				continue
+			}
+			if err := writeSSE(w, event); err != nil {
+				return
+			}
+			last = event.Cursor
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}
+}
+
+func (r *Runner) serveArtifact(w http.ResponseWriter, request *http.Request, attemptID, artifactID string) {
+	r.mu.Lock()
+	attempt, attemptOK := r.state.Attempts[attemptID]
+	artifact, ok := r.state.Artifacts[artifactID]
+	if !attemptOK || !ok || artifact.Artifact.ID != artifactID || !artifactBelongs(attempt, artifact.Artifact) {
+		r.mu.Unlock()
+		writeHTTPError(w, http.StatusNotFound, protocolError(ErrorUnavailable, false, "artifact not found", nil))
+		return
+	}
+	path := artifact.Path
+	metadata := artifact.Artifact
+	stateDir := r.cfg.StateDir
+	r.mu.Unlock()
+	if !pathWithin(stateDir, path) {
+		writeHTTPError(w, http.StatusGone, protocolError(ErrorUnavailable, true, "artifact path is outside runner state", nil))
+		return
+	}
+	contents, err := readImmutableArtifact(path, metadata)
+	if err != nil {
+		writeHTTPError(w, http.StatusGone, protocolError(ErrorUnavailable, true, "artifact is unavailable", nil))
+		return
+	}
+	w.Header().Set("Content-Type", metadata.MediaType)
+	w.Header().Set("Content-Length", strconv.FormatInt(metadata.Length, 10))
+	w.Header().Set("Digest", metadata.Digest)
+	w.Header().Set("ETag", fmt.Sprintf("%q", metadata.Digest))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(contents)
+}
+
+func readImmutableArtifact(path string, metadata Artifact) ([]byte, error) {
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	contents, err := io.ReadAll(io.LimitReader(file, metadata.Length+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(contents)) != metadata.Length {
+		return nil, errors.New("artifact length changed")
+	}
+	digest := sha256.Sum256(contents)
+	if got := "sha256:" + hex.EncodeToString(digest[:]); got != metadata.Digest {
+		return nil, errors.New("artifact digest changed")
+	}
+	return contents, nil
+}
+
+func artifactBelongs(attempt *attemptRecord, artifact Artifact) bool {
+	for _, item := range attempt.Receipt.Artifacts {
+		if item.ID == artifact.ID && item.Digest == artifact.Digest && item.Length == artifact.Length {
+			return true
+		}
+	}
+	return false
+}
+
+func writeSSE(w http.ResponseWriter, event Event) error {
+	b, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	writer := bufio.NewWriter(w)
+	if _, err := fmt.Fprintf(writer, "id: %d\nevent: %s\ndata: %s\n\n", event.Cursor, event.Type, b); err != nil {
+		return err
+	}
+	return writer.Flush()
+}
+
+func parseCursor(value string) (uint64, error) {
+	if value == "" {
+		return 0, nil
+	}
+	cursor, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, errors.New("after must be a nonnegative event cursor")
+	}
+	return cursor, nil
+}
+
+func cursorGap(events []Event, after uint64) *Error {
+	if len(events) == 0 {
+		return nil
+	}
+	first := events[0].Cursor
+	last := events[len(events)-1].Cursor
+	if after > last {
+		return &Error{Code: ErrorInvalidRequest, Retryable: false, Message: "after cursor is ahead of the attempt"}
+	}
+	if after+1 < first {
+		return &Error{Code: ErrorCursorExpired, Retryable: true, Message: "event cursor expired; inspect the attempt before replaying"}
+	}
+	return nil
+}
+
+func decodeJSONBody(request *http.Request, target any, maxBytes int) error {
+	if request.Body == nil {
+		return errors.New("request body is required")
+	}
+	body, err := io.ReadAll(io.LimitReader(request.Body, int64(maxBytes)+1))
+	if err != nil {
+		return fmt.Errorf("read request body: %w", err)
+	}
+	if len(body) > maxBytes {
+		return errors.New("request body exceeds size limit")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("decode request body: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("request body must contain one JSON value")
+		}
+		return fmt.Errorf("decode trailing request body: %w", err)
+	}
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeHTTPError(w http.ResponseWriter, status int, err *Error) {
+	writeJSON(w, status, err)
+}
+
+func writeRunnerError(w http.ResponseWriter, err error) {
+	var protocolErr *Error
+	if errors.As(err, &protocolErr) {
+		status := statusForCode(protocolErr.Code)
+		writeHTTPError(w, status, protocolErr)
+		return
+	}
+	writeHTTPError(w, http.StatusInternalServerError, protocolError(ErrorUnavailable, true, err.Error(), nil))
+}
+
+func statusForCode(code string) int {
+	switch code {
+	case ErrorUnauthorized:
+		return http.StatusUnauthorized
+	case ErrorForbidden:
+		return http.StatusForbidden
+	case ErrorBusy:
+		return http.StatusConflict
+	case ErrorStaleAttempt, ErrorIdempotencyConflict:
+		return http.StatusConflict
+	case ErrorCheckpointUnavailable:
+		return http.StatusConflict
+	case ErrorCursorExpired:
+		return http.StatusGone
+	case ErrorUnsupportedCapability, ErrorUnsupportedVersion:
+		return http.StatusBadRequest
+	case ErrorUnavailable:
+		return http.StatusServiceUnavailable
+	default:
+		return http.StatusBadRequest
+	}
+}

--- a/pkg/runner/lock_other.go
+++ b/pkg/runner/lock_other.go
@@ -1,0 +1,35 @@
+//go:build !linux && !darwin
+
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"fmt"
+	"os"
+)
+
+// Other operating systems are intentionally unsupported by the runner binary
+// today. Keeping this implementation buildable makes the package's failure
+// explicit instead of silently permitting two processes to share state.
+type processLock struct{ file *os.File }
+
+func acquireProcessLock(_ string) (*processLock, error) {
+	return nil, fmt.Errorf("runner process locking is unsupported on this operating system")
+}
+
+func (l *processLock) Close() error { return nil }

--- a/pkg/runner/lock_unix.go
+++ b/pkg/runner/lock_unix.go
@@ -1,0 +1,54 @@
+//go:build linux || darwin
+
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+type processLock struct {
+	file *os.File
+}
+
+func acquireProcessLock(path string) (*processLock, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open runner lock: %w", err)
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("runner state directory is already locked: %w", err)
+	}
+	return &processLock{file: f}, nil
+}
+
+func (l *processLock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	err := unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	closeErr := l.file.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
+}

--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ProtocolVersion is the wire protocol implemented by the local runner.
+const ProtocolVersion = "runner/v1"
+
+// Phase describes the durable lifecycle of an attempt.
+type Phase string
+
+const (
+	PhaseAccepted   Phase = "accepted"
+	PhaseStarting   Phase = "starting"
+	PhaseRunning    Phase = "running"
+	PhaseNeedsInput Phase = "needs_input"
+	PhaseCancelling Phase = "cancelling"
+	PhaseCancelled  Phase = "cancelled"
+	PhaseCompleted  Phase = "completed"
+	PhaseFailed     Phase = "failed"
+)
+
+// IsTerminal reports whether p no longer has a live execution.
+func (p Phase) IsTerminal() bool {
+	switch p {
+	case PhaseCancelled, PhaseCompleted, PhaseFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// EventType values are the bounded, replayable events exposed by the runner.
+const (
+	EventAccepted   = "accepted"
+	EventStarted    = "started"
+	EventProgress   = "progress"
+	EventCheckpoint = "checkpoint"
+	EventNeedsInput = "needs_input"
+	EventArtifact   = "artifact"
+	EventCompleted  = "completed"
+	EventFailed     = "failed"
+	EventCancelled  = "cancelled"
+)
+
+// ErrorCode values are stable protocol errors. Callers should branch on Code,
+// not on Message.
+const (
+	ErrorInvalidRequest        = "invalid_request"
+	ErrorUnauthorized          = "unauthorized"
+	ErrorForbidden             = "forbidden"
+	ErrorUnsupportedVersion    = "unsupported_version"
+	ErrorUnsupportedCapability = "unsupported_capability"
+	ErrorBusy                  = "busy"
+	ErrorStaleAttempt          = "stale_attempt"
+	ErrorIdempotencyConflict   = "idempotency_conflict"
+	ErrorCheckpointUnavailable = "checkpoint_unavailable"
+	ErrorCursorExpired         = "cursor_expired"
+	ErrorUnavailable           = "unavailable"
+)
+
+// HarnessCapability describes an installed harness and its readiness.
+type HarnessCapability struct {
+	Name    string   `json:"name"`
+	Version string   `json:"version"`
+	Ready   bool     `json:"ready"`
+	Reasons []string `json:"reasons,omitempty"`
+}
+
+// Capacity is the execution capacity advertised by a runner.
+type Capacity struct {
+	Maximum int `json:"maximum"`
+	Used    int `json:"used"`
+}
+
+// Capabilities is returned by GET /runner/v1/capabilities.
+type Capabilities struct {
+	ProtocolVersion string              `json:"protocolVersion"`
+	RunnerID        string              `json:"runnerID"`
+	Version         string              `json:"version"`
+	OS              string              `json:"os"`
+	Architecture    string              `json:"architecture"`
+	Harnesses       []HarnessCapability `json:"harnesses,omitempty"`
+	Toolchains      []string            `json:"toolchains,omitempty"`
+	Environment     []string            `json:"environment,omitempty"`
+	Verification    []string            `json:"verificationCapabilities,omitempty"`
+	Capacity        Capacity            `json:"capacity"`
+	Ready           bool                `json:"ready"`
+	Reasons         []string            `json:"reasons,omitempty"`
+}
+
+// ExecutionLimits bounds adapter execution. The runner enforces duration and
+// emitted-output limits; MaxTurns is limited to one because one adapter launch
+// represents one turn in this protocol revision.
+type ExecutionLimits struct {
+	MaxDurationSeconds int `json:"maxDurationSeconds,omitempty"`
+	MaxOutputBytes     int `json:"maxOutputBytes,omitempty"`
+	MaxTurns           int `json:"maxTurns,omitempty"`
+}
+
+// VerificationRequirements records the checks approved for an attempt.
+type VerificationRequirements struct {
+	Names    []string `json:"names,omitempty"`
+	Commands []string `json:"commands,omitempty"`
+}
+
+// ResourceRequest identifies a preconfigured shared resource. Resource values
+// are names only: the runner never provisions ports, containers, or clusters.
+type ResourceRequest struct {
+	Name string `json:"name"`
+}
+
+// ArtifactSpec is an approved logical artifact. Path is relative to the task
+// worktree and is only used when the adapter reports an artifact event.
+type ArtifactSpec struct {
+	Name      string `json:"name"`
+	Path      string `json:"path,omitempty"`
+	MediaType string `json:"mediaType,omitempty"`
+	Digest    string `json:"digest,omitempty"`
+}
+
+// StartRequest is the approved execution envelope accepted by Start.
+type StartRequest struct {
+	ProtocolVersion        string                   `json:"protocolVersion,omitempty"`
+	RequestID              string                   `json:"requestID"`
+	TaskID                 string                   `json:"taskID"`
+	AttemptID              string                   `json:"attemptID"`
+	AttemptEpoch           uint64                   `json:"attemptEpoch"`
+	RepositoryID           string                   `json:"repositoryID"`
+	BaseCommit             string                   `json:"baseCommit"`
+	Instructions           string                   `json:"instructions"`
+	Model                  string                   `json:"model,omitempty"`
+	ApprovedInput          json.RawMessage          `json:"approvedInput,omitempty"`
+	RequiredCapabilities   []string                 `json:"requiredCapabilities,omitempty"`
+	RequiredToolchains     []string                 `json:"requiredToolchains,omitempty"`
+	RequiredEnvironment    []string                 `json:"requiredEnvironment,omitempty"`
+	RequiredHarness        string                   `json:"requiredHarness,omitempty"`
+	RequiredHarnessVersion string                   `json:"requiredHarnessVersion,omitempty"`
+	Limits                 ExecutionLimits          `json:"limits,omitempty"`
+	Verification           VerificationRequirements `json:"verification,omitempty"`
+	Resources              []ResourceRequest        `json:"resources,omitempty"`
+	Artifacts              []ArtifactSpec           `json:"artifacts,omitempty"`
+}
+
+// CancelRequest requests cancellation of an active attempt.
+type CancelRequest struct {
+	ProtocolVersion string `json:"protocolVersion,omitempty"`
+	RequestID       string `json:"requestID"`
+	TaskID          string `json:"taskID"`
+	AttemptID       string `json:"attemptID"`
+	AttemptEpoch    uint64 `json:"attemptEpoch"`
+}
+
+// ResumeRequest continues a needs-input attempt in its existing session.
+type ResumeRequest struct {
+	ProtocolVersion string          `json:"protocolVersion,omitempty"`
+	RequestID       string          `json:"requestID"`
+	TaskID          string          `json:"taskID"`
+	AttemptID       string          `json:"attemptID"`
+	AttemptEpoch    uint64          `json:"attemptEpoch"`
+	SessionID       string          `json:"sessionID,omitempty"`
+	ApprovedInput   json.RawMessage `json:"approvedInput,omitempty"`
+	Resolution      string          `json:"resolution,omitempty"`
+	Instructions    string          `json:"instructions,omitempty"`
+}
+
+// Error describes a structured protocol failure.
+type Error struct {
+	Code             string   `json:"code"`
+	Retryable        bool     `json:"retryable"`
+	Message          string   `json:"message"`
+	Receipt          *Receipt `json:"receipt,omitempty"`
+	SnapshotRequired bool     `json:"snapshotRequired,omitempty"`
+}
+
+func (e *Error) Error() string { return e.Code + ": " + e.Message }
+
+// Event is an ordered, durable attempt event. Data is bounded by the runner
+// before the event is persisted.
+type Event struct {
+	Cursor       uint64          `json:"cursor"`
+	Timestamp    time.Time       `json:"timestamp"`
+	AttemptEpoch uint64          `json:"attemptEpoch"`
+	Type         string          `json:"type"`
+	Message      string          `json:"message,omitempty"`
+	Data         json.RawMessage `json:"data,omitempty"`
+}
+
+// Artifact is an immutable, named result reference.
+type Artifact struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Digest    string    `json:"digest"`
+	Length    int64     `json:"length"`
+	MediaType string    `json:"mediaType"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// Receipt is the durable view of an attempt returned by start and inspect.
+type Receipt struct {
+	ProtocolVersion string     `json:"protocolVersion"`
+	TaskID          string     `json:"taskID"`
+	AttemptID       string     `json:"attemptID"`
+	AttemptEpoch    uint64     `json:"attemptEpoch"`
+	Phase           Phase      `json:"phase"`
+	SessionID       string     `json:"sessionID,omitempty"`
+	Workdir         string     `json:"workdir,omitempty"`
+	Cursor          uint64     `json:"cursor"`
+	Blocker         string     `json:"blocker,omitempty"`
+	Resources       []string   `json:"resources,omitempty"`
+	LastError       *Error     `json:"lastError,omitempty"`
+	Artifacts       []Artifact `json:"artifacts,omitempty"`
+	AcceptedAt      time.Time  `json:"acceptedAt"`
+	UpdatedAt       time.Time  `json:"updatedAt"`
+}
+
+// ArtifactResponse contains immutable artifact metadata and bytes are served
+// by the artifact endpoint. It is kept separate so callers never receive a
+// filesystem path.
+type ArtifactResponse struct {
+	Artifact
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -41,6 +41,13 @@ import (
 const (
 	maxIdentifierBytes = 128
 	maxMessageBytes    = 8 << 10
+
+	// This is the blocker that runner/v1 wrote when Close cancelled an
+	// adapter. Keep it exact because the v1 -> v2 migration only reopens this
+	// ambiguous receipt when the rest of the durable state proves that no
+	// operator cancellation was requested.
+	legacyShutdownCancellationBlocker = "harness exited after cancellation"
+	shutdownBlocker                   = "runner shut down while harness was active; reconcile the existing harness session before resuming"
 )
 
 // Runner is the generic local execution service. It owns protocol state and
@@ -58,6 +65,9 @@ type Runner struct {
 	wg           sync.WaitGroup
 	listener     net.Listener
 	closed       bool
+	closeDone    chan struct{}
+	closeErr     error
+	shutdown     map[string]struct{}
 	capabilities Capabilities
 }
 
@@ -160,6 +170,8 @@ func New(cfg Config, adapter harness.Adapter) (*Runner, error) {
 		lock:         lock,
 		running:      map[string]context.CancelFunc{},
 		subscribers:  map[string]map[chan Event]struct{}{},
+		closeDone:    make(chan struct{}),
+		shutdown:     map[string]struct{}{},
 		capabilities: capabilities,
 	}
 	if err := r.recoverLocked(); err != nil {
@@ -243,16 +255,24 @@ func (r *Runner) ListenAndServe(ctx context.Context) error {
 	return err
 }
 
-// Close cancels active adapters, waits for them to exit, closes the listener,
-// and releases the singleton state lock.
+// Close gracefully drains active adapters, waits for them to exit, closes the
+// listener, and releases the singleton state lock. An adapter interrupted by
+// this shutdown remains resumable; an explicit Cancel request is still
+// terminal.
 func (r *Runner) Close() error {
 	r.mu.Lock()
 	if r.closed {
+		done := r.closeDone
 		r.mu.Unlock()
-		return nil
+		<-done
+		r.mu.Lock()
+		err := r.closeErr
+		r.mu.Unlock()
+		return err
 	}
 	r.closed = true
-	for _, cancel := range r.running {
+	for attemptID, cancel := range r.running {
+		r.shutdown[attemptID] = struct{}{}
 		cancel()
 	}
 	listener := r.listener
@@ -261,7 +281,12 @@ func (r *Runner) Close() error {
 		_ = listener.Close()
 	}
 	r.wg.Wait()
-	return r.lock.Close()
+	closeErr := r.lock.Close()
+	r.mu.Lock()
+	r.closeErr = closeErr
+	close(r.closeDone)
+	r.mu.Unlock()
+	return closeErr
 }
 
 // Start accepts an approved attempt and returns once its receipt and accepted
@@ -650,10 +675,13 @@ func (r *Runner) execute(ctx context.Context, launch harness.Launch, attemptID s
 	defer r.mu.Unlock()
 	attempt, ok := r.state.Attempts[attemptID]
 	if !ok {
+		delete(r.shutdown, attemptID)
 		delete(r.running, attemptID)
 		return
 	}
 	delete(r.running, attemptID)
+	_, shutdown := r.shutdown[attemptID]
+	delete(r.shutdown, attemptID)
 	if attempt.Receipt.LastError != nil {
 		blocker := attempt.Receipt.Blocker
 		if blocker == "" {
@@ -669,16 +697,27 @@ func (r *Runner) execute(ctx context.Context, launch harness.Launch, attemptID s
 		r.finishLocked(attempt, PhaseFailed, "harness returned a foreign session ID", errors.New("foreign session ID"))
 		return
 	}
-	if attempt.CancelPending || errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		if attempt.LimitExceeded || errors.Is(ctx.Err(), context.DeadlineExceeded) && !attempt.CancelPending {
-			blocker := attempt.Receipt.Blocker
-			if blocker == "" && errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				blocker = "harness exceeded the approved execution duration"
-			}
-			r.finishLocked(attempt, PhaseFailed, blocker, nil)
-			return
+	if attempt.LimitExceeded || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		blocker := attempt.Receipt.Blocker
+		if blocker == "" && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			blocker = "harness exceeded the approved execution duration"
 		}
-		r.finishLocked(attempt, PhaseCancelled, "harness exited after cancellation", nil)
+		r.finishLocked(attempt, PhaseFailed, blocker, nil)
+		return
+	}
+	if attempt.CancelPending {
+		r.finishLocked(attempt, PhaseCancelled, legacyShutdownCancellationBlocker, nil)
+		return
+	}
+	// Close cancels the adapter context so the child process can be drained.
+	// That cancellation is a resumable interruption, unlike an explicit
+	// Cancel request. Only map a context cancellation to needs_input here; if
+	// an adapter completed or failed before shutdown won the reconciliation
+	// race, its terminal result below remains authoritative.
+	resultPhase := Phase(result.Phase)
+	shutdownInterrupted := (resultPhase == PhaseCancelled || resultPhase == PhaseNeedsInput || resultPhase == "") && (runErr == nil || errors.Is(runErr, context.Canceled))
+	if shutdown && errors.Is(ctx.Err(), context.Canceled) && shutdownInterrupted {
+		r.finishLocked(attempt, PhaseNeedsInput, shutdownBlocker, nil)
 		return
 	}
 	if runErr != nil {
@@ -983,6 +1022,14 @@ func (r *Runner) recoverLocked() error {
 	for attemptID, attempt := range r.state.Attempts {
 		if attempt == nil {
 			delete(r.state.Attempts, attemptID)
+			changed = true
+			continue
+		}
+		if _, migrated := r.state.migratedLegacyShutdown[attemptID]; migrated {
+			delete(r.state.migratedLegacyShutdown, attemptID)
+			if _, err := r.appendEventLocked(attemptID, EventNeedsInput, attempt.Receipt.Blocker, nil); err != nil {
+				return err
+			}
 			changed = true
 			continue
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1,0 +1,1213 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+const (
+	maxIdentifierBytes = 128
+	maxMessageBytes    = 8 << 10
+)
+
+// Runner is the generic local execution service. It owns protocol state and
+// workspace/resource boundaries; harness.Adapter owns the child process.
+type Runner struct {
+	cfg     Config
+	adapter harness.Adapter
+	store   *stateStore
+	state   persistedState
+	lock    *processLock
+
+	mu           sync.Mutex
+	running      map[string]context.CancelFunc
+	subscribers  map[string]map[chan Event]struct{}
+	wg           sync.WaitGroup
+	listener     net.Listener
+	closed       bool
+	capabilities Capabilities
+}
+
+// executionGate keeps adapter callbacks ordered with terminal result
+// reconciliation. An adapter may emit from another goroutine, so the runner
+// must wait for callbacks that started before Run returned before accepting
+// the adapter's result.
+type executionGate struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	active int
+	closed bool
+}
+
+func newExecutionGate() *executionGate {
+	gate := &executionGate{}
+	gate.cond = sync.NewCond(&gate.mu)
+	return gate
+}
+
+func (g *executionGate) begin() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.closed {
+		return false
+	}
+	g.active++
+	return true
+}
+
+func (g *executionGate) end() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.active--
+	if g.active == 0 {
+		g.cond.Broadcast()
+	}
+}
+
+func (g *executionGate) close() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.closed = true
+	for g.active > 0 {
+		g.cond.Wait()
+	}
+}
+
+// New creates a runner, loads durable state, probes the harness without model
+// calls, and acquires the state-directory singleton lock.
+func New(cfg Config, adapter harness.Adapter) (*Runner, error) {
+	if adapter == nil {
+		return nil, errors.New("runner harness adapter is required")
+	}
+	if err := cfg.applyDefaults(); err != nil {
+		return nil, err
+	}
+	store, err := newStateStore(cfg.StateDir)
+	if err != nil {
+		return nil, err
+	}
+	lock, err := acquireProcessLock(filepath.Join(cfg.StateDir, "runner.lock"))
+	if err != nil {
+		return nil, err
+	}
+	state, err := store.load()
+	if err != nil {
+		_ = lock.Close()
+		return nil, err
+	}
+	info, probeErr := adapter.Probe(context.Background())
+	capabilities := Capabilities{
+		ProtocolVersion: cfg.ProtocolVersion,
+		RunnerID:        cfg.RunnerID,
+		Version:         cfg.Version,
+		OS:              runtime.GOOS,
+		Architecture:    runtime.GOARCH,
+		Toolchains:      append([]string(nil), cfg.Toolchains...),
+		Environment:     append([]string(nil), cfg.Environment...),
+		Verification:    append([]string(nil), cfg.Verification...),
+		Capacity:        Capacity{Maximum: cfg.MaximumCapacity},
+		Ready:           probeErr == nil && info.Ready && len(info.Reasons) == 0,
+	}
+	harnessReasons := append([]string(nil), info.Reasons...)
+	if probeErr != nil {
+		reason := "harness probe failed: " + probeErr.Error()
+		capabilities.Reasons = []string{reason}
+		harnessReasons = append(harnessReasons, reason)
+	}
+	capabilities.Harnesses = []HarnessCapability{{Name: info.Name, Version: info.Version, Ready: probeErr == nil && info.Ready && len(info.Reasons) == 0, Reasons: harnessReasons}}
+	capabilities.Reasons = append(capabilities.Reasons, info.Reasons...)
+	if !info.Ready && probeErr == nil && len(info.Reasons) == 0 {
+		capabilities.Reasons = append(capabilities.Reasons, "harness is not ready")
+	}
+	r := &Runner{
+		cfg:          cfg,
+		adapter:      adapter,
+		store:        store,
+		state:        state,
+		lock:         lock,
+		running:      map[string]context.CancelFunc{},
+		subscribers:  map[string]map[chan Event]struct{}{},
+		capabilities: capabilities,
+	}
+	if err := r.recoverLocked(); err != nil {
+		_ = lock.Close()
+		return nil, err
+	}
+	if err := r.persistLocked(); err != nil {
+		_ = lock.Close()
+		return nil, err
+	}
+	return r, nil
+}
+
+// NewRunner is an explicit alias for callers that prefer the type name.
+func NewRunner(cfg Config, adapter harness.Adapter) (*Runner, error) {
+	return New(cfg, adapter)
+}
+
+// NewServer is retained as a transport-oriented constructor alias.
+func NewServer(cfg Config, adapter harness.Adapter) (*Runner, error) {
+	return New(cfg, adapter)
+}
+
+// Capabilities returns a copy of the current discovery document.
+func (r *Runner) Capabilities() Capabilities {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.capabilitiesLocked()
+}
+
+func (r *Runner) capabilitiesLocked() Capabilities {
+	c := r.capabilities
+	c.Harnesses = append([]HarnessCapability(nil), c.Harnesses...)
+	c.Toolchains = append([]string(nil), c.Toolchains...)
+	c.Environment = append([]string(nil), c.Environment...)
+	c.Verification = append([]string(nil), c.Verification...)
+	c.Reasons = append([]string(nil), c.Reasons...)
+	c.Capacity.Used = r.activeCountLocked()
+	if c.Capacity.Maximum <= 0 {
+		c.Capacity.Maximum = 1
+	}
+	return c
+}
+
+// Handler returns the authenticated loopback runner protocol handler. The
+// handler itself does not bind a socket; ListenAndServe enforces loopback.
+func (r *Runner) Handler() http.Handler {
+	return http.HandlerFunc(r.serveHTTP)
+}
+
+// ListenAndServe starts the runner on the configured loopback address and
+// stops when ctx is cancelled.
+func (r *Runner) ListenAndServe(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if !isLoopbackListenAddress(r.cfg.Listen) {
+		return fmt.Errorf("runner listen address %q is not loopback-only", r.cfg.Listen)
+	}
+	listener, err := net.Listen("tcp", r.cfg.Listen)
+	if err != nil {
+		return fmt.Errorf("listen for runner: %w", err)
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		_ = listener.Close()
+		return errors.New("runner is closed")
+	}
+	r.listener = listener
+	r.mu.Unlock()
+	go func() {
+		<-ctx.Done()
+		_ = listener.Close()
+	}()
+	server := &http.Server{Handler: r.Handler()}
+	err = server.Serve(listener)
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, os.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+// Close cancels active adapters, waits for them to exit, closes the listener,
+// and releases the singleton state lock.
+func (r *Runner) Close() error {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	for _, cancel := range r.running {
+		cancel()
+	}
+	listener := r.listener
+	r.mu.Unlock()
+	if listener != nil {
+		_ = listener.Close()
+	}
+	r.wg.Wait()
+	return r.lock.Close()
+}
+
+// Start accepts an approved attempt and returns once its receipt and accepted
+// event have been durably persisted. Execution continues asynchronously.
+func (r *Runner) Start(ctx context.Context, request StartRequest) (Receipt, error) {
+	if err := validateProtocolVersion(request.ProtocolVersion); err != nil {
+		return Receipt{}, protocolError(ErrorUnsupportedVersion, false, err.Error(), nil)
+	}
+	if err := validateStartRequest(request); err != nil {
+		return Receipt{}, protocolError(ErrorInvalidRequest, false, err.Error(), nil)
+	}
+	fingerprint := fingerprintOf(request)
+	opKey := operationKey("start", request.TaskID, request.AttemptID, request.AttemptEpoch, request.RequestID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return Receipt{}, protocolError(ErrorUnavailable, true, "runner is closed", nil)
+	}
+	if prior, ok := r.state.Operations[opKey]; ok {
+		if prior.Fingerprint != fingerprint {
+			priorReceipt, _ := r.receiptForAttemptLocked(prior.AttemptID)
+			return Receipt{}, protocolError(ErrorIdempotencyConflict, false, "request ID was already used with different content", &priorReceipt)
+		}
+		if attempt := r.state.Attempts[prior.AttemptID]; attempt != nil && attempt.Receipt.Phase == PhaseAccepted && !attempt.CancelPending {
+			if err := r.startExecutionLocked(prior.AttemptID, attempt.Start.Instructions, attempt.Start.Model); err != nil {
+				return Receipt{}, protocolError(ErrorUnavailable, true, "persist starting attempt: "+err.Error(), &attempt.Receipt)
+			}
+		}
+		return r.receiptForAttemptLocked(prior.AttemptID)
+	}
+	if err := r.checkEpochLocked(request.TaskID, request.AttemptID, request.AttemptEpoch); err != nil {
+		return Receipt{}, err
+	}
+	if existing, ok := r.state.Attempts[request.AttemptID]; ok {
+		if existing.Fingerprint != fingerprint || existing.Receipt.TaskID != request.TaskID || existing.Receipt.AttemptEpoch != request.AttemptEpoch {
+			return Receipt{}, protocolError(ErrorIdempotencyConflict, false, "attempt ID is already bound to different content", &existing.Receipt)
+		}
+		return existing.Receipt, nil
+	}
+	if err := r.checkStartRequirementsLocked(request); err != nil {
+		return Receipt{}, err
+	}
+	if err := r.reserveResourcesLocked(request.AttemptID, request.Resources); err != nil {
+		return Receipt{}, err
+	}
+	workdir, err := prepareWorkspace(ctx, r.cfg, request)
+	if err != nil {
+		r.releaseResourcesLocked(request.AttemptID, request.Resources)
+		return Receipt{}, protocolError(ErrorUnavailable, true, err.Error(), nil)
+	}
+	now := eventNow()
+	receipt := Receipt{
+		ProtocolVersion: ProtocolVersion,
+		TaskID:          request.TaskID,
+		AttemptID:       request.AttemptID,
+		AttemptEpoch:    request.AttemptEpoch,
+		Phase:           PhaseAccepted,
+		Workdir:         workdir,
+		Resources:       resourceNames(request.Resources),
+		AcceptedAt:      now,
+		UpdatedAt:       now,
+	}
+	r.state.Attempts[request.AttemptID] = &attemptRecord{
+		Receipt:       receipt,
+		Start:         cloneStartRequest(request),
+		Fingerprint:   fingerprint,
+		Resources:     resourceNames(request.Resources),
+		ArtifactSpecs: append([]ArtifactSpec(nil), request.Artifacts...),
+	}
+	r.state.Operations[opKey] = operationRecord{Fingerprint: fingerprint, AttemptID: request.AttemptID}
+	if _, err := r.appendEventLocked(request.AttemptID, EventAccepted, "attempt accepted", nil); err != nil {
+		delete(r.state.Operations, opKey)
+		delete(r.state.Attempts, request.AttemptID)
+		r.releaseResourcesLocked(request.AttemptID, request.Resources)
+		return Receipt{}, err
+	}
+	if err := r.persistLocked(); err != nil {
+		return Receipt{}, protocolError(ErrorUnavailable, true, "persist accepted attempt: "+err.Error(), nil)
+	}
+	if err := r.startExecutionLocked(request.AttemptID, request.Instructions, request.Model); err != nil {
+		return Receipt{}, protocolError(ErrorUnavailable, true, "persist starting attempt: "+err.Error(), &r.state.Attempts[request.AttemptID].Receipt)
+	}
+	return receiptForResponse(r.state.Attempts[request.AttemptID].Receipt), nil
+}
+
+// Inspect returns the durable current receipt.
+func (r *Runner) Inspect(_ context.Context, attemptID string) (Receipt, error) {
+	if err := validateIdentifier("attemptID", attemptID); err != nil {
+		return Receipt{}, protocolError(ErrorInvalidRequest, false, err.Error(), nil)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	attempt, ok := r.state.Attempts[attemptID]
+	if !ok {
+		return Receipt{}, protocolError(ErrorUnavailable, false, "attempt not found", nil)
+	}
+	return receiptForResponse(attempt.Receipt), nil
+}
+
+// Cancel requests adapter cancellation. It returns while the attempt is in
+// cancelling; only adapter exit transitions it to cancelled.
+func (r *Runner) Cancel(_ context.Context, request CancelRequest) (Receipt, error) {
+	if err := validateMutationIdentity(request.TaskID, request.AttemptID, request.AttemptEpoch, request.RequestID); err != nil {
+		return Receipt{}, protocolError(ErrorInvalidRequest, false, err.Error(), nil)
+	}
+	if request.ProtocolVersion != ProtocolVersion {
+		return Receipt{}, protocolError(ErrorUnsupportedVersion, false, "protocolVersion must be runner/v1", nil)
+	}
+	fingerprint := fingerprintOf(request)
+	opKey := operationKey("cancel", request.TaskID, request.AttemptID, request.AttemptEpoch, request.RequestID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return Receipt{}, protocolError(ErrorUnavailable, true, "runner is closed", nil)
+	}
+	if prior, ok := r.state.Operations[opKey]; ok {
+		if prior.Fingerprint != fingerprint {
+			priorReceipt, _ := r.receiptForAttemptLocked(prior.AttemptID)
+			return Receipt{}, protocolError(ErrorIdempotencyConflict, false, "request ID was already used with different content", &priorReceipt)
+		}
+		return r.receiptForAttemptLocked(prior.AttemptID)
+	}
+	attempt, err := r.attemptForMutationLocked(request.TaskID, request.AttemptID, request.AttemptEpoch)
+	if err != nil {
+		return Receipt{}, err
+	}
+	r.state.Operations[opKey] = operationRecord{Fingerprint: fingerprint, AttemptID: request.AttemptID}
+	if attempt.Receipt.Phase.IsTerminal() {
+		if err := r.persistLocked(); err != nil {
+			return Receipt{}, protocolError(ErrorUnavailable, true, err.Error(), &attempt.Receipt)
+		}
+		return receiptForResponse(attempt.Receipt), nil
+	}
+	attempt.CancelPending = true
+	attempt.Receipt.Phase = PhaseCancelling
+	attempt.Receipt.Blocker = "cancellation requested; waiting for harness exit"
+	attempt.Receipt.UpdatedAt = eventNow()
+	if _, err := r.appendEventLocked(request.AttemptID, EventProgress, "cancellation requested", nil); err != nil {
+		return Receipt{}, err
+	}
+	if err := r.persistLocked(); err != nil {
+		return Receipt{}, protocolError(ErrorUnavailable, true, err.Error(), &attempt.Receipt)
+	}
+	if cancel := r.running[request.AttemptID]; cancel != nil {
+		cancel()
+	} else {
+		// A recovered attempt has no child to wait for. It is safe to acknowledge
+		// cancellation immediately while retaining the worktree and session.
+		r.finishLocked(attempt, PhaseCancelled, "cancelled after restart; no active harness process", nil)
+	}
+	return receiptForResponse(attempt.Receipt), nil
+}
+
+// Resume continues a needs-input attempt with its existing session and
+// worktree. It never accepts a different instruction envelope or session ID.
+func (r *Runner) Resume(ctx context.Context, request ResumeRequest) (Receipt, error) {
+	if err := validateMutationIdentity(request.TaskID, request.AttemptID, request.AttemptEpoch, request.RequestID); err != nil {
+		return Receipt{}, protocolError(ErrorInvalidRequest, false, err.Error(), nil)
+	}
+	if request.ProtocolVersion != ProtocolVersion {
+		return Receipt{}, protocolError(ErrorUnsupportedVersion, false, "protocolVersion must be runner/v1", nil)
+	}
+	fingerprint := fingerprintOf(request)
+	opKey := operationKey("resume", request.TaskID, request.AttemptID, request.AttemptEpoch, request.RequestID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return Receipt{}, protocolError(ErrorUnavailable, true, "runner is closed", nil)
+	}
+	if prior, ok := r.state.Operations[opKey]; ok {
+		if prior.Fingerprint != fingerprint {
+			priorReceipt, _ := r.receiptForAttemptLocked(prior.AttemptID)
+			return Receipt{}, protocolError(ErrorIdempotencyConflict, false, "request ID was already used with different content", &priorReceipt)
+		}
+		return r.receiptForAttemptLocked(prior.AttemptID)
+	}
+	attempt, err := r.attemptForMutationLocked(request.TaskID, request.AttemptID, request.AttemptEpoch)
+	if err != nil {
+		return Receipt{}, err
+	}
+	if attempt.Receipt.Phase != PhaseNeedsInput {
+		if attempt.Receipt.Phase.IsTerminal() {
+			return Receipt{}, protocolError(ErrorCheckpointUnavailable, false, "attempt is not resumable", &attempt.Receipt)
+		}
+		return Receipt{}, protocolError(ErrorBusy, true, "attempt is still executing", &attempt.Receipt)
+	}
+	if request.SessionID == "" || request.SessionID != attempt.Receipt.SessionID {
+		return Receipt{}, protocolError(ErrorCheckpointUnavailable, false, "resume session does not match the attempt", &attempt.Receipt)
+	}
+	if len(request.ApprovedInput) > 0 && !equivalentJSON(request.ApprovedInput, attempt.Start.ApprovedInput) {
+		return Receipt{}, protocolError(ErrorForbidden, false, "resume cannot amend approved input", &attempt.Receipt)
+	}
+	if request.Instructions != "" && request.Instructions != attempt.Start.Instructions {
+		return Receipt{}, protocolError(ErrorForbidden, false, "resume cannot amend approved instructions", &attempt.Receipt)
+	}
+	if strings.TrimSpace(request.Resolution) == "" {
+		return Receipt{}, protocolError(ErrorInvalidRequest, false, "resume requires an explicit resolution", &attempt.Receipt)
+	}
+	if attempt.Receipt.SessionID == "" {
+		return Receipt{}, protocolError(ErrorCheckpointUnavailable, false, "attempt has no recoverable session", &attempt.Receipt)
+	}
+	if err := verifyWorkspace(ctx, r.cfg, attempt.Start, attempt.Receipt.Workdir); err != nil {
+		return Receipt{}, protocolError(ErrorCheckpointUnavailable, false, err.Error(), &attempt.Receipt)
+	}
+	if err := r.checkStartRequirementsLocked(attempt.Start); err != nil {
+		return Receipt{}, err
+	}
+	if err := r.reserveResourcesLocked(request.AttemptID, resourceRequests(attempt.Resources)); err != nil {
+		return Receipt{}, err
+	}
+	r.state.Operations[opKey] = operationRecord{Fingerprint: fingerprint, AttemptID: request.AttemptID}
+	attempt.CancelPending = false
+	attempt.Receipt.Phase = PhaseAccepted
+	attempt.Receipt.Blocker = ""
+	attempt.Receipt.LastError = nil
+	attempt.Receipt.UpdatedAt = eventNow()
+	if _, err := r.appendEventLocked(request.AttemptID, EventAccepted, "resume accepted", nil); err != nil {
+		return Receipt{}, err
+	}
+	if err := r.persistLocked(); err != nil {
+		return Receipt{}, protocolError(ErrorUnavailable, true, err.Error(), &attempt.Receipt)
+	}
+	instructions := attempt.Start.Instructions + "\n\nResolution:\n" + request.Resolution
+	if err := r.startExecutionLocked(request.AttemptID, instructions, attempt.Start.Model); err != nil {
+		return Receipt{}, protocolError(ErrorUnavailable, true, "persist starting resume: "+err.Error(), &attempt.Receipt)
+	}
+	return receiptForResponse(attempt.Receipt), nil
+}
+
+func (r *Runner) checkStartRequirementsLocked(request StartRequest) error {
+	if !r.capabilities.Ready {
+		return protocolError(ErrorUnavailable, true, "runner is not ready: "+strings.Join(r.capabilities.Reasons, "; "), nil)
+	}
+	if request.Limits.MaxTurns > 1 {
+		return protocolError(ErrorUnsupportedCapability, false, "runner supports at most one harness turn per execution", nil)
+	}
+	for _, required := range request.RequiredCapabilities {
+		if !contains(r.capabilities.Verification, required) && !contains(r.cfg.Environment, required) && !contains(r.cfg.Toolchains, required) {
+			return protocolError(ErrorUnsupportedCapability, false, "required capability is unavailable: "+required, nil)
+		}
+	}
+	for _, required := range request.RequiredToolchains {
+		if !contains(r.cfg.Toolchains, required) {
+			return protocolError(ErrorUnsupportedCapability, false, "required toolchain is unavailable: "+required, nil)
+		}
+	}
+	for _, required := range request.RequiredEnvironment {
+		if !contains(r.cfg.Environment, required) {
+			return protocolError(ErrorUnsupportedCapability, false, "required environment is unavailable: "+required, nil)
+		}
+	}
+	if request.RequiredHarness != "" {
+		found := false
+		for _, h := range r.capabilities.Harnesses {
+			if h.Name == request.RequiredHarness && (request.RequiredHarnessVersion == "" || h.Version == request.RequiredHarnessVersion) && h.Ready {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return protocolError(ErrorUnsupportedCapability, false, "required harness is unavailable", nil)
+		}
+	}
+	for _, resource := range request.Resources {
+		if _, ok := r.cfg.Resources[resource.Name]; !ok {
+			return protocolError(ErrorUnsupportedCapability, false, "resource is not configured: "+resource.Name, nil)
+		}
+	}
+	if r.activeCountLocked() >= r.cfg.MaximumCapacity {
+		return protocolError(ErrorBusy, true, "runner execution capacity is full", nil)
+	}
+	return nil
+}
+
+func (r *Runner) checkEpochLocked(taskID, attemptID string, epoch uint64) error {
+	var highest uint64
+	for id, attempt := range r.state.Attempts {
+		if attempt.Receipt.TaskID != taskID || id == attemptID {
+			continue
+		}
+		if attempt.Receipt.AttemptEpoch > highest {
+			highest = attempt.Receipt.AttemptEpoch
+		}
+	}
+	if highest != 0 && epoch <= highest {
+		for _, attempt := range r.state.Attempts {
+			if attempt.Receipt.TaskID == taskID && attempt.Receipt.AttemptEpoch == highest {
+				return protocolError(ErrorStaleAttempt, false, "attempt epoch is obsolete", &attempt.Receipt)
+			}
+		}
+	}
+	return nil
+}
+
+func (r *Runner) attemptForMutationLocked(taskID, attemptID string, epoch uint64) (*attemptRecord, error) {
+	attempt, ok := r.state.Attempts[attemptID]
+	if !ok {
+		return nil, protocolError(ErrorUnavailable, false, "attempt not found", nil)
+	}
+	if attempt.Receipt.TaskID != taskID || attempt.Receipt.AttemptEpoch != epoch {
+		return nil, protocolError(ErrorStaleAttempt, false, "attempt identity or epoch is obsolete", &attempt.Receipt)
+	}
+	return attempt, nil
+}
+
+func (r *Runner) reserveResourcesLocked(attemptID string, requested []ResourceRequest) error {
+	for _, request := range requested {
+		resource, ok := r.cfg.Resources[request.Name]
+		if !ok {
+			return protocolError(ErrorUnsupportedCapability, false, "resource is not configured: "+request.Name, nil)
+		}
+		used := 0
+		for key, reservation := range r.state.Reservations {
+			if reservation.AttemptID == attemptID {
+				continue
+			}
+			separator := strings.LastIndexByte(key, '/')
+			if separator > 0 && key[:separator] == request.Name {
+				used++
+			}
+		}
+		if used >= resource.Capacity {
+			return protocolError(ErrorBusy, true, "resource is already reserved: "+request.Name, nil)
+		}
+	}
+	for _, request := range requested {
+		r.state.Reservations[request.Name+"/"+attemptID] = reservationRecord{AttemptID: attemptID}
+	}
+	return nil
+}
+
+func (r *Runner) releaseResourcesLocked(attemptID string, requested []ResourceRequest) {
+	for _, request := range requested {
+		delete(r.state.Reservations, request.Name+"/"+attemptID)
+	}
+}
+
+func (r *Runner) startExecutionLocked(attemptID, instructions, model string) error {
+	if _, running := r.running[attemptID]; running {
+		return nil
+	}
+	attempt, ok := r.state.Attempts[attemptID]
+	if !ok {
+		return errors.New("attempt not found")
+	}
+	previousPhase := attempt.Receipt.Phase
+	previousBlocker := attempt.Receipt.Blocker
+	previousUpdatedAt := attempt.Receipt.UpdatedAt
+	execCtx := context.Background()
+	var cancel context.CancelFunc
+	if attempt.Start.Limits.MaxDurationSeconds > 0 {
+		execCtx, cancel = context.WithTimeout(execCtx, time.Duration(attempt.Start.Limits.MaxDurationSeconds)*time.Second)
+	} else {
+		execCtx, cancel = context.WithCancel(execCtx)
+	}
+	r.running[attemptID] = cancel
+	attempt.Receipt.Phase = PhaseStarting
+	attempt.Receipt.Blocker = ""
+	attempt.Receipt.UpdatedAt = eventNow()
+	if err := r.persistLocked(); err != nil {
+		cancel()
+		delete(r.running, attemptID)
+		attempt.Receipt.Phase = previousPhase
+		attempt.Receipt.Blocker = previousBlocker
+		attempt.Receipt.UpdatedAt = previousUpdatedAt
+		return err
+	}
+	launch := harness.Launch{AttemptID: attemptID, Workdir: attempt.Receipt.Workdir, SessionID: attempt.Receipt.SessionID, Instructions: instructions, Model: model}
+	r.wg.Add(1)
+	go r.execute(execCtx, launch, attemptID)
+	return nil
+}
+
+func (r *Runner) execute(ctx context.Context, launch harness.Launch, attemptID string) {
+	defer r.wg.Done()
+	gate := newExecutionGate()
+	result, runErr := r.adapter.Run(ctx, launch, func(event harness.Event) error {
+		if !gate.begin() {
+			return errors.New("harness event arrived after adapter execution ended")
+		}
+		defer gate.end()
+		return r.handleHarnessEvent(attemptID, event)
+	})
+	gate.close()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	attempt, ok := r.state.Attempts[attemptID]
+	if !ok {
+		delete(r.running, attemptID)
+		return
+	}
+	delete(r.running, attemptID)
+	if attempt.Receipt.LastError != nil {
+		blocker := attempt.Receipt.Blocker
+		if blocker == "" {
+			blocker = attempt.Receipt.LastError.Message
+		}
+		r.finishLocked(attempt, PhaseFailed, blocker, nil)
+		return
+	}
+	if attempt.Receipt.SessionID == "" && result.SessionID != "" {
+		attempt.Receipt.SessionID = result.SessionID
+	}
+	if result.SessionID != "" && result.SessionID != attempt.Receipt.SessionID {
+		r.finishLocked(attempt, PhaseFailed, "harness returned a foreign session ID", errors.New("foreign session ID"))
+		return
+	}
+	if attempt.CancelPending || errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		if attempt.LimitExceeded || errors.Is(ctx.Err(), context.DeadlineExceeded) && !attempt.CancelPending {
+			blocker := attempt.Receipt.Blocker
+			if blocker == "" && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				blocker = "harness exceeded the approved execution duration"
+			}
+			r.finishLocked(attempt, PhaseFailed, blocker, nil)
+			return
+		}
+		r.finishLocked(attempt, PhaseCancelled, "harness exited after cancellation", nil)
+		return
+	}
+	if runErr != nil {
+		r.finishLocked(attempt, PhaseFailed, runErr.Error(), runErr)
+		return
+	}
+	switch Phase(result.Phase) {
+	case PhaseCompleted:
+		r.finishLocked(attempt, PhaseCompleted, "", nil)
+	case PhaseCancelled:
+		r.finishLocked(attempt, PhaseCancelled, "harness cancelled", nil)
+	case PhaseNeedsInput:
+		r.finishLocked(attempt, PhaseNeedsInput, result.Blocker, nil)
+	case PhaseFailed:
+		r.finishLocked(attempt, PhaseFailed, result.Blocker, nil)
+	default:
+		r.finishLocked(attempt, PhaseFailed, "harness returned no terminal phase", nil)
+	}
+}
+
+func (r *Runner) handleHarnessEvent(attemptID string, event harness.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	attempt, ok := r.state.Attempts[attemptID]
+	if !ok {
+		return errors.New("attempt no longer exists")
+	}
+	if attempt.Receipt.LastError != nil {
+		return firstHarnessFailure(attempt)
+	}
+	if attempt.Receipt.Phase.IsTerminal() {
+		return fmt.Errorf("harness event arrived after attempt entered terminal phase %s", attempt.Receipt.Phase)
+	}
+	fail := func(err error) error {
+		return r.failHarnessEventLocked(attemptID, attempt, err)
+	}
+	if event.SessionID != "" {
+		if attempt.Receipt.SessionID != "" && event.SessionID != attempt.Receipt.SessionID {
+			return fail(errors.New("harness event returned a foreign session ID"))
+		}
+		if attempt.Receipt.SessionID == "" {
+			// The adapter's session event is the first durable identity of a new
+			// Codex thread. Persisting it in the same journal transaction makes
+			// it available before any turn event and avoids passing a fabricated
+			// resume ID to a fresh harness session.
+			attempt.Receipt.SessionID = event.SessionID
+		}
+	}
+	if event.Data != nil && len(event.Data) > r.cfg.MaxEventBytes {
+		return fail(fmt.Errorf("harness event exceeds %d-byte limit", r.cfg.MaxEventBytes))
+	}
+	if event.Message != "" && len(event.Message) > maxMessageBytes {
+		event.Message = event.Message[:maxMessageBytes]
+	}
+	eventBytes := int64(len(event.Message) + len(event.Data))
+	if limit := attempt.Start.Limits.MaxOutputBytes; limit > 0 && attempt.OutputBytes+eventBytes > int64(limit) {
+		attempt.LimitExceeded = true
+		return fail(errors.New("harness output limit exceeded"))
+	}
+	attempt.OutputBytes += eventBytes
+	if event.Type == "" {
+		event.Type = EventProgress
+	}
+	protocolType := event.Type
+	switch event.Type {
+	case "session", "turn_started", "turn_completed":
+		protocolType = EventProgress
+	case EventAccepted, EventStarted, EventProgress, EventCheckpoint, EventNeedsInput, EventArtifact, EventCompleted, EventFailed, EventCancelled:
+	default:
+		protocolType = EventProgress
+	}
+	if _, err := r.appendEventLocked(attemptID, protocolType, event.Message, event.Data); err != nil {
+		return fail(err)
+	}
+	switch protocolType {
+	case EventStarted, EventProgress, EventCheckpoint:
+		if attempt.Receipt.Phase != PhaseCancelling {
+			attempt.Receipt.Phase = PhaseRunning
+		}
+	case EventNeedsInput:
+		attempt.Receipt.Phase = PhaseNeedsInput
+		attempt.Receipt.Blocker = event.Message
+	case EventCompleted, EventFailed:
+		// The adapter's terminal result is authoritative. Recording the event
+		// before Run returns must not make cancellation look complete.
+		if attempt.Receipt.Phase != PhaseCancelling {
+			attempt.Receipt.Phase = PhaseRunning
+		}
+	case EventCancelled:
+		// Cancellation is terminal only after Adapter.Run returns.
+		attempt.Receipt.Phase = PhaseCancelling
+	}
+	attempt.Receipt.UpdatedAt = eventNow()
+	if protocolType == EventArtifact {
+		if err := r.recordArtifactLocked(attempt, event.Data); err != nil {
+			return fail(err)
+		}
+	}
+	if err := r.persistLocked(); err != nil {
+		return fail(err)
+	}
+	return nil
+}
+
+func (r *Runner) failHarnessEventLocked(attemptID string, attempt *attemptRecord, failure error) error {
+	if failure == nil {
+		return nil
+	}
+	if attempt.Receipt.LastError != nil {
+		return firstHarnessFailure(attempt)
+	}
+	message := failure.Error()
+	if message == "" {
+		message = "harness event handling failed"
+	}
+	attempt.CancelPending = true
+	attempt.Receipt.Phase = PhaseCancelling
+	attempt.Receipt.Blocker = message
+	attempt.Receipt.LastError = &Error{Code: ErrorUnavailable, Retryable: false, Message: message}
+	attempt.Receipt.UpdatedAt = eventNow()
+	_, appendErr := r.appendEventLocked(attemptID, EventProgress, message, nil)
+	persistErr := r.persistLocked()
+	if cancel := r.running[attemptID]; cancel != nil {
+		cancel()
+	}
+	if appendErr != nil || persistErr != nil {
+		return errors.Join(failure, appendErr, persistErr)
+	}
+	return failure
+}
+
+func firstHarnessFailure(attempt *attemptRecord) error {
+	if attempt.Receipt.LastError != nil && attempt.Receipt.LastError.Message != "" {
+		return errors.New(attempt.Receipt.LastError.Message)
+	}
+	return errors.New("harness event handling failed")
+}
+
+func (r *Runner) recordArtifactLocked(attempt *attemptRecord, data json.RawMessage) error {
+	var input struct {
+		Name      string `json:"name"`
+		Path      string `json:"path"`
+		MediaType string `json:"mediaType"`
+		Digest    string `json:"digest"`
+	}
+	if len(data) == 0 || json.Unmarshal(data, &input) != nil {
+		return errors.New("artifact event requires a JSON name/path payload")
+	}
+	var spec *ArtifactSpec
+	for i := range attempt.ArtifactSpecs {
+		if attempt.ArtifactSpecs[i].Name == input.Name {
+			spec = &attempt.ArtifactSpecs[i]
+			break
+		}
+	}
+	if spec == nil {
+		return errors.New("artifact name is not in the approved allowlist")
+	}
+	for _, prior := range attempt.Receipt.Artifacts {
+		if prior.Name == input.Name {
+			return errors.New("artifact name has already been recorded and is immutable")
+		}
+	}
+	if spec.Path != "" && spec.Path != input.Path {
+		return errors.New("artifact path differs from the approved allowlist")
+	}
+	if input.MediaType == "" {
+		input.MediaType = spec.MediaType
+	}
+	if input.MediaType == "" {
+		input.MediaType = "application/octet-stream"
+	}
+	source, err := artifactSource(attempt.Receipt.Workdir, input.Path)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(source)
+	if err != nil || !info.Mode().IsRegular() {
+		if err == nil {
+			err = errors.New("artifact source is not a regular file")
+		}
+		return err
+	}
+	if info.Size() > r.cfg.MaxArtifactSize {
+		return fmt.Errorf("artifact exceeds %d-byte limit", r.cfg.MaxArtifactSize)
+	}
+	f, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	artifactDir := filepath.Join(r.cfg.StateDir, "artifacts", attempt.Receipt.AttemptID)
+	if err := os.MkdirAll(artifactDir, 0o700); err != nil {
+		return err
+	}
+	artifactID := newArtifactID(input.Name)
+	dest := filepath.Join(artifactDir, artifactID+".bin")
+	tmp, err := os.CreateTemp(artifactDir, ".artifact-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}()
+	hash := sha256.New()
+	written, err := io.Copy(io.MultiWriter(tmp, hash), io.LimitReader(f, r.cfg.MaxArtifactSize+1))
+	if err != nil {
+		return err
+	}
+	if written > r.cfg.MaxArtifactSize {
+		return fmt.Errorf("artifact exceeds %d-byte limit", r.cfg.MaxArtifactSize)
+	}
+	digest := "sha256:" + hex.EncodeToString(hash.Sum(nil))
+	if spec.Digest != "" && spec.Digest != digest {
+		return errors.New("artifact digest differs from the approved allowlist")
+	}
+	if input.Digest != "" && input.Digest != digest {
+		return errors.New("artifact event digest does not match bytes")
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, dest); err != nil {
+		return err
+	}
+	artifact := Artifact{ID: artifactID, Name: input.Name, Digest: digest, Length: written, MediaType: input.MediaType, CreatedAt: eventNow()}
+	r.state.Artifacts[artifactID] = artifactRecord{Artifact: artifact, Path: dest}
+	attempt.Receipt.Artifacts = append(attempt.Receipt.Artifacts, artifact)
+	return nil
+}
+
+func (r *Runner) finishLocked(attempt *attemptRecord, phase Phase, blocker string, lastErr error) {
+	if attempt.Receipt.Phase.IsTerminal() && phase != PhaseCancelling {
+		return
+	}
+	attempt.Receipt.Phase = phase
+	attempt.Receipt.Blocker = blocker
+	attempt.Receipt.UpdatedAt = eventNow()
+	if lastErr != nil && attempt.Receipt.LastError == nil {
+		attempt.Receipt.LastError = &Error{Code: ErrorUnavailable, Retryable: false, Message: lastErr.Error()}
+	}
+	eventType := EventProgress
+	switch phase {
+	case PhaseCompleted:
+		eventType = EventCompleted
+	case PhaseFailed:
+		eventType = EventFailed
+	case PhaseCancelled:
+		eventType = EventCancelled
+	case PhaseNeedsInput:
+		eventType = EventNeedsInput
+	}
+	alreadyRecorded := false
+	if events := r.state.Events[attempt.Receipt.AttemptID]; len(events) > 0 {
+		last := events[len(events)-1]
+		alreadyRecorded = last.Type == eventType && phase == PhaseNeedsInput
+	}
+	if !alreadyRecorded {
+		_, _ = r.appendEventLocked(attempt.Receipt.AttemptID, eventType, blocker, nil)
+	}
+	r.releaseResourcesLocked(attempt.Receipt.AttemptID, resourceRequests(attempt.Resources))
+	_ = r.persistLocked()
+}
+
+func (r *Runner) appendEventLocked(attemptID, eventType, message string, data json.RawMessage) (Event, error) {
+	attempt, ok := r.state.Attempts[attemptID]
+	if !ok {
+		return Event{}, errors.New("attempt not found")
+	}
+	if len(data) > r.cfg.MaxEventBytes {
+		return Event{}, fmt.Errorf("event data exceeds %d-byte limit", r.cfg.MaxEventBytes)
+	}
+	events := r.state.Events[attemptID]
+	var cursor uint64
+	if len(events) > 0 {
+		cursor = events[len(events)-1].Cursor
+	}
+	event := Event{Cursor: cursor + 1, Timestamp: eventNow(), AttemptEpoch: attempt.Receipt.AttemptEpoch, Type: eventType, Message: boundedMessage(message), Data: cloneRaw(data)}
+	events = append(events, event)
+	if len(events) > r.cfg.MaxEvents {
+		events = events[len(events)-r.cfg.MaxEvents:]
+	}
+	r.state.Events[attemptID] = events
+	attempt.Receipt.Cursor = event.Cursor
+	attempt.Receipt.UpdatedAt = event.Timestamp
+	for subscriber := range r.subscribers[attemptID] {
+		select {
+		case subscriber <- event:
+		default:
+		}
+	}
+	return event, nil
+}
+
+func (r *Runner) recoverLocked() error {
+	changed := false
+	for attemptID, attempt := range r.state.Attempts {
+		if attempt == nil {
+			delete(r.state.Attempts, attemptID)
+			changed = true
+			continue
+		}
+		if attempt.Receipt.Phase.IsTerminal() || attempt.Receipt.Phase == PhaseNeedsInput {
+			continue
+		}
+		attempt.Receipt.Phase = PhaseNeedsInput
+		attempt.Receipt.Blocker = "runner restarted; reconcile the existing harness session before resuming"
+		attempt.Receipt.UpdatedAt = eventNow()
+		if _, err := r.appendEventLocked(attemptID, EventNeedsInput, attempt.Receipt.Blocker, nil); err != nil {
+			return err
+		}
+		changed = true
+	}
+	if changed {
+		return nil
+	}
+	return nil
+}
+
+func (r *Runner) persistLocked() error { return r.store.save(r.state) }
+
+func (r *Runner) receiptForAttemptLocked(attemptID string) (Receipt, error) {
+	attempt, ok := r.state.Attempts[attemptID]
+	if !ok {
+		return Receipt{}, protocolError(ErrorUnavailable, false, "attempt not found", nil)
+	}
+	return receiptForResponse(attempt.Receipt), nil
+}
+
+func (r *Runner) activeCountLocked() int {
+	count := 0
+	for _, attempt := range r.state.Attempts {
+		if !attempt.Receipt.Phase.IsTerminal() && attempt.Receipt.Phase != PhaseNeedsInput {
+			count++
+		}
+	}
+	return count
+}
+
+func validateStartRequest(request StartRequest) error {
+	if err := validateProtocolVersion(request.ProtocolVersion); err != nil {
+		return err
+	}
+	if err := validateMutationIdentity(request.TaskID, request.AttemptID, request.AttemptEpoch, request.RequestID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(request.RepositoryID) == "" || strings.TrimSpace(request.BaseCommit) == "" {
+		return errors.New("repositoryID and baseCommit are required")
+	}
+	if strings.TrimSpace(request.Instructions) == "" {
+		return errors.New("instructions are required")
+	}
+	if len(request.ApprovedInput) == 0 {
+		return errors.New("approvedInput provenance envelope is required")
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(request.ApprovedInput, &envelope); err != nil || len(envelope) == 0 {
+		return errors.New("approvedInput must be a nonempty JSON object")
+	}
+	if !nonEmptyJSON(envelope["provenance"]) && !nonEmptyJSON(envelope["manualAuthorization"]) && !nonEmptyJSON(envelope["authorization"]) {
+		return errors.New("approvedInput must include provenance or manualAuthorization")
+	}
+	for _, resource := range request.Resources {
+		if err := validateIdentifier("resource name", resource.Name); err != nil {
+			return err
+		}
+	}
+	resourceNamesSeen := map[string]struct{}{}
+	for _, resource := range request.Resources {
+		if _, ok := resourceNamesSeen[resource.Name]; ok {
+			return errors.New("resource reservations contain duplicate names")
+		}
+		resourceNamesSeen[resource.Name] = struct{}{}
+	}
+	seen := map[string]struct{}{}
+	for _, artifact := range request.Artifacts {
+		if err := validateIdentifier("artifact name", artifact.Name); err != nil {
+			return err
+		}
+		if _, ok := seen[artifact.Name]; ok {
+			return errors.New("artifact allowlist contains duplicate names")
+		}
+		seen[artifact.Name] = struct{}{}
+		if artifact.Path == "" {
+			return errors.New("artifact allowlist requires an approved relative path")
+		}
+		if err := validateArtifactRelativePath(artifact.Path); err != nil {
+			return err
+		}
+	}
+	if request.Limits.MaxDurationSeconds < 0 || request.Limits.MaxOutputBytes < 0 || request.Limits.MaxTurns < 0 {
+		return errors.New("execution limits cannot be negative")
+	}
+	return nil
+}
+
+func nonEmptyJSON(raw json.RawMessage) bool {
+	if len(raw) == 0 || string(raw) == "null" {
+		return false
+	}
+	var value any
+	return json.Unmarshal(raw, &value) == nil && value != nil
+}
+
+func equivalentJSON(left, right json.RawMessage) bool {
+	var leftValue, rightValue any
+	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
+		return false
+	}
+	return fingerprintOf(leftValue) == fingerprintOf(rightValue)
+}
+
+func validateMutationIdentity(taskID, attemptID string, epoch uint64, requestID string) error {
+	if err := validateIdentifier("taskID", taskID); err != nil {
+		return err
+	}
+	if err := validateIdentifier("attemptID", attemptID); err != nil {
+		return err
+	}
+	if epoch == 0 {
+		return errors.New("attemptEpoch is required")
+	}
+	return validateIdentifier("requestID", requestID)
+}
+
+func validateProtocolVersion(value string) error {
+	if value != ProtocolVersion {
+		return errors.New("protocolVersion must be runner/v1")
+	}
+	return nil
+}
+
+func validateIdentifier(name, value string) error {
+	if value == "" || len(value) > maxIdentifierBytes || !identifierPattern.MatchString(value) {
+		return fmt.Errorf("%s is invalid", name)
+	}
+	return nil
+}
+
+func protocolError(code string, retryable bool, message string, receipt *Receipt) *Error {
+	var copied *Receipt
+	if receipt != nil {
+		c := receiptForResponse(*receipt)
+		copied = &c
+	}
+	return &Error{Code: code, Retryable: retryable, Message: message, Receipt: copied}
+}
+
+func operationKey(kind, taskID, attemptID string, epoch uint64, requestID string) string {
+	return kind + "\x00" + taskID + "\x00" + attemptID + "\x00" + fmt.Sprint(epoch) + "\x00" + requestID
+}
+
+func fingerprintOf(value any) string {
+	b, _ := json.Marshal(value)
+	hash := sha256.Sum256(b)
+	return hex.EncodeToString(hash[:])
+}
+
+func cloneStartRequest(request StartRequest) StartRequest {
+	request.ApprovedInput = cloneRaw(request.ApprovedInput)
+	request.RequiredCapabilities = append([]string(nil), request.RequiredCapabilities...)
+	request.RequiredToolchains = append([]string(nil), request.RequiredToolchains...)
+	request.RequiredEnvironment = append([]string(nil), request.RequiredEnvironment...)
+	request.Verification.Names = append([]string(nil), request.Verification.Names...)
+	request.Verification.Commands = append([]string(nil), request.Verification.Commands...)
+	request.Resources = append([]ResourceRequest(nil), request.Resources...)
+	request.Artifacts = append([]ArtifactSpec(nil), request.Artifacts...)
+	return request
+}
+
+func receiptForResponse(receipt Receipt) Receipt {
+	receipt.Artifacts = append([]Artifact(nil), receipt.Artifacts...)
+	receipt.Resources = append([]string(nil), receipt.Resources...)
+	if receipt.LastError != nil {
+		lastErr := *receipt.LastError
+		receipt.LastError = &lastErr
+	}
+	return receipt
+}
+
+func boundedMessage(value string) string {
+	if len(value) <= maxMessageBytes {
+		return value
+	}
+	return value[:maxMessageBytes]
+}
+
+func cloneRaw(raw json.RawMessage) json.RawMessage {
+	if raw == nil {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}
+
+func contains(values []string, value string) bool {
+	for _, item := range values {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceNames(requests []ResourceRequest) []string {
+	result := make([]string, 0, len(requests))
+	for _, request := range requests {
+		result = append(result, request.Name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func resourceRequests(names []string) []ResourceRequest {
+	result := make([]ResourceRequest, 0, len(names))
+	for _, name := range names {
+		result = append(result, ResourceRequest{Name: name})
+	}
+	return result
+}
+
+func newArtifactID(name string) string {
+	var raw [8]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "artifact-" + name + "-" + fmt.Sprint(time.Now().UnixNano())
+	}
+	return "artifact-" + name + "-" + hex.EncodeToString(raw[:])
+}

--- a/pkg/runner/runner_contract_test.go
+++ b/pkg/runner/runner_contract_test.go
@@ -1,0 +1,575 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+func TestStartFencingKeepsDuplicateSingleAndRejectsConflictAndStaleEpoch(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-fencing"
+	request.AttemptID = "attempt-fencing-1"
+	request.RequestID = "start-fencing-1"
+
+	first, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	duplicate, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("duplicate Start: %v", err)
+	}
+	if duplicate.AttemptID != first.AttemptID || duplicate.AttemptEpoch != first.AttemptEpoch {
+		t.Fatalf("duplicate receipt = %+v, want attempt %q epoch %d", duplicate, first.AttemptID, first.AttemptEpoch)
+	}
+	waitForPhase(t, runner, first.AttemptID, PhaseCompleted)
+	if got := adapter.runs.Load(); got != 1 {
+		t.Fatalf("duplicate start launched adapter %d times, want one", got)
+	}
+
+	conflict := request
+	conflict.Instructions = "different approved instructions"
+	_, err = runner.Start(context.Background(), conflict)
+	assertProtocolCode(t, err, ErrorIdempotencyConflict)
+
+	stale := request
+	stale.AttemptID = "attempt-fencing-stale"
+	stale.RequestID = "start-fencing-stale"
+	_, err = runner.Start(context.Background(), stale)
+	assertProtocolCode(t, err, ErrorStaleAttempt)
+
+	next := request
+	next.AttemptID = "attempt-fencing-2"
+	next.RequestID = "start-fencing-2"
+	next.AttemptEpoch = 2
+	second, err := runner.Start(context.Background(), next)
+	if err != nil {
+		t.Fatalf("next epoch Start: %v", err)
+	}
+	waitForPhase(t, runner, second.AttemptID, PhaseCompleted)
+	if got := adapter.runs.Load(); got != 2 {
+		t.Fatalf("next epoch launched adapter %d times, want two total", got)
+	}
+}
+
+func TestAcceptedStateIsDurableBeforeAdapterRuns(t *testing.T) {
+	source, commit := testGitSource(t)
+	stateDir := t.TempDir()
+	observed := make(chan persistedState, 1)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		raw, err := os.ReadFile(filepath.Join(stateDir, "state.json"))
+		if err != nil {
+			observed <- persistedState{}
+			return harness.Result{}, err
+		}
+		var state persistedState
+		if err := json.Unmarshal(raw, &state); err != nil {
+			observed <- persistedState{}
+			return harness.Result{}, err
+		}
+		observed <- state
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunnerAt(t, adapter, stateDir, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-checkpoint"
+	request.AttemptID = "attempt-checkpoint"
+	request.RequestID = "start-checkpoint"
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	var state persistedState
+	select {
+	case state = <-observed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("adapter did not observe the durable launch checkpoint")
+	}
+	attempt, ok := state.Attempts[receipt.AttemptID]
+	if !ok || attempt == nil {
+		t.Fatalf("durable state omitted accepted attempt: %+v", state.Attempts)
+	}
+	if attempt.Receipt.Phase != PhaseStarting {
+		t.Fatalf("durable phase at adapter launch = %s, want starting", attempt.Receipt.Phase)
+	}
+	if attempt.Receipt.Workdir == "" {
+		t.Fatal("durable checkpoint omitted task workdir")
+	}
+	accepted := false
+	for _, event := range state.Events[receipt.AttemptID] {
+		if event.Type == EventAccepted {
+			accepted = true
+			break
+		}
+	}
+	if !accepted {
+		t.Fatalf("durable checkpoint omitted accepted event: %+v", state.Events[receipt.AttemptID])
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+}
+
+func TestCancellationReleasesCapacityAfterAdapterExit(t *testing.T) {
+	source, commit := testGitSource(t)
+	started := make(chan struct{})
+	cancelObserved := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	adapter := &fakeAdapter{run: func(ctx context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if launch.AttemptID == "attempt-cancel-capacity" {
+			startedOnce.Do(func() { close(started) })
+			<-ctx.Done()
+			close(cancelObserved)
+			<-release
+			return harness.Result{Phase: string(PhaseCancelled), SessionID: launch.SessionID}, nil
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	firstRequest := testStartRequest(commit)
+	firstRequest.TaskID = "task-cancel-capacity"
+	firstRequest.AttemptID = "attempt-cancel-capacity"
+	firstRequest.RequestID = "start-cancel-capacity"
+	first, err := runner.Start(context.Background(), firstRequest)
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancellable adapter did not start")
+	}
+	cancelled, err := runner.Cancel(context.Background(), CancelRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "cancel-capacity",
+		TaskID:          first.TaskID,
+		AttemptID:       first.AttemptID,
+		AttemptEpoch:    first.AttemptEpoch,
+	})
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if cancelled.Phase != PhaseCancelling {
+		t.Fatalf("Cancel phase = %s, want cancelling", cancelled.Phase)
+	}
+	select {
+	case <-cancelObserved:
+	case <-time.After(2 * time.Second):
+		t.Fatal("adapter did not observe cancellation")
+	}
+
+	secondRequest := testStartRequest(commit)
+	secondRequest.TaskID = "task-cancel-capacity-2"
+	secondRequest.AttemptID = "attempt-cancel-capacity-2"
+	secondRequest.RequestID = "start-cancel-capacity-2"
+	_, err = runner.Start(context.Background(), secondRequest)
+	assertProtocolCode(t, err, ErrorBusy)
+
+	close(release)
+	waitForPhase(t, runner, first.AttemptID, PhaseCancelled)
+	second, err := runner.Start(context.Background(), secondRequest)
+	if err != nil {
+		t.Fatalf("Start after cancellation completed: %v", err)
+	}
+	waitForPhase(t, runner, second.AttemptID, PhaseCompleted)
+}
+
+func TestForeignHarnessEventCannotCompleteApprovedSession(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventStarted, SessionID: "session-approved"}); err != nil {
+			return harness.Result{}, err
+		}
+		// A hostile adapter may ignore the error from a rejected event. The
+		// runner must retain the failure rather than accepting the later result.
+		_ = emit(harness.Event{Type: EventCompleted, SessionID: "session-foreign"})
+		_ = emit(harness.Event{Type: EventProgress, SessionID: "session-approved", Message: "later event"})
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: "session-approved"}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-foreign-session"
+	request.AttemptID = "attempt-foreign-session"
+	request.RequestID = "start-foreign-session"
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseFailed)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(got.Blocker), "foreign") {
+		t.Fatalf("foreign-session failure blocker = %q", got.Blocker)
+	}
+	if got.LastError == nil || !strings.Contains(strings.ToLower(got.LastError.Message), "foreign") {
+		t.Fatalf("foreign-session durable error = %+v", got.LastError)
+	}
+}
+
+func TestLateHarnessEventsAreRejectedAfterAdapterResult(t *testing.T) {
+	source, commit := testGitSource(t)
+	release := make(chan struct{})
+	lateErr := make(chan error, 1)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		go func() {
+			<-release
+			lateErr <- emit(harness.Event{Type: EventProgress, SessionID: launch.SessionID, Message: "late event"})
+		}()
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-late-event"
+	request.AttemptID = "attempt-late-event"
+	request.RequestID = "start-late-event"
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	before, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect before late event: %v", err)
+	}
+	close(release)
+	select {
+	case err := <-lateErr:
+		if err == nil {
+			t.Fatal("late harness event was accepted after adapter result")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("late harness callback did not return")
+	}
+	after, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect after late event: %v", err)
+	}
+	if after.Phase != PhaseCompleted || after.Cursor != before.Cursor {
+		t.Fatalf("late event changed completed receipt: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestArtifactContainmentRejectsTraversalAndSymlink(t *testing.T) {
+	source, commit := testGitSource(t)
+	invalidAdapter := &fakeAdapter{}
+	invalidRunner := newTestRunner(t, invalidAdapter, source, commit)
+	invalid := testStartRequest(commit)
+	invalid.TaskID = "task-artifact-invalid"
+	invalid.AttemptID = "attempt-artifact-invalid"
+	invalid.RequestID = "start-artifact-invalid"
+	invalid.Artifacts = []ArtifactSpec{{Name: "escape", Path: "../outside.txt"}}
+	_, err := invalidRunner.Start(context.Background(), invalid)
+	assertProtocolCode(t, err, ErrorInvalidRequest)
+
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte("outside\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		link := filepath.Join(launch.Workdir, "report.txt")
+		if err := os.Symlink(outsidePath, link); err != nil {
+			return harness.Result{}, err
+		}
+		data := json.RawMessage(`{"name":"report","path":"report.txt"}`)
+		if err := emit(harness.Event{Type: EventArtifact, SessionID: launch.SessionID, Data: data}); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-artifact-symlink"
+	request.AttemptID = "attempt-artifact-symlink"
+	request.RequestID = "start-artifact-symlink"
+	request.Artifacts = []ArtifactSpec{{Name: "report", Path: "report.txt"}}
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start symlink artifact: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseFailed)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect symlink artifact: %v", err)
+	}
+	if len(got.Artifacts) != 0 {
+		t.Fatalf("escaped artifact was recorded: %+v", got.Artifacts)
+	}
+	if contents, err := os.ReadFile(outsidePath); err != nil || string(contents) != "outside\n" {
+		t.Fatalf("outside artifact changed: err=%v contents=%q", err, contents)
+	}
+}
+
+func TestSourceCheckoutLeavesInteractiveSourceUnchanged(t *testing.T) {
+	source, commit := testGitSource(t)
+	readme := filepath.Join(source, "README.md")
+	untracked := filepath.Join(source, "local-only.txt")
+	if err := os.WriteFile(readme, []byte("local edit\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(untracked, []byte("local only\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	beforeReadme, err := os.ReadFile(readme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeStatus := string(runGit(t, source, "status", "--porcelain=v1", "--untracked-files=all"))
+	beforeConfig, err := os.ReadFile(filepath.Join(source, ".git", "config"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if filepath.Clean(launch.Workdir) == filepath.Clean(source) {
+			return harness.Result{}, errors.New("adapter received interactive source checkout")
+		}
+		if err := os.WriteFile(filepath.Join(launch.Workdir, "runner-only.txt"), []byte("runner\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		if err := os.WriteFile(filepath.Join(launch.Workdir, "README.md"), []byte("runner edit\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-source-isolation"
+	request.AttemptID = "attempt-source-isolation"
+	request.RequestID = "start-source-isolation"
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	afterReadme, err := os.ReadFile(readme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterStatus := string(runGit(t, source, "status", "--porcelain=v1", "--untracked-files=all"))
+	afterConfig, err := os.ReadFile(filepath.Join(source, ".git", "config"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterReadme) != string(beforeReadme) || afterStatus != beforeStatus || string(afterConfig) != string(beforeConfig) {
+		t.Fatalf("source checkout changed: readme=%q/%q status=%q/%q config=%q/%q", afterReadme, beforeReadme, afterStatus, beforeStatus, afterConfig, beforeConfig)
+	}
+	if _, err := os.Stat(filepath.Join(source, "runner-only.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("runner output leaked into source checkout: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(receipt.Workdir, "runner-only.txt")); err != nil {
+		t.Fatalf("runner output missing from task checkout: %v", err)
+	}
+}
+
+func TestInterruptedRestartResumeKeepsExactSessionAndWorkspace(t *testing.T) {
+	source, commit := testGitSource(t)
+	stateDir := t.TempDir()
+	firstAdapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventStarted, SessionID: "session-interrupted"}); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: "session-interrupted"}, nil
+	}}
+	first := newTestRunnerAt(t, firstAdapter, stateDir, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-interrupted-restart"
+	request.AttemptID = "attempt-interrupted-restart"
+	request.RequestID = "start-interrupted-restart"
+	started, err := first.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	waitForPhase(t, first, started.AttemptID, PhaseCompleted)
+	checkpoint, err := first.Inspect(context.Background(), started.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect checkpoint: %v", err)
+	}
+	first.mu.Lock()
+	first.state.Attempts[started.AttemptID].Receipt.Phase = PhaseRunning
+	if err := first.persistLocked(); err != nil {
+		first.mu.Unlock()
+		t.Fatalf("persist interrupted state: %v", err)
+	}
+	first.mu.Unlock()
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close interrupted runner: %v", err)
+	}
+
+	secondAdapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if launch.SessionID != checkpoint.SessionID {
+			return harness.Result{}, fmt.Errorf("resume session = %q, want %q", launch.SessionID, checkpoint.SessionID)
+		}
+		if launch.Workdir != checkpoint.Workdir {
+			return harness.Result{}, fmt.Errorf("resume workdir = %q, want %q", launch.Workdir, checkpoint.Workdir)
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	second := newTestRunnerAt(t, secondAdapter, stateDir, source, commit)
+	recovered, err := second.Inspect(context.Background(), started.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect recovered attempt: %v", err)
+	}
+	if recovered.Phase != PhaseNeedsInput || recovered.SessionID != checkpoint.SessionID || recovered.Workdir != checkpoint.Workdir {
+		t.Fatalf("recovered checkpoint = %+v, want needs-input exact session/workspace", recovered)
+	}
+	resumed, err := second.Resume(context.Background(), ResumeRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "resume-interrupted-restart",
+		TaskID:          recovered.TaskID,
+		AttemptID:       recovered.AttemptID,
+		AttemptEpoch:    recovered.AttemptEpoch,
+		SessionID:       recovered.SessionID,
+		Resolution:      "continue the approved work",
+	})
+	if err != nil {
+		t.Fatalf("Resume recovered attempt: %v", err)
+	}
+	waitForPhase(t, second, resumed.AttemptID, PhaseCompleted)
+}
+
+func TestLoopbackHTTPRequiresExactBearerToken(t *testing.T) {
+	adapter := &fakeAdapter{}
+	if _, err := New(Config{
+		RunnerID: "non-loopback-test",
+		StateDir: t.TempDir(),
+		Token:    "test-token",
+		Listen:   "0.0.0.0:0",
+	}, adapter); err == nil || !strings.Contains(err.Error(), "loopback") {
+		t.Fatalf("non-loopback runner construction error = %v, want loopback rejection", err)
+	}
+	runner, err := New(Config{
+		RunnerID: "loopback-test",
+		StateDir: t.TempDir(),
+		Token:    "test-token",
+		Listen:   "127.0.0.1:0",
+	}, adapter)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = runner.Close() }()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- runner.ListenAndServe(ctx) }()
+
+	var addr string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		runner.mu.Lock()
+		if runner.listener != nil {
+			addr = runner.listener.Addr().String()
+		}
+		runner.mu.Unlock()
+		if addr != "" {
+			break
+		}
+		select {
+		case err := <-serveDone:
+			t.Fatalf("ListenAndServe exited before exposing a listener: %v", err)
+		default:
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if addr == "" {
+		t.Fatal("ListenAndServe did not expose a listener")
+	}
+	client := &http.Client{Timeout: time.Second}
+	status := func(auth string) int {
+		req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/runner/v1/capabilities", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+		response, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = response.Body.Close() }()
+		_, _ = io.Copy(io.Discard, response.Body)
+		return response.StatusCode
+	}
+	if got := status(""); got != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want %d", got, http.StatusUnauthorized)
+	}
+	if got := status("Bearer wrong-token"); got != http.StatusUnauthorized {
+		t.Fatalf("wrong-token status = %d, want %d", got, http.StatusUnauthorized)
+	}
+	if got := status("Basic test-token"); got != http.StatusUnauthorized {
+		t.Fatalf("non-bearer status = %d, want %d", got, http.StatusUnauthorized)
+	}
+	if got := status("Bearer test-token"); got != http.StatusOK {
+		t.Fatalf("valid-token status = %d, want %d", got, http.StatusOK)
+	}
+	cancel()
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Fatalf("ListenAndServe after cancellation: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListenAndServe did not stop after context cancellation")
+	}
+}
+
+func TestEventCursorRejectsValueAheadOfAttempt(t *testing.T) {
+	source, commit := testGitSource(t)
+	runner := newTestRunner(t, &fakeAdapter{}, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-cursor-ahead"
+	request.AttemptID = "attempt-cursor-ahead"
+	request.RequestID = "start-cursor-ahead"
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/runner/v1/attempts/"+receipt.AttemptID+"/events?after=999999", nil)
+	req.Header.Set("Authorization", "Bearer "+runner.cfg.Token)
+	response := httptest.NewRecorder()
+	runner.Handler().ServeHTTP(response, req)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("ahead cursor status = %d body=%s", response.Code, response.Body.String())
+	}
+	var protocolErr Error
+	if err := json.Unmarshal(response.Body.Bytes(), &protocolErr); err != nil {
+		t.Fatal(err)
+	}
+	if protocolErr.Code != ErrorInvalidRequest {
+		t.Fatalf("ahead cursor error = %+v", protocolErr)
+	}
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1,0 +1,528 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+type fakeAdapter struct {
+	run    func(context.Context, harness.Launch, harness.Emit) (harness.Result, error)
+	mu     sync.Mutex
+	probes atomic.Int32
+	runs   atomic.Int32
+}
+
+type probeBlockedAdapter struct{}
+
+func (probeBlockedAdapter) Probe(context.Context) (harness.Info, error) {
+	return harness.Info{Name: "blocked", Version: "1", Ready: true}, errors.New("probe unavailable")
+}
+
+func (probeBlockedAdapter) Run(context.Context, harness.Launch, harness.Emit) (harness.Result, error) {
+	return harness.Result{}, errors.New("run must not be called")
+}
+
+func (f *fakeAdapter) Probe(context.Context) (harness.Info, error) {
+	f.probes.Add(1)
+	return harness.Info{Name: "fake", Version: "1", Ready: true}, nil
+}
+
+func (f *fakeAdapter) Run(ctx context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+	f.runs.Add(1)
+	f.mu.Lock()
+	run := f.run
+	f.mu.Unlock()
+	if run == nil {
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}
+	return run(ctx, launch, emit)
+}
+
+func TestStartIsIdempotentAndPersistsBeforeExecution(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if receipt.Phase != PhaseAccepted && receipt.Phase != PhaseStarting && receipt.Phase != PhaseRunning && receipt.Phase != PhaseCompleted {
+		t.Fatalf("unexpected initial phase: %s", receipt.Phase)
+	}
+	if _, err := os.Stat(filepath.Join(runner.cfg.StateDir, "state.json")); err != nil {
+		t.Fatalf("durable state missing before start returned: %v", err)
+	}
+	replayed, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("idempotent Start: %v", err)
+	}
+	if replayed.AttemptID != receipt.AttemptID || replayed.SessionID != receipt.SessionID {
+		t.Fatalf("idempotent receipt changed: first=%+v second=%+v", receipt, replayed)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for adapter.runs.Load() < 1 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := adapter.runs.Load(); got != 1 {
+		t.Fatalf("adapter runs = %d, want one", got)
+	}
+}
+
+func TestProbeFailureNeverAdvertisesReady(t *testing.T) {
+	runner, err := New(Config{RunnerID: "probe-test", StateDir: t.TempDir(), Token: "test-token", Listen: "127.0.0.1:0"}, probeBlockedAdapter{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = runner.Close() }()
+	caps := runner.Capabilities()
+	if caps.Ready || len(caps.Reasons) == 0 || len(caps.Harnesses) != 1 || caps.Harnesses[0].Ready {
+		t.Fatalf("probe-blocked capabilities = %+v", caps)
+	}
+}
+
+func TestCancelRemainsCancellingUntilAdapterExits(t *testing.T) {
+	source, commit := testGitSource(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	adapter := &fakeAdapter{run: func(ctx context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventStarted, SessionID: launch.SessionID, Message: "started"}); err != nil {
+			return harness.Result{}, err
+		}
+		close(started)
+		select {
+		case <-release:
+			return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+		case <-ctx.Done():
+			<-release
+			return harness.Result{Phase: string(PhaseCancelled), SessionID: launch.SessionID}, nil
+		}
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	receipt, err := runner.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	<-started
+	cancelled, err := runner.Cancel(context.Background(), CancelRequest{ProtocolVersion: ProtocolVersion, TaskID: receipt.TaskID, AttemptID: receipt.AttemptID, AttemptEpoch: receipt.AttemptEpoch, RequestID: "cancel-1"})
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if cancelled.Phase != PhaseCancelling {
+		t.Fatalf("cancel phase = %s, want cancelling", cancelled.Phase)
+	}
+	inspected, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil || inspected.Phase != PhaseCancelling {
+		t.Fatalf("Inspect during cancellation = %+v, %v", inspected, err)
+	}
+	close(release)
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCancelled)
+}
+
+func TestRestartConvergesRecoveredActiveAttemptToNeedsInput(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{}
+	stateDir := t.TempDir()
+	runner := newTestRunnerAt(t, adapter, stateDir, source, commit)
+	receipt, err := runner.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	runner.mu.Lock()
+	runner.state.Attempts[receipt.AttemptID].Receipt.Phase = PhaseRunning
+	if err := runner.persistLocked(); err != nil {
+		runner.mu.Unlock()
+		t.Fatalf("persist simulated active attempt: %v", err)
+	}
+	runner.mu.Unlock()
+	if err := runner.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	restartedAdapter := &fakeAdapter{}
+	restarted := newTestRunnerAt(t, restartedAdapter, stateDir, source, commit)
+	defer func() { _ = restarted.Close() }()
+	got, err := restarted.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect after restart: %v", err)
+	}
+	if got.Phase != PhaseNeedsInput || !strings.Contains(got.Blocker, "reconcile") {
+		t.Fatalf("recovered receipt = %+v", got)
+	}
+	if restartedAdapter.runs.Load() != 0 {
+		t.Fatal("restart auto-executed recovered attempt")
+	}
+}
+
+func TestRestartResumeRetainsWorktreeAndSession(t *testing.T) {
+	source, commit := testGitSource(t)
+	stateDir := t.TempDir()
+	firstAdapter := &fakeAdapter{run: func(_ context.Context, _ harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventStarted, SessionID: "session-restart"}); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseNeedsInput), SessionID: "session-restart", Blocker: "operator decision required"}, nil
+	}}
+	first := newTestRunnerAt(t, firstAdapter, stateDir, source, commit)
+	started, err := first.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, first, started.AttemptID, PhaseNeedsInput)
+	checkpoint, err := first.Inspect(context.Background(), started.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect checkpoint: %v", err)
+	}
+	if checkpoint.SessionID != "session-restart" || checkpoint.Workdir == "" {
+		t.Fatalf("checkpoint lost session/worktree: %+v", checkpoint)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close before restart: %v", err)
+	}
+
+	secondAdapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if launch.SessionID != "session-restart" {
+			return harness.Result{}, fmt.Errorf("resume session = %q, want session-restart", launch.SessionID)
+		}
+		if launch.Workdir != checkpoint.Workdir {
+			return harness.Result{}, fmt.Errorf("resume workdir = %q, want %q", launch.Workdir, checkpoint.Workdir)
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	second := newTestRunnerAt(t, secondAdapter, stateDir, source, commit)
+	resumed, err := second.Resume(context.Background(), ResumeRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "resume-after-restart",
+		TaskID:          checkpoint.TaskID,
+		AttemptID:       checkpoint.AttemptID,
+		AttemptEpoch:    checkpoint.AttemptEpoch,
+		SessionID:       checkpoint.SessionID,
+		Resolution:      "operator approved continuation",
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	waitForPhase(t, second, resumed.AttemptID, PhaseCompleted)
+	if got := secondAdapter.runs.Load(); got != 1 {
+		t.Fatalf("resumed adapter runs = %d, want one", got)
+	}
+}
+
+func TestResumeRejectsScopeAndSessionChanges(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventStarted, SessionID: "session-1"}); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseNeedsInput), SessionID: launch.SessionID, Blocker: "approval required"}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	receipt, err := runner.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseNeedsInput)
+	needsInput, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect needs-input attempt: %v", err)
+	}
+	_, err = runner.Resume(context.Background(), ResumeRequest{ProtocolVersion: ProtocolVersion, TaskID: receipt.TaskID, AttemptID: receipt.AttemptID, AttemptEpoch: receipt.AttemptEpoch, RequestID: "resume-1", SessionID: needsInput.SessionID, Instructions: "different", Resolution: "approved"})
+	assertProtocolCode(t, err, ErrorForbidden)
+	_, err = runner.Resume(context.Background(), ResumeRequest{ProtocolVersion: ProtocolVersion, TaskID: receipt.TaskID, AttemptID: receipt.AttemptID, AttemptEpoch: receipt.AttemptEpoch, RequestID: "resume-2", SessionID: "foreign", Resolution: "approved"})
+	assertProtocolCode(t, err, ErrorCheckpointUnavailable)
+	_, err = runner.Resume(context.Background(), ResumeRequest{TaskID: receipt.TaskID, AttemptID: receipt.AttemptID, AttemptEpoch: receipt.AttemptEpoch, RequestID: "resume-3", SessionID: needsInput.SessionID, Resolution: "approved"})
+	assertProtocolCode(t, err, ErrorUnsupportedVersion)
+	_, err = runner.Resume(context.Background(), ResumeRequest{ProtocolVersion: ProtocolVersion, TaskID: receipt.TaskID, AttemptID: receipt.AttemptID, AttemptEpoch: receipt.AttemptEpoch, RequestID: "resume-4", Resolution: "approved"})
+	assertProtocolCode(t, err, ErrorCheckpointUnavailable)
+	_, err = runner.Resume(context.Background(), ResumeRequest{ProtocolVersion: ProtocolVersion, TaskID: receipt.TaskID, AttemptID: receipt.AttemptID, AttemptEpoch: receipt.AttemptEpoch, RequestID: "resume-5", SessionID: needsInput.SessionID, ApprovedInput: json.RawMessage(`{"provenance":{"source":"changed"}}`), Resolution: "approved"})
+	assertProtocolCode(t, err, ErrorForbidden)
+}
+
+func TestHTTPAuthCapabilitiesAndCursorGap(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		for i := 0; i < 4; i++ {
+			if err := emit(harness.Event{Type: EventProgress, SessionID: launch.SessionID, Message: "progress"}); err != nil {
+				return harness.Result{}, err
+			}
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	runner.cfg.MaxEvents = 2
+	request := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/runner/v1/capabilities", nil)
+	response := httptest.NewRecorder()
+	runner.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d", response.Code)
+	}
+
+	request = httptest.NewRequest(http.MethodGet, "http://127.0.0.1/runner/v1/capabilities", nil)
+	request.Header.Set("Authorization", "Bearer "+runner.cfg.Token)
+	response = httptest.NewRecorder()
+	runner.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("capabilities status = %d", response.Code)
+	}
+
+	receipt, err := runner.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	request = httptest.NewRequest(http.MethodGet, "http://127.0.0.1/runner/v1/attempts/"+receipt.AttemptID+"/events?after=0", nil)
+	request.Header.Set("Authorization", "Bearer "+runner.cfg.Token)
+	response = httptest.NewRecorder()
+	runner.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusGone {
+		t.Fatalf("cursor gap status = %d body=%s", response.Code, response.Body.String())
+	}
+	var protocolErr Error
+	if err := json.NewDecoder(response.Body).Decode(&protocolErr); err != nil {
+		t.Fatal(err)
+	}
+	if protocolErr.Code != ErrorCursorExpired || !protocolErr.SnapshotRequired {
+		t.Fatalf("cursor gap error = %+v", protocolErr)
+	}
+}
+
+func TestGitEnvironmentDropsInteractiveConfiguration(t *testing.T) {
+	source, commit := testGitSource(t)
+	maliciousDir := t.TempDir()
+	globalConfig := filepath.Join(maliciousDir, "gitconfig")
+	marker := filepath.Join(maliciousDir, "marker")
+	if err := os.WriteFile(globalConfig, []byte("[alias]\n\trev-parse = !touch "+marker+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+	t.Setenv("GITHUB_TOKEN", "secret")
+	t.Setenv("SSH_AUTH_SOCK", "/tmp/agent.sock")
+	for _, value := range sanitizedGitEnvironment() {
+		if strings.HasPrefix(value, "GIT_CONFIG_GLOBAL=") && value != "GIT_CONFIG_GLOBAL=/dev/null" {
+			t.Fatalf("global Git config leaked: %q", value)
+		}
+		if strings.HasPrefix(value, "GITHUB_TOKEN=") || strings.HasPrefix(value, "SSH_AUTH_SOCK=") {
+			t.Fatalf("interactive credential leaked: %q", value)
+		}
+	}
+	stateDir := t.TempDir()
+	workdir, err := prepareWorkspace(context.Background(), Config{
+		StateDir: stateDir,
+		Repositories: map[string]RepositoryConfig{
+			"repo": {Source: source, BaseCommit: commit},
+		},
+	}, StartRequest{TaskID: "task-env", AttemptID: "attempt-env", RepositoryID: "repo", BaseCommit: commit})
+	if err != nil {
+		t.Fatalf("prepareWorkspace with hostile global config: %v", err)
+	}
+	if workdir == "" {
+		t.Fatal("prepareWorkspace returned an empty worktree")
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("hostile Git alias ran: marker stat error=%v", err)
+	}
+}
+
+func TestArtifactRequiresApprovedNameAndServesImmutableDigest(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := os.WriteFile(filepath.Join(launch.Workdir, "report.txt"), []byte("evidence\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		data := json.RawMessage(`{"name":"report","path":"report.txt"}`)
+		if err := emit(harness.Event{Type: EventArtifact, SessionID: launch.SessionID, Data: data}); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.Artifacts = []ArtifactSpec{{Name: "report", Path: "report.txt"}}
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	inspected, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil || len(inspected.Artifacts) != 1 {
+		t.Fatalf("artifact receipt = %+v, %v", inspected, err)
+	}
+	artifactID := inspected.Artifacts[0].ID
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/runner/v1/attempts/"+receipt.AttemptID+"/artifacts/"+artifactID, nil)
+	req.Header.Set("Authorization", "Bearer "+runner.cfg.Token)
+	response := httptest.NewRecorder()
+	runner.Handler().ServeHTTP(response, req)
+	if response.Code != http.StatusOK || response.Body.String() != "evidence\n" {
+		t.Fatalf("artifact response = %d %q", response.Code, response.Body.String())
+	}
+	runner.mu.Lock()
+	artifactPath := runner.state.Artifacts[artifactID].Path
+	runner.mu.Unlock()
+	if err := os.WriteFile(artifactPath, []byte("tampered\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	response = httptest.NewRecorder()
+	runner.Handler().ServeHTTP(response, req)
+	if response.Code != http.StatusGone {
+		t.Fatalf("tampered artifact status = %d, want gone", response.Code)
+	}
+}
+
+func TestExecutionLimitsAreEnforcedByCore(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(ctx context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventProgress, SessionID: launch.SessionID, Message: "too much"}); err != nil {
+			return harness.Result{}, err
+		}
+		<-ctx.Done()
+		return harness.Result{Phase: string(PhaseCancelled), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	tooManyTurns := testStartRequest(commit)
+	tooManyTurns.AttemptID = "attempt-many-turns"
+	tooManyTurns.RequestID = "start-many-turns"
+	tooManyTurns.Limits.MaxTurns = 2
+	_, err := runner.Start(context.Background(), tooManyTurns)
+	assertProtocolCode(t, err, ErrorUnsupportedCapability)
+
+	bounded := testStartRequest(commit)
+	bounded.AttemptID = "attempt-output-limit"
+	bounded.RequestID = "start-output-limit"
+	bounded.Limits.MaxOutputBytes = 2
+	receipt, err := runner.Start(context.Background(), bounded)
+	if err != nil {
+		t.Fatalf("bounded Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseFailed)
+	inspected, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil || !strings.Contains(inspected.Blocker, "output") {
+		t.Fatalf("output-limited receipt = %+v, %v", inspected, err)
+	}
+}
+
+func TestConfigRejectsConcurrentExecutionCapacity(t *testing.T) {
+	config := Config{Token: "test-token", MaximumCapacity: 2}
+	if err := config.applyDefaults(); err == nil || !strings.Contains(err.Error(), "maximumCapacity") {
+		t.Fatalf("applyDefaults error = %v, want single-capacity rejection", err)
+	}
+}
+
+func newTestRunner(t *testing.T, adapter *fakeAdapter, source, commit string) *Runner {
+	return newTestRunnerAt(t, adapter, t.TempDir(), source, commit)
+}
+
+func newTestRunnerAt(t *testing.T, adapter *fakeAdapter, stateDir, source, commit string) *Runner {
+	t.Helper()
+	runner, err := New(Config{
+		RunnerID: "test-runner",
+		Version:  "test",
+		StateDir: stateDir,
+		Token:    "test-token",
+		Listen:   "127.0.0.1:0",
+		Repositories: map[string]RepositoryConfig{
+			"repo": {Source: source, BaseCommit: commit},
+		},
+	}, adapter)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = runner.Close() })
+	return runner
+}
+
+func testStartRequest(commit string) StartRequest {
+	return StartRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "start-1",
+		TaskID:          "task-1",
+		AttemptID:       "attempt-1",
+		AttemptEpoch:    1,
+		RepositoryID:    "repo",
+		BaseCommit:      commit,
+		Instructions:    "do the approved work",
+		ApprovedInput:   json.RawMessage(`{"provenance":{"source":"test"}}`),
+	}
+}
+
+func waitForPhase(t *testing.T, runner *Runner, attemptID string, want Phase) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		receipt, err := runner.Inspect(context.Background(), attemptID)
+		if err == nil && receipt.Phase == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	receipt, _ := runner.Inspect(context.Background(), attemptID)
+	t.Fatalf("attempt phase = %s, want %s", receipt.Phase, want)
+}
+
+func assertProtocolCode(t *testing.T, err error, code string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want %s", code)
+	}
+	var protocolErr *Error
+	if !errors.As(err, &protocolErr) || protocolErr.Code != code {
+		t.Fatalf("error = %v, want code %s", err, code)
+	}
+}
+
+func testGitSource(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--initial-branch=main")
+	runGit(t, dir, "config", "user.email", "runner-test@example.invalid")
+	runGit(t, dir, "config", "user.name", "Runner Test")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("runner test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "initial")
+	return dir, strings.TrimSpace(string(runGit(t, dir, "rev-parse", "HEAD")))
+}
+
+func runGit(t *testing.T, dir string, args ...string) []byte {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-c", "core.hooksPath=/dev/null"}, args...)...)
+	command.Dir = dir
+	command.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null", "GIT_TERMINAL_PROMPT=0")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+	return output
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -150,6 +150,313 @@ func TestCancelRemainsCancellingUntilAdapterExits(t *testing.T) {
 	waitForPhase(t, runner, receipt.AttemptID, PhaseCancelled)
 }
 
+func TestClosePersistsResumableNeedsInputAndResumeKeepsSessionAndWorktree(t *testing.T) {
+	source, commit := testGitSource(t)
+	stateDir := t.TempDir()
+	started := make(chan struct{})
+	firstAdapter := &fakeAdapter{run: func(ctx context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventStarted, SessionID: "session-shutdown", Message: "started"}); err != nil {
+			return harness.Result{}, err
+		}
+		close(started)
+		<-ctx.Done()
+		return harness.Result{Phase: string(PhaseCancelled), SessionID: launch.SessionID}, nil
+	}}
+	first := newTestRunnerAt(t, firstAdapter, stateDir, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-shutdown"
+	request.AttemptID = "attempt-shutdown"
+	request.RequestID = "start-shutdown"
+	startedReceipt, err := first.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("adapter did not start")
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	checkpoint, err := first.Inspect(context.Background(), startedReceipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect after Close: %v", err)
+	}
+	if checkpoint.Phase != PhaseNeedsInput || checkpoint.SessionID != "session-shutdown" || checkpoint.Workdir != startedReceipt.Workdir {
+		t.Fatalf("shutdown checkpoint = %+v, want needs_input with exact session/worktree", checkpoint)
+	}
+	if !strings.Contains(checkpoint.Blocker, "shut down") {
+		t.Fatalf("shutdown blocker = %q, want shutdown reconciliation", checkpoint.Blocker)
+	}
+
+	secondAdapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if launch.SessionID != checkpoint.SessionID || launch.Workdir != checkpoint.Workdir {
+			return harness.Result{}, fmt.Errorf("resume launch = session %q/workdir %q, want %q/%q", launch.SessionID, launch.Workdir, checkpoint.SessionID, checkpoint.Workdir)
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	second := newTestRunnerAt(t, secondAdapter, stateDir, source, commit)
+	resumed, err := second.Resume(context.Background(), ResumeRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "resume-shutdown",
+		TaskID:          checkpoint.TaskID,
+		AttemptID:       checkpoint.AttemptID,
+		AttemptEpoch:    checkpoint.AttemptEpoch,
+		SessionID:       checkpoint.SessionID,
+		Resolution:      "continue after the runner restarted",
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	waitForPhase(t, second, resumed.AttemptID, PhaseCompleted)
+	if got := secondAdapter.runs.Load(); got != 1 {
+		t.Fatalf("resumed adapter runs = %d, want one", got)
+	}
+}
+
+func TestClosePreservesIndependentAdapterFailure(t *testing.T) {
+	source, commit := testGitSource(t)
+	started := make(chan struct{})
+	adapter := &fakeAdapter{run: func(ctx context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventStarted, SessionID: "session-failure"}); err != nil {
+			return harness.Result{}, err
+		}
+		close(started)
+		<-ctx.Done()
+		return harness.Result{Phase: string(PhaseFailed), SessionID: launch.SessionID}, errors.New("adapter failed independently")
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	receipt, err := runner.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	<-started
+	if err := runner.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect after Close: %v", err)
+	}
+	if got.Phase != PhaseFailed || !strings.Contains(got.Blocker, "adapter failed independently") {
+		t.Fatalf("failure receipt = %+v, want failed independent of shutdown", got)
+	}
+}
+
+func TestClosePreservesAdapterErrorWhenResultLooksInterrupted(t *testing.T) {
+	for _, resultPhase := range []Phase{PhaseCancelled, PhaseNeedsInput} {
+		t.Run(string(resultPhase), func(t *testing.T) {
+			source, commit := testGitSource(t)
+			started := make(chan struct{})
+			adapter := &fakeAdapter{run: func(ctx context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+				if err := emit(harness.Event{Type: EventStarted, SessionID: launch.SessionID}); err != nil {
+					return harness.Result{}, err
+				}
+				close(started)
+				<-ctx.Done()
+				return harness.Result{Phase: string(resultPhase), SessionID: launch.SessionID}, errors.New("adapter failed independently")
+			}}
+			runner := newTestRunner(t, adapter, source, commit)
+			receipt, err := runner.Start(context.Background(), testStartRequest(commit))
+			if err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			<-started
+			if err := runner.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+			if err != nil {
+				t.Fatalf("Inspect after Close: %v", err)
+			}
+			if got.Phase != PhaseFailed || !strings.Contains(got.Blocker, "adapter failed independently") {
+				t.Fatalf("result phase %s with adapter error = %+v, want failed independent of shutdown", resultPhase, got)
+			}
+		})
+	}
+}
+
+func TestCloseRejectsNewAdmissionsAndConcurrentCloseWaitsForDrain(t *testing.T) {
+	source, commit := testGitSource(t)
+	stateDir := t.TempDir()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	adapter := &fakeAdapter{run: func(ctx context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		close(started)
+		<-ctx.Done()
+		<-release
+		return harness.Result{Phase: string(PhaseCancelled), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunnerAt(t, adapter, stateDir, source, commit)
+	receipt, err := runner.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	<-started
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- runner.Close() }()
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before adapter drained: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	if _, err := runner.Start(context.Background(), StartRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "start-after-close",
+		TaskID:          "task-after-close",
+		AttemptID:       "attempt-after-close",
+		AttemptEpoch:    1,
+		RepositoryID:    "repo",
+		BaseCommit:      commit,
+		Instructions:    "must be rejected",
+		ApprovedInput:   json.RawMessage(`{"provenance":{"source":"test"}}`),
+	}); err == nil {
+		t.Fatal("Start after Close was admitted")
+	} else {
+		assertProtocolCode(t, err, ErrorUnavailable)
+	}
+	secondCloseDone := make(chan error, 1)
+	go func() { secondCloseDone <- runner.Close() }()
+	select {
+	case err := <-secondCloseDone:
+		t.Fatalf("concurrent Close returned before adapter drained: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(release)
+	if err := <-closeDone; err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := <-secondCloseDone; err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	final, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect after concurrent Close: %v", err)
+	}
+	if final.Phase != PhaseNeedsInput {
+		t.Fatalf("final phase = %s, want %s", final.Phase, PhaseNeedsInput)
+	}
+}
+
+func TestLegacyShutdownReceiptMigrationRequiresDurableProof(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*persistedState, *attemptRecord)
+	}{
+		{name: "cancel pending", mutate: func(_ *persistedState, attempt *attemptRecord) { attempt.CancelPending = true }},
+		{name: "cancel operation", mutate: func(state *persistedState, attempt *attemptRecord) {
+			state.Operations[operationKey("cancel", attempt.Receipt.TaskID, attempt.Receipt.AttemptID, attempt.Receipt.AttemptEpoch, "cancel-legacy")] = operationRecord{AttemptID: attempt.Receipt.AttemptID}
+		}},
+		{name: "different blocker", mutate: func(_ *persistedState, attempt *attemptRecord) {
+			attempt.Receipt.Blocker = "operator cancelled the attempt"
+		}},
+		{name: "missing session", mutate: func(_ *persistedState, attempt *attemptRecord) { attempt.Receipt.SessionID = "" }},
+		{name: "output or duration limit", mutate: func(_ *persistedState, attempt *attemptRecord) { attempt.LimitExceeded = true }},
+		{name: "durable adapter error", mutate: func(_ *persistedState, attempt *attemptRecord) {
+			attempt.Receipt.LastError = &Error{Code: ErrorUnavailable, Message: "adapter failed"}
+		}},
+		{name: "current state version", mutate: func(state *persistedState, _ *attemptRecord) { state.Version = stateVersion }},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			stateDir := t.TempDir()
+			state, attempt := legacyShutdownState()
+			testCase.mutate(&state, attempt)
+			writeRunnerState(t, stateDir, state)
+			runner, err := New(Config{RunnerID: "legacy-migration", StateDir: stateDir, Token: "test-token", Listen: "127.0.0.1:0"}, &fakeAdapter{})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			defer func() { _ = runner.Close() }()
+			got, err := runner.Inspect(context.Background(), attempt.Receipt.AttemptID)
+			if err != nil {
+				t.Fatalf("Inspect: %v", err)
+			}
+			if got.Phase != PhaseCancelled {
+				t.Fatalf("migrated phase = %s, want %s", got.Phase, PhaseCancelled)
+			}
+		})
+	}
+
+	stateDir := t.TempDir()
+	state, attempt := legacyShutdownState()
+	writeRunnerState(t, stateDir, state)
+	adapter := &fakeAdapter{}
+	runner, err := New(Config{RunnerID: "legacy-migration-positive", StateDir: stateDir, Token: "test-token", Listen: "127.0.0.1:0"}, adapter)
+	if err != nil {
+		t.Fatalf("New positive migration: %v", err)
+	}
+	defer func() { _ = runner.Close() }()
+	if adapter.runs.Load() != 0 {
+		t.Fatalf("legacy migration auto-started adapter %d times", adapter.runs.Load())
+	}
+	got, err := runner.Inspect(context.Background(), attempt.Receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect positive migration: %v", err)
+	}
+	if got.Phase != PhaseNeedsInput || got.SessionID != "session-legacy" || !strings.Contains(got.Blocker, "shut down") {
+		t.Fatalf("positive migration receipt = %+v", got)
+	}
+	loaded, err := newStateStore(stateDir)
+	if err != nil {
+		t.Fatalf("newStateStore: %v", err)
+	}
+	persisted, err := loaded.load()
+	if err != nil {
+		t.Fatalf("load migrated state: %v", err)
+	}
+	if persisted.Version != stateVersion || persisted.Attempts[attempt.Receipt.AttemptID].Receipt.Phase != PhaseNeedsInput {
+		t.Fatalf("persisted migration state = %+v", persisted)
+	}
+}
+
+func TestRunnerRejectsUnknownStateVersion(t *testing.T) {
+	for _, version := range []int{0, stateVersion + 1} {
+		t.Run(fmt.Sprintf("version-%d", version), func(t *testing.T) {
+			stateDir := t.TempDir()
+			state, _ := legacyShutdownState()
+			state.Version = version
+			writeRunnerState(t, stateDir, state)
+			_, err := New(Config{RunnerID: "unknown-version", StateDir: stateDir, Token: "test-token", Listen: "127.0.0.1:0"}, &fakeAdapter{})
+			if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("unsupported runner state version %d", version)) {
+				t.Fatalf("New(%d) error = %v, want unsupported-version rejection", version, err)
+			}
+		})
+	}
+}
+
+func legacyShutdownState() (persistedState, *attemptRecord) {
+	state := emptyPersistedState()
+	state.Version = legacyStateVersion
+	attempt := &attemptRecord{Receipt: Receipt{
+		ProtocolVersion: ProtocolVersion,
+		TaskID:          "task-legacy",
+		AttemptID:       "attempt-legacy",
+		AttemptEpoch:    1,
+		Phase:           PhaseCancelled,
+		SessionID:       "session-legacy",
+		Workdir:         "/tmp/legacy-worktree",
+		Blocker:         legacyShutdownCancellationBlocker,
+		AcceptedAt:      eventNow(),
+		UpdatedAt:       eventNow(),
+	}}
+	state.Attempts[attempt.Receipt.AttemptID] = attempt
+	state.Events[attempt.Receipt.AttemptID] = []Event{{Cursor: 1, AttemptEpoch: 1, Type: EventCancelled, Message: legacyShutdownCancellationBlocker}}
+	return state, attempt
+}
+
+func writeRunnerState(t *testing.T, stateDir string, state persistedState) {
+	t.Helper()
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal runner state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "state.json"), append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("write runner state: %v", err)
+	}
+}
+
 func TestRestartConvergesRecoveredActiveAttemptToNeedsInput(t *testing.T) {
 	source, commit := testGitSource(t)
 	adapter := &fakeAdapter{}

--- a/pkg/runner/store.go
+++ b/pkg/runner/store.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const stateVersion = 1
+
+type persistedState struct {
+	Version      int                          `json:"version"`
+	Attempts     map[string]*attemptRecord    `json:"attempts"`
+	Operations   map[string]operationRecord   `json:"operations"`
+	Events       map[string][]Event           `json:"events"`
+	Artifacts    map[string]artifactRecord    `json:"artifacts"`
+	Reservations map[string]reservationRecord `json:"reservations"`
+}
+
+type attemptRecord struct {
+	Receipt       Receipt        `json:"receipt"`
+	Start         StartRequest   `json:"start"`
+	Fingerprint   string         `json:"fingerprint"`
+	Resources     []string       `json:"resources,omitempty"`
+	ArtifactSpecs []ArtifactSpec `json:"artifactSpecs,omitempty"`
+	CancelPending bool           `json:"cancelPending,omitempty"`
+	OutputBytes   int64          `json:"outputBytes,omitempty"`
+	LimitExceeded bool           `json:"limitExceeded,omitempty"`
+}
+
+type operationRecord struct {
+	Fingerprint string `json:"fingerprint"`
+	AttemptID   string `json:"attemptID"`
+}
+
+type artifactRecord struct {
+	Artifact Artifact `json:"artifact"`
+	Path     string   `json:"path"`
+}
+
+type reservationRecord struct {
+	AttemptID string `json:"attemptID"`
+}
+
+type stateStore struct {
+	dir  string
+	path string
+}
+
+func newStateStore(dir string) (*stateStore, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create runner state directory: %w", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("protect runner state directory: %w", err)
+	}
+	return &stateStore{dir: dir, path: filepath.Join(dir, "state.json")}, nil
+}
+
+func (s *stateStore) load() (persistedState, error) {
+	state := emptyPersistedState()
+	f, err := os.Open(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return state, nil
+	}
+	if err != nil {
+		return state, fmt.Errorf("open runner state: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	decoder := json.NewDecoder(io.LimitReader(f, 32<<20))
+	if err := decoder.Decode(&state); err != nil {
+		return state, fmt.Errorf("decode runner state: %w", err)
+	}
+	if state.Version != stateVersion {
+		return state, fmt.Errorf("unsupported runner state version %d", state.Version)
+	}
+	if state.Attempts == nil {
+		state.Attempts = map[string]*attemptRecord{}
+	}
+	if state.Operations == nil {
+		state.Operations = map[string]operationRecord{}
+	}
+	if state.Events == nil {
+		state.Events = map[string][]Event{}
+	}
+	if state.Artifacts == nil {
+		state.Artifacts = map[string]artifactRecord{}
+	}
+	if state.Reservations == nil {
+		state.Reservations = map[string]reservationRecord{}
+	}
+	return state, nil
+}
+
+func emptyPersistedState() persistedState {
+	return persistedState{
+		Version:      stateVersion,
+		Attempts:     map[string]*attemptRecord{},
+		Operations:   map[string]operationRecord{},
+		Events:       map[string][]Event{},
+		Artifacts:    map[string]artifactRecord{},
+		Reservations: map[string]reservationRecord{},
+	}
+}
+
+func (s *stateStore) save(state persistedState) error {
+	state.Version = stateVersion
+	b, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode runner state: %w", err)
+	}
+	tmp, err := os.CreateTemp(s.dir, ".state-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create runner state temporary file: %w", err)
+	}
+	tmpName := tmp.Name()
+	removeTemp := true
+	defer func() {
+		_ = tmp.Close()
+		if removeTemp {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return fmt.Errorf("protect runner state temporary file: %w", err)
+	}
+	if _, err := tmp.Write(b); err != nil {
+		return fmt.Errorf("write runner state temporary file: %w", err)
+	}
+	if _, err := tmp.Write([]byte("\n")); err != nil {
+		return fmt.Errorf("write runner state terminator: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("sync runner state temporary file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close runner state temporary file: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return fmt.Errorf("replace runner state: %w", err)
+	}
+	removeTemp = false
+	if dir, err := os.Open(s.dir); err == nil {
+		syncErr := dir.Sync()
+		closeErr := dir.Close()
+		if syncErr != nil {
+			return fmt.Errorf("sync runner state directory: %w", syncErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close runner state directory: %w", closeErr)
+		}
+	}
+	return nil
+}
+
+func eventNow() time.Time { return time.Now().UTC() }

--- a/pkg/runner/store.go
+++ b/pkg/runner/store.go
@@ -23,10 +23,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
-const stateVersion = 1
+const (
+	legacyStateVersion = 1
+	stateVersion       = 2
+)
 
 type persistedState struct {
 	Version      int                          `json:"version"`
@@ -35,6 +39,11 @@ type persistedState struct {
 	Events       map[string][]Event           `json:"events"`
 	Artifacts    map[string]artifactRecord    `json:"artifacts"`
 	Reservations map[string]reservationRecord `json:"reservations"`
+
+	// migratedLegacyShutdown holds one-shot in-memory markers. They let the
+	// runner append a truthful needs_input event after the narrowly-scoped
+	// v1 receipt migration without persisting migration bookkeeping.
+	migratedLegacyShutdown map[string]struct{} `json:"-"`
 }
 
 type attemptRecord struct {
@@ -91,7 +100,12 @@ func (s *stateStore) load() (persistedState, error) {
 	if err := decoder.Decode(&state); err != nil {
 		return state, fmt.Errorf("decode runner state: %w", err)
 	}
-	if state.Version != stateVersion {
+	switch state.Version {
+	case stateVersion:
+	case legacyStateVersion:
+		state.Version = stateVersion
+		state.migratedLegacyShutdown = migrateLegacyShutdownReceipts(state)
+	default:
 		return state, fmt.Errorf("unsupported runner state version %d", state.Version)
 	}
 	if state.Attempts == nil {
@@ -114,13 +128,60 @@ func (s *stateStore) load() (persistedState, error) {
 
 func emptyPersistedState() persistedState {
 	return persistedState{
-		Version:      stateVersion,
-		Attempts:     map[string]*attemptRecord{},
-		Operations:   map[string]operationRecord{},
-		Events:       map[string][]Event{},
-		Artifacts:    map[string]artifactRecord{},
-		Reservations: map[string]reservationRecord{},
+		Version:                stateVersion,
+		Attempts:               map[string]*attemptRecord{},
+		Operations:             map[string]operationRecord{},
+		Events:                 map[string][]Event{},
+		Artifacts:              map[string]artifactRecord{},
+		Reservations:           map[string]reservationRecord{},
+		migratedLegacyShutdown: map[string]struct{}{},
 	}
+}
+
+// migrateLegacyShutdownReceipts repairs only the runner/v1 receipt produced by
+// the old Close path. That path used the same blocker as explicit cancellation,
+// so reopening is safe only when the durable record proves all of the
+// following: the receipt is cancelled, CancelPending is false, no cancel
+// operation references the attempt, the blocker is exact, and a session ID is
+// present. Newer state versions intentionally do not apply this migration.
+func migrateLegacyShutdownReceipts(state persistedState) map[string]struct{} {
+	recovered := make(map[string]struct{})
+	for attemptID, attempt := range state.Attempts {
+		if attempt == nil || attempt.Receipt.Phase != PhaseCancelled || attempt.CancelPending || attempt.LimitExceeded || attempt.Receipt.Blocker != legacyShutdownCancellationBlocker || attempt.Receipt.LastError != nil || !validSessionID(attempt.Receipt.SessionID) {
+			continue
+		}
+		if hasCancelOperation(state.Operations, attemptID) {
+			continue
+		}
+		attempt.Receipt.Phase = PhaseNeedsInput
+		attempt.Receipt.Blocker = shutdownBlocker
+		attempt.Receipt.UpdatedAt = eventNow()
+		recovered[attemptID] = struct{}{}
+	}
+	return recovered
+}
+
+func hasCancelOperation(operations map[string]operationRecord, attemptID string) bool {
+	for key, operation := range operations {
+		if !strings.HasPrefix(key, "cancel\x00") {
+			continue
+		}
+		if operation.AttemptID == attemptID {
+			return true
+		}
+		// The operation value is authoritative in normal state, but parsing the
+		// stable key as a defensive fallback prevents a malformed cancel record
+		// from being mistaken for proof that no operator cancellation exists.
+		parts := strings.Split(key, "\x00")
+		if len(parts) >= 3 && parts[2] == attemptID {
+			return true
+		}
+	}
+	return false
+}
+
+func validSessionID(sessionID string) bool {
+	return sessionID != "" && sessionID == strings.TrimSpace(sessionID) && len(sessionID) <= maxIdentifierBytes
 }
 
 func (s *stateStore) save(state persistedState) error {

--- a/pkg/runner/workspace.go
+++ b/pkg/runner/workspace.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var commitPattern = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
+
+func prepareWorkspace(ctx context.Context, cfg Config, request StartRequest) (string, error) {
+	repo, ok := cfg.Repositories[request.RepositoryID]
+	if !ok {
+		return "", fmt.Errorf("repository %q is not enrolled", request.RepositoryID)
+	}
+	baseCommit := strings.TrimSpace(request.BaseCommit)
+	if !commitPattern.MatchString(baseCommit) {
+		return "", errors.New("baseCommit must be a full 40-character commit")
+	}
+	baseCommit = strings.ToLower(baseCommit)
+	if repo.BaseCommit != "" && strings.ToLower(strings.TrimSpace(repo.BaseCommit)) != baseCommit {
+		return "", errors.New("base commit is not the exact commit enrolled for this repository")
+	}
+	source, err := filepath.Abs(repo.Source)
+	if err != nil {
+		return "", fmt.Errorf("resolve repository source: %w", err)
+	}
+	if info, err := os.Stat(source); err != nil || !info.IsDir() {
+		if err == nil {
+			err = errors.New("source is not a directory")
+		}
+		return "", fmt.Errorf("repository source unavailable: %w", err)
+	}
+	resolved, err := gitOutput(ctx, source, "rev-parse", "--verify", baseCommit+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("base commit is not available: %w", err)
+	}
+	if strings.TrimSpace(resolved) != baseCommit {
+		return "", fmt.Errorf("base commit resolved to %q, want exact %q", strings.TrimSpace(resolved), baseCommit)
+	}
+	workdir := filepath.Join(cfg.StateDir, "worktrees", request.TaskID, request.AttemptID)
+	if info, err := os.Lstat(workdir); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", errors.New("task worktree path must not be a symlink")
+		}
+		if !info.IsDir() {
+			return "", errors.New("task worktree path exists and is not a directory")
+		}
+		if err := verifyTaskPath(cfg.StateDir, workdir); err != nil {
+			return "", err
+		}
+		head, err := gitOutput(ctx, workdir, "rev-parse", "HEAD")
+		if err != nil || strings.TrimSpace(head) != baseCommit {
+			return "", errors.New("existing task worktree does not match approved base commit")
+		}
+		return workdir, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("inspect task worktree: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(workdir), 0o700); err != nil {
+		return "", fmt.Errorf("create task worktree parent: %w", err)
+	}
+	if err := verifyTaskPath(cfg.StateDir, workdir); err != nil {
+		return "", err
+	}
+	// --no-local keeps clone setup read-only from the source repository. In
+	// particular, this avoids `git worktree add`, which edits the interactive
+	// checkout's administrative metadata.
+	if _, err := gitOutput(ctx, "", "clone", "--no-local", "--no-hardlinks", "--no-checkout", "--upload-pack=git-upload-pack", "--config", "core.hooksPath=/dev/null", source, workdir); err != nil {
+		_ = os.RemoveAll(workdir)
+		return "", fmt.Errorf("clone task worktree: %w", err)
+	}
+	if _, err := gitOutput(ctx, workdir, "checkout", "--detach", "--force", baseCommit); err != nil {
+		_ = os.RemoveAll(workdir)
+		return "", fmt.Errorf("checkout approved base commit: %w", err)
+	}
+	return workdir, nil
+}
+
+func verifyWorkspace(ctx context.Context, cfg Config, request StartRequest, workdir string) error {
+	if err := verifyTaskPath(cfg.StateDir, workdir); err != nil {
+		return err
+	}
+	info, err := os.Lstat(workdir)
+	if err != nil {
+		return fmt.Errorf("task worktree is unavailable: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return errors.New("task worktree is not a private directory")
+	}
+	baseCommit := strings.ToLower(strings.TrimSpace(request.BaseCommit))
+	if !commitPattern.MatchString(baseCommit) {
+		return errors.New("approved base commit is not a full commit")
+	}
+	head, err := gitOutput(ctx, workdir, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("inspect task worktree: %w", err)
+	}
+	if strings.TrimSpace(head) != baseCommit {
+		return errors.New("task worktree no longer matches the approved base commit")
+	}
+	repo, ok := cfg.Repositories[request.RepositoryID]
+	if !ok || repo.Source == "" {
+		return errors.New("repository is no longer enrolled")
+	}
+	if repo.BaseCommit != "" && strings.ToLower(strings.TrimSpace(repo.BaseCommit)) != baseCommit {
+		return errors.New("repository enrollment no longer permits the approved base commit")
+	}
+	return nil
+}
+
+func verifyTaskPath(stateDir, workdir string) error {
+	stateRoot, err := filepath.Abs(stateDir)
+	if err != nil {
+		return fmt.Errorf("resolve runner state directory: %w", err)
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(workdir))
+	if err != nil {
+		return fmt.Errorf("resolve task worktree parent: %w", err)
+	}
+	if !pathWithin(stateRoot, parent) {
+		return errors.New("task worktree parent escapes the runner state directory")
+	}
+	return nil
+}
+
+func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	// Every Git invocation is fixed by the runner. Do not let a developer's
+	// global config, credential helper, SSH agent, GitHub token, or hook change
+	// the meaning of an approved source/commit operation.
+	safeArgs := append([]string{"-c", "core.hooksPath=/dev/null"}, args...)
+	cmd := exec.CommandContext(cmdCtx, "git", safeArgs...)
+	cmd.Env = sanitizedGitEnvironment()
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return "", errors.New(message)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func sanitizedGitEnvironment() []string {
+	env := make([]string, 0, len(os.Environ())+5)
+	for _, value := range os.Environ() {
+		key, _, ok := strings.Cut(value, "=")
+		if ok && (strings.HasPrefix(key, "GIT_") || strings.HasPrefix(key, "GH_") || strings.HasPrefix(key, "GITHUB_") || key == "SSH_AUTH_SOCK") {
+			continue
+		}
+		env = append(env, value)
+	}
+	return append(env,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ALLOW_PROTOCOL=file",
+	)
+}
+
+func pathWithin(root, candidate string) bool {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	candidateAbs, err := filepath.Abs(candidate)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootAbs, candidateAbs)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func artifactSource(workdir, relative string) (string, error) {
+	if relative == "" || filepath.IsAbs(relative) {
+		return "", errors.New("artifact path must be relative to the task worktree")
+	}
+	clean := filepath.Clean(relative)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", errors.New("artifact path escapes the task worktree")
+	}
+	candidate := filepath.Join(workdir, clean)
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve artifact path: %w", err)
+	}
+	if !pathWithin(workdir, resolved) {
+		return "", errors.New("artifact path escapes the task worktree")
+	}
+	return resolved, nil
+}
+
+func validateArtifactRelativePath(relative string) error {
+	if relative == "" || filepath.IsAbs(relative) {
+		return errors.New("artifact path must be relative to the task worktree")
+	}
+	clean := filepath.Clean(relative)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return errors.New("artifact path escapes the task worktree")
+	}
+	return nil
+}


### PR DESCRIPTION
Adds a durable local coding runner reachable through an authenticated Edges Service. Requests run in isolated Git worktrees under an explicit repository allowlist, with durable attempt identities, event journals, capacity reservations, cancellation, and same-worker session recovery.

Includes a Codex app-server adapter and macOS setup tooling. Dedicated Codex-home handling preserves required caches while isolating extensions, and managed-worktree trust and graceful shutdown handling support resuming existing tasks.

Validation: focused Go/race/session-recovery checks, scoped lint, and native/Darwin builds passed during implementation. Live Mac acceptance completed a real fixture through the consumer integration, resumed the same session/worktree, passed its verification command, and preserved the clean source checkout. Fresh graceful-shutdown classification is covered by deterministic regression tests; the live continuation also crossed an older receipt migration. Full root `make verify` is not claimed.

Based on `main` following the merge of macOS Edges PR #700. This PR contains only the runner layer and subsequent acceptance fixes.
