### PR TITLE
Support durable runner clarifications and scoped Linear thread replies

### DIFF
--- a/docs/linear-provider-architecture.md
+++ b/docs/linear-provider-architecture.md
@@ -6,6 +6,16 @@ Human and machine callers author the same immutable Operation resources; the
 provider reconciles them against Linear and stores observed outcomes in status.
 Uncertain writes remain explicit and are never automatically replayed.
 
+The Operation API supports the read action `replies`. It takes an `issueID` and
+`commentID`, validates that the parent comment belongs to the requested issue
+and an allowed team, and returns the existing bounded comment `nodes` and
+`pageInfo` shape. The implementation reads Linear's native `Comment.children`
+connection, with stable comment IDs, parent IDs, issue IDs, author metadata,
+and timestamps. It does not treat an unfiltered issue comment list as a
+threaded-reply fallback. Read pagination remains explicit through `first` and
+`after`; operation results are durable and uncertain writes stay
+operator-reconcilable.
+
 The provider discovers tenant APIs through its APIExportEndpointSlice. It reads
 referenced Secrets through its declared Secret-get claim, with Connection team
 policy applied to issue operations and webhook events. Portal and MCP command

--- a/docs/local-runner.md
+++ b/docs/local-runner.md
@@ -290,6 +290,21 @@ resolution. It cannot amend the approved input or instructions. A missing or
 unrecoverable checkpoint is a blocker; the runner never silently starts a new
 session as a substitute.
 
+A genuine harness `request-user-input` interaction may additionally populate
+`receipt.clarification` with a bounded `{id,text}` value and emit a matching
+`needs_input` event. The Codex adapter derives a stable ID from the session,
+turn, and interaction item, preserves the bounded question and options, and
+rejects secret, malformed, empty, or oversized input. Authentication, approval,
+restart, and generic error blockers never acquire a clarification value.
+
+`clarification-v1` is advertised in the capabilities response when this
+support is available. A resume for such a receipt must include the same
+`clarificationID`; the runner rejects a missing, stale, or foreign ID. The
+resolution is explicit text passed to the existing session, while approved
+input and instructions remain immutable. The durable operation record makes a
+repeated identical resume return the newer receipt without launching another
+turn, including when the first response was lost.
+
 ## Restart and recovery
 
 The state journal, task worktree, and Codex home are same-machine state. On

--- a/pkg/runner/clarification_test.go
+++ b/pkg/runner/clarification_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+func TestClarificationReceiptPersistsAcrossRestartAndAdvertisesCapability(t *testing.T) {
+	source, commit := testGitSource(t)
+	stateDir := t.TempDir()
+	want := &harness.Clarification{ID: "clarification-first", Text: "Which bounded change should be made?"}
+	firstAdapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventStarted, SessionID: "session-clarification"}); err != nil {
+			return harness.Result{}, err
+		}
+		return harness.Result{Phase: string(PhaseNeedsInput), SessionID: launch.SessionID, Clarification: want}, nil
+	}}
+	first := newTestRunnerAt(t, firstAdapter, stateDir, source, commit)
+	started, err := first.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, first, started.AttemptID, PhaseNeedsInput)
+	checkpoint, err := first.Inspect(context.Background(), started.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if checkpoint.Clarification == nil || *checkpoint.Clarification != (Clarification{ID: want.ID, Text: want.Text}) {
+		t.Fatalf("clarification checkpoint = %+v, want %+v", checkpoint.Clarification, want)
+	}
+	if !contains(first.Capabilities().Verification, clarificationCapability) {
+		t.Fatalf("verification capabilities = %+v, want %q", first.Capabilities().Verification, clarificationCapability)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	second := newTestRunnerAt(t, &fakeAdapter{}, stateDir, source, commit)
+	deferred, err := second.Inspect(context.Background(), started.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect after restart: %v", err)
+	}
+	if deferred.Clarification == nil || *deferred.Clarification != *checkpoint.Clarification {
+		t.Fatalf("restart clarification = %+v, want %+v", deferred.Clarification, checkpoint.Clarification)
+	}
+}
+
+func TestClarificationResumeFenceAndReplayKeepsSecondQuestion(t *testing.T) {
+	source, commit := testGitSource(t)
+	firstQuestion := &harness.Clarification{ID: "clarification-first", Text: "Which bounded change should be made?"}
+	secondQuestion := &harness.Clarification{ID: "clarification-second", Text: "Which verification should run next?"}
+	var runCount atomic.Int32
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventStarted, SessionID: "session-clarification"}); err != nil {
+			return harness.Result{}, err
+		}
+		if runCount.Add(1) == 1 {
+			return harness.Result{Phase: string(PhaseNeedsInput), SessionID: launch.SessionID, Clarification: firstQuestion}, nil
+		}
+		return harness.Result{Phase: string(PhaseNeedsInput), SessionID: launch.SessionID, Clarification: secondQuestion}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	started, err := runner.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, started.AttemptID, PhaseNeedsInput)
+	checkpoint, err := runner.Inspect(context.Background(), started.AttemptID)
+	if err != nil || checkpoint.Clarification == nil {
+		t.Fatalf("first checkpoint = %+v, %v", checkpoint, err)
+	}
+
+	stale := ResumeRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "resume-stale",
+		TaskID:          checkpoint.TaskID,
+		AttemptID:       checkpoint.AttemptID,
+		AttemptEpoch:    checkpoint.AttemptEpoch,
+		SessionID:       checkpoint.SessionID,
+		ClarificationID: "clarification-old",
+		Resolution:      "answer from an old question",
+	}
+	_, err = runner.Resume(context.Background(), stale)
+	assertProtocolCode(t, err, ErrorCheckpointUnavailable)
+
+	resume := stale
+	resume.RequestID = "resume-first-question"
+	resume.ClarificationID = checkpoint.Clarification.ID
+	resume.Resolution = "the bounded answer"
+	if _, err := runner.Resume(context.Background(), resume); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	waitForPhase(t, runner, started.AttemptID, PhaseNeedsInput)
+	second, err := runner.Inspect(context.Background(), started.AttemptID)
+	if err != nil || second.Clarification == nil || second.Clarification.ID != secondQuestion.ID {
+		t.Fatalf("second checkpoint = %+v, %v", second, err)
+	}
+
+	replayed, err := runner.Resume(context.Background(), resume)
+	if err != nil {
+		t.Fatalf("replay Resume: %v", err)
+	}
+	if replayed.Clarification == nil || replayed.Clarification.ID != secondQuestion.ID {
+		t.Fatalf("replayed receipt = %+v, want second question", replayed)
+	}
+	oldAnswer := resume
+	oldAnswer.RequestID = "resume-old-after-second-question"
+	_, err = runner.Resume(context.Background(), oldAnswer)
+	assertProtocolCode(t, err, ErrorCheckpointUnavailable)
+	if got := adapter.runs.Load(); got != 2 {
+		t.Fatalf("adapter runs = %d, want two (stale resumes must not execute)", got)
+	}
+}
+
+func TestInvalidHarnessClarificationDoesNotBecomeProductQuestion(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, _ harness.Emit) (harness.Result, error) {
+		return harness.Result{
+			Phase:     string(PhaseNeedsInput),
+			SessionID: "session-invalid-clarification",
+			Blocker:   "operator input is required",
+			Clarification: &harness.Clarification{
+				ID:   "contains whitespace",
+				Text: "this must remain an operator blocker",
+			},
+		}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	started, err := runner.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, started.AttemptID, PhaseNeedsInput)
+	got, err := runner.Inspect(context.Background(), started.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if got.Clarification != nil || !strings.Contains(got.Blocker, "operator") {
+		t.Fatalf("invalid clarification became product question: %+v", got)
+	}
+}

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -31,12 +31,13 @@ import (
 )
 
 const (
-	defaultMaxEvents       = 256
-	defaultMaxEventBytes   = 64 << 10
-	defaultMaxBodyBytes    = 2 << 20
-	defaultMaxArtifactSize = 32 << 20
-	gitResultCapability    = "git-result-v1"
-	gitFetchCapability     = "git-fetch-v1"
+	defaultMaxEvents        = 256
+	defaultMaxEventBytes    = 64 << 10
+	defaultMaxBodyBytes     = 2 << 20
+	defaultMaxArtifactSize  = 32 << 20
+	gitResultCapability     = "git-result-v1"
+	gitFetchCapability      = "git-fetch-v1"
+	clarificationCapability = "clarification-v1"
 )
 
 var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)

