### PR TITLE
fix(portal): isolate terminal and admin state across accounts

### DIFF
--- a/hack/ui-conformance-exceptions.json
+++ b/hack/ui-conformance-exceptions.json
@@ -211,7 +211,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 57,
+      "line": 68,
       "column": 20,
       "match": "#0b0c11",
       "reference": "design.quality.exceptions",
@@ -220,7 +220,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 58,
+      "line": 69,
       "column": 20,
       "match": "#c8c8d0",
       "reference": "design.quality.exceptions",
@@ -229,7 +229,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 59,
+      "line": 70,
       "column": 16,
       "match": "#8b6bff",
       "reference": "design.quality.exceptions",
@@ -238,7 +238,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 60,
+      "line": 71,
       "column": 29,
       "match": "#8b6bff33",
       "reference": "design.quality.exceptions",
@@ -247,7 +247,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 61,
+      "line": 72,
       "column": 15,
       "match": "#0b0c11",
       "reference": "design.quality.exceptions",
@@ -256,7 +256,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 62,
+      "line": 73,
       "column": 13,
       "match": "#f87171",
       "reference": "design.quality.exceptions",
@@ -265,7 +265,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 63,
+      "line": 74,
       "column": 15,
       "match": "#34d399",
       "reference": "design.quality.exceptions",
@@ -274,7 +274,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 64,
+      "line": 75,
       "column": 16,
       "match": "#fbbf24",
       "reference": "design.quality.exceptions",
@@ -283,7 +283,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 65,
+      "line": 76,
       "column": 14,
       "match": "#60a5fa",
       "reference": "design.quality.exceptions",
@@ -292,7 +292,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 66,
+      "line": 77,
       "column": 17,
       "match": "#a78bfa",
       "reference": "design.quality.exceptions",
@@ -301,7 +301,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 67,
+      "line": 78,
       "column": 14,
       "match": "#22d3ee",
       "reference": "design.quality.exceptions",
@@ -310,7 +310,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 68,
+      "line": 79,
       "column": 15,
       "match": "#c8c8d0",
       "reference": "design.quality.exceptions",
@@ -319,7 +319,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 69,
+      "line": 80,
       "column": 21,
       "match": "#404050",
       "reference": "design.quality.exceptions",
@@ -328,7 +328,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 70,
+      "line": 81,
       "column": 19,
       "match": "#fca5a5",
       "reference": "design.quality.exceptions",
@@ -337,7 +337,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 71,
+      "line": 82,
       "column": 21,
       "match": "#6ee7b7",
       "reference": "design.quality.exceptions",
@@ -346,7 +346,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 72,
+      "line": 83,
       "column": 22,
       "match": "#fcd34d",
       "reference": "design.quality.exceptions",
@@ -355,7 +355,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 73,
+      "line": 84,
       "column": 20,
       "match": "#93c5fd",
       "reference": "design.quality.exceptions",
@@ -364,7 +364,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 74,
+      "line": 85,
       "column": 23,
       "match": "#c4b5fd",
       "reference": "design.quality.exceptions",
@@ -373,7 +373,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 75,
+      "line": 86,
       "column": 20,
       "match": "#67e8f9",
       "reference": "design.quality.exceptions",
@@ -382,7 +382,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 76,
+      "line": 87,
       "column": 21,
       "match": "#f0f0f5",
       "reference": "design.quality.exceptions",
