### PR TITLE
runner: export Git results and fetch approved commits from enrolled remotes

### DIFF
--- a/docs/local-runner.md
+++ b/docs/local-runner.md
@@ -267,6 +267,49 @@ Do not copy the state directory to another machine or assume raw Codex session
 files are portable. Cross-machine continuation, migration, scheduling, and
 publication are outside this runner contract.
 
+## Optional Git result export
+
+The runner advertises `git-result-v1` in `verificationCapabilities`. A caller
+must explicitly set `exportGitResult: true` in the approved Start request to
+request the export; ordinary completed attempts produce no Git result
+artifacts. The export is intended for a separate coordinator that owns
+publication. The runner itself never pushes Git or creates a pull request.
+
+Example request field:
+
+```json
+{
+  "exportGitResult": true
+}
+```
+
+After a successful harness completion, the runner snapshots tracked and
+nonignored files from the task worktree using a temporary index. It preserves
+the worktree's normal HEAD and index, and writes owner-only artifacts below the
+runner state directory:
+
+- `git-result.json` is a bounded `git-result/v1` document containing Task and
+  Attempt identity, the approved `baseCommit`, result commit/tree identity,
+  and `noChanges`.
+- `git-result.bundle` is present only when the snapshot differs from the base.
+  It contains one deterministic sanitized snapshot commit whose sole parent is
+  the approved base commit, with fixed runner identity, timestamp, and commit
+  message. The bundle advertises only the runner-result ref.
+
+The generated names are reserved. A harness cannot submit an artifact under
+either name when export is enabled. If export fails, the attempt is failed and
+does not report completion with a partial result. If the snapshot tree equals
+the approved base tree, `noChanges` is true and the result omits commit, tree,
+bundle digest, and bundle artifact. Unstaged deletions and file/directory
+transitions are included; symlink ancestors are rejected.
+
+The exporter includes the final tracked and nonignored worktree contents. A
+caller that uses this export should instruct the harness not to place private
+planning documents, transcripts, credentials, or verification logs in that
+tree, but the exporter is not a content secret scanner. Callers must treat the
+worktree and resulting bundle as private and apply their own publication
+policy.
+
 ## Limits and verification boundary
 
 The default bounds are 256 retained events per attempt, 64 KiB per event
@@ -276,10 +319,10 @@ callers should use the advertised protocol response and error code as the
 authority. The runner supports at most one harness turn per execution and one
 simultaneous execution by default.
 
-Focused runner tests, race and vet checks, native builds, Darwin arm64 and
-amd64 builds, and two no-model Codex `0.147.0` authentication probes have
-passed for the current implementation. These checks establish protocol,
-process, and harness contracts. They do not establish that a real Mac has
-successfully completed a coding task. A real-Mac acceptance still needs an
-actual enrolled host, approved local repository, start/observe path,
-interruption, restart, and same-session resume evidence.
+Focused runner tests, race/vet/lint checks, and Linux and Darwin arm64/amd64
+builds have passed after the final exporter repair. A local artifact-consumer
+fixture also accepted the real runner artifacts. These checks establish
+protocol, process, harness, and local artifact contracts. They do not establish
+live GitHub publication or that a real Mac has completed a coding task. Live
+acceptance still needs an actual enrolled host, approved local repository,
+start/observe path, interruption, restart, and same-session resume evidence.

--- a/docs/local-runner.md
+++ b/docs/local-runner.md
@@ -72,7 +72,8 @@ bootstrap endpoint for creating this credential.
 Use an absolute, private state directory and an absolute token-file path. A
 configuration can enroll several named local Git sources, but each source must
 be explicitly allowlisted. `baseCommit`, when set, further restricts that
-source to one commit.
+source to one commit. An optional operator-only `fetchRemoteURL` permits the
+runner to fetch a missing approved commit into the isolated task clone.
 
 ```json
 {
@@ -103,13 +104,55 @@ source to one commit.
 runner defaults `runnerID` to a platform-qualified value, `stateDir` to the
 user configuration directory followed by `faros-runner`, and `maximumCapacity`
 to one. It rejects a capacity greater than one. The source path is resolved at
-startup; the source directory must exist and contain the requested full commit.
+startup and the source directory must exist. Without `fetchRemoteURL`, the
+requested full commit must already exist in that source. With it, the runner
+keeps the source as the enrolled local checkout and may fetch the exact
+requested commit only into the task-owned clone; it never updates the source.
 
 The runner stores durable state as a protected file below `stateDir`, takes a
 single-process lock for that directory, and places task workspaces below
 `stateDir/worktrees/<taskID>/<attemptID>`. Keep this directory on durable
 storage on the same machine. Do not share one state directory between runner
 instances.
+
+### Allow an enrolled repository to fetch a missing commit
+
+Set `fetchRemoteURL` on the repository enrollment when the local `source` may
+not contain every approved commit. This field is operator configuration; a
+start request cannot supply or change it. The existing `baseCommit` pin is
+still enforced when it is set, and every start request must still name one
+full 40-character commit.
+
+The remote can be a local path, a `file://` URL, public `https://`, or an
+ordinary SSH URL (`ssh://...` or `user@host:path`). Embedded credentials,
+HTTPS query or fragment options, and interactive HTTPS authentication are not
+allowed. For example:
+
+```json
+{
+  "repositories": {
+    "app": {
+      "source": "/srv/repos/app",
+      "baseCommit": "<40-character-commit>",
+      "fetchRemoteURL": "ssh://git@example.com/acme/app.git"
+    }
+  }
+}
+```
+
+Before enrolling an SSH remote, the operator should test access and the
+expected host key with the same key and `known_hosts` configuration. Fetch
+uses strict host-key checking, batch mode, and disables agent forwarding and
+other forwarding. It may use an operator-provided SSH key or agent for this
+fetch operation only. The coding harness does not receive the SSH agent,
+GitHub tokens, API keys, or other Git credentials, and its execution remains
+network-disabled.
+
+The runner advertises `git-fetch-v1` in `verificationCapabilities` when any
+enrolled repository has a `fetchRemoteURL`. The capability is an availability
+signal; the per-repository opt-in and remote validation still apply. Git fetch
+command failures return fixed bounded messages (`git fetch failed`, `git fetch
+timed out`, or `git fetch canceled`) instead of remote command output.
 
 ## Start the runner
 
@@ -177,10 +220,13 @@ attempt epoch is stale and cannot mutate the newer attempt.
 A start request must include the enrolled `repositoryID`, the full 40-character
 `baseCommit`, non-empty instructions, and a non-empty JSON `approvedInput`
 object containing `provenance`, `manualAuthorization`, or `authorization`.
-The base commit must resolve exactly in the enrolled local source. The runner
-clones that source with fixed, non-interactive Git settings into the task-owned
-worktree and checks out the commit detached. It does not use `git worktree add`
-and does not modify the enrolled source checkout.
+The approved commit must resolve exactly in the enrolled source or, when that
+repository has opted in with `fetchRemoteURL`, be fetched exactly into the
+isolated task clone. The runner clones the local source with fixed,
+non-interactive Git settings into the task-owned worktree, performs that
+operator-configured fetch only if the clone lacks the approved commit, and
+checks out the commit detached. It does not use `git worktree add` and does
+not modify the enrolled source checkout.
 
 The request may additionally require configured capabilities, toolchains,
 environment entries, a named ready harness, verification names or commands,
@@ -319,10 +365,11 @@ callers should use the advertised protocol response and error code as the
 authority. The runner supports at most one harness turn per execution and one
 simultaneous execution by default.
 
-Focused runner tests, race/vet/lint checks, and Linux and Darwin arm64/amd64
-builds have passed after the final exporter repair. A local artifact-consumer
-fixture also accepted the real runner artifacts. These checks establish
-protocol, process, harness, and local artifact contracts. They do not establish
-live GitHub publication or that a real Mac has completed a coding task. Live
-acceptance still needs an actual enrolled host, approved local repository,
-start/observe path, interruption, restart, and same-session resume evidence.
+Independent focused Git-fetch and race invocation tests passed. The full runner
+executor checks (runner tests, race, lint, vet, and build) also passed, along
+with Linux and Darwin arm64/amd64 builds. A local artifact-consumer fixture
+accepted the real runner artifacts. These checks establish protocol, process,
+harness, Git-fetch, and local artifact contracts. They do not establish live
+GitHub publication or provide live Mac stage6B proof. Live acceptance still
+needs an actual enrolled host, approved local repository, start/observe path,
+interruption, restart, and same-session resume evidence.

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -36,15 +36,19 @@ const (
 	defaultMaxBodyBytes    = 2 << 20
 	defaultMaxArtifactSize = 32 << 20
 	gitResultCapability    = "git-result-v1"
+	gitFetchCapability     = "git-fetch-v1"
 )
 
 var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
 
 // RepositoryConfig enrolls one local Git source. The source is read-only from
 // the runner's point of view; attempts are cloned into task-owned worktrees.
+// FetchRemoteURL is operator-only enrollment data; it is never accepted from
+// a start request or exposed as a runner protocol field.
 type RepositoryConfig struct {
-	Source     string `json:"source"`
-	BaseCommit string `json:"baseCommit,omitempty"`
+	Source         string `json:"source"`
+	BaseCommit     string `json:"baseCommit,omitempty"`
+	FetchRemoteURL string `json:"fetchRemoteURL,omitempty"`
 }
 
 // ResourceConfig names a preconfigured shared resource. Capacity is a count
@@ -169,10 +173,17 @@ func (c *Config) applyDefaults() error {
 		}
 		if abs, err := filepath.Abs(repo.Source); err == nil {
 			repo.Source = abs
-			c.Repositories[id] = repo
 		} else {
 			return fmt.Errorf("resolve repository %q source: %w", id, err)
 		}
