### PR TITLE
[AUTOMATED BOT PR] hub: org admins are implicit admins in every child workspace (O-15)

### DIFF
--- a/pkg/hub/restapi/workspaces.go
+++ b/pkg/hub/restapi/workspaces.go
@@ -57,11 +57,13 @@ func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request) {
 	}
 	orgUUID := mux.Vars(r)["org"]
 
-	// Org admins: list every child workspace. Their per-workspace role
-	// still comes from their own UMI rows — the middleware matches exact
-	// (org, ws) rows, so an org admin manages only workspaces they hold a
-	// workspace-admin row in, and the projected role must say so rather
-	// than let the portal render controls that 403.
+	// Org admins: list every child workspace. An org admin is implicitly
+	// admin in every child workspace (docs/organizations.md O-15, enforced
+	// by the tenant middleware's org-admin fallback), so a workspace the
+	// admin holds no row in is projected as admin rather than as "no
+	// role" — the portal keys its member-management controls on this
+	// field, and those controls now succeed. An explicit workspace row
+	// still wins when present (an org admin can hold a member row).
 	if tc.Role == tenancyv1alpha1.MembershipRoleAdmin {
 		roleByWS := map[string]string{}
 		if idx, err := h.mgr.client.UserMembershipIndices().Get(r.Context(), tc.User, metav1.GetOptions{}); err == nil {
@@ -83,6 +85,9 @@ func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			view.Role = roleByWS[wsUUID]
+			if view.Role == "" {
+				view.Role = tenancyv1alpha1.MembershipRoleAdmin
+			}
 			out = append(out, view)
 		}
 		writeJSON(w, http.StatusOK, ListResponse[WorkspaceView]{Items: out})
@@ -223,7 +228,8 @@ func (h *Handler) getWorkspace(w http.ResponseWriter, r *http.Request) {
 		writeStatus(w, http.StatusNotFound, "NotFound", "workspace not found")
 		return
 	}
-	// tc.Role is the middleware's exact (org, ws) row match for this caller.
+	// tc.Role is the middleware's (org, ws) resolution for this caller: the
+	// exact workspace row, or admin via the org-admin fallback.
 	view.Role = tc.Role
 	writeJSON(w, http.StatusOK, view)
 }

--- a/pkg/hub/tenant/context.go
+++ b/pkg/hub/tenant/context.go
@@ -55,9 +55,11 @@ type TenantContext struct {
 
 	// Role is the granted role for the matching Membership: "admin" or
 	// "member". For Workspace-scoped requests this is the role from the
-	// workspace-scope Membership; for Org-scoped requests it is the
-	// role from the org-scope Membership. Validated against
-	// MembershipRole* constants in apis/tenancy/v1alpha1.
+	// workspace-scope Membership, or "admin" when the caller holds no
+	// workspace row but is an admin of the Org (Org admins are implicit
+	// admins in every child Workspace, docs/organizations.md O-15); for
+	// Org-scoped requests it is the role from the org-scope Membership.
+	// Validated against MembershipRole* constants in apis/tenancy/v1alpha1.
 	Role string
 }
 

--- a/pkg/hub/tenant/middleware.go
+++ b/pkg/hub/tenant/middleware.go
@@ -195,7 +195,7 @@ func optionalOrgContext(r *http.Request, userResolver UserResolver, lookup Membe
 		return tc, true
 	}
 	workspaceUUID := r.Header.Get(HeaderFarosWorkspace)
-	role, ok := matchEntry(index, orgUUID, workspaceUUID)
+	role, ok := matchEntryOrOrgAdmin(index, orgUUID, workspaceUUID)
 	if !ok {
 		return tc, true
 	}