@@ -391,7 +391,7 @@
     {
       "rule": "raw-color",
       "path": "portal/src/components/TerminalInstance.vue",
-      "line": 196,
+      "line": 222,
       "column": 65,
       "match": "#0b0c11",
       "reference": "design.quality.exceptions",

--- a/portal/src/auth/session.ts
+++ b/portal/src/auth/session.ts
@@ -16,7 +16,7 @@
 // `@/auth/token` (pure functions) and the DOM keeps this leaf-level and
 // cycle-free.
 import { readTenant } from '@/portalkit/tenant'
-import { loadAuth, isExpired, refreshToken } from '@/auth/token'
+import { loadAuth, isExpired, refreshToken, authSessionRevision, assertAuthSession } from '@/auth/token'
 
 // Window event the shell listens for to drop a dead session and redirect
 // to /login (see portal/src/App.vue). No-op inside provider
@@ -51,11 +51,13 @@ export function resetSessionExpired(): void {
 // themselves. This is the store-free core; useAuthStore.getValidToken()
 // wraps it to also sync the reactive token ref.
 export async function getBearerToken(): Promise<string | null> {
+  const revision = authSessionRevision()
   const stored = loadAuth()
   if (!stored) return null
   if (!isExpired(stored)) return stored.idToken
 
   const refreshed = await refreshToken(stored)
+  assertAuthSession(revision)
   if (refreshed) return refreshed.idToken
 
   // Expired and unrefreshable: the session is dead.
@@ -95,8 +97,10 @@ export async function authFetch(
   opts: RequestInit & AuthHeaderOptions = {},
 ): Promise<Response> {
   const { tenant, headers, ...init } = opts
+  const revision = authSessionRevision()
   const selectedHeaders = tenant ? tenantHeaders() : undefined
   const token = await getBearerToken()
+  assertAuthSession(revision)
 
   // Build via the Headers API so every HeadersInit shape a caller might
   // pass (plain object, [name,value][], or a Headers instance) is merged
@@ -113,6 +117,7 @@ export async function authFetch(
     headers: merged,
   })
 
+  assertAuthSession(revision)
   if (res.status === 401) notifySessionExpired()
   return res
 }

--- a/portal/src/auth/token.ts
+++ b/portal/src/auth/token.ts
@@ -2,6 +2,17 @@ import { STORAGE_KEYS } from '@/lib/constants'
 import type { StoredAuth } from './types'
 
 const EXPIRY_BUFFER_SECONDS = 30
+// Login/logout replace the browser session; ordinary bearer refresh does not.
+// Fence async work even when an account logs out and immediately logs back in.
+let sessionRevision = 0
+
+export function authSessionRevision(): number {
+  return sessionRevision
+}
+
+export function assertAuthSession(revision: number): void {
+  if (revision !== sessionRevision) throw new DOMException('The account has changed', 'AbortError')
+}
 
 export function loadAuth(): StoredAuth | null {
   try {
@@ -14,10 +25,12 @@ export function loadAuth(): StoredAuth | null {
 }
 
 export function saveAuth(auth: StoredAuth): void {
+  sessionRevision++
   localStorage.setItem(STORAGE_KEYS.auth, JSON.stringify(auth))
 }
 
 export function clearAuth(): void {
+  sessionRevision++
   localStorage.removeItem(STORAGE_KEYS.auth)
 }
 
@@ -28,6 +41,7 @@ export function isExpired(auth: StoredAuth): boolean {
 }
 
 export async function refreshToken(auth: StoredAuth): Promise<StoredAuth | null> {
+  const revision = sessionRevision
   if (!auth.refreshToken || !auth.issuerUrl || !auth.clientId) return null
 
   try {
@@ -35,6 +49,7 @@ export async function refreshToken(auth: StoredAuth): Promise<StoredAuth | null>
     const discoveryRes = await fetch(`${auth.issuerUrl}/.well-known/openid-configuration`)
     if (!discoveryRes.ok) return null
     const discovery = await discoveryRes.json()
+    assertAuthSession(revision)
     const tokenEndpoint = discovery.token_endpoint as string
 
     // Refresh using public client (no client_secret, matches PKCE pattern)
@@ -53,6 +68,7 @@ export async function refreshToken(auth: StoredAuth): Promise<StoredAuth | null>
     if (!res.ok) return null
 
     const data = await res.json()
+    assertAuthSession(revision)
     const idToken = data.id_token as string
     const refreshTokenNew = (data.refresh_token as string) || auth.refreshToken
     const expiresIn = data.expires_in as number
@@ -63,9 +79,10 @@ export async function refreshToken(auth: StoredAuth): Promise<StoredAuth | null>
       refreshToken: refreshTokenNew,
       expiresAt: Math.floor(Date.now() / 1000) + expiresIn,
     }
-    saveAuth(updated)
+    localStorage.setItem(STORAGE_KEYS.auth, JSON.stringify(updated))
     return updated
   } catch {
+    assertAuthSession(revision)
     return null
   }
 }

--- a/portal/src/components/TerminalInstance.vue
+++ b/portal/src/components/TerminalInstance.vue
@@ -23,6 +23,16 @@ let heartbeatTimer: ReturnType<typeof setInterval> | null = null
 let dataDisposable: { dispose: () => void } | null = null
 let resizeDisposable: { dispose: () => void } | null = null
 let initialized = false
+let lifecycle = 0
+let disposed = false
+const owner = JSON.stringify(auth.user)
+
+// A terminal belongs to the identity that opened it. Disconnect immediately,
+// before the parent removes its session row on the next render.
+watch(() => JSON.stringify(auth.user), () => {
+  disposed = true
+  cleanup()
+}, { flush: 'sync' })
 
 const statusLabel = computed(() => {
   switch (connectionStatus.value) {
@@ -45,7 +55,8 @@ function buildWsUrl(token: string): string {
 }
 
 async function initialize() {
-  if (initialized || !termEl.value) return
+  if (disposed || !auth.token || JSON.stringify(auth.user) !== owner || initialized || !termEl.value) return
+  const attempt = ++lifecycle
   initialized = true
   connectionStatus.value = 'connecting'
 
@@ -82,7 +93,15 @@ async function initialize() {
   terminal.open(termEl.value)
   fitAddon.fit()
 
-  const token = await auth.getValidToken()
+  let token: string
+  try {
+    token = await auth.getValidToken()
+  } catch {
+    if (attempt === lifecycle) cleanup()
+    return
+  }
+  // Logout, unmount, or reconnect can occur while token refresh is pending.
+  if (attempt !== lifecycle || disposed || JSON.stringify(auth.user) !== owner) return
   ws = new WebSocket(buildWsUrl(token))
   ws.binaryType = 'arraybuffer'
 
@@ -155,13 +174,19 @@ async function reconnect() {
 }
 
 function cleanup() {
+  lifecycle++
+  connectionStatus.value = 'disconnected'
   stopHeartbeat()
   dataDisposable?.dispose()
   resizeDisposable?.dispose()
   dataDisposable = null
   resizeDisposable = null
-  if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
-    ws.close()
+  if (ws) {
+    ws.onopen = null
+    ws.onmessage = null
+    ws.onclose = null
+    ws.onerror = null
+    if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) ws.close()
   }
   ws = null
   terminal?.dispose()
@@ -174,6 +199,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  disposed = true
   cleanup()
 })
 

--- a/portal/src/stores/accountIsolation.test.mjs
+++ b/portal/src/stores/accountIsolation.test.mjs
@@ -1,0 +1,342 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createServer, transformWithEsbuild } from 'vite'
+import { parse, compileScript } from '@vue/compiler-sfc'
+import { createRenderer, nextTick } from 'vue'
+import { createPinia, setActivePinia, disposePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Render the real component with an in-memory Vue host. Only the browser's
+// terminal and socket transports are doubles; auth, stores and routing are real.
+const terminals = []
+const sockets = []
+class FakeTerminal {
+  cols = 80; rows = 24; disposed = false; data = null; resize = null
+  constructor() { terminals.push(this) }
+  loadAddon() {} open() {} write() {} focus() {} clear() {}
+  onData(callback) { this.data = callback; return { dispose: () => { this.data = null } } }
+  onResize(callback) { this.resize = callback; return { dispose: () => { this.resize = null } } }
+  dispose() { this.disposed = true }
+}
+class FakeSocket {
+  static CONNECTING = 0; static OPEN = 1; static CLOSED = 3
+  readyState = 0; sent = []; closed = false
+  constructor(url) { this.url = url; sockets.push(this) }
+  send(data) { this.sent.push(data) }
+  close() { this.closed = true; this.readyState = FakeSocket.CLOSED }
+}
+globalThis.__accountIsolationTerminal = FakeTerminal
+const vite = await createServer({
+  appType: 'custom', configFile: false, root: new URL('../../', import.meta.url).pathname,
+  cacheDir: join(tmpdir(), 'faros-account-isolation-test'),
+  resolve: { alias: { '@': new URL('../', import.meta.url).pathname } },
+  ssr: { noExternal: [/^@xterm\//] },
+  optimizeDeps: { noDiscovery: true }, server: { middlewareMode: true, hmr: false, ws: false },
+  plugins: [{
+    name: 'terminal-test-transports', enforce: 'pre',
+    resolveId(id) { if (id.startsWith('@xterm/')) return '\0' + id },
+    load(id) {
+      if (id === '\0@xterm/xterm') return 'export const Terminal = globalThis.__accountIsolationTerminal'
+      if (id === '\0@xterm/addon-fit') return 'export class FitAddon { fit() {} }'
+      if (id === '\0@xterm/xterm/css/xterm.css') return ''
+    },
+    async transform(source, id) {
+      if (!id.endsWith('/TerminalInstance.vue')) return
+      const { descriptor } = parse(source)
+      const compiled = compileScript(descriptor, { id: 'terminal-test', inlineTemplate: true })
+      return transformWithEsbuild(compiled.content, id + '.ts', { loader: 'ts' })
+    },
+  }],
+})
+const { useAuthStore } = await vite.ssrLoadModule('/src/stores/auth.ts')
+const { useAdminStore } = await vite.ssrLoadModule('/src/stores/admin.ts')
+const { useTerminalSessionsStore } = await vite.ssrLoadModule('/src/stores/terminalSessions.ts')
+const { default: TerminalInstance } = await vite.ssrLoadModule('/src/components/TerminalInstance.vue')
+const { routes } = await vite.ssrLoadModule('/src/router/routes.ts')
+const { installContextGuard } = await vite.ssrLoadModule('/src/router/contextGuard.ts')
+test.after(() => { delete globalThis.__accountIsolationTerminal; return vite.close() })
+const node = (type, text = '') => ({ type, text, children: [], parent: null })
+const renderer = createRenderer({
+  createElement: node, createText: text => node('text', text), createComment: text => node('comment', text),
+  setText: (el, text) => { el.text = text }, setElementText: (el, text) => { el.text = text },
+  parentNode: el => el.parent, nextSibling: el => el.parent?.children[el.parent.children.indexOf(el) + 1],
+  patchProp() {},
+  insert(el, parent, anchor) {
+    if (el.parent) el.parent.children.splice(el.parent.children.indexOf(el), 1)
+    const index = anchor ? parent.children.indexOf(anchor) : -1
+    parent.children.splice(index < 0 ? parent.children.length : index, 0, el)
+    el.parent = parent
+  },
+  remove(el) { if (el.parent) el.parent.children.splice(el.parent.children.indexOf(el), 1); el.parent = null },
+})
+const response = (body, status = 200) => new Response(JSON.stringify(body), { status })
+const deferred = () => { let resolve; const promise = new Promise(r => { resolve = r }); return { promise, resolve } }
+const flush = async () => { await nextTick(); await new Promise(resolve => setImmediate(resolve)) }
+function setup(t) {
+  const data = new Map()
+  globalThis.localStorage = { getItem: key => data.get(key) ?? null, setItem: (key, value) => data.set(key, value), removeItem: key => data.delete(key) }
+  globalThis.sessionStorage = globalThis.localStorage
+  globalThis.location = { protocol: 'https:', host: 'faros.test', pathname: '/ui/bonkers/users' }
+  globalThis.window = { location: globalThis.location, dispatchEvent() {} }
+  globalThis.WebSocket = FakeSocket
+  globalThis.fetch = async () => response({})
+  sockets.length = terminals.length = 0
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const auth = useAuthStore()
+  const login = (userId = 'admin') => auth.loginFromOIDCResponse({ idToken: userId + '-token', expiresAt: 9999999999, email: userId + '@example.test', userId, clusterName: 'cluster-a' })
+  login()
+  auth.initialized = true
+  t.after(() => disposePinia(pinia))
+  return { auth, login, pinia, admin: useAdminStore(), sessions: useTerminalSessionsStore() }
+}
+function mountTerminal(t, pinia) {
+  const app = renderer.createApp(TerminalInstance, { edgeName: 'private-server', cluster: 'cluster-a', isActive: true })
+  app.use(pinia)
+  const component = app.mount(node('root'))
+  t.after(() => app.unmount())
+  return { app, component }
+}
+
+test('logout closes live SSH immediately and removes all sessions; navigation and token rotation preserve them', async t => {
+  const { auth, login, pinia, sessions } = setup(t)
+  sessions.openSession({ edgeName: 'private-server', cluster: 'cluster-a' })
+  sessions.openSession({ edgeName: 'another-server', cluster: 'cluster-b' })
+  const { component } = mountTerminal(t, pinia)
+  await flush()
+  assert.equal(sockets.length, 1)
+  const socket = sockets[0], terminal = terminals[0]
+  socket.readyState = FakeSocket.OPEN
+  socket.onopen()
+  terminal.data('whoami\n')
+  assert.ok(socket.sent.some(message => JSON.parse(message).type === 'cmd'))
+  auth.token = 'rotated-token'
+  auth.setClusterName('cluster-b')
+  await flush()
+  assert.equal(socket.closed, false)
+  assert.equal(sessions.sessions.length, 2)
+  auth.logout()
+  // Assert before Vue's next render: an open transport must close synchronously.
+  assert.equal(socket.closed, true)
+  assert.equal(terminal.disposed, true)
+  assert.equal(terminal.data, null)
+  assert.equal(terminal.resize, null)
+  assert.equal(socket.onmessage, null)
+  assert.deepEqual(sessions.sessions, [])
+  assert.equal(sessions.activeSessionId, null)
+  assert.equal(sessions.isVisible, false)
+  login('member')
+  await component.reconnect()
+  assert.equal(sockets.length, 1, 'old component cannot reconnect as the next account')
+})
+
+test('direct identity replacement closes a connecting socket', async t => {
+  const { login, pinia, sessions } = setup(t)
+  sessions.openSession({ edgeName: 'private-server', cluster: 'cluster-a' })
+  mountTerminal(t, pinia)
+  await flush()
+  assert.equal(sockets[0].readyState, FakeSocket.CONNECTING)
+  login('member')
+  assert.equal(sockets[0].closed, true)
+  assert.deepEqual(sessions.sessions, [])
+})
+
+test('a pending token cannot create a socket after logout, identity replacement or unmount', async t => {
+  for (const action of ['logout', 'replace', 'unmount']) {
+    await t.test(action, async t => {
+      const { auth, login, pinia } = setup(t)
+      const token = deferred()
+      auth.getValidToken = () => token.promise
+      const { app } = mountTerminal(t, pinia)
+      await flush()
+      assert.equal(terminals.length, 1)
+      if (action === 'logout') auth.logout()
+      else if (action === 'replace') login('member')
+      else app.unmount()
+      token.resolve('old-admin-token')
+      await flush()
+      assert.equal(sockets.length, 0)
+      assert.equal(terminals[0].disposed, true)
+    })
+  }
+})
+
+test('reconnect fences the previous token attempt and keeps only the replacement transport', async t => {
+  const { auth, pinia } = setup(t)
+  const old = deferred()
+  auth.getValidToken = () => old.promise
+  const { component } = mountTerminal(t, pinia)
+  await flush()
+  auth.getValidToken = async () => 'new-token'
+  await component.reconnect()
+  old.resolve('old-token')
+  await flush()
+  assert.equal(sockets.length, 1)
+  assert.ok(sockets[0].url.endsWith('token=new-token'))
+  assert.equal(terminals[0].disposed, true)
+  assert.equal(terminals[1].disposed, false)
+})
+
+async function seedAdmin(admin) {
+  globalThis.fetch = async path => response(path === '/api/admin/access'
+    ? { kubeconfigServers: ['internal', 'external'] } : { items: [{ name: 'private-' + path }] })
+  assert.equal(await admin.checkAccess(), true)
+  await admin.refresh()
+  assert.equal(admin.loaded, true)
+}
+function assertEmptyAdmin(admin) {
+  for (const key of ['users', 'orgs', 'providers', 'identities', 'kubeconfigServers']) assert.deepEqual(admin[key], [], key)
+  assert.equal(admin.isAdmin, null)
+  assert.equal(admin.loaded, false)
+  assert.equal(admin.loading, false)
+  assert.equal(admin.forbidden, false)
+  assert.equal(admin.error, null)
+}
+
+test('logout resets admin data and access; the next account must pass a fresh route check', async t => {
+  const { auth, login, admin } = setup(t)
+  await seedAdmin(admin)
+  auth.token = 'rotated-token'
+  auth.setClusterName('cluster-b')
+  assert.equal(admin.isAdmin, true)
+  assert.equal(admin.users.length, 1)
+  auth.logout()
+  assertEmptyAdmin(admin)
+  login('member')
+  const calls = []
+  globalThis.fetch = async path => { calls.push(path); return response({}, 403) }
+  const router = createRouter({ history: createMemoryHistory('/ui/'), routes })
+  for (const record of router.getRoutes()) if (record.components) record.components.default = { render: () => null }
+  installContextGuard(router)
+  await router.push('/bonkers/users')
+  assert.ok(calls.includes('/api/admin/access'))
+  assert.equal(admin.isAdmin, false)
+  assert.notEqual(router.currentRoute.value.path, '/bonkers/users')
+  assert.deepEqual(admin.users, [])
+})
+
+test('late admin access and collection bodies cannot restore prior-account data or end a new refresh', async t => {
+  const { login, admin } = setup(t)
+  const accessBody = deferred(), collectionBody = deferred(), newBody = deferred()
+  globalThis.fetch = async path => ({ ok: true, status: 200, json: () => path === '/api/admin/access' ? accessBody.promise : collectionBody.promise })
+  const oldAccess = admin.checkAccess(), oldRefresh = admin.refresh()
+  await flush()
+  login('member')
+  assertEmptyAdmin(admin)
+  globalThis.fetch = async () => ({ ok: true, status: 200, json: () => newBody.promise })
+  const newRefresh = admin.refresh()
+  await flush()
+  accessBody.resolve({ kubeconfigServers: ['internal'] })
+  collectionBody.resolve({ items: [{ name: 'private-old-account' }] })
+  assert.equal(await oldAccess, false)
+  await oldRefresh
+  assert.equal(admin.isAdmin, null)
+  assert.deepEqual(admin.kubeconfigServers, [])
+  assert.deepEqual(admin.users, [])
+  assert.equal(admin.loading, true)
+  newBody.resolve({ items: [{ name: 'new-account' }] })
+  await newRefresh
+  assert.equal(admin.loading, false)
+  assert.equal(admin.users[0].name, 'new-account')
+})
+
+test('stale denied responses cannot overwrite the new account admin state', async t => {
+  const { login, admin } = setup(t)
+  const pending = deferred()
+  globalThis.fetch = () => pending.promise
+  const access = admin.checkAccess(), refresh = admin.refresh()
+  await flush()
+  login('other-admin')
+  await seedAdmin(admin)
+  pending.resolve(response({}, 403))
+  await Promise.all([access, refresh])
+  assert.equal(admin.isAdmin, true)
+  assert.equal(admin.forbidden, false)
+  assert.equal(admin.loaded, true)
+  assert.equal(admin.users.length, 1)
+})
+
+test('an in-flight kubeconfig download cannot deliver old-account credentials', async t => {
+  const { login, admin } = setup(t)
+  const body = deferred()
+  let downloads = 0
+  globalThis.document = { createElement() { downloads++; return { click() {} } } }
+  t.after(() => { delete globalThis.document })
+  globalThis.fetch = async () => ({ ok: true, status: 200, text: () => body.promise })
+  const download = admin.downloadProviderKubeconfig('private-provider', 'internal')
+  const rejected = assert.rejects(download, { name: 'AbortError' })
+  await flush()
+  login('member')
+  body.resolve('private-kubeconfig')
+  await rejected
+  assert.equal(downloads, 0)
+})
+
+test('delayed OIDC refresh cannot resurrect credentials or dispatch an admin request after the session changes', async t => {
+  const { authFetch } = await vite.ssrLoadModule('/src/auth/session.ts')
+  const { loadAuth } = await vite.ssrLoadModule('/src/auth/token.ts')
+  for (const action of ['logout', 'replace', 'same-account-relogin']) {
+    await t.test(action, async t => {
+      const { auth, login } = setup(t)
+      auth.loginFromOIDCResponse({ idToken: 'expired-admin-token', expiresAt: 1,
+        email: 'admin@example.test', userId: 'admin', refreshToken: 'old-refresh',
+        issuerUrl: 'https://issuer.test', clientId: 'portal' })
+      const tokenBody = deferred()
+      let exchanges = 0
+      const requests = []
+      globalThis.fetch = async path => {
+        requests.push(path)
+        if (path.endsWith('/.well-known/openid-configuration')) return response({ token_endpoint: 'https://issuer.test/token' })
+        if (path === 'https://issuer.test/token') {
+          exchanges++
+          return { ok: true, json: () => tokenBody.promise }
+        }
+        return response({})
+      }
+      const terminalToken = assert.rejects(auth.getValidToken(), { name: 'AbortError' })
+      const adminRequest = assert.rejects(authFetch('/api/admin/users'), { name: 'AbortError' })
+      await flush()
+      assert.equal(exchanges, 2)
+      auth.logout()
+      if (action !== 'logout') login(action === 'replace' ? 'member' : 'admin')
+      tokenBody.resolve({ id_token: 'refreshed-old-admin-token', expires_in: 3600 })
+      await Promise.all([terminalToken, adminRequest])
+      assert.equal(requests.includes('/api/admin/users'), false)
+      assert.equal(auth.token, action === 'logout' ? null : action === 'replace' ? 'member-token' : 'admin-token')
+      assert.equal(loadAuth()?.idToken ?? null, auth.token)
+    })
+  }
+})
+
+test('an old request returning 401 cannot expire the replacement account', async t => {
+  const { login, auth } = setup(t)
+  const { authFetch } = await vite.ssrLoadModule('/src/auth/session.ts')
+  const pending = deferred()
+  let expired = 0
+  window.dispatchEvent = () => { expired++ }
+  globalThis.fetch = () => pending.promise
+  const rejected = assert.rejects(authFetch('/api/admin/users'), { name: 'AbortError' })
+  await flush()
+  login('member')
+  pending.resolve(response({}, 401))
+  await rejected
+  assert.equal(expired, 0)
+  assert.equal(auth.user.userId, 'member')
+})
+
+test('normal OIDC refresh preserves the same account admin cache and returns a usable bearer', async t => {
+  const { auth, admin } = setup(t)
+  await seedAdmin(admin)
+  auth.loginFromOIDCResponse({ idToken: 'expired-token', expiresAt: 1,
+    email: 'admin@example.test', userId: 'admin', refreshToken: 'refresh',
+    issuerUrl: 'https://issuer.test', clientId: 'portal' })
+  globalThis.fetch = async path => path.endsWith('/.well-known/openid-configuration')
+    ? response({ token_endpoint: 'https://issuer.test/token' })
+    : response({ id_token: 'refreshed-token', expires_in: 3600 })
+  assert.equal(await auth.getValidToken(), 'refreshed-token')
+  assert.equal(auth.token, 'refreshed-token')
+  assert.equal(admin.isAdmin, true)
+  assert.equal(admin.users.length, 1)
+})

--- a/portal/src/stores/admin.ts
+++ b/portal/src/stores/admin.ts
@@ -2,7 +2,8 @@
 // /api/admin/* surface, which is gated server-side by --admin-users: a
 // non-admin caller gets 403, which this store surfaces as `forbidden`.
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
+import { useAuthStore } from './auth'
 
 import { authFetch } from '@/auth/session'
 
@@ -73,33 +74,63 @@ export const useAdminStore = defineStore('admin', () => {
   // present when the hub runs with --hub-internal-url, so the providers
   // table can offer the in-cluster download only where it would work.
   const kubeconfigServers = ref<KubeconfigServer[]>([])
+  const auth = useAuthStore()
+  let identityRevision = 0
+  let accessSequence = 0
+  let refreshSequence = 0
+
+  watch(() => JSON.stringify(auth.user), () => {
+    identityRevision++
+    accessSequence++
+    refreshSequence++
+    users.value = []
+    orgs.value = []
+    providers.value = []
+    identities.value = []
+    kubeconfigServers.value = []
+    isAdmin.value = null
+    loaded.value = false
+    loading.value = false
+    forbidden.value = false
+    error.value = null
+  }, { flush: 'sync' })
+
+  function assertIdentity(revision: number): void {
+    if (revision !== identityRevision) throw new DOMException('The account has changed', 'AbortError')
+  }
 
   // checkAccess probes /api/admin/access once. 200 → admin; 403/404/any other →
   // not admin. Never throws; failed requests are swallowed so non-admin
   // sessions stay quiet.
   async function checkAccess(): Promise<boolean> {
+    const sequence = ++accessSequence
+    const revision = identityRevision
+    const current = () => sequence === accessSequence && revision === identityRevision
     try {
       const resp = await authFetch('/api/admin/access')
+      if (!current()) return false
       isAdmin.value = resp.ok
       if (resp.ok) {
         // Older hubs answer with just {"admin":true}; treat a missing list as
         // "external only" so the download keeps working against them.
         const body = (await resp.json().catch(() => ({}))) as { kubeconfigServers?: string[] }
+        if (!current()) return false
         const servers = (body.kubeconfigServers ?? ['external']).filter(
           (s): s is KubeconfigServer => s === 'internal' || s === 'external',
         )
         kubeconfigServers.value = servers
       }
     } catch {
+      if (!current()) return false
       isAdmin.value = false
     }
     return isAdmin.value === true
   }
 
-  async function get<T>(path: string): Promise<T[]> {
+  async function get<T>(path: string, revision: number): Promise<T[]> {
     const resp = await authFetch(path)
+    assertIdentity(revision)
     if (resp.status === 403) {
-      forbidden.value = true
       throw new Error('forbidden')
     }
     if (!resp.ok) throw new Error(`${path}: ${resp.status} ${resp.statusText}`)
@@ -108,27 +139,33 @@ export const useAdminStore = defineStore('admin', () => {
   }
 
   async function refresh(): Promise<void> {
+    const revision = identityRevision
+    const sequence = ++refreshSequence
+    const current = () => revision === identityRevision && sequence === refreshSequence
     loading.value = true
     error.value = null
     forbidden.value = false
     try {
       const [u, o, p, i] = await Promise.all([
-        get<AdminUser>('/api/admin/users'),
-        get<AdminOrg>('/api/admin/organizations'),
-        get<AdminProvider>('/api/admin/providers'),
-        get<RootIdentity>('/api/admin/identities'),
+        get<AdminUser>('/api/admin/users', revision),
+        get<AdminOrg>('/api/admin/organizations', revision),
+        get<AdminProvider>('/api/admin/providers', revision),
+        get<RootIdentity>('/api/admin/identities', revision),
       ])
+      if (!current()) return
       users.value = u
       orgs.value = o
       providers.value = p
       identities.value = i
       loaded.value = true
     } catch (e) {
-      if ((e as Error).message !== 'forbidden') {
+      if (!current()) return
+      if ((e as Error).message === 'forbidden') forbidden.value = true
+      else {
         error.value = (e as Error).message
       }
     } finally {
-      loading.value = false
+      if (current()) loading.value = false
     }
   }
 
@@ -136,11 +173,13 @@ export const useAdminStore = defineStore('admin', () => {
   // The hub's Provider controller then provisions the sub-workspace +
   // ServiceAccount + kubeconfig Secret. Declarative — no imperative onboard.
   async function createProvider(name: string, displayName: string): Promise<void> {
+    const revision = identityRevision
     const resp = await authFetch('/api/admin/providers', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, displayName }),
     })
+    assertIdentity(revision)
     if (resp.status === 403) {
       forbidden.value = true
       throw new Error('forbidden')
@@ -151,9 +190,11 @@ export const useAdminStore = defineStore('admin', () => {
   // deleteProvider removes the Provider object; the controller's finalizer
   // tears down the provisioned sub-workspace.
   async function deleteProvider(name: string): Promise<void> {
+    const revision = identityRevision
     const resp = await authFetch(`/api/admin/providers/${encodeURIComponent(name)}`, {
       method: 'DELETE',
     })
+    assertIdentity(revision)
     if (resp.status === 403) {
       forbidden.value = true
       throw new Error('forbidden')
@@ -172,8 +213,10 @@ export const useAdminStore = defineStore('admin', () => {
   // in-cluster Service, so its traffic never leaves), 'external' for one running
   // anywhere else. Omitted downloads whatever the controller minted.
   async function downloadProviderKubeconfig(name: string, server?: KubeconfigServer): Promise<void> {
+    const revision = identityRevision
     const query = server ? `?server=${server}` : ''
     const resp = await authFetch(`/api/admin/providers/${encodeURIComponent(name)}/kubeconfig${query}`)
+    assertIdentity(revision)
     if (resp.status === 403) {
       forbidden.value = true
       throw new Error('forbidden')
@@ -183,9 +226,11 @@ export const useAdminStore = defineStore('admin', () => {
       // 400 carries an actionable message (e.g. the hub has no internal URL
       // configured); surface it instead of a bare status code.
       const body = (await resp.json().catch(() => ({}))) as { error?: string }
+      assertIdentity(revision)
       throw new Error(body.error ?? `download kubeconfig ${name}: ${resp.status} ${resp.statusText}`)
     }
     const text = await resp.text()
+    assertIdentity(revision)
     const url = URL.createObjectURL(new Blob([text], { type: 'application/yaml' }))
     const a = document.createElement('a')
     a.href = url

--- a/portal/src/stores/auth.ts
+++ b/portal/src/stores/auth.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import type { AuthMode, HealthzResponse, StoredAuth } from '@/auth/types'
-import { loadAuth, saveAuth, clearAuth, parseClusterName } from '@/auth/token'
+import { loadAuth, saveAuth, clearAuth, parseClusterName, authSessionRevision, assertAuthSession } from '@/auth/token'
 import { getBearerToken, resetSessionExpired } from '@/auth/session'
 import { bootstrapBrowserSession, fetchHealthz, loginWithToken } from '@/lib/api'
 import { STORAGE_KEYS } from '@/lib/constants'
@@ -107,11 +107,13 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function getValidToken(): Promise<string> {
+    const revision = authSessionRevision()
     // Shared load/refresh core (also used by REST authFetch). It fires
     // SESSION_EXPIRED_EVENT itself when an expired token can't be
     // refreshed, so the shell already redirects; we still clear local
     // state and throw so in-flight callers stop.
     const valid = await getBearerToken()
+    assertAuthSession(revision)
     if (valid) {
       token.value = valid
       return valid

--- a/portal/src/stores/terminalSessions.ts
+++ b/portal/src/stores/terminalSessions.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
+import { useAuthStore } from './auth'
 
 export interface TerminalSession {
   id: string
@@ -46,6 +47,9 @@ export const useTerminalSessionsStore = defineStore('terminalSessions', () => {
   const activeSessionId = ref<string | null>(null)
   const isVisible = ref(false)
   const panelState = ref<PanelState>(loadPanelState())
+
+  const auth = useAuthStore()
+  watch(() => JSON.stringify(auth.user), closeAllSessions, { flush: 'sync' })
 
   watch(
     panelState,

--- a/providers/linear/portal/src/portalkit/navigation.ts
+++ b/providers/linear/portal/src/portalkit/navigation.ts
@@ -1,0 +1,39 @@
+// Canonical portal URL contract. Navigation is separate from provider asset URLs.
+export const UUID_PATTERN = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+export const ORGANIZATION_ROUTE = `/:orgID(${UUID_PATTERN})`
+export const WORKSPACE_ROUTE = `${ORGANIZATION_ROUTE}/:workspaceID(${UUID_PATTERN})`
+const scopePattern = new RegExp(`^/(${UUID_PATTERN})(?:/(${UUID_PATTERN}))?(?=/|$)`)
+
+export interface NavigationScope {
+  orgUUID: string | null
+  workspaceUUID: string | null
+}
+
+/** Takes a router path (without /ui); global routes have no scope. */
+export function parsePortalScope(path: string): NavigationScope | null {
+  const match = scopePattern.exec(path)
+  return match ? { orgUUID: match[1], workspaceUUID: match[2] ?? null } : null
+}
+
+export function portalRoutePath(path: string): string {
+  return path.replace(scopePattern, '') || '/'
+}
+
+/** Builds a router path. No remembered/default workspace is inferred here. */
+export function scopedPath(path: string, scope: NavigationScope): string {
+  if (parsePortalScope(path) || /^\/(?:login|auth|organizations|bonkers)(?:[/?#]|$)/.test(path)) return path
+  if (!scope.orgUUID) return '/organizations'
+  const org = `/${encodeURIComponent(scope.orgUUID)}`
+  if (path === '/settings' || path.startsWith('/settings/')) return org + path
+  if (!scope.workspaceUUID) return path === '/providers' ? org + path : org + '/settings/workspaces'
+  return `${org}/${encodeURIComponent(scope.workspaceUUID)}${path === '/' ? '' : path}`
+}
+
+/** Native links use the current document's URL, never cross-tab localStorage. */
+export function portalHref(path: string, scope?: Partial<NavigationScope> | null): string {
+  const route = path.replace(/^\/ui(?=\/|$)/, '') || '/'
+  const current = scope === undefined && typeof window !== 'undefined' && !!window.location?.pathname
+    ? parsePortalScope(window.location.pathname.replace(/^\/ui(?=\/|$)/, ''))
+    : scope
+  return current ? '/ui' + scopedPath(route, { orgUUID: current.orgUUID ?? null, workspaceUUID: current.workspaceUUID ?? null }) : '/ui/'
+}

--- a/providers/linear/portal/src/portalkit/tenant.ts
+++ b/providers/linear/portal/src/portalkit/tenant.ts
@@ -1,3 +1,5 @@
+import { parsePortalScope } from './navigation.js'
+
 // CANONICAL SOURCE — provider-sdk/portalkit. Do not edit vendored copies under
 // providers/*/portal/src/portalkit/; edit here and run `make sync-portalkit`.
 //
@@ -27,6 +29,13 @@ export const TENANT_STORAGE_KEY = 'faros:portal:tenant'
 // readTenant returns the active org/workspace from localStorage, tolerating a
 // missing or malformed value (both null).
 export function readTenant(): Tenant {
+  // A hosted document is scoped by its own URL. Another tab may update the
+  // remembered landing preference without changing this document's authority.
+  if (typeof window !== 'undefined' && window.location?.pathname) {
+    const scope = parsePortalScope(window.location.pathname.replace(/^\/ui(?=\/|$)/, ''))
+    if (scope) return scope
+    if (/^\/ui(?:\/|$)/.test(window.location.pathname)) return { orgUUID: null, workspaceUUID: null }
+  }
   try {
     const raw = localStorage.getItem(TENANT_STORAGE_KEY)
     if (!raw) return { orgUUID: null, workspaceUUID: null }


### PR DESCRIPTION
Logout previously left SSH terminals connected and retained platform-admin access decisions and cached records in the portal. This follow-up to #703 closes terminal transports synchronously and clears terminal/admin state when the account changes. Navigation and bearer refresh for the same account preserve existing sessions.

Fence pending terminal initialization, admin responses, and kubeconfig downloads so work started by the previous account cannot restore state or deliver credentials. Also prevent a delayed OIDC refresh from restoring logged-out credentials or allowing an old 401 response to expire the replacement account.

The required shared-kit check exposed pre-existing Linear copy drift on main; regenerate its navigation and tenant helpers. Update existing terminal palette exception line locators to match the lifecycle edits.

Validation:
- `make test-portal`: 223 tests pass, including real Vue terminal lifecycle tests with mocked transports, admin route checks, delayed response/download races, and OIDC refresh races.
- `make build-portal` and `make build-linear-provider-portal`: pass.
- `make verify-design-docs`, `make verify-portalkit`, and `make verify-ui-conformance`: pass (local custom Node build required a temporary TypeScript loader).
- Compiled portal smoke test against the local hub: token-login deep-link return, separate workspace tabs, denied destination/retry, and removed legacy routes pass; no uncaught browser errors. Callback continuation uses a test response rather than a live IdP exchange.

Final code review completed; the delayed-refresh finding was fixed and covered by regressions.