--- a/pkg/runner/harness/codex/auth_secret_review_test.go
+++ b/pkg/runner/harness/codex/auth_secret_review_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codex
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+func TestAuthFailureEventsExcludeCredentialPayloads(t *testing.T) {
+	const secret = "refresh-token-secret-that-must-not-escape"
+	params := json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","reason":"expired","accessToken":"refresh-token-secret-that-must-not-escape","refreshToken":"refresh-token-secret-that-must-not-escape"}`)
+
+	t.Run("native auth notification", func(t *testing.T) {
+		var event harness.Event
+		state := &runState{emit: func(got harness.Event) error {
+			event = got
+			return nil
+		}}
+		if err := state.handle(wireMessage{Method: "account/chatgptAuthTokens/refresh", Params: params}); err == nil || !needsInput(err) {
+			t.Fatalf("auth notification error = %v, want needs-input", err)
+		}
+		assertAuthEventSafe(t, event, secret)
+	})
+
+	t.Run("auth RPC response", func(t *testing.T) {
+		var event harness.Event
+		result := authResult(&runState{sessionID: "thread-1", turnID: "turn-1"}, &rpcError{
+			Code:    401,
+			Message: "authentication required",
+			Data:    params,
+		}, func(got harness.Event) error {
+			event = got
+			return nil
+		})
+		if result.Phase != "needs_input" {
+			t.Fatalf("auth RPC result = %+v, want needs_input", result)
+		}
+		assertAuthEventSafe(t, event, secret)
+	})
+}
+
+func assertAuthEventSafe(t *testing.T, event harness.Event, secret string) {
+	t.Helper()
+	if event.Type != "auth_failure" {
+		t.Fatalf("auth event type = %q, want auth_failure", event.Type)
+	}
+	if bytes.Contains(event.Data, []byte(secret)) {
+		t.Fatalf("auth event exposed credential payload: %s", event.Data)
+	}
+	var safe map[string]any
+	if err := json.Unmarshal(event.Data, &safe); err != nil {
+		t.Fatalf("auth event data = %q, want bounded safe metadata: %v", event.Data, err)
+	}
+	if safe["reason"] != "expired" {
+		t.Fatalf("auth event lost safe reason metadata: %v", safe)
+	}
+}
+
+func TestAuthFailureEventsRedactNestedCredentialFields(t *testing.T) {
+	secrets := []string{"nested-client-secret", "nested-api-key", "nested-bearer-token"}
+	params := json.RawMessage(`{"reason":"expired","details":{"CLIENT_SECRET":"nested-client-secret","items":[{"api-key":"nested-api-key","Authorization":"nested-bearer-token"}]},"safe":"retain"}`)
+	var event harness.Event
+	state := &runState{emit: func(got harness.Event) error {
+		event = got
+		return nil
+	}}
+	if err := state.handle(wireMessage{Method: "account/chatgptAuthTokens/refresh", Params: params}); err == nil || !needsInput(err) {
+		t.Fatalf("auth notification error = %v, want needs-input", err)
+	}
+	for _, secret := range secrets {
+		if bytes.Contains(event.Data, []byte(secret)) {
+			t.Fatalf("nested auth event exposed %q: %s", secret, event.Data)
+		}
+	}
+	var safe map[string]any
+	if err := json.Unmarshal(event.Data, &safe); err != nil {
+		t.Fatalf("nested auth event data = %q: %v", event.Data, err)
+	}
+	if safe["reason"] != "expired" || safe["safe"] != "retain" {
+		t.Fatalf("safe auth metadata changed: %v", safe)
+	}
+}
+
+func TestTurnCompletedAuthFailureRedactsCredentialFields(t *testing.T) {
+	const secret = "turn-refresh-token-secret"
+	params := json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-1","status":"failed","error":{"message":"authentication required","accessToken":"turn-access-token-secret","refreshToken":"turn-refresh-token-secret"}}}`)
+	var event harness.Event
+	state := &runState{emit: func(got harness.Event) error {
+		event = got
+		return nil
+	}}
+	if err := state.handle(wireMessage{Method: "turn/completed", Params: params}); err != nil {
+		t.Fatalf("turn completion error = %v", err)
+	}
+	if state.phase != "needs_input" || event.Type != "turn_completed" {
+		t.Fatalf("turn auth state phase=%q event=%+v, want needs_input turn_completed", state.phase, event)
+	}
+	if bytes.Contains(event.Data, []byte(secret)) || bytes.Contains(event.Data, []byte("turn-access-token-secret")) {
+		t.Fatalf("turn completion exposed auth credentials: %s", event.Data)
+	}
+	var safe map[string]any
+	if err := json.Unmarshal(event.Data, &safe); err != nil {
+		t.Fatalf("turn completion data = %q: %v", event.Data, err)
+	}
+	turn, ok := safe["turn"].(map[string]any)
+	if !ok || turn["status"] != "failed" {
+		t.Fatalf("turn completion lost safe status metadata: %v", safe)
+	}
+}
+
+func TestAuthFailureEventsMalformedAndOversizedPayloadsStayBounded(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		params json.RawMessage
+		check  func(*testing.T, []byte)
+	}{
+		{
+			name:   "malformed",
+			params: json.RawMessage(`{"reason":"expired"`),
+			check: func(t *testing.T, data []byte) {
+				if string(data) != `{"redacted":true}` {
+					t.Fatalf("malformed auth data = %s, want redacted marker", data)
+				}
+			},
+		},
+		{
+			name:   "oversized",
+			params: json.RawMessage(`{"reason":"expired","token":"` + strings.Repeat("x", maxEventData) + `"}`),
+			check: func(t *testing.T, data []byte) {
+				if !bytes.Contains(data, []byte(`"truncated":true`)) || bytes.Contains(data, []byte(strings.Repeat("x", 32))) {
+					t.Fatalf("oversized auth data = %s, want bounded truncation without payload", data)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var event harness.Event
+			state := &runState{emit: func(got harness.Event) error {
+				event = got
+				return nil
+			}}
+			if err := state.handle(wireMessage{Method: "account/chatgptAuthTokens/refresh", Params: tc.params}); err == nil || !needsInput(err) {
+				t.Fatalf("auth notification error = %v, want needs-input", err)
+			}
+			if event.Type != "auth_failure" {
+				t.Fatalf("auth event type = %q, want auth_failure", event.Type)
+			}
+			tc.check(t, event.Data)
+		})
+	}
+}