@@ -219,7 +219,11 @@ func optionalOrgContext(r *http.Request, userResolver UserResolver, lookup Membe
 //     "not found"; 500 on other errors.
 //  5. Walks index.spec.entries looking for a (OrgUUID, WorkspaceUUID)
 //     match where WorkspaceUUID can be empty (org-scope request) or
-//     equal to the header value (workspace-scope request).
+//     equal to the header value (workspace-scope request). A
+//     workspace-scope request with no workspace row still matches when
+//     the caller holds a live org-scope admin row: an Org admin is
+//     implicitly admin in every child Workspace (docs/organizations.md
+//     O-15). Org members get no such implicit grant.
 //  6. On match, attaches a TenantContext via WithContext and invokes
 //     next; on no match, returns 403.
 //
@@ -320,6 +324,30 @@ func matchEntry(index *tenancyv1alpha1.UserMembershipIndex, orgUUID, workspaceUU
 	return "", false
 }
 
+// matchEntryOrOrgAdmin is matchEntry plus the O-15 rule: an Org admin is
+// implicitly admin in every child Workspace of that Org. A workspace-scope
+// lookup that finds no live workspace row therefore falls back to the
+// caller's live org-scope row, and grants admin only when that row says
+// admin. Org members still need an explicit workspace row (the portal, the
+// kcp proxy authorizer and the provider tenant resolver all describe an
+// org-scope row as "the whole org"; this keeps the REST surface consistent
+// with them without widening the member role). The fallback is deliberately
+// keyed on a live org row: a soft-deleted org grant never reaches a
+// workspace, and a soft-deleted workspace row is irrelevant once the caller
+// is a current Org admin.
+func matchEntryOrOrgAdmin(index *tenancyv1alpha1.UserMembershipIndex, orgUUID, workspaceUUID string) (string, bool) {
+	if role, ok := matchEntry(index, orgUUID, workspaceUUID); ok {
+		return role, true
+	}
+	if workspaceUUID == "" {
+		return "", false
+	}
+	if orgRole, ok := matchEntry(index, orgUUID, ""); ok && orgRole == tenancyv1alpha1.MembershipRoleAdmin {
+		return tenancyv1alpha1.MembershipRoleAdmin, true
+	}
+	return "", false
+}
+
 // matchEntryForRequest applies the normal membership rule and the narrow
 // lifecycle exceptions needed to recover an Org or Workspace after the
 // reconciler has marked its UMI row SoftDeletedAt. The exceptions are
@@ -327,7 +355,7 @@ func matchEntry(index *tenancyv1alpha1.UserMembershipIndex, orgUUID, workspaceUU
 // must never authorize an ordinary Org or Workspace API just because the
 // caller was once an admin there.
 func matchEntryForRequest(r *http.Request, index *tenancyv1alpha1.UserMembershipIndex, orgUUID, workspaceUUID string) (string, bool) {
-	if role, ok := matchEntry(index, orgUUID, workspaceUUID); ok {
+	if role, ok := matchEntryOrOrgAdmin(index, orgUUID, workspaceUUID); ok {
 		return role, true
 	}
 

--- a/pkg/hub/tenant/middleware_test.go
+++ b/pkg/hub/tenant/middleware_test.go
@@ -538,3 +538,163 @@ func assertStatusEnvelope(t *testing.T, rec *httptest.ResponseRecorder, wantReas
 		}
 	}
 }
+
+// An Org admin is implicitly admin in every child Workspace
+// (docs/organizations.md O-15): a workspace-scope request with no
+// workspace row still passes on the live org-scope admin row.
+func TestMiddleware_OrgAdminImplicitWorkspaceAdmin(t *testing.T) {
+	index := fakeIndex("alice", tenancyv1alpha1.MembershipIndexEntry{
+		OrgUUID: "org-uuid",
+		Role:    tenancyv1alpha1.MembershipRoleAdmin,
+	})
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return "alice", nil })
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		return index, nil
+	})
+
+	var got TenantContext
+	reached := make(chan struct{}, 1)
+	h := Middleware(resolver, lookup)(captureNext(&got, reached))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/orgs/org-uuid/workspaces/ws-uuid/memberships", nil)
+	req.Header.Set(HeaderFarosOrg, "org-uuid")
+	req.Header.Set(HeaderFarosWorkspace, "ws-uuid")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	select {
+	case <-reached:
+	default:
+		t.Fatal("next handler was not invoked")
+	}
+	if got.OrgUUID != "org-uuid" || got.WorkspaceUUID != "ws-uuid" || got.Role != tenancyv1alpha1.MembershipRoleAdmin {
+		t.Errorf("TenantContext: got %#v, want org-uuid/ws-uuid/admin", got)
+	}
+}
+
+// An explicit workspace row still wins over the org-admin fallback: an org
+// admin holding a member row in a workspace is a member there.
+func TestMiddleware_OrgAdminExplicitWorkspaceRowWins(t *testing.T) {
+	index := fakeIndex("alice",
+		tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "org-uuid", Role: tenancyv1alpha1.MembershipRoleAdmin},
+		tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "org-uuid", WorkspaceUUID: "ws-uuid", Role: tenancyv1alpha1.MembershipRoleMember},
+	)
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return "alice", nil })
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		return index, nil
+	})
+	var got TenantContext
+	reached := make(chan struct{}, 1)
+	h := Middleware(resolver, lookup)(captureNext(&got, reached))
+	req := httptest.NewRequest(http.MethodGet, "/api/orgs/org-uuid/workspaces/ws-uuid/memberships", nil)
+	req.Header.Set(HeaderFarosOrg, "org-uuid")
+	req.Header.Set(HeaderFarosWorkspace, "ws-uuid")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if got.Role != tenancyv1alpha1.MembershipRoleMember {
+		t.Errorf("Role: got %q, want member (explicit workspace row must win)", got.Role)
+	}
+}
+
+// Org members get no implicit workspace access: without a workspace row the
+// workspace-scope request is still refused.
+func TestMiddleware_OrgMemberNeedsWorkspaceRow(t *testing.T) {
+	index := fakeIndex("bob", tenancyv1alpha1.MembershipIndexEntry{
+		OrgUUID: "org-uuid",
+		Role:    tenancyv1alpha1.MembershipRoleMember,
+	})
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return "bob", nil })
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		return index, nil
+	})
+	nextCalled := false
+	h := Middleware(resolver, lookup)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/orgs/org-uuid/workspaces/ws-uuid/memberships", nil)
+	req.Header.Set(HeaderFarosOrg, "org-uuid")
+	req.Header.Set(HeaderFarosWorkspace, "ws-uuid")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status: got %d, want 403; body: %s", rec.Code, rec.Body.String())
+	}
+	if nextCalled {
+		t.Error("org member reached a workspace handler without a workspace row")
+	}
+	if !strings.Contains(rec.Body.String(), "no membership found") {
+		t.Errorf("body: %s", rec.Body.String())
+	}
+}
+
+// A soft-deleted org-scope admin row is not a live org grant, so it never
+// reaches a child workspace through the fallback.
+func TestMiddleware_SoftDeletedOrgAdminDoesNotReachWorkspace(t *testing.T) {
+	requestedAt := metav1.NewTime(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	index := fakeIndex("alice", tenancyv1alpha1.MembershipIndexEntry{
+		OrgUUID:       "org-uuid",
+		Role:          tenancyv1alpha1.MembershipRoleAdmin,
+		SoftDeletedAt: &requestedAt,
+	})
+	resolver := UserResolverFunc(func(_ *http.Request) (string, error) { return "alice", nil })
+	lookup := MembershipLookupFunc(func(_ context.Context, _ string) (*tenancyv1alpha1.UserMembershipIndex, error) {
+		return index, nil
+	})
+	h := Middleware(resolver, lookup)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("handler reached through a soft-deleted org grant")
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/orgs/org-uuid/workspaces/ws-uuid/memberships", nil)
+	req.Header.Set(HeaderFarosOrg, "org-uuid")
+	req.Header.Set(HeaderFarosWorkspace, "ws-uuid")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status: got %d, want 403; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMatchEntryOrOrgAdmin(t *testing.T) {
+	deleted := metav1.NewTime(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	orgAdmin := tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "org", Role: tenancyv1alpha1.MembershipRoleAdmin}
+	orgMember := tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "org", Role: tenancyv1alpha1.MembershipRoleMember}
+	wsMember := tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "org", WorkspaceUUID: "ws", Role: tenancyv1alpha1.MembershipRoleMember}
+	deletedOrgAdmin := orgAdmin
+	deletedOrgAdmin.SoftDeletedAt = &deleted
+
+	cases := []struct {
+		name     string
+		entries  []tenancyv1alpha1.MembershipIndexEntry
+		org, ws  string
+		wantRole string
+		wantOK   bool
+	}{
+		{"org admin, no ws row, ws request", []tenancyv1alpha1.MembershipIndexEntry{orgAdmin}, "org", "ws", "admin", true},
+		{"org admin, ws member row wins", []tenancyv1alpha1.MembershipIndexEntry{orgAdmin, wsMember}, "org", "ws", "member", true},
+		{"org member, no ws row", []tenancyv1alpha1.MembershipIndexEntry{orgMember}, "org", "ws", "", false},
+		{"org admin, org-scope request unchanged", []tenancyv1alpha1.MembershipIndexEntry{orgAdmin}, "org", "", "admin", true},
+		{"no org row, org-scope request", []tenancyv1alpha1.MembershipIndexEntry{wsMember}, "org", "", "", false},
+		{"soft-deleted org admin", []tenancyv1alpha1.MembershipIndexEntry{deletedOrgAdmin}, "org", "ws", "", false},
+		{"org admin of another org", []tenancyv1alpha1.MembershipIndexEntry{orgAdmin}, "other-org", "ws", "", false},
+		{"nil index", nil, "org", "ws", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var idx *tenancyv1alpha1.UserMembershipIndex
+			if tc.entries != nil {
+				idx = fakeIndex("u", tc.entries...)
+			}
+			role, ok := matchEntryOrOrgAdmin(idx, tc.org, tc.ws)
+			if ok != tc.wantOK || role != tc.wantRole {
+				t.Errorf("got (%q, %v), want (%q, %v)", role, ok, tc.wantRole, tc.wantOK)
+			}
+		})
+	}
+}