+		if strings.TrimSpace(repo.FetchRemoteURL) != "" {
+			remote, err := validateFetchRemoteURL(repo.FetchRemoteURL)
+			if err != nil {
+				return fmt.Errorf("repository %q fetch remote URL: %w", id, err)
+			}
+			repo.FetchRemoteURL = remote
+		}
+		c.Repositories[id] = repo
 	}
 	for name, resource := range c.Resources {
 		if !identifierPattern.MatchString(name) {
@@ -187,6 +198,15 @@ func (c *Config) applyDefaults() error {
 		}
 	}
 	return nil
+}
+
+func hasFetchRemote(repositories map[string]RepositoryConfig) bool {
+	for _, repository := range repositories {
+		if strings.TrimSpace(repository.FetchRemoteURL) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func isLoopbackListenAddress(address string) bool {

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -35,6 +35,7 @@ const (
 	defaultMaxEventBytes   = 64 << 10
 	defaultMaxBodyBytes    = 2 << 20
 	defaultMaxArtifactSize = 32 << 20
+	gitResultCapability    = "git-result-v1"
 )
 
 var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)

--- a/pkg/runner/git_fetch.go
+++ b/pkg/runner/git_fetch.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const maxGitFetchErrorBytes = 1024
+
+const secureSSHCommand = "ssh -o BatchMode=yes -o StrictHostKeyChecking=yes -o ForwardAgent=no -o ClearAllForwardings=yes"
+
+type fetchRemoteKind string
+
+const (
+	fetchRemoteLocal fetchRemoteKind = "file"
+	fetchRemoteHTTPS fetchRemoteKind = "https"
+	fetchRemoteSSH   fetchRemoteKind = "ssh"
+)
+
+// validateFetchRemoteURL accepts only an operator-configured remote that Git
+// can use without interpreting caller-controlled options. Local paths are
+// useful for the enrolled-host acceptance fixture; network remotes are limited
+// to public HTTPS and ordinary SSH URLs.
+func validateFetchRemoteURL(raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("fetch remote URL is empty")
+	}
+	if strings.TrimSpace(raw) != raw {
+		return "", errors.New("fetch remote URL must not have surrounding whitespace")
+	}
+	if strings.HasPrefix(raw, "-") {
+		return "", errors.New("fetch remote URL must not begin with an option")
+	}
+	if hasControlCharacter(raw) {
+		return "", errors.New("fetch remote URL contains a control character")
+	}
+
+	if isWindowsAbsolutePath(raw) {
+		if !filepath.IsAbs(raw) {
+			return "", errors.New("windows fetch remote paths are only valid on Windows")
+		}
+		return filepath.Abs(raw)
+	}
+	if filepath.IsAbs(raw) {
+		return filepath.Abs(raw)
+	}
+	if isSCPRemote(raw) {
+		return raw, nil
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", errors.New("fetch remote URL is malformed")
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "":
+		// Relative paths are resolved once at enrollment time. This keeps the
+		// fetch target fixed if the runner later changes its working directory.
+		return filepath.Abs(raw)
+	case "file":
+		return localPathFromFileURL(parsed)
+	case "https":
+		if err := validateNetworkRemote(parsed, false); err != nil {
+			return "", err
+		}
+		return raw, nil
+	case "ssh":
+		if err := validateNetworkRemote(parsed, true); err != nil {
+			return "", err
+		}
+		return raw, nil
+	default:
+		return "", errors.New("fetch remote URL scheme is not allowed")
+	}
+}
+
+func localPathFromFileURL(parsed *url.URL) (string, error) {
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Opaque != "" {
+		return "", errors.New("file fetch remote URL has unsupported credentials or options")
+	}
+	if parsed.Host != "" && !strings.EqualFold(parsed.Host, "localhost") {
+		return "", errors.New("file fetch remote URL must not name a remote host")
+	}
+	if parsed.Path == "" || hasControlCharacter(parsed.Path) || hasControlCharacter(parsed.RawPath) {
+		return "", errors.New("file fetch remote URL has an invalid path")
+	}
+	path := filepath.FromSlash(parsed.Path)
+	if isWindowsAbsolutePath(path) && runtimeIsWindows() && !filepath.IsAbs(path) {
+		return "", errors.New("file fetch remote URL has an invalid Windows path")
+	}
+	return filepath.Abs(path)
+}
+
+func validateNetworkRemote(parsed *url.URL, ssh bool) error {
+	if parsed.Opaque != "" || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("fetch remote URL has unsupported options")
+	}
+	if parsed.User != nil {
+		_, hasPassword := parsed.User.Password()
+		if !ssh || hasPassword {
+			return errors.New("fetch remote URL must not contain embedded credentials")
+		}
+		if hasControlCharacter(parsed.User.Username()) {
+			return errors.New("fetch remote URL contains an invalid SSH user")
+		}
+	}
+	host := parsed.Hostname()
+	if host == "" || strings.HasPrefix(host, "-") || hasControlCharacter(host) {
+		return errors.New("fetch remote URL has an invalid host")
+	}
+	if parsed.Path == "" || hasControlCharacter(parsed.Path) || hasControlCharacter(parsed.RawPath) {
+		return errors.New("fetch remote URL has an invalid path")
+	}
+	return nil
+}
+
+func isSCPRemote(value string) bool {
+	if strings.HasPrefix(strings.ToLower(value), "ext::") {
+		return false
+	}
+	separator := strings.IndexByte(value, ':')
+	if separator <= 0 || separator == len(value)-1 || strings.Contains(value[:separator], "/") {
+		return false
+	}
+	if strings.HasPrefix(value[separator+1:], "//") {
+		return false
+	}
+	if strings.ContainsAny(value, " \t\r\n?#") || hasControlCharacter(value) {
+		return false
+	}
+	userHost := value[:separator]
+	host := userHost
+	if at := strings.LastIndexByte(userHost, '@'); at >= 0 {
+		if at == 0 || at == len(userHost)-1 || strings.Contains(userHost[:at], ":") {
+			return false
+		}
+		host = userHost[at+1:]
+	}
+	return validSSHHost(host)
+}
+
+func validSSHHost(host string) bool {
+	return host != "" && !strings.HasPrefix(host, "-") && !hasControlCharacter(host) && !strings.ContainsAny(host, " \t\r\n/?#")
+}
+
+func hasControlCharacter(value string) bool {
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func isWindowsAbsolutePath(value string) bool {
+	return len(value) >= 3 && ((value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')) && value[1] == ':' && (value[2] == '/' || value[2] == '\\')
+}
+
+func runtimeIsWindows() bool { return filepath.Separator == '\\' }
+
+func fetchRemoteKindOf(remote string) fetchRemoteKind {
+	if isSCPRemote(remote) || strings.HasPrefix(strings.ToLower(remote), "ssh://") {
+		return fetchRemoteSSH
+	}
+	if strings.HasPrefix(strings.ToLower(remote), "https://") {
+		return fetchRemoteHTTPS
+	}
+	return fetchRemoteLocal
+}
+
+// fetchGitEnvironment is intentionally separate from sanitizedGitEnvironment.
+// SSH_AUTH_SOCK is allowed only for the one explicitly configured SSH fetch;
+// it remains absent from all source-only Git operations and the harness.
+func fetchGitEnvironment(remote string) []string {
+	env := make([]string, 0, len(os.Environ())+7)
+	for _, value := range os.Environ() {
+		key, _, ok := strings.Cut(value, "=")
+		if !ok || strings.HasPrefix(key, "GIT_") || strings.HasPrefix(key, "GH_") || strings.HasPrefix(key, "GITHUB_") || key == "SSH_AUTH_SOCK" || key == "SSH_AGENT_PID" || key == "SSH_ASKPASS" || key == "SSH_ASKPASS_REQUIRE" {
+			continue
+		}
+		env = append(env, value)
+	}
+	allowProtocol := string(fetchRemoteKindOf(remote))
+	if allowProtocol == "" {
+		allowProtocol = string(fetchRemoteLocal)
+	}
+	env = append(env,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ALLOW_PROTOCOL="+allowProtocol,
+	)
+	if fetchRemoteKindOf(remote) == fetchRemoteSSH {
+		if socket, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok && socket != "" {
+			env = append(env, "SSH_AUTH_SOCK="+socket)
+		}
+	}
+	return env
+}
+
+func fetchExactCommit(ctx context.Context, workdir, remote, commit string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	remote, err := validateFetchRemoteURL(remote)
+	if err != nil {
+		return fmt.Errorf("fetch remote URL is not allowed: %w", err)
+	}
+	if !commitPattern.MatchString(commit) {
+		return errors.New("fetch commit is not a full 40-character commit")
+	}
+	cmdCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	args := []string{
+		"-c", "core.hooksPath=/dev/null",
+		"-c", "credential.helper=",
+		"-c", "fetch.recurseSubmodules=false",
+	}
+	if fetchRemoteKindOf(remote) == fetchRemoteSSH {
+		args = append(args, "-c", "core.sshCommand="+secureSSHCommand)
+	}
+	args = append(args, "fetch", "--no-tags", "--no-prune", "--no-write-fetch-head", remote, strings.ToLower(commit))
+	cmd := exec.CommandContext(cmdCtx, "git", args...)
+	cmd.Dir = workdir
+	cmd.Env = fetchGitEnvironment(remote)
+	var stderr boundedGitBuffer
+	cmd.Stdout = io.Discard
+	cmd.Stderr = &stderr
+	if runErr := cmd.Run(); runErr != nil {
+		return boundedGitFetchError(remote, stderr.String(), runErr, cmdCtx.Err())
+	}
+	return nil
+}
+
+func boundedGitFetchError(_ string, _ string, _ error, ctxErr error) error {
+	switch {
+	case errors.Is(ctxErr, context.DeadlineExceeded):
+		return errors.New("git fetch timed out")
+	case errors.Is(ctxErr, context.Canceled):
+		return errors.New("git fetch canceled")
+	default:
+		return errors.New("git fetch failed")
+	}
+}
+
+type boundedGitBuffer struct {
+	value     strings.Builder
+	truncated bool
+}
+
+func (b *boundedGitBuffer) Write(p []byte) (int, error) {
+	remaining := maxGitFetchErrorBytes - b.value.Len()
+	if remaining <= 0 {
+		b.truncated = true
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		_, _ = b.value.Write(p[:remaining])
+		b.truncated = true
+		return len(p), nil
+	}
+	_, _ = b.value.Write(p)
+	return len(p), nil
+}
+
+func (b *boundedGitBuffer) String() string {
+	value := b.value.String()
+	if b.truncated {
+		return value + "..."
+	}
+	return value
+}

--- a/pkg/runner/git_fetch_invocation_test.go
+++ b/pkg/runner/git_fetch_invocation_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFetchExactCommitUsesNonInteractiveSSHAndHidesRemoteDiagnostics(t *testing.T) {
+	tmp := t.TempDir()
+	argsPath := filepath.Join(tmp, "args")
+	envPath := filepath.Join(tmp, "env")
+	fakeGit := filepath.Join(tmp, "git")
+	script := "#!/bin/sh\n" +
+		"set -eu\n" +
+		"printf '%s\\n' \"$@\" > \"$FETCH_ARGS_PATH\"\n" +
+		"env | sort > \"$FETCH_ENV_PATH\"\n" +
+		"printf '%s\\n' 'remote credential and host diagnostic' >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(fakeGit, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tmp+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FETCH_ARGS_PATH", argsPath)
+	t.Setenv("FETCH_ENV_PATH", envPath)
+	t.Setenv("SSH_AUTH_SOCK", "/tmp/runner-agent.sock")
+	t.Setenv("SSH_AGENT_PID", "1234")
+	t.Setenv("SSH_ASKPASS", "/tmp/askpass")
+	t.Setenv("SSH_ASKPASS_REQUIRE", "force")
+	t.Setenv("GIT_ASKPASS", "/tmp/git-askpass")
+	t.Setenv("GIT_SSH_COMMAND", "ssh -i /tmp/private-key")
+	t.Setenv("GH_TOKEN", "gh-secret")
+	t.Setenv("GITHUB_TOKEN", "github-secret")
+
+	commit := strings.Repeat("a", 40)
+	err := fetchExactCommit(context.Background(), tmp, "ssh://git@example.com/repo.git", commit)
+	if err == nil || err.Error() != "git fetch failed" {
+		t.Fatalf("fetchExactCommit error = %v, want fixed fetch error", err)
+	}
+	if strings.Contains(err.Error(), "remote credential") || strings.Contains(err.Error(), "github-secret") {
+		t.Fatalf("fetchExactCommit leaked remote diagnostic: %v", err)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argLines := strings.Split(strings.TrimSpace(string(args)), "\n")
+	for _, want := range []string{
+		"-c",
+		"core.sshCommand=" + secureSSHCommand,
+		"fetch",
+		"--no-tags",
+		"--no-prune",
+		"--no-write-fetch-head",
+		"ssh://git@example.com/repo.git",
+		commit,
+	} {
+		if !contains(argLines, want) {
+			t.Fatalf("git invocation args = %q, missing %q", argLines, want)
+		}
+	}
+
+	envBytes, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := environmentMap(strings.Split(strings.TrimSpace(string(envBytes)), "\n"))
+	if env["SSH_AUTH_SOCK"] != "/tmp/runner-agent.sock" {
+		t.Fatalf("SSH_AUTH_SOCK = %q, want explicit SSH agent", env["SSH_AUTH_SOCK"])
+	}
+	for _, key := range []string{
+		"SSH_AGENT_PID",
+		"SSH_ASKPASS",
+		"SSH_ASKPASS_REQUIRE",
+		"GIT_ASKPASS",
+		"GIT_SSH_COMMAND",
+		"GH_TOKEN",
+		"GITHUB_TOKEN",
+	} {
+		if env[key] != "" {
+			t.Fatalf("fetch environment leaked %s=%q", key, env[key])
+		}
+	}
+	if env["GIT_TERMINAL_PROMPT"] != "0" || env["GIT_ALLOW_PROTOCOL"] != "ssh" {
+		t.Fatalf("fetch environment interactivity/protocol = terminal=%q protocol=%q", env["GIT_TERMINAL_PROMPT"], env["GIT_ALLOW_PROTOCOL"])
+	}
+}

--- a/pkg/runner/git_fetch_test.go
+++ b/pkg/runner/git_fetch_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateFetchRemoteURL(t *testing.T) {
+	local := filepath.Join(t.TempDir(), "remote.git")
+	fileURL := "file://" + filepath.ToSlash(local)
+	valid := []string{
+		local,
+		fileURL,
+		"https://github.com/faroshq/faros.git",
+		"ssh://git@example.com/faroshq/faros.git",
+		"git@example.com:faroshq/faros.git",
+	}
+	for _, value := range valid {
+		t.Run("valid/"+value, func(t *testing.T) {
+			if _, err := validateFetchRemoteURL(value); err != nil {
+				t.Fatalf("validateFetchRemoteURL(%q): %v", value, err)
+			}
+		})
+	}
+	invalid := []string{
+		"--upload-pack=sh -c evil",
+		"ext::sh -c evil",
+		"ext::/bin/sh",
+		"http://example.com/repo.git",
+		"https://user@example.com/repo.git",
+		"https://user:secret@example.com/repo.git",
+		"https://example.com/repo.git?token=secret",
+		"ssh://git:secret@example.com/repo.git",
+		"git@example.com:repo.git --upload-pack=evil",
+		"https://example.com/repo.git\nX-Injected: yes",
+	}
+	for _, value := range invalid {
+		t.Run("invalid/"+strings.NewReplacer("/", "_", ":", "_", "?", "_").Replace(value), func(t *testing.T) {
+			if _, err := validateFetchRemoteURL(value); err == nil {
+				t.Fatalf("validateFetchRemoteURL(%q) accepted an unsafe remote", value)
+			}
+		})
+	}
+}
+
+func TestPrepareWorkspaceFetchesExactMissingCommitWithoutMutatingSource(t *testing.T) {
+	source, sourceCommit := testGitSource(t)
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, t.TempDir(), "clone", "--bare", source, remote)
+
+	publisher := filepath.Join(t.TempDir(), "publisher")
+	runGit(t, t.TempDir(), "clone", source, publisher)
+	if err := os.WriteFile(filepath.Join(publisher, "remote-only.txt"), []byte("fetched\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, publisher, "add", "remote-only.txt")
+	runGit(t, publisher, "-c", "user.name=Runner Test", "-c", "user.email=runner-test@example.invalid", "commit", "-m", "remote commit")
+	targetCommit := strings.TrimSpace(string(runGit(t, publisher, "rev-parse", "HEAD")))
+	runGit(t, publisher, "remote", "set-url", "origin", remote)
+	runGit(t, publisher, "push", "origin", targetCommit+":refs/heads/main")
+
+	stateDir := t.TempDir()
+	workdir, err := prepareWorkspace(context.Background(), Config{
+		StateDir: stateDir,
+		Repositories: map[string]RepositoryConfig{
+			"repo": {Source: source, FetchRemoteURL: remote},
+		},
+	}, StartRequest{TaskID: "task-fetch", AttemptID: "attempt-fetch", RepositoryID: "repo", BaseCommit: targetCommit})
+	if err != nil {
+		t.Fatalf("prepareWorkspace: %v", err)
+	}
+	if head := strings.TrimSpace(string(runGit(t, workdir, "rev-parse", "HEAD"))); head != targetCommit {
+		t.Fatalf("fetched worktree HEAD = %s, want %s", head, targetCommit)
+	}
+	if status := string(runGit(t, workdir, "status", "--porcelain=v1")); status != "" {
+		t.Fatalf("fetched worktree status = %q", status)
+	}
+	if head := strings.TrimSpace(string(runGit(t, source, "rev-parse", "HEAD"))); head != sourceCommit {
+		t.Fatalf("enrolled source HEAD = %s, want %s", head, sourceCommit)
+	}
+	if status := string(runGit(t, source, "status", "--porcelain=v1", "--untracked-files=all")); status != "" {
+		t.Fatalf("enrolled source status changed: %q", status)
+	}
+}
+
+func TestPrepareWorkspaceRefetchesSourceObjectOmittedByClone(t *testing.T) {
+	source, sourceCommit := testGitSource(t)
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, t.TempDir(), "clone", "--bare", source, remote)
+
+	publisher := filepath.Join(t.TempDir(), "publisher")
+	runGit(t, t.TempDir(), "clone", source, publisher)
+	if err := os.WriteFile(filepath.Join(publisher, "unreachable.txt"), []byte("fetch head only\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, publisher, "add", "unreachable.txt")
+	runGit(t, publisher, "-c", "user.name=Runner Test", "-c", "user.email=runner-test@example.invalid", "commit", "-m", "unreachable commit")
+	targetCommit := strings.TrimSpace(string(runGit(t, publisher, "rev-parse", "HEAD")))
+	runGit(t, publisher, "remote", "set-url", "origin", remote)
+	runGit(t, publisher, "push", "origin", targetCommit+":refs/heads/main")
+
+	// Put the target only in the enrolled source's object database and
+	// FETCH_HEAD. A clone advertises the source refs, so it must not inherit
+	// this unreachable object and must use the opted-in remote again.
+	runGit(t, source, "fetch", remote, targetCommit)
+	if got := strings.TrimSpace(string(runGit(t, source, "rev-parse", "FETCH_HEAD"))); got != targetCommit {
+		t.Fatalf("source FETCH_HEAD = %s, want %s", got, targetCommit)
+	}
+	if got := strings.TrimSpace(string(runGit(t, source, "rev-parse", "HEAD"))); got != sourceCommit {
+		t.Fatalf("source HEAD = %s, want %s", got, sourceCommit)
+	}
+
+	stateDir := t.TempDir()
+	workdir, err := prepareWorkspace(context.Background(), Config{
+		StateDir: stateDir,
+		Repositories: map[string]RepositoryConfig{
+			"repo": {Source: source, FetchRemoteURL: remote},
+		},
+	}, StartRequest{TaskID: "task-unreachable", AttemptID: "attempt-unreachable", RepositoryID: "repo", BaseCommit: targetCommit})
+	if err != nil {
+		t.Fatalf("prepareWorkspace: %v", err)
+	}
+	if got := strings.TrimSpace(string(runGit(t, workdir, "rev-parse", "HEAD"))); got != targetCommit {
+		t.Fatalf("refetched worktree HEAD = %s, want %s", got, targetCommit)
+	}
+}
+
+func TestPrepareWorkspaceDoesNotFetchWhenDisabledOrBaseCommitIsNotEnrolled(t *testing.T) {
+	source, sourceCommit := testGitSource(t)
+	missingCommit := strings.Repeat("f", 40)
+	stateDir := t.TempDir()
+	_, err := prepareWorkspace(context.Background(), Config{
+		StateDir: stateDir,
+		Repositories: map[string]RepositoryConfig{
+			"repo": {Source: source, BaseCommit: sourceCommit},
+		},
+	}, StartRequest{TaskID: "task-disabled", AttemptID: "attempt-disabled", RepositoryID: "repo", BaseCommit: missingCommit})
+	if err == nil || !strings.Contains(err.Error(), "exact commit enrolled") {
+		t.Fatalf("disabled or unenrolled commit error = %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(stateDir, "worktrees")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("disabled fetch created worktree state: %v", statErr)
+	}
+}
+
+func TestPrepareWorkspaceRejectsMissingCommitWithoutFetchRemote(t *testing.T) {
+	source, sourceCommit := testGitSource(t)
+	missingCommit := strings.Repeat("f", 40)
+	stateDir := t.TempDir()
+	_, err := prepareWorkspace(context.Background(), Config{
+		StateDir: stateDir,
+		Repositories: map[string]RepositoryConfig{
+			"repo": {Source: source, BaseCommit: ""},
+		},
+	}, StartRequest{TaskID: "task-no-fetch", AttemptID: "attempt-no-fetch", RepositoryID: "repo", BaseCommit: missingCommit})
+	if err == nil || !strings.Contains(err.Error(), "not available in the enrolled source") {
+		t.Fatalf("missing commit error = %v", err)
+	}
+	if head := strings.TrimSpace(string(runGit(t, source, "rev-parse", "HEAD"))); head != sourceCommit {
+		t.Fatalf("source HEAD changed after disabled fetch: %s", head)
+	}
+}
+
+func TestPrepareWorkspaceMissingFetchedCommitReturnsFixedError(t *testing.T) {
+	source, _ := testGitSource(t)
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, t.TempDir(), "clone", "--bare", source, remote)
+	missingCommit := strings.Repeat("f", 40)
+	_, err := prepareWorkspace(context.Background(), Config{
+		StateDir: t.TempDir(),
+		Repositories: map[string]RepositoryConfig{
+			"repo": {Source: source, FetchRemoteURL: remote},
+		},
+	}, StartRequest{TaskID: "task-fetch-missing", AttemptID: "attempt-fetch-missing", RepositoryID: "repo", BaseCommit: missingCommit})
+	if err == nil || err.Error() != "git fetch failed" {
+		t.Fatalf("missing fetched commit error = %v, want fixed fetch error", err)
+	}
+}
+
+func TestFetchCapabilityRequiresOptedInRepository(t *testing.T) {
+	source, commit := testGitSource(t)
+	without, err := New(Config{RunnerID: "without-fetch", StateDir: t.TempDir(), Token: "token", Listen: "127.0.0.1:0", Repositories: map[string]RepositoryConfig{
+		"repo": {Source: source, BaseCommit: commit},
+	}}, &fakeAdapter{})
+	if err != nil {
+		t.Fatalf("New without fetch: %v", err)
+	}
+	defer func() { _ = without.Close() }()
+	if contains(without.Capabilities().Verification, gitFetchCapability) {
+		t.Fatal("git-fetch capability advertised without an opted-in repository")
+	}
+
+	with, err := New(Config{RunnerID: "with-fetch", StateDir: t.TempDir(), Token: "token", Listen: "127.0.0.1:0", Repositories: map[string]RepositoryConfig{
+		"repo": {Source: source, BaseCommit: commit, FetchRemoteURL: source},
+	}}, &fakeAdapter{})
+	if err != nil {
+		t.Fatalf("New with fetch: %v", err)
+	}
+	defer func() { _ = with.Close() }()
+	if !contains(with.Capabilities().Verification, gitFetchCapability) {
+		t.Fatal("git-fetch capability omitted for an opted-in repository")
+	}
+}
+
+func TestFetchGitEnvironmentScopesCredentialsToSSHFetch(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "github-secret")
+	t.Setenv("GH_TOKEN", "gh-secret")
+	t.Setenv("GIT_SSH_COMMAND", "ssh -i /secret/key")
+	t.Setenv("SSH_AUTH_SOCK", "/tmp/runner-agent.sock")
+	t.Setenv("SSH_ASKPASS", "/tmp/interactive-askpass")
+	t.Setenv("SSH_ASKPASS_REQUIRE", "force")
+	sshEnv := environmentMap(fetchGitEnvironment("ssh://git@example.com/repo.git"))
+	if sshEnv["SSH_AUTH_SOCK"] != "/tmp/runner-agent.sock" {
+		t.Fatalf("SSH fetch environment omitted local agent: %q", sshEnv["SSH_AUTH_SOCK"])
+	}
+	for _, key := range []string{"GITHUB_TOKEN", "GH_TOKEN", "GIT_SSH_COMMAND", "SSH_AGENT_PID", "SSH_ASKPASS", "SSH_ASKPASS_REQUIRE"} {
+		if sshEnv[key] != "" {
+			t.Fatalf("SSH fetch environment leaked %s", key)
+		}
+	}
+	if sshEnv["GIT_ALLOW_PROTOCOL"] != "ssh" {
+		t.Fatalf("SSH fetch protocol allowlist = %q", sshEnv["GIT_ALLOW_PROTOCOL"])
+	}
+	for _, option := range []string{"BatchMode=yes", "StrictHostKeyChecking=yes", "ForwardAgent=no", "ClearAllForwardings=yes"} {
+		if !strings.Contains(secureSSHCommand, option) {
+			t.Fatalf("secure SSH command omitted %s: %q", option, secureSSHCommand)
+		}
+	}
+
+	httpsEnv := environmentMap(fetchGitEnvironment("https://example.com/repo.git"))
+	if httpsEnv["SSH_AUTH_SOCK"] != "" {
+		t.Fatal("HTTPS fetch environment forwarded SSH agent")
+	}
+	if httpsEnv["GIT_ALLOW_PROTOCOL"] != "https" {
+		t.Fatalf("HTTPS fetch protocol allowlist = %q", httpsEnv["GIT_ALLOW_PROTOCOL"])
+	}
+}
+
+func TestBoundedGitFetchErrorIsSanitized(t *testing.T) {
+	if err := boundedGitFetchError("remote", strings.Repeat("server secret ", maxGitFetchErrorBytes), errors.New("raw failure"), nil); err == nil || err.Error() != "git fetch failed" {
+		t.Fatalf("fetch failure = %v, want fixed error", err)
+	}
+	if err := boundedGitFetchError("remote", "server secret", errors.New("raw failure"), context.DeadlineExceeded); err == nil || err.Error() != "git fetch timed out" {
+		t.Fatalf("fetch timeout = %v, want fixed error", err)
+	}
+	if err := boundedGitFetchError("remote", "server secret", errors.New("raw failure"), context.Canceled); err == nil || err.Error() != "git fetch canceled" {
+		t.Fatalf("fetch cancellation = %v, want fixed error", err)
+	}
+}
+
+func environmentMap(values []string) map[string]string {
+	result := make(map[string]string, len(values))
+	for _, value := range values {
+		key, item, ok := strings.Cut(value, "=")
+		if ok {
+			result[key] = item
+		}
+	}
+	return result
+}

--- a/pkg/runner/git_result.go
+++ b/pkg/runner/git_result.go
@@ -1,0 +1,607 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	gitResultBundleName = "git-result.bundle"
+	gitResultJSONName   = "git-result.json"
+	gitResultRef        = "refs/heads/runner-result"
+	gitResultMessage    = "Implementation snapshot"
+	gitResultName       = "Faros Runner"
+	gitResultEmail      = "runner@localhost"
+	gitResultDate       = "2000-01-01T00:00:00Z"
+)
+
+type gitResultExport struct {
+	artifacts []gitResultArtifact
+}
+
+type gitResultArtifact struct {
+	artifact Artifact
+	path     string
+}
+
+type gitResultDocument struct {
+	Version      string `json:"version"`
+	TaskID       string `json:"taskID"`
+	AttemptID    string `json:"attemptID"`
+	AttemptEpoch uint64 `json:"attemptEpoch"`
+	BaseCommit   string `json:"baseCommit"`
+	Commit       string `json:"commit,omitempty"`
+	Tree         string `json:"tree,omitempty"`
+	BundleSHA256 string `json:"bundleSHA256,omitempty"`
+	NoChanges    bool   `json:"noChanges"`
+}
+
+// isGitResultArtifactName reports whether the runner owns an artifact name.
+// Harness-produced artifacts cannot use these names because the runner adds
+// their immutable records only after it has validated a completed turn.
+func isGitResultArtifactName(name string) bool {
+	return name == gitResultBundleName || name == gitResultJSONName
+}
+
+func cleanupGitResultArtifacts(result gitResultExport) {
+	for _, item := range result.artifacts {
+		if item.path != "" {
+			_ = os.Remove(item.path)
+		}
+	}
+}
+
+// finishGitResultLocked adds generated artifacts and the terminal event to the
+// same persisted state image. On a save failure it restores the in-memory
+// attempt journal so the caller can durably record failure instead.
+func (r *Runner) finishGitResultLocked(attempt *attemptRecord, result gitResultExport) error {
+	if attempt == nil || attempt.Receipt.Phase.IsTerminal() {
+		return errors.New("attempt is already terminal")
+	}
+	priorReceipt := receiptForResponse(attempt.Receipt)
+	priorEvents := append([]Event(nil), r.state.Events[attempt.Receipt.AttemptID]...)
+	added := make([]string, 0, len(result.artifacts))
+	restore := func() {
+		attempt.Receipt = priorReceipt
+		for _, id := range added {
+			delete(r.state.Artifacts, id)
+		}
+		r.state.Events[attempt.Receipt.AttemptID] = priorEvents
+	}
+	for _, item := range result.artifacts {
+		if !isGitResultArtifactName(item.artifact.Name) {
+			return errors.New("git result artifact name is not reserved")
+		}
+		if !pathWithin(r.cfg.StateDir, item.path) {
+			return errors.New("git result artifact path is outside runner state")
+		}
+		if _, exists := r.state.Artifacts[item.artifact.ID]; exists {
+			return errors.New("git result artifact ID already exists")
+		}
+		r.state.Artifacts[item.artifact.ID] = artifactRecord{Artifact: item.artifact, Path: item.path}
+		added = append(added, item.artifact.ID)
+		attempt.Receipt.Artifacts = append(attempt.Receipt.Artifacts, item.artifact)
+		if _, err := r.appendEventLocked(attempt.Receipt.AttemptID, EventArtifact, "Git result artifact exported: "+item.artifact.Name, nil); err != nil {
+			restore()
+			return err
+		}
+	}
+	attempt.Receipt.Phase = PhaseCompleted
+	attempt.Receipt.Blocker = ""
+	attempt.Receipt.UpdatedAt = eventNow()
+	if _, err := r.appendEventLocked(attempt.Receipt.AttemptID, EventCompleted, "", nil); err != nil {
+		restore()
+		return err
+	}
+	r.releaseResourcesLocked(attempt.Receipt.AttemptID, resourceRequests(attempt.Resources))
+	if err := r.persistLocked(); err != nil {
+		restore()
+		for _, resource := range attempt.Resources {
+			r.state.Reservations[resource+"/"+attempt.Receipt.AttemptID] = reservationRecord{AttemptID: attempt.Receipt.AttemptID}
+		}
+		return err
+	}
+	return nil
+}
+
+// exportGitResult snapshots the task worktree without changing its HEAD or
+// normal index. It uses a temporary index rooted at the approved base commit,
+// then creates one commit object and a v2 bundle that advertises only the
+// runner-result ref. All files are written below the runner-owned artifact
+// directory and are returned to the caller for one durable receipt commit.
+func exportGitResult(ctx context.Context, cfg Config, request StartRequest, workdir string) (gitResultExport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return gitResultExport{}, err
+	}
+	baseCommit := strings.ToLower(strings.TrimSpace(request.BaseCommit))
+	if !commitPattern.MatchString(baseCommit) {
+		return gitResultExport{}, errors.New("approved base commit is not a full commit")
+	}
+	if err := verifyTaskPath(cfg.StateDir, workdir); err != nil {
+		return gitResultExport{}, err
+	}
+	if info, err := os.Lstat(workdir); err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		if err == nil {
+			err = errors.New("task worktree is not a private directory")
+		}
+		return gitResultExport{}, err
+	}
+
+	maxSize := cfg.MaxArtifactSize
+	if maxSize <= 0 {
+		maxSize = defaultMaxArtifactSize
+	}
+	artifactDir := filepath.Join(cfg.StateDir, "artifacts", request.AttemptID)
+	if err := os.MkdirAll(artifactDir, 0o700); err != nil {
+		return gitResultExport{}, fmt.Errorf("create Git result artifact directory: %w", err)
+	}
+	if err := os.Chmod(artifactDir, 0o700); err != nil {
+		return gitResultExport{}, fmt.Errorf("protect Git result artifact directory: %w", err)
+	}
+
+	indexDir := filepath.Join(cfg.StateDir, "git-result")
+	if err := os.MkdirAll(indexDir, 0o700); err != nil {
+		return gitResultExport{}, fmt.Errorf("create Git result temporary directory: %w", err)
+	}
+	indexFile, err := os.CreateTemp(indexDir, "index-*.tmp")
+	if err != nil {
+		return gitResultExport{}, fmt.Errorf("create Git result temporary index: %w", err)
+	}
+	indexPath := indexFile.Name()
+	if err := indexFile.Close(); err != nil {
+		_ = os.Remove(indexPath)
+		return gitResultExport{}, fmt.Errorf("close Git result temporary index: %w", err)
+	}
+	if err := os.Remove(indexPath); err != nil {
+		return gitResultExport{}, fmt.Errorf("prepare Git result temporary index: %w", err)
+	}
+	defer func() { _ = os.Remove(indexPath) }()
+	indexEnv := map[string]string{"GIT_INDEX_FILE": indexPath}
+
+	if _, err := gitResultCommand(ctx, workdir, indexEnv, nil, "read-tree", baseCommit); err != nil {
+		return gitResultExport{}, fmt.Errorf("initialize Git result index: %w", err)
+	}
+	baseTree, err := gitOutput(ctx, workdir, "rev-parse", baseCommit+"^{tree}")
+	if err != nil {
+		return gitResultExport{}, fmt.Errorf("resolve approved base tree: %w", err)
+	}
+
+	basePaths, err := gitResultCommand(ctx, workdir, nil, nil, "ls-tree", "-r", "--name-only", "-z", baseCommit)
+	if err != nil {
+		return gitResultExport{}, fmt.Errorf("list approved base Git paths: %w", err)
+	}
+	for _, path := range nulPaths(basePaths) {
+		_, info, err := inspectGitResultPath(workdir, path)
+		if errors.Is(err, os.ErrNotExist) || (err == nil && info.IsDir()) {
+			if _, err := gitResultCommand(ctx, workdir, indexEnv, nil, "update-index", "--remove", "--", path); err != nil {
+				return gitResultExport{}, fmt.Errorf("remove missing base Git path %q: %w", path, err)
+			}
+		} else if err != nil {
+			return gitResultExport{}, fmt.Errorf("inspect base Git path %q: %w", path, err)
+		}
+	}
+	paths, err := worktreeSnapshotPaths(ctx, workdir)
+	if err != nil {
+		return gitResultExport{}, err
+	}
+	for _, path := range paths {
+		_, info, err := inspectGitResultPath(workdir, path)
+		if errors.Is(err, os.ErrNotExist) {
+			// ls-files includes tracked paths removed from the worktree. The
+			// base-path pass above removes those entries from the temporary index.
+			continue
+		}
+		if err != nil {
+			return gitResultExport{}, fmt.Errorf("inspect snapshot path %q: %w", path, err)
+		}
+		if info.IsDir() {
+			// A tracked file can be replaced by a directory. Its old base
+			// entry was removed above, while any nonignored files below it are
+			// included by ls-files as separate paths.
+			continue
+		}
+		mode, object, err := hashWorktreePath(ctx, workdir, path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return gitResultExport{}, fmt.Errorf("snapshot %q: %w", path, err)
+		}
+		if _, err := gitResultCommand(ctx, workdir, indexEnv, nil, "update-index", "--add", "--cacheinfo", mode, object, path); err != nil {
+			return gitResultExport{}, fmt.Errorf("stage Git result path %q: %w", path, err)
+		}
+	}
+	tree, err := gitResultCommand(ctx, workdir, indexEnv, nil, "write-tree")
+	if err != nil {
+		return gitResultExport{}, fmt.Errorf("write Git result tree: %w", err)
+	}
+	tree = strings.TrimSpace(tree)
+	if !commitPattern.MatchString(tree) {
+		return gitResultExport{}, errors.New("git result tree is not a full object ID")
+	}
+
+	document := gitResultDocument{
+		Version:      "git-result/v1",
+		TaskID:       request.TaskID,
+		AttemptID:    request.AttemptID,
+		AttemptEpoch: request.AttemptEpoch,
+		BaseCommit:   baseCommit,
+		NoChanges:    tree == strings.TrimSpace(baseTree),
+	}
+	var bundlePath string
+	if !document.NoChanges {
+		document.Tree = tree
+		commit, err := createGitResultCommit(ctx, workdir, tree, baseCommit)
+		if err != nil {
+			return gitResultExport{}, err
+		}
+		document.Commit = commit
+		bundlePath, document.BundleSHA256, err = createGitResultBundle(ctx, workdir, artifactDir, commit, baseCommit, maxSize)
+		if err != nil {
+			return gitResultExport{}, err
+		}
+	}
+
+	jsonBytes, err := json.Marshal(document)
+	if err != nil {
+		if bundlePath != "" {
+			_ = os.Remove(bundlePath)
+		}
+		return gitResultExport{}, fmt.Errorf("encode Git result document: %w", err)
+	}
+	jsonBytes = append(jsonBytes, '\n')
+	if int64(len(jsonBytes)) > maxSize {
+		if bundlePath != "" {
+			_ = os.Remove(bundlePath)
+		}
+		return gitResultExport{}, fmt.Errorf("git result document exceeds %d-byte limit", maxSize)
+	}
+	jsonPath, err := writeGitResultJSON(artifactDir, jsonBytes)
+	if err != nil {
+		if bundlePath != "" {
+			_ = os.Remove(bundlePath)
+		}
+		return gitResultExport{}, err
+	}
+	jsonArtifact, err := makeGitResultArtifact(gitResultJSONName, jsonPath, "application/json")
+	if err != nil {
+		_ = os.Remove(jsonPath)
+		if bundlePath != "" {
+			_ = os.Remove(bundlePath)
+		}
+		return gitResultExport{}, err
+	}
+	result := gitResultExport{artifacts: []gitResultArtifact{jsonArtifact}}
+	if bundlePath != "" {
+		bundleArtifact, err := makeGitResultArtifact(gitResultBundleName, bundlePath, "application/x-git-bundle")
+		if err != nil {
+			_ = os.Remove(jsonPath)
+			_ = os.Remove(bundlePath)
+			return gitResultExport{}, err
+		}
+		result.artifacts = append(result.artifacts, bundleArtifact)
+	}
+	return result, nil
+}
+
+func worktreeSnapshotPaths(ctx context.Context, workdir string) ([]string, error) {
+	listed, err := gitResultCommand(ctx, workdir, nil, nil, "ls-files", "-z", "-c", "-o", "--exclude-standard", "--")
+	if err != nil {
+		return nil, fmt.Errorf("list tracked and nonignored Git paths: %w", err)
+	}
+	paths := nulPaths(listed)
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func nulPaths(value string) []string {
+	parts := strings.Split(value, "\x00")
+	paths := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			paths = append(paths, part)
+		}
+	}
+	return paths
+}
+
+func hashWorktreePath(ctx context.Context, workdir, path string) (string, string, error) {
+	full, info, err := inspectGitResultPath(workdir, path)
+	if err != nil {
+		return "", "", err
+	}
+	var input io.Reader
+	var closeFile *os.File
+	mode := "100644"
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		target, err := os.Readlink(full)
+		if err != nil {
+			return "", "", err
+		}
+		input = strings.NewReader(target)
+		mode = "120000"
+	case info.Mode().IsRegular():
+		closeFile, err = os.Open(full)
+		if err != nil {
+			return "", "", err
+		}
+		input = closeFile
+		if info.Mode().Perm()&0o111 != 0 {
+			mode = "100755"
+		}
+	default:
+		return "", "", fmt.Errorf("unsupported file type %s", info.Mode())
+	}
+	defer func() {
+		if closeFile != nil {
+			_ = closeFile.Close()
+		}
+	}()
+	object, err := gitResultCommand(ctx, workdir, nil, input, "hash-object", "-w", "--stdin")
+	if err != nil {
+		return "", "", err
+	}
+	object = strings.TrimSpace(object)
+	if !commitPattern.MatchString(object) {
+		return "", "", errors.New("git path hash is not a full object ID")
+	}
+	return mode, object, nil
+}
+
+// inspectGitResultPath validates a Git relative path while preserving a final
+// symlink as a Git link. Every parent component is checked with Lstat so a
+// tracked path cannot follow a directory symlink outside the task worktree.
+func inspectGitResultPath(workdir, path string) (string, os.FileInfo, error) {
+	if path == "" || filepath.IsAbs(path) {
+		return "", nil, errors.New("git path is not relative")
+	}
+	clean := filepath.Clean(filepath.FromSlash(path))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", nil, errors.New("git path escapes the task worktree")
+	}
+	full := filepath.Join(workdir, clean)
+	if !pathWithin(workdir, full) {
+		return "", nil, errors.New("git path escapes the task worktree")
+	}
+	current := workdir
+	parts := strings.Split(clean, string(filepath.Separator))
+	for index, part := range parts {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return "", nil, err
+		}
+		if index < len(parts)-1 {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return "", nil, errors.New("git path has a symlink parent")
+			}
+			if !info.IsDir() {
+				if info.Mode().IsRegular() {
+					// A regular file replaced a base directory. Descendants
+					// below it are absent from the current worktree and must
+					// be removed from the temporary index.
+					return "", nil, os.ErrNotExist
+				}
+				return "", nil, errors.New("git path parent is not a directory")
+			}
+		}
+		if index == len(parts)-1 {
+			return current, info, nil
+		}
+	}
+	return "", nil, errors.New("git path is empty")
+}
+
+func createGitResultCommit(ctx context.Context, workdir, tree, baseCommit string) (string, error) {
+	env := map[string]string{
+		"GIT_AUTHOR_NAME":     gitResultName,
+		"GIT_AUTHOR_EMAIL":    gitResultEmail,
+		"GIT_AUTHOR_DATE":     gitResultDate,
+		"GIT_COMMITTER_NAME":  gitResultName,
+		"GIT_COMMITTER_EMAIL": gitResultEmail,
+		"GIT_COMMITTER_DATE":  gitResultDate,
+	}
+	commit, err := gitResultCommand(ctx, workdir, env, strings.NewReader(gitResultMessage+"\n"), "commit-tree", tree, "-p", baseCommit)
+	if err != nil {
+		return "", fmt.Errorf("create Git result commit: %w", err)
+	}
+	commit = strings.TrimSpace(commit)
+	if !commitPattern.MatchString(commit) {
+		return "", errors.New("git result commit is not a full object ID")
+	}
+	return commit, nil
+}
+
+func createGitResultBundle(ctx context.Context, workdir, artifactDir, commit, baseCommit string, maxSize int64) (string, string, error) {
+	previousRef, refErr := gitResultCommand(ctx, workdir, nil, nil, "rev-parse", "-q", "--verify", gitResultRef)
+	hadPreviousRef := refErr == nil && strings.TrimSpace(previousRef) != ""
+	// rev-parse exits one when the fixed runner-result ref is absent. Any
+	// nonzero result is treated as absence; update-ref below remains the
+	// authoritative operation and reports real repository failures.
+	previousRef = strings.TrimSpace(previousRef)
+	defer func() {
+		if hadPreviousRef {
+			_, _ = gitResultCommand(context.Background(), workdir, nil, nil, "update-ref", gitResultRef, previousRef)
+		} else {
+			_, _ = gitResultCommand(context.Background(), workdir, nil, nil, "update-ref", "-d", gitResultRef)
+		}
+	}()
+	if _, err := gitResultCommand(ctx, workdir, nil, nil, "update-ref", gitResultRef, commit); err != nil {
+		return "", "", fmt.Errorf("prepare Git result ref: %w", err)
+	}
+	tmp, err := os.CreateTemp(artifactDir, ".git-result-bundle-*.tmp")
+	if err != nil {
+		return "", "", fmt.Errorf("create Git result bundle: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", "", fmt.Errorf("close Git result bundle: %w", err)
+	}
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := gitResultCommand(ctx, workdir, nil, nil, "bundle", "create", "--version=2", tmpPath, gitResultRef, "^"+baseCommit); err != nil {
+		return "", "", fmt.Errorf("create Git result bundle: %w", err)
+	}
+	info, err := os.Stat(tmpPath)
+	if err != nil {
+		return "", "", fmt.Errorf("stat Git result bundle: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", "", errors.New("git result bundle is not a regular file")
+	}
+	if info.Size() > maxSize {
+		return "", "", fmt.Errorf("git result bundle exceeds %d-byte limit", maxSize)
+	}
+	digest, err := digestFile(tmpPath, maxSize)
+	if err != nil {
+		return "", "", fmt.Errorf("digest Git result bundle: %w", err)
+	}
+	dest := filepath.Join(artifactDir, gitResultBundleName)
+	if err := os.Remove(dest); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", "", fmt.Errorf("replace Git result bundle: %w", err)
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		return "", "", fmt.Errorf("publish Git result bundle: %w", err)
+	}
+	if err := os.Chmod(dest, 0o600); err != nil {
+		_ = os.Remove(dest)
+		return "", "", fmt.Errorf("protect Git result bundle: %w", err)
+	}
+	tmpPath = ""
+	return dest, digest, nil
+}
+
+func digestFile(path string, maxSize int64) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	written, err := io.Copy(hash, io.LimitReader(file, maxSize+1))
+	if err != nil {
+		return "", err
+	}
+	if written > maxSize {
+		return "", fmt.Errorf("file exceeds %d-byte limit", maxSize)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func writeGitResultJSON(artifactDir string, contents []byte) (string, error) {
+	tmp, err := os.CreateTemp(artifactDir, ".git-result-json-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("create Git result document: %w", err)
+	}
+	tmpPath := tmp.Name()
+	remove := true
+	defer func() {
+		_ = tmp.Close()
+		if remove {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return "", fmt.Errorf("protect Git result document: %w", err)
+	}
+	if _, err := tmp.Write(contents); err != nil {
+		return "", fmt.Errorf("write Git result document: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return "", fmt.Errorf("sync Git result document: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close Git result document: %w", err)
+	}
+	dest := filepath.Join(artifactDir, gitResultJSONName)
+	if err := os.Remove(dest); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("replace Git result document: %w", err)
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		return "", fmt.Errorf("publish Git result document: %w", err)
+	}
+	if err := os.Chmod(dest, 0o600); err != nil {
+		_ = os.Remove(dest)
+		return "", fmt.Errorf("protect Git result document: %w", err)
+	}
+	remove = false
+	return dest, nil
+}
+
+func makeGitResultArtifact(name, path, mediaType string) (gitResultArtifact, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return gitResultArtifact{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return gitResultArtifact{}, errors.New("git result artifact is not a regular file")
+	}
+	digest, err := digestFile(path, info.Size())
+	if err != nil {
+		return gitResultArtifact{}, err
+	}
+	return gitResultArtifact{
+		artifact: Artifact{ID: newArtifactID(name), Name: name, Digest: "sha256:" + digest, Length: info.Size(), MediaType: mediaType, CreatedAt: eventNow()},
+		path:     path,
+	}, nil
+}
+
+func gitResultCommand(ctx context.Context, dir string, extraEnv map[string]string, stdin io.Reader, args ...string) (string, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	safeArgs := append([]string{"-c", "core.hooksPath=/dev/null", "-c", "commit.gpgSign=false", "-c", "core.fsmonitor=false", "-c", "core.logAllRefUpdates=false"}, args...)
+	cmd := exec.CommandContext(cmdCtx, "git", safeArgs...)
+	cmd.Env = sanitizedGitEnvironment()
+	for key, value := range extraEnv {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Stdin = stdin
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return "", errors.New(message)
+	}
+	return stdout.String(), nil
+}

--- a/pkg/runner/git_result_test.go
+++ b/pkg/runner/git_result_test.go
@@ -1,0 +1,605 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+func TestGitResultExportTracksCommittedAndUncommittedWorktree(t *testing.T) {
+	source, commit := testGitSource(t)
+	harnessHead := make(chan string, 1)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if err := os.WriteFile(filepath.Join(launch.Workdir, "committed.txt"), []byte("committed\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		runGit(t, launch.Workdir, "-c", "user.name=Harness", "-c", "user.email=harness@example.invalid", "add", "committed.txt")
+		runGit(t, launch.Workdir, "-c", "user.name=Harness", "-c", "user.email=harness@example.invalid", "commit", "-m", "harness commit")
+		if err := os.WriteFile(filepath.Join(launch.Workdir, "README.md"), []byte("changed\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		if err := os.WriteFile(filepath.Join(launch.Workdir, "new.txt"), []byte("new\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		harnessHead <- strings.TrimSpace(string(runGit(t, launch.Workdir, "rev-parse", "HEAD")))
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.ExportGitResult = true
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		current, inspectErr := runner.Inspect(context.Background(), receipt.AttemptID)
+		if inspectErr == nil && current.Phase.IsTerminal() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	current, inspectErr := runner.Inspect(context.Background(), receipt.AttemptID)
+	if inspectErr != nil || current.Phase != PhaseCompleted {
+		t.Fatalf("export phase = %+v, inspect error=%v", current, inspectErr)
+	}
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if len(got.Artifacts) != 2 {
+		t.Fatalf("artifacts = %+v, want JSON and bundle", got.Artifacts)
+	}
+	var document gitResultDocument
+	var bundlePath string
+	for _, artifact := range got.Artifacts {
+		path := runner.state.Artifacts[artifact.ID].Path
+		switch artifact.Name {
+		case gitResultJSONName:
+			contents, err := readImmutableArtifact(path, artifact)
+			if err != nil {
+				t.Fatalf("read result JSON: %v", err)
+			}
+			if err := json.Unmarshal(contents, &document); err != nil {
+				t.Fatalf("decode result JSON: %v", err)
+			}
+		case gitResultBundleName:
+			bundlePath = path
+		}
+	}
+	if document.Version != "git-result/v1" || document.NoChanges || document.BaseCommit != commit || document.Commit == "" || document.BundleSHA256 == "" {
+		t.Fatalf("result document = %+v", document)
+	}
+	if got.Phase != PhaseCompleted {
+		t.Fatalf("phase = %s", got.Phase)
+	}
+	if heads := string(runGit(t, t.TempDir(), "bundle", "list-heads", bundlePath)); !strings.Contains(heads, document.Commit+" refs/heads/runner-result") {
+		t.Fatalf("bundle heads = %q", heads)
+	}
+	show := string(runGit(t, got.Workdir, "show", "-s", "--format=%P%n%an%n%ae%n%cn%n%ce%n%at%n%ct%n%B", document.Commit))
+	if !strings.Contains(show, commit+"\nFaros Runner\nrunner@localhost\nFaros Runner\nrunner@localhost\n946684800\n946684800\nImplementation snapshot\n") {
+		t.Fatalf("result commit metadata = %q", show)
+	}
+	expectedHead := <-harnessHead
+	if head := strings.TrimSpace(string(runGit(t, got.Workdir, "rev-parse", "HEAD"))); head != expectedHead {
+		t.Fatalf("worktree HEAD = %s, want harness HEAD %s", head, expectedHead)
+	}
+	resultPaths := string(runGit(t, got.Workdir, "ls-tree", "-r", "--name-only", document.Commit))
+	if !strings.Contains(resultPaths, "committed.txt\n") || !strings.Contains(resultPaths, "new.txt\n") {
+		t.Fatalf("result tree paths = %q", resultPaths)
+	}
+	if status := string(runGit(t, got.Workdir, "status", "--porcelain=v1", "--untracked-files=all")); status != " M README.md\n?? new.txt\n" {
+		t.Fatalf("worktree status changed by export: %q", status)
+	}
+	if status := string(runGit(t, source, "status", "--porcelain=v1", "--untracked-files=all")); status != "" {
+		t.Fatalf("source status changed by export: %q", status)
+	}
+}
+
+func TestGitResultExportUnchangedWorktreeOmitsCommitAndBundle(t *testing.T) {
+	source, commit := testGitSource(t)
+	runner := newTestRunner(t, &fakeAdapter{}, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-git-result-unchanged"
+	request.AttemptID = "attempt-git-result-unchanged"
+	request.RequestID = "start-git-result-unchanged"
+	request.ExportGitResult = true
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if len(got.Artifacts) != 1 || got.Artifacts[0].Name != gitResultJSONName {
+		t.Fatalf("unchanged artifacts = %+v, want one JSON artifact", got.Artifacts)
+	}
+	path := runner.state.Artifacts[got.Artifacts[0].ID].Path
+	contents, err := readImmutableArtifact(path, got.Artifacts[0])
+	if err != nil {
+		t.Fatalf("read result JSON: %v", err)
+	}
+	var document gitResultDocument
+	if err := json.Unmarshal(contents, &document); err != nil {
+		t.Fatalf("decode result JSON: %v", err)
+	}
+	if !document.NoChanges || document.Tree != "" || document.Commit != "" || document.BundleSHA256 != "" {
+		t.Fatalf("unchanged document = %+v", document)
+	}
+}
+
+func TestGitResultExportIncludesCommittedDeletion(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		runGit(t, launch.Workdir, "rm", "README.md")
+		runGit(t, launch.Workdir, "-c", "user.name=Harness", "-c", "user.email=harness@example.invalid", "commit", "-m", "delete README")
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-git-result-deletion"
+	request.AttemptID = "attempt-git-result-deletion"
+	request.RequestID = "start-git-result-deletion"
+	request.ExportGitResult = true
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		current, inspectErr := runner.Inspect(context.Background(), receipt.AttemptID)
+		if inspectErr == nil && current.Phase.IsTerminal() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	current, inspectErr := runner.Inspect(context.Background(), receipt.AttemptID)
+	if inspectErr != nil || current.Phase != PhaseCompleted {
+		t.Fatalf("deletion export phase = %+v, inspect error=%v", current, inspectErr)
+	}
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	var document gitResultDocument
+	for _, artifact := range got.Artifacts {
+		if artifact.Name != gitResultJSONName {
+			continue
+		}
+		contents, err := readImmutableArtifact(runner.state.Artifacts[artifact.ID].Path, artifact)
+		if err != nil {
+			t.Fatalf("read result JSON: %v", err)
+		}
+		if err := json.Unmarshal(contents, &document); err != nil {
+			t.Fatalf("decode result JSON: %v", err)
+		}
+	}
+	if document.NoChanges || document.Commit == "" {
+		t.Fatalf("deletion document = %+v", document)
+	}
+	paths := string(runGit(t, got.Workdir, "ls-tree", "-r", "--name-only", document.Commit))
+	if strings.Contains(paths, "README.md\n") {
+		t.Fatalf("deleted path remained in result tree: %q", paths)
+	}
+}
+
+func TestGitResultExportHandlesUncommittedDeletion(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if err := os.Remove(filepath.Join(launch.Workdir, "README.md")); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-git-result-unstaged-delete"
+	request.AttemptID = "attempt-git-result-unstaged-delete"
+	request.RequestID = "start-git-result-unstaged-delete"
+	request.ExportGitResult = true
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	var document gitResultDocument
+	for _, artifact := range got.Artifacts {
+		if artifact.Name != gitResultJSONName {
+			continue
+		}
+		contents, err := readImmutableArtifact(runner.state.Artifacts[artifact.ID].Path, artifact)
+		if err != nil {
+			t.Fatalf("read result JSON: %v", err)
+		}
+		if err := json.Unmarshal(contents, &document); err != nil {
+			t.Fatalf("decode result JSON: %v", err)
+		}
+	}
+	if document.NoChanges || document.Commit == "" {
+		t.Fatalf("unstaged deletion document = %+v", document)
+	}
+	paths := string(runGit(t, got.Workdir, "ls-tree", "-r", "--name-only", document.Commit))
+	if strings.Contains(paths, "README.md\n") {
+		t.Fatalf("unstaged deletion remained in result tree: %q", paths)
+	}
+}
+
+func TestGitResultExportHandlesFileDirectoryReplacement(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		readme := filepath.Join(launch.Workdir, "README.md")
+		if err := os.Remove(readme); err != nil {
+			return harness.Result{}, err
+		}
+		if err := os.Mkdir(readme, 0o700); err != nil {
+			return harness.Result{}, err
+		}
+		if err := os.WriteFile(filepath.Join(readme, "replacement.txt"), []byte("replacement\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-git-result-file-directory"
+	request.AttemptID = "attempt-git-result-file-directory"
+	request.RequestID = "start-git-result-file-directory"
+	request.ExportGitResult = true
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	var document gitResultDocument
+	for _, artifact := range got.Artifacts {
+		if artifact.Name != gitResultJSONName {
+			continue
+		}
+		contents, err := readImmutableArtifact(runner.state.Artifacts[artifact.ID].Path, artifact)
+		if err != nil {
+			t.Fatalf("read result JSON: %v", err)
+		}
+		if err := json.Unmarshal(contents, &document); err != nil {
+			t.Fatalf("decode result JSON: %v", err)
+		}
+	}
+	if document.NoChanges || document.Commit == "" {
+		t.Fatalf("replacement document = %+v", document)
+	}
+	paths := string(runGit(t, got.Workdir, "ls-tree", "-r", "--name-only", document.Commit))
+	if strings.Contains(paths, "README.md\n") || !strings.Contains(paths, "README.md/replacement.txt\n") {
+		t.Fatalf("replacement result tree paths = %q", paths)
+	}
+}
+
+func TestGitResultExportHandlesDirectoryFileReplacement(t *testing.T) {
+	source, _ := testGitSource(t)
+	if err := os.MkdirAll(filepath.Join(source, "dir"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "dir", "child.txt"), []byte("child\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "add", "dir/child.txt")
+	runGit(t, source, "commit", "-m", "add directory child")
+	commit := strings.TrimSpace(string(runGit(t, source, "rev-parse", "HEAD")))
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		dir := filepath.Join(launch.Workdir, "dir")
+		if err := os.RemoveAll(dir); err != nil {
+			return harness.Result{}, err
+		}
+		if err := os.WriteFile(dir, []byte("directory replaced by file\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-git-result-directory-file"
+	request.AttemptID = "attempt-git-result-directory-file"
+	request.RequestID = "start-git-result-directory-file"
+	request.ExportGitResult = true
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	var document gitResultDocument
+	for _, artifact := range got.Artifacts {
+		if artifact.Name != gitResultJSONName {
+			continue
+		}
+		contents, err := readImmutableArtifact(runner.state.Artifacts[artifact.ID].Path, artifact)
+		if err != nil {
+			t.Fatalf("read result JSON: %v", err)
+		}
+		if err := json.Unmarshal(contents, &document); err != nil {
+			t.Fatalf("decode result JSON: %v", err)
+		}
+	}
+	if document.NoChanges || document.Commit == "" {
+		t.Fatalf("directory-file document = %+v", document)
+	}
+	paths := string(runGit(t, got.Workdir, "ls-tree", "-r", "--name-only", document.Commit))
+	if strings.Contains(paths, "dir/child.txt\n") || !strings.Contains(paths, "dir\n") {
+		t.Fatalf("directory-file result tree paths = %q", paths)
+	}
+}
+
+func TestGitResultExportRejectsSymlinkParent(t *testing.T) {
+	source, _ := testGitSource(t)
+	if err := os.MkdirAll(filepath.Join(source, "nested"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "nested", "tracked.txt"), []byte("tracked\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "add", "nested/tracked.txt")
+	runGit(t, source, "commit", "-m", "add nested tracked file")
+	commit := strings.TrimSpace(string(runGit(t, source, "rev-parse", "HEAD")))
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("private\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if err := os.RemoveAll(filepath.Join(launch.Workdir, "nested")); err != nil {
+			return harness.Result{}, err
+		}
+		if err := os.Symlink(outside, filepath.Join(launch.Workdir, "nested")); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-git-result-symlink-parent"
+	request.AttemptID = "attempt-git-result-symlink-parent"
+	request.RequestID = "start-git-result-symlink-parent"
+	request.ExportGitResult = true
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseFailed)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if len(got.Artifacts) != 0 || !strings.Contains(got.Blocker, "symlink parent") {
+		t.Fatalf("symlink-parent receipt = %+v", got)
+	}
+	if contents, err := os.ReadFile(secret); err != nil || string(contents) != "private\n" {
+		t.Fatalf("outside secret changed or unavailable: err=%v contents=%q", err, contents)
+	}
+}
+
+func TestGitResultExportIsOptInAndAdvertised(t *testing.T) {
+	source, commit := testGitSource(t)
+	runner := newTestRunner(t, &fakeAdapter{}, source, commit)
+	if !contains(runner.Capabilities().Verification, gitResultCapability) {
+		t.Fatalf("verification capabilities = %+v, want %q", runner.Capabilities().Verification, gitResultCapability)
+	}
+	receipt, err := runner.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCompleted)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if len(got.Artifacts) != 0 {
+		t.Fatalf("no-opt-in artifacts = %+v, want none", got.Artifacts)
+	}
+}
+
+func TestGitResultExportReservesGeneratedArtifactNames(t *testing.T) {
+	source, commit := testGitSource(t)
+	runner := newTestRunner(t, &fakeAdapter{}, source, commit)
+	request := testStartRequest(commit)
+	request.ExportGitResult = true
+	request.Artifacts = []ArtifactSpec{{Name: gitResultJSONName, Path: "result.json"}}
+	if _, err := runner.Start(context.Background(), request); err == nil {
+		t.Fatal("Start accepted a runner-owned artifact name")
+	} else {
+		assertProtocolCode(t, err, ErrorInvalidRequest)
+	}
+}
+
+func TestGitResultExportFailureNeverCompletes(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if err := os.RemoveAll(filepath.Join(launch.Workdir, ".git")); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-git-result-failure"
+	request.AttemptID = "attempt-git-result-failure"
+	request.RequestID = "start-git-result-failure"
+	request.ExportGitResult = true
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseFailed)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if len(got.Artifacts) != 0 || !strings.Contains(got.Blocker, "git result export") {
+		t.Fatalf("failed export receipt = %+v", got)
+	}
+}
+
+func TestGitResultExportHonorsArtifactSizeBound(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if err := os.WriteFile(filepath.Join(launch.Workdir, "new.txt"), []byte("new\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	runner.cfg.MaxArtifactSize = 64
+	request := testStartRequest(commit)
+	request.TaskID = "task-git-result-size"
+	request.AttemptID = "attempt-git-result-size"
+	request.RequestID = "start-git-result-size"
+	request.ExportGitResult = true
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseFailed)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if len(got.Artifacts) != 0 || !strings.Contains(got.Blocker, "exceeds") {
+		t.Fatalf("size-bound receipt = %+v", got)
+	}
+}
+
+func TestGitResultExportCancelDoesNotPublishArtifacts(t *testing.T) {
+	source, commit := testGitSource(t)
+	started := make(chan struct{})
+	adapter := &fakeAdapter{run: func(ctx context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if err := os.WriteFile(filepath.Join(launch.Workdir, "new.txt"), []byte("new\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		close(started)
+		<-ctx.Done()
+		return harness.Result{Phase: string(PhaseCancelled), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-git-result-cancel"
+	request.AttemptID = "attempt-git-result-cancel"
+	request.RequestID = "start-git-result-cancel"
+	request.ExportGitResult = true
+	receipt, err := runner.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("adapter did not start")
+	}
+	if _, err := runner.Cancel(context.Background(), CancelRequest{ProtocolVersion: ProtocolVersion, RequestID: "cancel-git-result", TaskID: receipt.TaskID, AttemptID: receipt.AttemptID, AttemptEpoch: receipt.AttemptEpoch}); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	waitForPhase(t, runner, receipt.AttemptID, PhaseCancelled)
+	got, err := runner.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if len(got.Artifacts) != 0 {
+		t.Fatalf("cancelled artifacts = %+v", got.Artifacts)
+	}
+}
+
+func TestGitResultExportRestartPublishesOneArtifactSet(t *testing.T) {
+	source, commit := testGitSource(t)
+	stateDir := t.TempDir()
+	started := make(chan struct{})
+	firstAdapter := &fakeAdapter{run: func(ctx context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		close(started)
+		<-ctx.Done()
+		return harness.Result{Phase: string(PhaseCancelled), SessionID: "session-restart"}, nil
+	}}
+	first := newTestRunnerAt(t, firstAdapter, stateDir, source, commit)
+	request := testStartRequest(commit)
+	request.TaskID = "task-git-result-restart"
+	request.AttemptID = "attempt-git-result-restart"
+	request.RequestID = "start-git-result-restart"
+	request.ExportGitResult = true
+	receipt, err := first.Start(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("adapter did not start")
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	checkpoint, err := first.Inspect(context.Background(), receipt.AttemptID)
+	if err != nil || checkpoint.Phase != PhaseNeedsInput {
+		t.Fatalf("checkpoint = %+v, err=%v", checkpoint, err)
+	}
+
+	secondAdapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		if launch.SessionID != checkpoint.SessionID {
+			return harness.Result{}, errors.New("resume session changed")
+		}
+		if err := os.WriteFile(filepath.Join(launch.Workdir, "new.txt"), []byte("new\n"), 0o600); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	second := newTestRunnerAt(t, secondAdapter, stateDir, source, commit)
+	resumed, err := second.Resume(context.Background(), ResumeRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "resume-git-result-restart",
+		TaskID:          checkpoint.TaskID,
+		AttemptID:       checkpoint.AttemptID,
+		AttemptEpoch:    checkpoint.AttemptEpoch,
+		SessionID:       checkpoint.SessionID,
+		Resolution:      "continue",
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	waitForPhase(t, second, resumed.AttemptID, PhaseCompleted)
+	got, err := second.Inspect(context.Background(), resumed.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if len(got.Artifacts) != 2 {
+		t.Fatalf("restarted artifacts = %+v, want one JSON and one bundle", got.Artifacts)
+	}
+}

--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -154,6 +154,7 @@ type StartRequest struct {
 	RequiredEnvironment    []string                 `json:"requiredEnvironment,omitempty"`
 	RequiredHarness        string                   `json:"requiredHarness,omitempty"`
 	RequiredHarnessVersion string                   `json:"requiredHarnessVersion,omitempty"`
+	ExportGitResult        bool                     `json:"exportGitResult,omitempty"`
 	Limits                 ExecutionLimits          `json:"limits,omitempty"`
 	Verification           VerificationRequirements `json:"verification,omitempty"`
 	Resources              []ResourceRequest        `json:"resources,omitempty"`

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -147,7 +147,7 @@ func New(cfg Config, adapter harness.Adapter) (*Runner, error) {
 		Architecture:    runtime.GOARCH,
 		Toolchains:      append([]string(nil), cfg.Toolchains...),
 		Environment:     append([]string(nil), cfg.Environment...),
-		Verification:    append([]string(nil), cfg.Verification...),
+		Verification:    appendUnique(append([]string(nil), cfg.Verification...), gitResultCapability),
 		Capacity:        Capacity{Maximum: cfg.MaximumCapacity},
 		Ready:           probeErr == nil && info.Ready && len(info.Reasons) == 0,
 	}
@@ -672,29 +672,33 @@ func (r *Runner) execute(ctx context.Context, launch harness.Launch, attemptID s
 	})
 	gate.close()
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	attempt, ok := r.state.Attempts[attemptID]
 	if !ok {
 		delete(r.shutdown, attemptID)
 		delete(r.running, attemptID)
+		r.mu.Unlock()
 		return
 	}
-	delete(r.running, attemptID)
 	_, shutdown := r.shutdown[attemptID]
-	delete(r.shutdown, attemptID)
 	if attempt.Receipt.LastError != nil {
 		blocker := attempt.Receipt.Blocker
 		if blocker == "" {
 			blocker = attempt.Receipt.LastError.Message
 		}
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
 		r.finishLocked(attempt, PhaseFailed, blocker, nil)
+		r.mu.Unlock()
 		return
 	}
 	if attempt.Receipt.SessionID == "" && result.SessionID != "" {
 		attempt.Receipt.SessionID = result.SessionID
 	}
 	if result.SessionID != "" && result.SessionID != attempt.Receipt.SessionID {
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
 		r.finishLocked(attempt, PhaseFailed, "harness returned a foreign session ID", errors.New("foreign session ID"))
+		r.mu.Unlock()
 		return
 	}
 	if attempt.LimitExceeded || errors.Is(ctx.Err(), context.DeadlineExceeded) {
@@ -702,11 +706,17 @@ func (r *Runner) execute(ctx context.Context, launch harness.Launch, attemptID s
 		if blocker == "" && errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			blocker = "harness exceeded the approved execution duration"
 		}
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
 		r.finishLocked(attempt, PhaseFailed, blocker, nil)
+		r.mu.Unlock()
 		return
 	}
 	if attempt.CancelPending {
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
 		r.finishLocked(attempt, PhaseCancelled, legacyShutdownCancellationBlocker, nil)
+		r.mu.Unlock()
 		return
 	}
 	// Close cancels the adapter context so the child process can be drained.
@@ -717,24 +727,98 @@ func (r *Runner) execute(ctx context.Context, launch harness.Launch, attemptID s
 	resultPhase := Phase(result.Phase)
 	shutdownInterrupted := (resultPhase == PhaseCancelled || resultPhase == PhaseNeedsInput || resultPhase == "") && (runErr == nil || errors.Is(runErr, context.Canceled))
 	if shutdown && errors.Is(ctx.Err(), context.Canceled) && shutdownInterrupted {
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
 		r.finishLocked(attempt, PhaseNeedsInput, shutdownBlocker, nil)
+		r.mu.Unlock()
 		return
 	}
 	if runErr != nil {
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
 		r.finishLocked(attempt, PhaseFailed, runErr.Error(), runErr)
+		r.mu.Unlock()
 		return
 	}
 	switch Phase(result.Phase) {
 	case PhaseCompleted:
-		r.finishLocked(attempt, PhaseCompleted, "", nil)
+		if !attempt.Start.ExportGitResult {
+			delete(r.running, attemptID)
+			delete(r.shutdown, attemptID)
+			r.finishLocked(attempt, PhaseCompleted, "", nil)
+			r.mu.Unlock()
+			return
+		}
+		request := cloneStartRequest(attempt.Start)
+		workdir := attempt.Receipt.Workdir
+		r.mu.Unlock()
+		gitResult, exportErr := exportGitResult(ctx, r.cfg, request, workdir)
+		r.mu.Lock()
+		attempt, ok = r.state.Attempts[attemptID]
+		if !ok {
+			cleanupGitResultArtifacts(gitResult)
+			delete(r.running, attemptID)
+			delete(r.shutdown, attemptID)
+			r.mu.Unlock()
+			return
+		}
+		_, shutdown = r.shutdown[attemptID]
+		if attempt.CancelPending {
+			cleanupGitResultArtifacts(gitResult)
+			delete(r.running, attemptID)
+			delete(r.shutdown, attemptID)
+			r.finishLocked(attempt, PhaseCancelled, legacyShutdownCancellationBlocker, nil)
+			r.mu.Unlock()
+			return
+		}
+		if shutdown && errors.Is(ctx.Err(), context.Canceled) {
+			cleanupGitResultArtifacts(gitResult)
+			delete(r.running, attemptID)
+			delete(r.shutdown, attemptID)
+			r.finishLocked(attempt, PhaseNeedsInput, shutdownBlocker, nil)
+			r.mu.Unlock()
+			return
+		}
+		if exportErr != nil {
+			cleanupGitResultArtifacts(gitResult)
+			delete(r.running, attemptID)
+			delete(r.shutdown, attemptID)
+			message := "git result export failed: " + exportErr.Error()
+			r.finishLocked(attempt, PhaseFailed, message, errors.New(message))
+			r.mu.Unlock()
+			return
+		}
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
+		if err := r.finishGitResultLocked(attempt, gitResult); err != nil {
+			cleanupGitResultArtifacts(gitResult)
+			// The durable state transaction failed before a completed receipt
+			// could be committed. Keep the attempt terminally failed so callers
+			// never observe completion without its immutable result artifacts.
+			message := "persist git result export: " + err.Error()
+			r.finishLocked(attempt, PhaseFailed, message, errors.New(message))
+		}
+		r.mu.Unlock()
 	case PhaseCancelled:
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
 		r.finishLocked(attempt, PhaseCancelled, "harness cancelled", nil)
+		r.mu.Unlock()
 	case PhaseNeedsInput:
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
 		r.finishLocked(attempt, PhaseNeedsInput, result.Blocker, nil)
+		r.mu.Unlock()
 	case PhaseFailed:
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
 		r.finishLocked(attempt, PhaseFailed, result.Blocker, nil)
+		r.mu.Unlock()
 	default:
+		delete(r.running, attemptID)
+		delete(r.shutdown, attemptID)
 		r.finishLocked(attempt, PhaseFailed, "harness returned no terminal phase", nil)
+		r.mu.Unlock()
 	}
 }
 
@@ -865,6 +949,9 @@ func (r *Runner) recordArtifactLocked(attempt *attemptRecord, data json.RawMessa
 	}
 	if len(data) == 0 || json.Unmarshal(data, &input) != nil {
 		return errors.New("artifact event requires a JSON name/path payload")
+	}
+	if attempt.Start.ExportGitResult && isGitResultArtifactName(input.Name) {
+		return errors.New("artifact name is reserved for the runner Git result export")
 	}
 	var spec *ArtifactSpec
 	for i := range attempt.ArtifactSpecs {
@@ -1110,6 +1197,9 @@ func validateStartRequest(request StartRequest) error {
 		if err := validateIdentifier("artifact name", artifact.Name); err != nil {
 			return err
 		}
+		if request.ExportGitResult && isGitResultArtifactName(artifact.Name) {
+			return errors.New("artifact name is reserved for the runner Git result export")
+		}
 		if _, ok := seen[artifact.Name]; ok {
 			return errors.New("artifact allowlist contains duplicate names")
 		}
@@ -1232,6 +1322,13 @@ func contains(values []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func appendUnique(values []string, value string) []string {
+	if contains(values, value) {
+		return values
+	}
+	return append(values, value)
 }
 
 func resourceNames(requests []ResourceRequest) []string {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -147,10 +147,15 @@ func New(cfg Config, adapter harness.Adapter) (*Runner, error) {
 		Architecture:    runtime.GOARCH,
 		Toolchains:      append([]string(nil), cfg.Toolchains...),
 		Environment:     append([]string(nil), cfg.Environment...),
-		Verification:    appendUnique(append([]string(nil), cfg.Verification...), gitResultCapability),
 		Capacity:        Capacity{Maximum: cfg.MaximumCapacity},
 		Ready:           probeErr == nil && info.Ready && len(info.Reasons) == 0,
 	}
+	verificationCapabilities := append([]string(nil), cfg.Verification...)
+	verificationCapabilities = appendUnique(verificationCapabilities, gitResultCapability)
+	if hasFetchRemote(cfg.Repositories) {
+		verificationCapabilities = appendUnique(verificationCapabilities, gitFetchCapability)
+	}
+	capabilities.Verification = verificationCapabilities
 	harnessReasons := append([]string(nil), info.Reasons...)
 	if probeErr != nil {
 		reason := "harness probe failed: " + probeErr.Error()

--- a/pkg/runner/workspace.go
+++ b/pkg/runner/workspace.go
@@ -43,6 +43,14 @@ func prepareWorkspace(ctx context.Context, cfg Config, request StartRequest) (st
 	if repo.BaseCommit != "" && strings.ToLower(strings.TrimSpace(repo.BaseCommit)) != baseCommit {
 		return "", errors.New("base commit is not the exact commit enrolled for this repository")
 	}
+	fetchRemote := strings.TrimSpace(repo.FetchRemoteURL)
+	if fetchRemote != "" {
+		var err error
+		fetchRemote, err = validateFetchRemoteURL(fetchRemote)
+		if err != nil {
+			return "", fmt.Errorf("repository fetch remote URL is not allowed: %w", err)
+		}
+	}
 	source, err := filepath.Abs(repo.Source)
 	if err != nil {
 		return "", fmt.Errorf("resolve repository source: %w", err)
@@ -53,12 +61,10 @@ func prepareWorkspace(ctx context.Context, cfg Config, request StartRequest) (st
 		}
 		return "", fmt.Errorf("repository source unavailable: %w", err)
 	}
-	resolved, err := gitOutput(ctx, source, "rev-parse", "--verify", baseCommit+"^{commit}")
-	if err != nil {
-		return "", fmt.Errorf("base commit is not available: %w", err)
-	}
-	if strings.TrimSpace(resolved) != baseCommit {
-		return "", fmt.Errorf("base commit resolved to %q, want exact %q", strings.TrimSpace(resolved), baseCommit)
+	resolved, sourceErr := gitOutput(ctx, source, "rev-parse", "--verify", baseCommit+"^{commit}")
+	sourceHasCommit := sourceErr == nil && strings.TrimSpace(resolved) == baseCommit
+	if !sourceHasCommit && fetchRemote == "" {
+		return "", errors.New("base commit is not available in the enrolled source")
 	}
 	workdir := filepath.Join(cfg.StateDir, "worktrees", request.TaskID, request.AttemptID)
 	if info, err := os.Lstat(workdir); err == nil {
@@ -91,6 +97,27 @@ func prepareWorkspace(ctx context.Context, cfg Config, request StartRequest) (st
 	if _, err := gitOutput(ctx, "", "clone", "--no-local", "--no-hardlinks", "--no-checkout", "--upload-pack=git-upload-pack", "--config", "core.hooksPath=/dev/null", source, workdir); err != nil {
 		_ = os.RemoveAll(workdir)
 		return "", fmt.Errorf("clone task worktree: %w", err)
+	}
+	resolved, cloneErr := gitOutput(ctx, workdir, "rev-parse", "--verify", baseCommit+"^{commit}")
+	cloneHasCommit := cloneErr == nil && strings.TrimSpace(resolved) == baseCommit
+	if !cloneHasCommit {
+		if fetchRemote == "" {
+			_ = os.RemoveAll(workdir)
+			return "", errors.New("base commit is not available in the cloned source")
+		}
+		if err := fetchExactCommit(ctx, workdir, fetchRemote, baseCommit); err != nil {
+			_ = os.RemoveAll(workdir)
+			return "", err
+		}
+		resolved, err := gitOutput(ctx, workdir, "rev-parse", "--verify", baseCommit+"^{commit}")
+		if err != nil {
+			_ = os.RemoveAll(workdir)
+			return "", errors.New("fetched base commit could not be resolved")
+		}
+		if strings.TrimSpace(resolved) != baseCommit {
+			_ = os.RemoveAll(workdir)
+			return "", errors.New("fetched base commit did not resolve to the requested commit")
+		}
 	}
 	if _, err := gitOutput(ctx, workdir, "checkout", "--detach", "--force", baseCommit); err != nil {
 		_ = os.RemoveAll(workdir)


### PR DESCRIPTION
## Change

A coordinator can request an immutable Git-result snapshot from a completed local runner task and fetch an approved commit that is missing from the enrolled source clone. Export is opt-in and produces a sanitized single-parent Git bundle; fetching is enabled only by the operator-configured repository remote and runs inside an isolated clone.

The original source checkout stays unchanged. SSH fetch uses strict host verification, noninteractive authentication, and disabled forwarding; credentials are not passed to the coding harness. Includes result validation, conflict and fetch-isolation regression coverage, and operator documentation.

## Validation

- Full runner regression passed again after rebasing onto current main; `git range-diff` confirmed both commits retained identical patches.
- Runner race, lint/vet, Linux and Darwin builds passed during implementation.
- Live macOS execution exported a result, fetched subsequent exact commits, and completed two follow-up revisions on one implementation PR. Source and credential boundaries have deterministic coverage.

This is generic runner functionality. Scheduling and provider-specific review policy remain outside the runner.