--- a/pkg/runner/harness/codex/clarification.go
+++ b/pkg/runner/harness/codex/clarification.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codex
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+const (
+	maxClarificationPayload   = 64 << 10
+	maxClarificationText      = 8 << 10
+	maxClarificationField     = 2 << 10
+	maxClarificationQuestions = 3
+	maxClarificationOptions   = 8
+)
+
+type requestUserInputParams struct {
+	ThreadID         string                     `json:"threadId"`
+	TurnID           string                     `json:"turnId"`
+	ItemID           string                     `json:"itemId"`
+	Questions        []requestUserInputQuestion `json:"questions"`
+	IsBlocking       *bool                      `json:"isBlocking"`
+	AutoResolutionMs *uint64                    `json:"autoResolutionMs"`
+}
+
+type requestUserInputQuestion struct {
+	ID       string                   `json:"id"`
+	Header   string                   `json:"header"`
+	Question string                   `json:"question"`
+	IsOther  bool                     `json:"isOther"`
+	IsSecret bool                     `json:"isSecret"`
+	Options  []requestUserInputOption `json:"options"`
+}
+
+type requestUserInputOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+func parseClarification(sessionID, turnID string, data json.RawMessage) (*harness.Clarification, error) {
+	if len(data) == 0 || len(data) > maxClarificationPayload || !utf8.Valid(data) {
+		return nil, errors.New("request-user-input payload is empty, invalid, or oversized")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var params requestUserInputParams
+	if err := decoder.Decode(&params); err != nil {
+		return nil, errors.New("request-user-input payload is malformed")
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, errors.New("request-user-input payload contains trailing data")
+	}
+	if params.ThreadID == "" || params.TurnID == "" || params.ItemID == "" {
+		return nil, errors.New("request-user-input payload is missing session identity")
+	}
+	if len(params.ThreadID) > maxClarificationField || len(params.TurnID) > maxClarificationField || len(params.ItemID) > maxClarificationField {
+		return nil, errors.New("request-user-input identity is oversized")
+	}
+	if sessionID != "" && params.ThreadID != sessionID {
+		return nil, errors.New("request-user-input payload referenced a foreign session")
+	}
+	if turnID != "" && params.TurnID != turnID {
+		return nil, errors.New("request-user-input payload referenced a foreign turn")
+	}
+	// The installed Codex app-server deserializer defaults an omitted
+	// isBlocking field to true for legacy request payloads. Preserve that
+	// runtime compatibility while rejecting an explicit nonblocking request.
+	if params.IsBlocking != nil && !*params.IsBlocking {
+		return nil, errors.New("nonblocking request-user-input payload is not resumable")
+	}
+	if len(params.Questions) == 0 || len(params.Questions) > maxClarificationQuestions {
+		return nil, errors.New("request-user-input payload has an unsupported question count")
+	}
+
+	var text strings.Builder
+	seenQuestionIDs := make(map[string]struct{}, len(params.Questions))
+	for index, question := range params.Questions {
+		if question.IsSecret {
+			return nil, errors.New("secret request-user-input payload is not a product question")
+		}
+		if !validClarificationText(question.ID) || !validClarificationText(question.Header) || !validClarificationText(question.Question) {
+			return nil, errors.New("request-user-input question is empty, invalid, or oversized")
+		}
+		if _, exists := seenQuestionIDs[question.ID]; exists {
+			return nil, errors.New("request-user-input question IDs are ambiguous")
+		}
+		seenQuestionIDs[question.ID] = struct{}{}
+		if len(question.Options) > maxClarificationOptions {
+			return nil, errors.New("request-user-input option count is oversized")
+		}
+		if index > 0 {
+			text.WriteString("\n\n")
+		}
+		text.WriteString(question.Header)
+		text.WriteString(": ")
+		text.WriteString(question.Question)
+		if len(question.Options) > 0 {
+			text.WriteString("\nOptions:")
+			for _, option := range question.Options {
+				if !validClarificationText(option.Label) || !validClarificationText(option.Description) {
+					return nil, errors.New("request-user-input option is empty, invalid, or oversized")
+				}
+				text.WriteString("\n- ")
+				text.WriteString(option.Label)
+				text.WriteString(": ")
+				text.WriteString(option.Description)
+			}
+		}
+		if text.Len() > maxClarificationText {
+			return nil, errors.New("request-user-input question text is oversized")
+		}
+	}
+
+	return &harness.Clarification{
+		ID:   stableClarificationID(params.ThreadID, params.TurnID, params.ItemID),
+		Text: text.String(),
+	}, nil
+}
+
+func validClarificationText(value string) bool {
+	return value != "" && strings.TrimSpace(value) != "" && len(value) <= maxClarificationField && utf8.ValidString(value)
+}
+
+func stableClarificationID(sessionID, turnID, itemID string) string {
+	digest := sha256.Sum256([]byte(sessionID + "\x00" + turnID + "\x00" + itemID))
+	return "clarification-" + hex.EncodeToString(digest[:])
+}

--- a/pkg/runner/harness/codex/clarification_test.go
+++ b/pkg/runner/harness/codex/clarification_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codex
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseClarificationRejectsSecretMalformedAndOversizedQuestions(t *testing.T) {
+	base := map[string]any{
+		"threadId":   "thread-1",
+		"turnId":     "turn-1",
+		"itemId":     "item-1",
+		"isBlocking": true,
+		"questions": []map[string]any{{
+			"id":       "question-1",
+			"header":   "Choice",
+			"question": "Choose one",
+			"options":  []map[string]string{{"label": "One", "description": "The first choice"}},
+		}},
+	}
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "secret", mutate: func(value map[string]any) {
+			value["questions"].([]map[string]any)[0]["isSecret"] = true
+		}},
+		{name: "empty question", mutate: func(value map[string]any) {
+			value["questions"].([]map[string]any)[0]["question"] = ""
+		}},
+		{name: "ambiguous duplicate IDs", mutate: func(value map[string]any) {
+			value["questions"] = []map[string]any{
+				value["questions"].([]map[string]any)[0],
+				value["questions"].([]map[string]any)[0],
+			}
+		}},
+		{name: "oversized", mutate: func(value map[string]any) {
+			value["questions"].([]map[string]any)[0]["question"] = strings.Repeat("x", maxClarificationField+1)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value := cloneMap(base)
+			test.mutate(value)
+			data, err := json.Marshal(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if clarification, err := parseClarification("thread-1", "turn-1", data); err == nil || clarification != nil {
+				t.Fatalf("parseClarification = %+v, %v; want rejection", clarification, err)
+			}
+		})
+	}
+}
+
+func TestParseClarificationAcceptsCodexNullableFields(t *testing.T) {
+	data, err := json.Marshal(map[string]any{
+		"threadId":         "thread-1",
+		"turnId":           "turn-1",
+		"itemId":           "item-1",
+		"isBlocking":       true,
+		"autoResolutionMs": nil,
+		"questions": []map[string]any{{
+			"id":       "question-1",
+			"header":   "Choice",
+			"question": "Choose one",
+			"options":  nil,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clarification, err := parseClarification("thread-1", "turn-1", data)
+	if err != nil {
+		t.Fatalf("parseClarification: %v", err)
+	}
+	if clarification == nil || clarification.Text != "Choice: Choose one" {
+		t.Fatalf("clarification = %+v", clarification)
+	}
+}
+
+func TestParseClarificationAcceptsCodexLegacyMissingBlockingFlag(t *testing.T) {
+	data, err := json.Marshal(map[string]any{
+		"threadId": "thread-1",
+		"turnId":   "turn-1",
+		"itemId":   "item-1",
+		"questions": []map[string]any{{
+			"id":       "question-1",
+			"header":   "Choice",
+			"question": "Choose one",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clarification, err := parseClarification("thread-1", "turn-1", data)
+	if err != nil {
+		t.Fatalf("parseClarification: %v", err)
+	}
+	if clarification == nil || clarification.Text != "Choice: Choose one" {
+		t.Fatalf("clarification = %+v", clarification)
+	}
+}
+
+func TestRequestUserInputMethodIsExact(t *testing.T) {
+	for _, method := range []string{"item/tool/request_user_input", "tool/requestUserInput", "mcpServer/elicitation/request"} {
+		if isRequestUserInput(method) {
+			t.Fatalf("method %q was accepted as the exact request-user-input interaction", method)
+		}
+	}
+	if !isRequestUserInput("item/tool/requestUserInput") {
+		t.Fatal("Codex request-user-input method was not recognized")
+	}
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	result := make(map[string]any, len(input))
+	for key, value := range input {
+		switch typed := value.(type) {
+		case []map[string]any:
+			copied := make([]map[string]any, len(typed))
+			for index, item := range typed {
+				copied[index] = cloneMap(item)
+			}
+			result[key] = copied
+		default:
+			result[key] = value
+		}
+	}
+	return result
+}

--- a/pkg/runner/harness/codex/codex.go
+++ b/pkg/runner/harness/codex/codex.go
@@ -530,6 +530,7 @@ func (a *Adapter) startServer(ctx context.Context, workdir string) (*serverProce
 	// Keep extension execution policy independent of whether Codex has created
 	// its cache directories. Apply it to probes, new sessions, and resumed ones.
 	cmd := exec.Command(a.cfg.Binary, "app-server", "--listen", "stdio://",
+		"--enable", "default_mode_request_user_input",
 		"--disable", "apps", "--disable", "plugins", "--disable", "hooks")
 	cmd.Env = safeEnv(a.cfg.Home)
 	if workdir != "" {
@@ -714,9 +715,10 @@ func hasID(id json.RawMessage) bool {
 }
 
 type needsInputError struct {
-	method  string
-	data    json.RawMessage
-	message string
+	method        string
+	data          json.RawMessage
+	message       string
+	clarification *harness.Clarification
 }
 
 func (e *needsInputError) Error() string {
@@ -744,7 +746,35 @@ func (s *runState) handle(msg wireMessage) error {
 	if msg.Method == "" {
 		return nil
 	}
-	if isInteractiveRequest(msg.Method) {
+	if isRequestUserInput(msg.Method) {
+		clarification, clarificationErr := parseClarification(s.sessionID, s.turnID, msg.Params)
+		if clarificationErr != nil {
+			const message = "Codex request-user-input payload was rejected as an unbounded or malformed product question"
+			if err := s.emitEvent(harness.Event{
+				Type:      "needs_input",
+				SessionID: s.sessionID,
+				TurnID:    turnIDFromParams(msg.Params, s.turnID),
+				Message:   message,
+			}); err != nil {
+				return err
+			}
+			return &needsInputError{method: msg.Method, message: message}
+		}
+		if err := s.observeSessionID(threadIDFromParams(msg.Params)); err != nil {
+			return err
+		}
+		if err := s.emitEvent(harness.Event{
+			Type:          msg.Method,
+			SessionID:     s.sessionID,
+			TurnID:        turnIDFromParams(msg.Params, s.turnID),
+			Message:       clarification.Text,
+			Clarification: clarification,
+		}); err != nil {
+			return err
+		}
+		return &needsInputError{method: msg.Method, message: "Codex requires user input", clarification: clarification}
+	}
+	if isApprovalRequest(msg.Method) {
 		if err := s.observeSessionID(threadIDFromParams(msg.Params)); err != nil {
 			return err
 		}
@@ -768,11 +798,11 @@ func (s *runState) handle(msg wireMessage) error {
 			SessionID: s.sessionID,
 			TurnID:    turnIDFromParams(msg.Params, s.turnID),
 			Message:   "Codex authentication requires user input",
-			Data:      boundedData(msg.Params),
+			Data:      authEventData(msg.Params),
 		}); err != nil {
 			return err
 		}
-		return &needsInputError{method: msg.Method, data: boundedData(msg.Params), message: "Codex authentication requires user input"}
+		return &needsInputError{method: msg.Method, data: authEventData(msg.Params), message: "Codex authentication requires user input"}
 	}
 
 	switch msg.Method {
@@ -826,11 +856,11 @@ func (s *runState) handle(msg wireMessage) error {
 				SessionID: s.sessionID,
 				TurnID:    turnIDFromParams(msg.Params, s.turnID),
 				Message:   "Codex authentication requires user input",
-				Data:      boundedData(msg.Params),
+				Data:      authEventData(msg.Params),
 			}); err != nil {
 				return err
 			}
-			return &needsInputError{method: msg.Method, data: boundedData(msg.Params), message: "Codex authentication requires user input"}
+			return &needsInputError{method: msg.Method, data: authEventData(msg.Params), message: "Codex authentication requires user input"}
 		}
 		if err := s.emitEvent(harness.Event{
 			Type:      msg.Method,
@@ -860,22 +890,27 @@ func (s *runState) handle(msg wireMessage) error {
 			s.turnID = params.Turn.ID
 		}
 		s.phase = "completed"
+		authTurnError := authData(params.Turn.Error)
 		if params.Turn.Status == "failed" || len(bytes.TrimSpace(params.Turn.Error)) > 0 && !bytes.Equal(bytes.TrimSpace(params.Turn.Error), []byte("null")) {
 			s.phase = "failed"
 			s.blocker = "Codex turn failed"
-			if authData(params.Turn.Error) {
+			if authTurnError {
 				s.phase = "needs_input"
 				s.blocker = "Codex authentication requires user input"
 			}
 		} else if params.Turn.Status == "interrupted" {
 			s.phase = "cancelled"
 		}
+		data := boundedData(msg.Params)
+		if authTurnError {
+			data = authEventData(msg.Params)
+		}
 		if err := s.emitEvent(harness.Event{
 			Type:      "turn_completed",
 			SessionID: s.sessionID,
 			TurnID:    s.turnID,
 			Message:   s.phase,
-			Data:      boundedData(msg.Params),
+			Data:      data,
 		}); err != nil {
 			return err
 		}
@@ -937,9 +972,16 @@ func needsInputResult(state *runState, err error) harness.Result {
 	result := state.result()
 	result.Phase = "needs_input"
 	var target *needsInputError
-	if errors.As(err, &target) && target.message != "" {
-		result.Blocker = target.message
-	} else {
+	if errors.As(err, &target) {
+		if target.message != "" {
+			result.Blocker = target.message
+		}
+		if target.clarification != nil {
+			clarification := *target.clarification
+			result.Clarification = &clarification
+		}
+	}
+	if result.Blocker == "" {
 		result.Blocker = "Codex requires user input"
 	}
 	return result
@@ -949,7 +991,7 @@ func authResult(state *runState, err error, emit harness.Emit) harness.Result {
 	data := json.RawMessage(nil)
 	var target *rpcError
 	if errors.As(err, &target) {
-		data = boundedData(target.Data)
+		data = authEventData(target.Data)
 	}
 	if emit != nil {
 		_ = emit(harness.Event{
@@ -981,8 +1023,19 @@ func missingSessionResult(state *runState, err error, emit harness.Emit) harness
 }
 
 func isInteractiveRequest(method string) bool {
+	return isApprovalRequest(method) || isRequestUserInput(method)
+}
+
+func isRequestUserInput(method string) bool {
+	// This exact app-server method is the only interaction that represents a
+	// product question. Approval, auth, MCP elicitation, and compatibility
+	// aliases remain operator blockers and never become clarifications.
+	return method == "item/tool/requestUserInput"
+}
+
+func isApprovalRequest(method string) bool {
 	method = strings.ToLower(method)
-	return strings.Contains(method, "requestapproval") || strings.Contains(method, "requestuserinput") || strings.Contains(method, "request_user_input") || strings.Contains(method, "approval")
+	return strings.Contains(method, "requestapproval") || strings.Contains(method, "approval")
 }
 
 func isAuthNotification(method string) bool {
@@ -1034,6 +1087,66 @@ func boundedData(data json.RawMessage) json.RawMessage {
 		return append(json.RawMessage(nil), data...)
 	}
 	return json.RawMessage(fmt.Sprintf(`{"truncated":true,"bytes":%d}`, len(data)))
+}
+
+func authEventData(data json.RawMessage) json.RawMessage {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+	if len(data) > maxEventData {
+		return boundedData(data)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	var payload map[string]any
+	if err := decoder.Decode(&payload); err != nil || payload == nil {
+		return json.RawMessage(`{"redacted":true}`)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return json.RawMessage(`{"redacted":true}`)
+	}
+
+	for key, value := range payload {
+		if sensitiveAuthField(key) {
+			delete(payload, key)
+			continue
+		}
+		payload[key] = redactAuthValue(value)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return json.RawMessage(`{"redacted":true}`)
+	}
+	return boundedData(encoded)
+}
+
+func redactAuthValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			if sensitiveAuthField(key) {
+				delete(typed, key)
+				continue
+			}
+			typed[key] = redactAuthValue(nested)
+		}
+	case []any:
+		for index, nested := range typed {
+			typed[index] = redactAuthValue(nested)
+		}
+	}
+	return value
+}
+
+func sensitiveAuthField(key string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(key, "_", ""), "-", ""))
+	return strings.Contains(normalized, "token") ||
+		strings.Contains(normalized, "secret") ||
+		strings.Contains(normalized, "apikey") ||
+		strings.Contains(normalized, "authorization") ||
+		strings.Contains(normalized, "password") ||
+		strings.Contains(normalized, "credential")
 }
 
 func threadID(data json.RawMessage) string {

--- a/pkg/runner/harness/codex/codex_test.go
+++ b/pkg/runner/harness/codex/codex_test.go
@@ -55,6 +55,22 @@ func TestProbeUsesVersionAndAccountReadWithoutModelCall(t *testing.T) {
 	}
 }
 
+func TestProbeMarksConfiguredVersionMismatchNotReady(t *testing.T) {
+	binary := fakeCodexBinary(t, "probe")
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.153.4"})
+
+	info, err := adapter.Probe(context.Background())
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if info.Ready || len(info.Reasons) == 0 {
+		t.Fatalf("version mismatch reported ready: %+v", info)
+	}
+	if !strings.Contains(strings.Join(info.Reasons, " "), "expected Codex 0.153.4") {
+		t.Fatalf("version mismatch reason = %v", info.Reasons)
+	}
+}
+
 func TestProbeAccountReadAuthenticationState(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -168,6 +184,44 @@ func TestRunLifecycleStartsSessionBeforeTurnAndSanitizesEnvironment(t *testing.T
 	}
 }
 
+func TestRunEnablesDefaultModeRequestUserInputForStartAndResume(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		sessionID string
+	}{
+		{name: "start"},
+		{name: "resume", sessionID: "thread-existing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			binary := fakeCodexBinary(t, "success")
+			adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+			result, err := adapter.Run(context.Background(), harness.Launch{
+				Workdir:      t.TempDir(),
+				SessionID:    tc.sessionID,
+				Instructions: "continue the approved work",
+			}, nil)
+			if err != nil || result.Phase != "completed" {
+				t.Fatalf("Run = %+v, %v", result, err)
+			}
+			raw, readErr := os.ReadFile(filepath.Join(filepath.Dir(binary), "argv"))
+			if readErr != nil {
+				t.Fatalf("read app-server args: %v", readErr)
+			}
+			args := strings.Split(strings.TrimSpace(string(raw)), "\n")
+			found := false
+			for index := 0; index+1 < len(args); index++ {
+				if args[index] == "--enable" && args[index+1] == "default_mode_request_user_input" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("app-server args = %v, missing default-mode request-user-input enablement", args)
+			}
+		})
+	}
+}
+
 func TestRunResumeMissingThreadNeedsInputWithoutStartingNewThread(t *testing.T) {
 	binary := fakeCodexBinary(t, "missing-resume")
 	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
@@ -206,6 +260,9 @@ func TestRunApprovalRequestNeedsInputWithoutAutoApproval(t *testing.T) {
 	if result.Phase != "needs_input" {
 		t.Fatalf("unexpected result: %+v", result)
 	}
+	if result.Clarification != nil {
+		t.Fatalf("approval result became a product question: %+v", result.Clarification)
+	}
 	if len(events) != 2 || events[1].Type != "item/commandExecution/requestApproval" {
 		t.Fatalf("approval events = %+v", events)
 	}
@@ -239,12 +296,43 @@ func TestRunAuthRequestNeedsInputWithoutAnswering(t *testing.T) {
 	if result.Phase != "needs_input" {
 		t.Fatalf("unexpected result: %+v", result)
 	}
+	if result.Clarification != nil {
+		t.Fatalf("auth result became a product question: %+v", result.Clarification)
+	}
 	if len(events) != 2 || events[1].Type != "auth_failure" {
 		t.Fatalf("auth events = %+v", events)
 	}
 	var params map[string]any
 	if err := json.Unmarshal(events[1].Data, &params); err != nil || params["reason"] != "expired" {
 		t.Fatalf("auth data = %s", events[1].Data)
+	}
+}
+
+func TestRunRequestUserInputProducesBoundedStableClarification(t *testing.T) {
+	binary := fakeCodexBinary(t, "clarification")
+	adapter := New(Config{Binary: binary, Home: t.TempDir(), ExpectedVersion: "0.147.0"})
+	var events []harness.Event
+	result, err := adapter.Run(context.Background(), harness.Launch{
+		Workdir:      t.TempDir(),
+		Instructions: "choose the approved option",
+	}, func(event harness.Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Phase != "needs_input" || result.Clarification == nil {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result.Clarification.ID == "" || !strings.HasPrefix(result.Clarification.ID, "clarification-") {
+		t.Fatalf("clarification ID = %q", result.Clarification.ID)
+	}
+	if !strings.Contains(result.Clarification.Text, "Which environment?") || !strings.Contains(result.Clarification.Text, "Local: Use the local environment") || !strings.Contains(result.Clarification.Text, "Remote: Use the remote environment") {
+		t.Fatalf("clarification text lost question or options: %q", result.Clarification.Text)
+	}
+	if len(events) != 2 || events[1].Clarification == nil || events[1].Clarification.ID != result.Clarification.ID {
+		t.Fatalf("clarification events = %+v", events)
 	}
 }
 
@@ -434,6 +522,22 @@ func TestFakeAppServerProcess(t *testing.T) {
 			case "approval":
 				writeRequest("item/commandExecution/requestApproval", "approval-1", map[string]any{"itemId": "item-1", "threadId": "thread-1", "turnId": "turn-1", "command": "uname"})
 				approvalPending = true
+			case "clarification":
+				writeRequest("item/tool/requestUserInput", "input-1", map[string]any{
+					"itemId":     "item-clarification-1",
+					"threadId":   "thread-1",
+					"turnId":     "turn-1",
+					"isBlocking": true,
+					"questions": []map[string]any{{
+						"id":       "environment",
+						"header":   "Environment",
+						"question": "Which environment?",
+						"options": []map[string]string{
+							{"label": "Local", "description": "Use the local environment"},
+							{"label": "Remote", "description": "Use the remote environment"},
+						},
+					}},
+				})
 			case "auth-request":
 				writeRequest("account/chatgptAuthTokens/refresh", "auth-1", map[string]any{"reason": "expired"})
 			case "cancel":

--- a/pkg/runner/harness/harness.go
+++ b/pkg/runner/harness/harness.go
@@ -41,18 +41,27 @@ type Launch struct {
 
 // Event is a bounded adapter event forwarded to the runner state engine.
 type Event struct {
-	Type      string          `json:"type"`
-	SessionID string          `json:"sessionID,omitempty"`
-	TurnID    string          `json:"turnID,omitempty"`
-	Message   string          `json:"message,omitempty"`
-	Data      json.RawMessage `json:"data,omitempty"`
+	Type          string          `json:"type"`
+	SessionID     string          `json:"sessionID,omitempty"`
+	TurnID        string          `json:"turnID,omitempty"`
+	Message       string          `json:"message,omitempty"`
+	Data          json.RawMessage `json:"data,omitempty"`
+	Clarification *Clarification  `json:"clarification,omitempty"`
+}
+
+// Clarification is a bounded product question that can be answered by a
+// caller before resuming the existing harness session.
+type Clarification struct {
+	ID   string `json:"id"`
+	Text string `json:"text"`
 }
 
 // Result is the terminal state of one adapter launch.
 type Result struct {
-	Phase     string `json:"phase"`
-	SessionID string `json:"sessionID,omitempty"`
-	Blocker   string `json:"blocker,omitempty"`
+	Phase         string         `json:"phase"`
+	SessionID     string         `json:"sessionID,omitempty"`
+	Blocker       string         `json:"blocker,omitempty"`
+	Clarification *Clarification `json:"clarification,omitempty"`
 }
 
 // Emit receives adapter events. Implementations must treat an error as a

--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -178,6 +178,7 @@ type ResumeRequest struct {
 	AttemptID       string          `json:"attemptID"`
 	AttemptEpoch    uint64          `json:"attemptEpoch"`
 	SessionID       string          `json:"sessionID,omitempty"`
+	ClarificationID string          `json:"clarificationID,omitempty"`
 	ApprovedInput   json.RawMessage `json:"approvedInput,omitempty"`
 	Resolution      string          `json:"resolution,omitempty"`
 	Instructions    string          `json:"instructions,omitempty"`
@@ -193,6 +194,14 @@ type Error struct {
 }
 
 func (e *Error) Error() string { return e.Code + ": " + e.Message }
+
+// Clarification is a bounded product question captured from a genuine
+// request-user-input harness interaction. Its ID is stable for one session,
+// turn, and interaction item and must be echoed by a matching resume.
+type Clarification struct {
+	ID   string `json:"id"`
+	Text string `json:"text"`
+}
 
 // Event is an ordered, durable attempt event. Data is bounded by the runner
 // before the event is persisted.
@@ -217,20 +226,21 @@ type Artifact struct {
 
 // Receipt is the durable view of an attempt returned by start and inspect.
 type Receipt struct {
-	ProtocolVersion string     `json:"protocolVersion"`
-	TaskID          string     `json:"taskID"`
-	AttemptID       string     `json:"attemptID"`
-	AttemptEpoch    uint64     `json:"attemptEpoch"`
-	Phase           Phase      `json:"phase"`
-	SessionID       string     `json:"sessionID,omitempty"`
-	Workdir         string     `json:"workdir,omitempty"`
-	Cursor          uint64     `json:"cursor"`
-	Blocker         string     `json:"blocker,omitempty"`
-	Resources       []string   `json:"resources,omitempty"`
-	LastError       *Error     `json:"lastError,omitempty"`
-	Artifacts       []Artifact `json:"artifacts,omitempty"`
-	AcceptedAt      time.Time  `json:"acceptedAt"`
-	UpdatedAt       time.Time  `json:"updatedAt"`
+	ProtocolVersion string         `json:"protocolVersion"`
+	TaskID          string         `json:"taskID"`
+	AttemptID       string         `json:"attemptID"`
+	AttemptEpoch    uint64         `json:"attemptEpoch"`
+	Phase           Phase          `json:"phase"`
+	SessionID       string         `json:"sessionID,omitempty"`
+	Workdir         string         `json:"workdir,omitempty"`
+	Cursor          uint64         `json:"cursor"`
+	Blocker         string         `json:"blocker,omitempty"`
+	Clarification   *Clarification `json:"clarification,omitempty"`
+	Resources       []string       `json:"resources,omitempty"`
+	LastError       *Error         `json:"lastError,omitempty"`
+	Artifacts       []Artifact     `json:"artifacts,omitempty"`
+	AcceptedAt      time.Time      `json:"acceptedAt"`
+	UpdatedAt       time.Time      `json:"updatedAt"`
 }
 
 // ArtifactResponse contains immutable artifact metadata and bytes are served

--- a/pkg/runner/resume_review_test.go
+++ b/pkg/runner/resume_review_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
+)
+
+func TestResumeReplayReturnsNewerTerminalReceipt(t *testing.T) {
+	source, commit := testGitSource(t)
+	question := &harness.Clarification{ID: "clarification-review", Text: "Which bounded change should be made?"}
+	var runs atomic.Int32
+	adapter := &fakeAdapter{run: func(_ context.Context, launch harness.Launch, emit harness.Emit) (harness.Result, error) {
+		if err := emit(harness.Event{Type: EventStarted, SessionID: "session-review"}); err != nil {
+			return harness.Result{}, err
+		}
+		if runs.Add(1) == 1 {
+			return harness.Result{Phase: string(PhaseNeedsInput), SessionID: launch.SessionID, Clarification: question}, nil
+		}
+		return harness.Result{Phase: string(PhaseCompleted), SessionID: launch.SessionID}, nil
+	}}
+	runner := newTestRunner(t, adapter, source, commit)
+	started, err := runner.Start(context.Background(), testStartRequest(commit))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForPhase(t, runner, started.AttemptID, PhaseNeedsInput)
+	checkpoint, err := runner.Inspect(context.Background(), started.AttemptID)
+	if err != nil || checkpoint.Clarification == nil {
+		t.Fatalf("needs-input checkpoint = %+v, error = %v", checkpoint, err)
+	}
+	resume := ResumeRequest{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "resume-review",
+		TaskID:          checkpoint.TaskID,
+		AttemptID:       checkpoint.AttemptID,
+		AttemptEpoch:    checkpoint.AttemptEpoch,
+		SessionID:       checkpoint.SessionID,
+		ClarificationID: checkpoint.Clarification.ID,
+		Resolution:      "the approved bounded answer",
+	}
+	accepted, err := runner.Resume(context.Background(), resume)
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	waitForPhase(t, runner, accepted.AttemptID, PhaseCompleted)
+	current, err := runner.Inspect(context.Background(), accepted.AttemptID)
+	if err != nil {
+		t.Fatalf("Inspect completed receipt: %v", err)
+	}
+	replayed, err := runner.Resume(context.Background(), resume)
+	if err != nil {
+		t.Fatalf("replayed Resume: %v", err)
+	}
+	if replayed.Phase != PhaseCompleted || replayed.Cursor != current.Cursor || replayed.UpdatedAt != current.UpdatedAt {
+		t.Fatalf("replayed receipt = %+v, current = %+v; replay must return the newer terminal receipt", replayed, current)
+	}
+	if replayed.Clarification != nil {
+		t.Fatalf("replayed terminal receipt retained clarification: %+v", replayed.Clarification)
+	}
+	if got := runs.Load(); got != 2 {
+		t.Fatalf("resume replay launched adapter %d times, want two total", got)
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/faroshq/faros/pkg/runner/harness"
 )
@@ -152,6 +153,7 @@ func New(cfg Config, adapter harness.Adapter) (*Runner, error) {
 	}
 	verificationCapabilities := append([]string(nil), cfg.Verification...)
 	verificationCapabilities = appendUnique(verificationCapabilities, gitResultCapability)
+	verificationCapabilities = appendUnique(verificationCapabilities, clarificationCapability)
 	if hasFetchRemote(cfg.Repositories) {
 		verificationCapabilities = appendUnique(verificationCapabilities, gitFetchCapability)
 	}
@@ -481,6 +483,18 @@ func (r *Runner) Resume(ctx context.Context, request ResumeRequest) (Receipt, er
 	if request.SessionID == "" || request.SessionID != attempt.Receipt.SessionID {
 		return Receipt{}, protocolError(ErrorCheckpointUnavailable, false, "resume session does not match the attempt", &attempt.Receipt)
 	}
+	if request.ClarificationID != "" {
+		if !validClarificationID(request.ClarificationID) {
+			return Receipt{}, protocolError(ErrorInvalidRequest, false, "clarificationID is invalid", &attempt.Receipt)
+		}
+	}
+	if outstanding := attempt.Receipt.Clarification; outstanding != nil {
+		if request.ClarificationID == "" || request.ClarificationID != outstanding.ID {
+			return Receipt{}, protocolError(ErrorCheckpointUnavailable, false, "resume clarification does not match the outstanding question", &attempt.Receipt)
+		}
+	} else if request.ClarificationID != "" {
+		return Receipt{}, protocolError(ErrorCheckpointUnavailable, false, "attempt has no outstanding clarification", &attempt.Receipt)
+	}
 	if len(request.ApprovedInput) > 0 && !equivalentJSON(request.ApprovedInput, attempt.Start.ApprovedInput) {
 		return Receipt{}, protocolError(ErrorForbidden, false, "resume cannot amend approved input", &attempt.Receipt)
 	}
@@ -506,6 +520,7 @@ func (r *Runner) Resume(ctx context.Context, request ResumeRequest) (Receipt, er
 	attempt.CancelPending = false
 	attempt.Receipt.Phase = PhaseAccepted
 	attempt.Receipt.Blocker = ""
+	attempt.Receipt.Clarification = nil
 	attempt.Receipt.LastError = nil
 	attempt.Receipt.UpdatedAt = eventNow()
 	if _, err := r.appendEventLocked(request.AttemptID, EventAccepted, "resume accepted", nil); err != nil {
@@ -706,6 +721,15 @@ func (r *Runner) execute(ctx context.Context, launch harness.Launch, attemptID s
 		r.mu.Unlock()
 		return
 	}
+	if result.Clarification != nil {
+		if Phase(result.Phase) != PhaseNeedsInput || !validHarnessClarification(result.Clarification) {
+			// A clarification is meaningful only as the result of a genuine
+			// needs-input interaction. Invalid or misplaced adapter data must not
+			// turn an auth, approval, error, or terminal blocker into a product
+			// question.
+			result.Clarification = nil
+		}
+	}
 	if attempt.LimitExceeded || errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		blocker := attempt.Receipt.Blocker
 		if blocker == "" && errors.Is(ctx.Err(), context.DeadlineExceeded) {
@@ -812,6 +836,9 @@ func (r *Runner) execute(ctx context.Context, launch harness.Launch, attemptID s
 	case PhaseNeedsInput:
 		delete(r.running, attemptID)
 		delete(r.shutdown, attemptID)
+		if result.Clarification != nil {
+			attempt.Receipt.Clarification = clarificationFromHarness(result.Clarification)
+		}
 		r.finishLocked(attempt, PhaseNeedsInput, result.Blocker, nil)
 		r.mu.Unlock()
 	case PhaseFailed:
@@ -904,6 +931,9 @@ func (r *Runner) handleHarnessEvent(attemptID string, event harness.Event) error
 		if err := r.recordArtifactLocked(attempt, event.Data); err != nil {
 			return fail(err)
 		}
+	}
+	if event.Clarification != nil && isClarificationEvent(event.Type) && validHarnessClarification(event.Clarification) {
+		attempt.Receipt.Clarification = clarificationFromHarness(event.Clarification)
 	}
 	if err := r.persistLocked(); err != nil {
 		return fail(err)
@@ -1052,6 +1082,9 @@ func (r *Runner) finishLocked(attempt *attemptRecord, phase Phase, blocker strin
 	}
 	attempt.Receipt.Phase = phase
 	attempt.Receipt.Blocker = blocker
+	if phase != PhaseNeedsInput {
+		attempt.Receipt.Clarification = nil
+	}
 	attempt.Receipt.UpdatedAt = eventNow()
 	if lastErr != nil && attempt.Receipt.LastError == nil {
 		attempt.Receipt.LastError = &Error{Code: ErrorUnavailable, Retryable: false, Message: lastErr.Error()}
@@ -1299,11 +1332,42 @@ func cloneStartRequest(request StartRequest) StartRequest {
 func receiptForResponse(receipt Receipt) Receipt {
 	receipt.Artifacts = append([]Artifact(nil), receipt.Artifacts...)
 	receipt.Resources = append([]string(nil), receipt.Resources...)
+	receipt.Clarification = cloneClarification(receipt.Clarification)
 	if receipt.LastError != nil {
 		lastErr := *receipt.LastError
 		receipt.LastError = &lastErr
 	}
 	return receipt
+}
+
+func cloneClarification(value *Clarification) *Clarification {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func validHarnessClarification(value *harness.Clarification) bool {
+	if value == nil || !validClarificationID(value.ID) {
+		return false
+	}
+	return utf8.ValidString(value.Text) && strings.TrimSpace(value.Text) != "" && len(value.Text) <= maxMessageBytes
+}
+
+func validClarificationID(value string) bool {
+	return value != "" && value == strings.TrimSpace(value) && len(value) <= maxIdentifierBytes && utf8.ValidString(value) && !strings.ContainsAny(value, " \t\r\n")
+}
+
+func isClarificationEvent(eventType string) bool {
+	return eventType == EventNeedsInput || eventType == "item/tool/requestUserInput"
+}
+
+func clarificationFromHarness(value *harness.Clarification) *Clarification {
+	if value == nil {
+		return nil
+	}
+	return &Clarification{ID: value.ID, Text: value.Text}
 }
 
 func boundedMessage(value string) string {

--- a/providers/linear/apis/v1alpha1/types.go
+++ b/providers/linear/apis/v1alpha1/types.go
@@ -72,10 +72,11 @@ type ConnectionList struct {
 type OperationSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	Connection string `json:"connection"`
-	// +kubebuilder:validation:Enum=teams;states;issues;issue;comments;createIssue;updateIssue;addComment;reconcile
-	Action  string `json:"action"`
-	TeamID  string `json:"teamID,omitempty"`
-	IssueID string `json:"issueID,omitempty"`
+	// +kubebuilder:validation:Enum=teams;states;issues;issue;comments;replies;createIssue;updateIssue;addComment;reconcile
+	Action    string `json:"action"`
+	TeamID    string `json:"teamID,omitempty"`
+	IssueID   string `json:"issueID,omitempty"`
+	CommentID string `json:"commentID,omitempty"`
 	// +kubebuilder:validation:MaxLength=1000
 	Query string `json:"query,omitempty"`
 	// +kubebuilder:validation:MaxLength=4096

--- a/providers/linear/config/crds/linear.providers.faros.sh_operations.yaml
+++ b/providers/linear/config/crds/linear.providers.faros.sh_operations.yaml
@@ -54,6 +54,7 @@ spec:
                 - issues
                 - issue
                 - comments
+                - replies
                 - createIssue
                 - updateIssue
                 - addComment
@@ -64,6 +65,8 @@ spec:
                 type: string
               body:
                 maxLength: 16000
+                type: string
+              commentID:
                 type: string
               connection:
                 minLength: 1

--- a/providers/linear/config/kcp/apiexport-linear.providers.faros.sh.yaml
+++ b/providers/linear/config/kcp/apiexport-linear.providers.faros.sh.yaml
@@ -16,7 +16,7 @@ spec:
       crd: {}
   - group: linear.providers.faros.sh
     name: operations
-    schema: v260911-8ec7b4c3.operations.linear.providers.faros.sh
+    schema: v260912-55471e4f.operations.linear.providers.faros.sh
     storage:
       crd: {}
 status: {}

--- a/providers/linear/config/kcp/apiresourceschema-operations.linear.providers.faros.sh.yaml
+++ b/providers/linear/config/kcp/apiresourceschema-operations.linear.providers.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260911-8ec7b4c3.operations.linear.providers.faros.sh
+  name: v260912-55471e4f.operations.linear.providers.faros.sh
 spec:
   group: linear.providers.faros.sh
   names:
@@ -50,6 +50,7 @@ spec:
               - issues
               - issue
               - comments
+              - replies
               - createIssue
               - updateIssue
               - addComment
@@ -60,6 +61,8 @@ spec:
               type: string
             body:
               maxLength: 16000
+              type: string
+            commentID:
               type: string
             connection:
               minLength: 1

--- a/providers/linear/deploy/chart/files/schemas/apiresourceschema-operations.linear.providers.faros.sh.yaml
+++ b/providers/linear/deploy/chart/files/schemas/apiresourceschema-operations.linear.providers.faros.sh.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260911-8ec7b4c3.operations.linear.providers.faros.sh
+  name: v260912-55471e4f.operations.linear.providers.faros.sh
 spec:
   group: linear.providers.faros.sh
   names:
@@ -50,6 +50,7 @@ spec:
               - issues
               - issue
               - comments
+              - replies
               - createIssue
               - updateIssue
               - addComment
@@ -60,6 +61,8 @@ spec:
               type: string
             body:
               maxLength: 16000
+              type: string
+            commentID:
               type: string
             connection:
               minLength: 1

--- a/providers/linear/internal/engine/engine.go
+++ b/providers/linear/internal/engine/engine.go
@@ -241,9 +241,12 @@ func Execute(ctx context.Context, c *linearapi.Client, conn api.Connection, s ap
 		return page, err
 	}
 	team := s.TeamID
-	if s.Action == "issue" || s.Action == "comments" || s.Action == "updateIssue" || s.Action == "addComment" {
+	if s.Action == "issue" || s.Action == "comments" || s.Action == "replies" || s.Action == "updateIssue" || s.Action == "addComment" {
 		if s.IssueID == "" {
 			return nil, errors.New("issueID required")
+		}
+		if s.Action == "replies" && s.CommentID == "" {
+			return nil, errors.New("commentID required")
 		}
 		issue, err := c.Issue(ctx, s.IssueID)
 		if err != nil {
@@ -255,6 +258,15 @@ func Execute(ctx context.Context, c *linearapi.Client, conn api.Connection, s ap
 		}
 		if s.Action == "issue" {
 			return issue, nil
+		}
+		if s.Action == "replies" {
+			parentIssueID, err := c.CommentIssueID(ctx, s.CommentID)
+			if err != nil {
+				return nil, err
+			}
+			if parentIssueID != issue.ID && parentIssueID != s.IssueID {
+				return nil, errors.New("comment is outside the requested issue")
+			}
 		}
 	}
 	if !Allowed(conn, team) {
@@ -296,6 +308,8 @@ func Execute(ctx context.Context, c *linearapi.Client, conn api.Connection, s ap
 		return c.Issues(ctx, team, s.Query, since, s.First, s.After)
 	case "comments":
 		return c.Comments(ctx, s.IssueID, s.First, s.After)
+	case "replies":
+		return c.CommentReplies(ctx, s.CommentID, s.First, s.After)
 	case "createIssue", "updateIssue":
 		input := map[string]any{}
 		if s.Title != nil {

--- a/providers/linear/internal/engine/engine_test.go
+++ b/providers/linear/internal/engine/engine_test.go
@@ -113,6 +113,59 @@ func TestIssueAndStatePolicyBeforeMutation(t *testing.T) {
 		t.Fatal("foreign team list was sent")
 	}
 }
+func TestCommentRepliesBindParentToAuthorizedIssue(t *testing.T) {
+	newServer := func(t *testing.T, teamID, parentIssueID string) (*httptest.Server, *int) {
+		t.Helper()
+		calls := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			var request struct {
+				Query string `json:"query"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode request: %v", err)
+				return
+			}
+			switch {
+			case strings.Contains(request.Query, "issue(id:$id)"):
+				_, _ = fmt.Fprintf(w, `{"data":{"issue":{"id":"issue-uuid","identifier":"ENG-1","url":"https://linear.app/acme/issue/ENG-1","team":{"id":%q,"name":"Team","key":"ENG"},"state":{"id":"state","name":"Open"}}}}`, teamID)
+			case strings.Contains(request.Query, "comment(id:$id){issueId}"):
+				_, _ = fmt.Fprintf(w, `{"data":{"comment":{"issueId":%q}}}`, parentIssueID)
+			case strings.Contains(request.Query, "children(first:$first"):
+				_, _ = w.Write([]byte(`{"data":{"comment":{"children":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
+			default:
+				t.Errorf("unexpected query %q", request.Query)
+				http.Error(w, "unexpected query", http.StatusBadRequest)
+			}
+		}))
+		return srv, &calls
+	}
+	connection := api.Connection{Spec: api.ConnectionSpec{Teams: []api.TeamReference{{ID: "allowed"}}}}
+	t.Run("authorized parent", func(t *testing.T) {
+		srv, calls := newServer(t, "allowed", "issue-uuid")
+		defer srv.Close()
+		page, err := Execute(context.Background(), testClient(srv), connection, api.OperationSpec{Action: "replies", IssueID: "ENG-1", CommentID: "comment-1", First: 2, After: "cursor-1"})
+		if err != nil || calls == nil || *calls != 3 {
+			t.Fatalf("Execute() page=%+v calls=%d error=%v", page, *calls, err)
+		}
+	})
+	t.Run("parent mismatch", func(t *testing.T) {
+		srv, calls := newServer(t, "allowed", "other-issue")
+		defer srv.Close()
+		_, err := Execute(context.Background(), testClient(srv), connection, api.OperationSpec{Action: "replies", IssueID: "ENG-1", CommentID: "comment-1"})
+		if err == nil || !strings.Contains(err.Error(), "outside the requested issue") || *calls != 2 {
+			t.Fatalf("error=%v calls=%d, want parent rejection before children", err, *calls)
+		}
+	})
+	t.Run("foreign issue team", func(t *testing.T) {
+		srv, calls := newServer(t, "forbidden", "issue-uuid")
+		defer srv.Close()
+		_, err := Execute(context.Background(), testClient(srv), connection, api.OperationSpec{Action: "replies", IssueID: "ENG-1", CommentID: "comment-1"})
+		if err == nil || !strings.Contains(err.Error(), "outside connection policy") || *calls != 1 {
+			t.Fatalf("error=%v calls=%d, want team policy rejection", err, *calls)
+		}
+	})
+}
 func signature(raw []byte) string {
 	m := hmac.New(sha256.New, []byte("a-long-signing-secret"))
 	_, _ = m.Write(raw)

--- a/providers/linear/internal/linearapi/client.go
+++ b/providers/linear/internal/linearapi/client.go
@@ -124,13 +124,37 @@ type Issue struct {
 	Team        Team   `json:"team"`
 	State       State  `json:"state"`
 }
+type CommentUser struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+}
+type CommentBotActor struct {
+	ID      *string `json:"id"`
+	Type    string  `json:"type"`
+	Name    *string `json:"name"`
+	SubType *string `json:"subType"`
+}
+type CommentExternalUser struct {
+	ID string `json:"id"`
+}
 type Comment struct {
-	ID    string `json:"id"`
-	Body  string `json:"body"`
-	Issue Issue  `json:"issue"`
+	ID           string               `json:"id"`
+	Body         string               `json:"body"`
+	IssueID      *string              `json:"issueId"`
+	ParentID     *string              `json:"parentId"`
+	CreatedAt    string               `json:"createdAt"`
+	UpdatedAt    string               `json:"updatedAt"`
+	EditedAt     *string              `json:"editedAt"`
+	URL          string               `json:"url"`
+	User         *CommentUser         `json:"user"`
+	BotActor     *CommentBotActor     `json:"botActor"`
+	ExternalUser *CommentExternalUser `json:"externalUser"`
+	Issue        Issue                `json:"issue"`
 }
 
 const issueFields = `id identifier title description url updatedAt team { id name key } state { id name }`
+const commentFields = `id body issueId parentId createdAt updatedAt editedAt url user{id name displayName} botActor{id type name subType} externalUser{id}`
 
 func pageVars(first int, after string) map[string]any {
 	if first < 1 || first > 50 {
@@ -197,8 +221,38 @@ func (c *Client) Comments(ctx context.Context, id string, first int, after strin
 	}
 	v := pageVars(first, after)
 	v["id"] = id
-	err := c.query(ctx, `query($id:String!,$first:Int!,$after:String){issue(id:$id){comments(first:$first,after:$after){nodes{id body} pageInfo{hasNextPage endCursor}}}}`, v, false, &d)
+	err := c.query(ctx, `query($id:String!,$first:Int!,$after:String){issue(id:$id){comments(first:$first,after:$after,orderBy:createdAt){nodes{`+commentFields+`} pageInfo{hasNextPage endCursor}}}}`, v, false, &d)
 	return d.Issue.Comments, err
+}
+func (c *Client) CommentIssueID(ctx context.Context, id string) (string, error) {
+	var d struct {
+		Comment *Comment `json:"comment"`
+	}
+	err := c.query(ctx, `query($id:String!){comment(id:$id){issueId}}`, map[string]any{"id": id}, false, &d)
+	if err != nil {
+		return "", err
+	}
+	if d.Comment == nil || d.Comment.IssueID == nil || *d.Comment.IssueID == "" {
+		return "", errors.New("linear comment unavailable")
+	}
+	return *d.Comment.IssueID, nil
+}
+func (c *Client) CommentReplies(ctx context.Context, id string, first int, after string) (Page[Comment], error) {
+	var d struct {
+		Comment *struct {
+			Children Page[Comment] `json:"children"`
+		} `json:"comment"`
+	}
+	v := pageVars(first, after)
+	v["id"] = id
+	err := c.query(ctx, `query($id:String!,$first:Int!,$after:String){comment(id:$id){children(first:$first,after:$after,orderBy:createdAt){nodes{`+commentFields+`} pageInfo{hasNextPage endCursor}}}}`, v, false, &d)
+	if err != nil {
+		return Page[Comment]{}, err
+	}
+	if d.Comment == nil {
+		return Page[Comment]{}, errors.New("linear comment unavailable")
+	}
+	return d.Comment.Children, nil
 }
 func (c *Client) CreateIssue(ctx context.Context, input map[string]any) (Issue, error) {
 	var d struct {
@@ -233,7 +287,7 @@ func (c *Client) AddComment(ctx context.Context, id, body string) (Comment, erro
 			Comment Comment `json:"comment"`
 		} `json:"commentCreate"`
 	}
-	err := c.query(ctx, `mutation($input:CommentCreateInput!){commentCreate(input:$input){success comment{id body}}}`, map[string]any{"input": map[string]any{"issueId": id, "body": body}}, true, &d)
+	err := c.query(ctx, `mutation($input:CommentCreateInput!){commentCreate(input:$input){success comment{`+commentFields+`}}}`, map[string]any{"input": map[string]any{"issueId": id, "body": body}}, true, &d)
 	if err == nil && (!d.Payload.Success || d.Payload.Comment.ID == "") {
 		err = &Error{Status: 200, Uncertain: true}
 	}

--- a/providers/linear/internal/linearapi/client_test.go
+++ b/providers/linear/internal/linearapi/client_test.go
@@ -10,6 +10,7 @@ package linearapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -74,5 +75,149 @@ func TestReadPaginationAndRedirectProtection(t *testing.T) {
 	_, err = c.Teams(context.Background(), 25, "")
 	if err == nil || calls != 2 {
 		t.Fatal("followed redirect")
+	}
+}
+
+func TestCommentsDecodeAttributionAndCreatedOrdering(t *testing.T) {
+	const wantQuery = `query($id:String!,$first:Int!,$after:String){issue(id:$id){comments(first:$first,after:$after,orderBy:createdAt){nodes{id body issueId parentId createdAt updatedAt editedAt url user{id name displayName} botActor{id type name subType} externalUser{id}} pageInfo{hasNextPage endCursor}}}}`
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var request struct {
+			Query     string `json:"query"`
+			Variables struct {
+				ID    string `json:"id"`
+				First int    `json:"first"`
+				After string `json:"after"`
+			} `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if request.Query != wantQuery {
+			t.Errorf("query = %q, want %q", request.Query, wantQuery)
+		}
+		if request.Variables.ID != "issue-1" || request.Variables.First != 2 || request.Variables.After != "cursor-1" {
+			t.Errorf("variables = %+v, want issue-1/2/cursor-1", request.Variables)
+		}
+		_, _ = w.Write([]byte(`{"data":{"issue":{"comments":{"nodes":[{"id":"comment-1","body":"first","issueId":"issue-1","parentId":"comment-0","createdAt":"2026-09-12T10:00:00Z","updatedAt":"2026-09-12T10:01:00Z","editedAt":"2026-09-12T10:02:00Z","url":"https://linear.app/acme/issue/ENG-1#comment-1","user":{"id":"user-1","name":"Ada Lovelace","displayName":"Ada"},"botActor":null,"externalUser":null},{"id":"comment-2","body":"second","issueId":"issue-1","parentId":null,"createdAt":"2026-09-12T10:03:00Z","updatedAt":"2026-09-12T10:03:00Z","editedAt":null,"url":"https://linear.app/acme/issue/ENG-1#comment-2","user":null,"botActor":{"id":null,"type":"workflow","name":null,"subType":null},"externalUser":{"id":"external-1"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-2"}}}}}`))
+	}))
+	defer srv.Close()
+	c := New("key")
+	c.endpoint = srv.URL
+	page, err := c.Comments(context.Background(), "issue-1", 2, "cursor-1")
+	if err != nil {
+		t.Fatalf("Comments() error = %v", err)
+	}
+	if calls != 1 || len(page.Nodes) != 2 || !page.PageInfo.HasNextPage || page.PageInfo.EndCursor != "cursor-2" {
+		t.Fatalf("page = %+v, calls = %d", page, calls)
+	}
+	first := page.Nodes[0]
+	if first.IssueID == nil || *first.IssueID != "issue-1" || first.ParentID == nil || *first.ParentID != "comment-0" || first.EditedAt == nil || *first.EditedAt != "2026-09-12T10:02:00Z" {
+		t.Fatalf("first comment metadata = %+v", first)
+	}
+	if first.User == nil || first.User.ID != "user-1" || first.User.Name != "Ada Lovelace" || first.User.DisplayName != "Ada" || first.BotActor != nil || first.ExternalUser != nil {
+		t.Fatalf("first comment attribution = %+v", first)
+	}
+	second := page.Nodes[1]
+	if second.ParentID != nil || second.EditedAt != nil || second.User != nil || second.BotActor == nil || second.ExternalUser == nil {
+		t.Fatalf("second comment nullable metadata = %+v", second)
+	}
+	if second.BotActor.ID != nil || second.BotActor.Type != "workflow" || second.BotActor.Name != nil || second.BotActor.SubType != nil || second.ExternalUser.ID != "external-1" {
+		t.Fatalf("second comment attribution = %+v", second)
+	}
+	encoded, err := json.Marshal(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"parentId", "editedAt", "user"} {
+		if string(fields[field]) != "null" {
+			t.Errorf("%s = %s, want null", field, fields[field])
+		}
+	}
+}
+
+func TestCommentRepliesValidateParentAndDecodePage(t *testing.T) {
+	const wantParentQuery = `query($id:String!){comment(id:$id){issueId}}`
+	const wantRepliesQuery = `query($id:String!,$first:Int!,$after:String){comment(id:$id){children(first:$first,after:$after,orderBy:createdAt){nodes{id body issueId parentId createdAt updatedAt editedAt url user{id name displayName} botActor{id type name subType} externalUser{id}} pageInfo{hasNextPage endCursor}}}}`
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var request struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		switch request.Query {
+		case wantParentQuery:
+			if request.Variables["id"] != "comment-1" {
+				t.Errorf("parent variables = %+v", request.Variables)
+			}
+			_, _ = w.Write([]byte(`{"data":{"comment":{"issueId":"issue-1"}}}`))
+		case wantRepliesQuery:
+			if request.Variables["id"] != "comment-1" || request.Variables["first"] != float64(2) || request.Variables["after"] != "cursor-1" {
+				t.Errorf("reply variables = %+v", request.Variables)
+			}
+			_, _ = w.Write([]byte(`{"data":{"comment":{"children":{"nodes":[{"id":"reply-1","body":"reply","issueId":"issue-1","parentId":"comment-1","createdAt":"2026-09-12T12:00:00Z","updatedAt":"2026-09-12T12:00:00Z","editedAt":null,"url":"https://linear.app/acme/issue/ENG-1#comment-reply-1","user":null,"botActor":null,"externalUser":null}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-2"}}}}}`))
+		default:
+			t.Errorf("unexpected query %q", request.Query)
+			http.Error(w, "unexpected query", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+	c := New("key")
+	c.endpoint = srv.URL
+	issueID, err := c.CommentIssueID(context.Background(), "comment-1")
+	if err != nil || issueID != "issue-1" {
+		t.Fatalf("CommentIssueID() = %q, error = %v", issueID, err)
+	}
+	page, err := c.CommentReplies(context.Background(), "comment-1", 2, "cursor-1")
+	if err != nil || calls != 2 || len(page.Nodes) != 1 || page.Nodes[0].ID != "reply-1" || !page.PageInfo.HasNextPage || page.PageInfo.EndCursor != "cursor-2" {
+		t.Fatalf("CommentReplies() = %+v, calls = %d, error = %v", page, calls, err)
+	}
+}
+
+func TestAddCommentReturnsAttributionMetadata(t *testing.T) {
+	const wantQuery = `mutation($input:CommentCreateInput!){commentCreate(input:$input){success comment{id body issueId parentId createdAt updatedAt editedAt url user{id name displayName} botActor{id type name subType} externalUser{id}}}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Query     string `json:"query"`
+			Variables struct {
+				Input struct {
+					IssueID string `json:"issueId"`
+					Body    string `json:"body"`
+				} `json:"input"`
+			} `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if request.Query != wantQuery {
+			t.Errorf("query = %q, want %q", request.Query, wantQuery)
+		}
+		if request.Variables.Input.IssueID != "issue-1" || request.Variables.Input.Body != "created" {
+			t.Errorf("input = %+v, want issue-1/created", request.Variables.Input)
+		}
+		_, _ = w.Write([]byte(`{"data":{"commentCreate":{"success":true,"comment":{"id":"comment-created","body":"created","issueId":"issue-1","parentId":null,"createdAt":"2026-09-12T11:00:00Z","updatedAt":"2026-09-12T11:00:00Z","editedAt":null,"url":"https://linear.app/acme/issue/ENG-1#comment-created","user":{"id":"user-1","name":"Ada Lovelace","displayName":"Ada"},"botActor":null,"externalUser":null}}}}`))
+	}))
+	defer srv.Close()
+	c := New("key")
+	c.endpoint = srv.URL
+	comment, err := c.AddComment(context.Background(), "issue-1", "created")
+	if err != nil {
+		t.Fatalf("AddComment() error = %v", err)
+	}
+	if comment.ID != "comment-created" || comment.Body != "created" || comment.IssueID == nil || *comment.IssueID != "issue-1" || comment.EditedAt != nil {
+		t.Fatalf("comment = %+v", comment)
+	}
+	if comment.User == nil || comment.User.DisplayName != "Ada" || comment.BotActor != nil || comment.ExternalUser != nil {
+		t.Fatalf("comment attribution = %+v", comment)
 	}
 }


### PR DESCRIPTION
Coding workers can now persist a bounded product clarification and resume the same execution with an answer tied to the outstanding question ID. The Codex adapter enables native user-input requests in normal coding mode, preserves restart/replay fencing, and redacts credential fields from authentication events.

The Linear provider exposes attributable comment metadata and a paginated `replies` operation backed by native comment children. Reply reads validate the parent comment's issue and the Connection's allowed team. Provider-specific scheduling and answer policy remain outside these reusable APIs.

Validation: runner tests and lint; full Linear provider race tests and lint; canonical Linear code generation; Darwin arm64 and amd64 runner builds. Regression coverage includes question identity, replay, authentication payload redaction, and reply authorization/pagination.

Live Mac-to-Linear question/answer acceptance remains pending. This PR does not enable automatic task execution or merge policy.