--- a/pkg/hub/tenant/optional_middleware_test.go
+++ b/pkg/hub/tenant/optional_middleware_test.go
@@ -178,3 +178,30 @@ func TestOptionalOrgMiddleware_WorkspaceScopeAttaches(t *testing.T) {
 		t.Errorf("context = %+v, want org-1/ws-1", tc)
 	}
 }
+
+// The optional middleware applies the same O-15 rule as Middleware: an org
+// admin keeps the workspace context for a child workspace they hold no row
+// in, while an org member has it dropped.
+func TestOptionalOrgMiddleware_OrgAdminImplicitWorkspace(t *testing.T) {
+	admin := fakeIndex("alice", tenancyv1alpha1.MembershipIndexEntry{
+		OrgUUID: "org-1", Role: tenancyv1alpha1.MembershipRoleAdmin,
+	})
+	_, tc, _ := serveOptional(t, okResolver("alice"), okLookup(admin), map[string]string{
+		HeaderFarosOrg:       "org-1",
+		HeaderFarosWorkspace: "ws-1",
+	})
+	if tc.OrgUUID != "org-1" || tc.WorkspaceUUID != "ws-1" || tc.Role != tenancyv1alpha1.MembershipRoleAdmin {
+		t.Errorf("org admin context = %+v, want org-1/ws-1/admin", tc)
+	}
+
+	member := fakeIndex("bob", tenancyv1alpha1.MembershipIndexEntry{
+		OrgUUID: "org-1", Role: tenancyv1alpha1.MembershipRoleMember,
+	})
+	_, tc, _ = serveOptional(t, okResolver("bob"), okLookup(member), map[string]string{
+		HeaderFarosOrg:       "org-1",
+		HeaderFarosWorkspace: "ws-1",
+	})
+	if tc.OrgUUID != "" || tc.WorkspaceUUID != "" {
+		t.Errorf("org member context = %+v, want no org/workspace", tc)
+	}
+}

--- a/portal/src/stores/tenant.ts
+++ b/portal/src/stores/tenant.ts
@@ -78,10 +78,10 @@ export interface WorkspaceRow {
   // in the sidebar; omitted by the hub until the workspace reports Ready.
   clusterName?: string
   deletionRequestedAt?: string | null
-  // The CALLER's workspace-scope role; absent when they hold no
-  // workspace-scope membership here (possible for org admins, who can
-  // list all workspaces but manage only those they're workspace-admin
-  // in). Gates the workspace-admin controls in tenant settings.
+  // The CALLER's workspace-scope role. Org admins are implicitly admin in
+  // every child workspace, so the hub projects 'admin' for workspaces they
+  // hold no explicit row in; an explicit row (admin or member) wins when
+  // present. Gates the workspace-admin controls in tenant settings.
   role?: 'admin' | 'member'
 }
 

--- a/test/e2e/suites/cli/cli_test.go
+++ b/test/e2e/suites/cli/cli_test.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -281,7 +282,43 @@ func TestMembershipCommands(t *testing.T) {
 	if out := a.run("org", "members", "set-role", bLabel, "admin", "--org", team.UUID); !strings.Contains(out, "already admin") {
 		t.Fatalf("idempotent set-role: %s", out)
 	}
+
+	// An org admin is implicitly admin in every child workspace (O-15). B
+	// holds no Platform row, yet as org admin B sees Platform projected as
+	// admin and can read its roster; the same call is refused again once B
+	// is demoted back to org member.
+	platformURL := hubURL + "/api/orgs/" + team.UUID + "/workspaces/" + platform.UUID
+	platformHeaders := map[string]string{"X-Faros-Org": team.UUID, "X-Faros-Workspace": platform.UUID}
+	if !waitFor(t, time.Minute, func() (bool, string) {
+		code, body, err := framework.DoRESTRequest(context.Background(), "GET", platformURL+"/memberships", tokenB, platformHeaders, nil)
+		if err != nil {
+			return false, err.Error()
+		}
+		return code == 200, fmt.Sprintf("%d %s", code, body)
+	}) {
+		t.Fatal("org admin B could not list Platform members without a workspace row")
+	}
+	var bWss []workspaceRow
+	b.runJSON(&bWss, "workspace", "list", "--org", team.UUID)
+	var bPlatform workspaceRow
+	for _, ws := range bWss {
+		if ws.UUID == platform.UUID {
+			bPlatform = ws
+		}
+	}
+	if bPlatform.UUID == "" || bPlatform.Role != "admin" {
+		t.Fatalf("org admin B's view of Platform = %+v, want role admin", bPlatform)
+	}
 	a.run("org", "members", "set-role", bLabel, "member", "--org", team.UUID)
+	if !waitFor(t, time.Minute, func() (bool, string) {
+		code, body, err := framework.DoRESTRequest(context.Background(), "GET", platformURL+"/memberships", tokenB, platformHeaders, nil)
+		if err != nil {
+			return false, err.Error()
+		}
+		return code == 403, fmt.Sprintf("%d %s", code, body)
+	}) {
+		t.Fatal("org member B still reads Platform members without a workspace row")
+	}
 
 	// Workspace members: add B to Platform, B switches into it.
 	var wsMembers []memberRow


### PR DESCRIPTION
> **This pull request was prepared by an automated coding agent (Claude Code) on behalf of @mjudeikis. Review accordingly.**

## Problem

An org admin added after a workspace was created gets `403 no membership found for user … / Workspace …` on every workspace route: listing members, adding members, even adding themselves. Seen on console-dev with org "Faros" / workspace "default".

The tenant middleware authorized workspace-scoped requests only against an exact (org, workspace) `UserMembershipIndex` row. Only the workspace creator and explicitly added members get such a row. `docs/organizations.md` O-15 promises org admins implicit admin in every child workspace, and the kcp proxy authorizer and the provider tenant resolver already treat an org-scope row as "the whole org". The REST middleware was the odd one out, and the comment in `listWorkspaces` acknowledged the gap.

## Fix

- `matchEntryOrOrgAdmin` in `pkg/hub/tenant/middleware.go`: a workspace-scoped request with no live workspace row falls back to the caller's live org-scope row and grants admin only when that row says admin.
  - Org members get no implicit grant.
  - A soft-deleted org row never qualifies.
  - An explicit workspace row (admin or member) always wins.
- Both `Middleware` and `OptionalOrgMiddleware` use it.
- `listWorkspaces` projects `admin` for workspaces an org admin holds no row in, so the portal's member-management controls render and succeed instead of 403ing. `getWorkspace` follows via the context role.
- Comments updated in the tenant context type, workspace handlers, and the portal `WorkspaceRow` type.

## Tests

- Five new unit tests in `pkg/hub/tenant`: implicit grant, explicit-row precedence, org-member denial, soft-deleted org denial, matcher table test. `go test ./pkg/hub/...`, vet and golangci-lint clean.
- CLI e2e `TestMembershipCommands`: B as org admin lists the Platform roster with no workspace row and sees Platform projected as admin, then is refused again after demotion to member. Not run locally (needs the dev hub environment).

## Not covered here

Org admins still receive no kcp `ClusterRoleBinding` in child workspaces (only creators and added members do), so `kubectl` into such a workspace still needs a workspace row. With this change an org admin can add themselves through the portal or CLI.

Composes with #709, which adds a separate org-role field to the same middleware; a trivial rebase is needed after whichever merges first.
