### PR TITLE
Handle native async clarification and fence unseen runner cancellations

### DIFF
--- a/docs/local-runner.md
+++ b/docs/local-runner.md
@@ -275,13 +275,23 @@ receipt with `Inspect` and replayable server-sent events. Events have ordered
 cursors; a cursor gap or `cursor_expired` response requires inspecting the
 receipt before continuing. Progress is an observation, not proof of completion.
 
-Cancellation has two states. An explicit cancel request first returns
+For an active attempt, an explicit cancel request first returns
 `cancelling`; it is complete only after the harness exits and the receipt or
 event reports `cancelled`. That cancellation remains terminal across process
 shutdown. A graceful shutdown drains active child processes and persists a
 shutdown interruption as `needs_input`, retaining the recorded session and
 worktree for same-session recovery. Adapter failures and approved output or
 duration limits retain failure precedence when shutdown overlaps them.
+
+Runners advertising `cancel-unseen-v1` also accept cancellation for an attempt
+not present in their journal. They persist a terminal cancellation fence before
+returning `cancelled`; the record has no accepted execution, worktree, or session.
+A delayed start for that attempt ID is rejected, including after restart. The
+cancel identity must match the task and epoch on replay; stale or foreign
+identities remain errors. A persistence failure never acknowledges cancellation.
+Operators may use the authenticated cancellation endpoint to retire a dispatched
+request with an unknown outcome. Coordinators must validate the returned identity
+and persist the terminal receipt before releasing their own reservations.
 
 Interactive approval, authentication, a missing Codex session, or another
 operator decision moves an attempt to `needs_input`. Resume requires the same
@@ -296,6 +306,12 @@ A genuine harness `request-user-input` interaction may additionally populate
 turn, and interaction item, preserves the bounded question and options, and
 rejects secret, malformed, empty, or oversized input. Authentication, approval,
 restart, and generic error blockers never acquire a clarification value.
+
+Codex asynchronous questions are recognized from completed `agentMessage`
+items carrying `delivery: "async"` and a structured `questions` array. These
+use the same bounded, session-bound clarification flow as synchronous native
+requests. Ordinary prose and incomplete item notifications do not authorize a
+clarification; malformed structured questions remain operator-held.
 
 `clarification-v1` is advertised in the capabilities response when this
 support is available. A resume for such a receipt must include the same

--- a/pkg/runner/cancel_unseen.go
+++ b/pkg/runner/cancel_unseen.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import "maps"
+
+// cancelUnseenLocked records a cancellation without inventing an execution or
+// worktree. Start's immutable attempt binding rejects every delayed start for
+// this attempt ID. The caller holds r.mu across persistence and publication.
+func (r *Runner) cancelUnseenLocked(request CancelRequest, opKey, fingerprint string) (Receipt, error) {
+	if err := r.checkEpochLocked(request.TaskID, request.AttemptID, request.AttemptEpoch); err != nil {
+		return Receipt{}, err
+	}
+	now := eventNow()
+	receipt := Receipt{
+		ProtocolVersion: ProtocolVersion,
+		TaskID:          request.TaskID,
+		AttemptID:       request.AttemptID,
+		AttemptEpoch:    request.AttemptEpoch,
+		Phase:           PhaseCancelled,
+		UpdatedAt:       now,
+		Cursor:          1,
+		Blocker:         "cancelled while absent from local journal; delayed start fenced",
+	}
+	// Do not expose a terminal receipt in memory until it is durable. In
+	// particular a failed write followed by Inspect or Cancel replay must not
+	// make the coordinator believe cancellation succeeded.
+	next := r.state
+	next.Attempts = maps.Clone(r.state.Attempts)
+	next.Operations = maps.Clone(r.state.Operations)
+	next.Events = maps.Clone(r.state.Events)
+	next.Attempts[request.AttemptID] = &attemptRecord{Receipt: receipt, Fingerprint: fingerprint, CancelPending: true}
+	next.Operations[opKey] = operationRecord{Fingerprint: fingerprint, AttemptID: request.AttemptID}
+	next.Events[request.AttemptID] = []Event{{Cursor: 1, Timestamp: now, AttemptEpoch: request.AttemptEpoch, Type: EventCancelled, Message: receipt.Blocker}}
+	if err := r.store.save(next); err != nil {
+		return Receipt{}, protocolError(ErrorUnavailable, true, "persist cancellation fence: "+err.Error(), nil)
+	}
+	r.state = next
+	return receiptForResponse(receipt), nil
+}

--- a/pkg/runner/cancel_unseen_test.go
+++ b/pkg/runner/cancel_unseen_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCancelUnseenFencesDelayedStartAcrossRestart(t *testing.T) {
+	source, commit := testGitSource(t)
+	adapter := &fakeAdapter{}
+	stateDir := t.TempDir()
+	r := newTestRunnerAt(t, adapter, stateDir, source, commit)
+	start := testStartRequest(commit)
+	cancel := CancelRequest{ProtocolVersion: ProtocolVersion, RequestID: "cancel-before-start", TaskID: start.TaskID, AttemptID: start.AttemptID, AttemptEpoch: start.AttemptEpoch}
+	receipt, err := r.Cancel(context.Background(), cancel)
+	if err != nil || receipt.Phase != PhaseCancelled || receipt.Workdir != "" || receipt.SessionID != "" || !receipt.AcceptedAt.IsZero() {
+		t.Fatalf("cancellation: %+v %v", receipt, err)
+	}
+	for i := 0; i < 2; i++ {
+		replay, err := r.Cancel(context.Background(), cancel)
+		if err != nil || replay.Cursor != receipt.Cursor || replay.Phase != PhaseCancelled {
+			t.Fatalf("replay: %+v %v", replay, err)
+		}
+		if _, err := r.Start(context.Background(), start); err == nil {
+			t.Fatal("delayed start accepted")
+		}
+		if adapter.runs.Load() != 0 || len(r.state.Reservations) != 0 {
+			t.Fatal("cancelled attempt consumed execution resources")
+		}
+		foreign := cancel
+		foreign.TaskID = "another-task"
+		if _, err := r.Cancel(context.Background(), foreign); err == nil {
+			t.Fatal("foreign identity accepted")
+		}
+		foreign = cancel
+		foreign.AttemptEpoch++
+		if _, err := r.Cancel(context.Background(), foreign); err == nil {
+			t.Fatal("changed epoch accepted")
+		}
+		if i == 0 {
+			if err := r.Close(); err != nil {
+				t.Fatal(err)
+			}
+			r = newTestRunnerAt(t, adapter, stateDir, source, commit)
+		}
+	}
+	stale := cancel
+	stale.AttemptID = "different-attempt"
+	stale.RequestID = "stale-cancel"
+	if _, err := r.Cancel(context.Background(), stale); err == nil {
+		t.Fatal("same epoch accepted for different attempt")
+	}
+	inspected, err := r.Inspect(context.Background(), start.AttemptID)
+	if err != nil || inspected.Phase != PhaseCancelled {
+		t.Fatalf("inspect: %+v %v", inspected, err)
+	}
+}
+
+func TestCancelUnseenWriteFailureDoesNotAcknowledge(t *testing.T) {
+	source, commit := testGitSource(t)
+	r := newTestRunner(t, &fakeAdapter{}, source, commit)
+	start := testStartRequest(commit)
+	request := CancelRequest{ProtocolVersion: ProtocolVersion, RequestID: "cancel-write-failure", TaskID: start.TaskID, AttemptID: start.AttemptID, AttemptEpoch: start.AttemptEpoch}
+	original := r.store.path
+	blocked := filepath.Join(t.TempDir(), "directory")
+	if err := os.Mkdir(blocked, 0700); err != nil {
+		t.Fatal(err)
+	}
+	r.store.path = blocked
+	for i := 0; i < 2; i++ {
+		if _, err := r.Cancel(context.Background(), request); err == nil {
+			t.Fatal("failed persistence acknowledged")
+		}
+		if _, err := r.Inspect(context.Background(), start.AttemptID); err == nil {
+			t.Fatal("undurable receipt exposed")
+		}
+		if len(r.state.Operations) != 0 || len(r.state.Attempts) != 0 || len(r.state.Events) != 0 {
+			t.Fatal("failed write leaked journal state")
+		}
+	}
+	r.store.path = original
+	receipt, err := r.Cancel(context.Background(), request)
+	if err != nil || receipt.Phase != PhaseCancelled {
+		t.Fatalf("retry: %+v %v", receipt, err)
+	}
+	if _, err := r.Start(context.Background(), start); err == nil {
+		t.Fatal("start bypassed successful retry")
+	}
+}

--- a/pkg/runner/harness/codex/clarification.go
+++ b/pkg/runner/harness/codex/clarification.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"unicode/utf8"
@@ -148,4 +149,52 @@ func validClarificationText(value string) bool {
 func stableClarificationID(sessionID, turnID, itemID string) string {
 	digest := sha256.Sum256([]byte(sessionID + "\x00" + turnID + "\x00" + itemID))
 	return "clarification-" + hex.EncodeToString(digest[:])
+}
+
+// normalizeAsyncQuestion recognizes Codex's structured asynchronous question
+// notification. Ordinary agent prose is never interpreted as a question.
+// A recognized but invalid item normalizes to an invalid payload, so the common
+// parser holds it as operator input rather than publishing an unsafe question.
+func normalizeAsyncQuestion(data json.RawMessage) (json.RawMessage, bool) {
+	var envelope struct {
+		ThreadID string `json:"threadId"`
+		TurnID   string `json:"turnId"`
+		Item     struct {
+			Type      string          `json:"type"`
+			ID        string          `json:"id"`
+			Delivery  string          `json:"delivery"`
+			Questions json.RawMessage `json:"questions"`
+		} `json:"item"`
+	}
+	if json.Unmarshal(data, &envelope) != nil || envelope.Item.Type != "agentMessage" || envelope.Item.Delivery != "async" || len(envelope.Item.Questions) == 0 || string(envelope.Item.Questions) == "null" {
+		return nil, false
+	}
+	if len(data) > maxClarificationPayload || !utf8.Valid(data) {
+		return nil, true
+	}
+	var questions []struct {
+		Title   string   `json:"title"`
+		Options []string `json:"options"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(envelope.Item.Questions))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&questions) != nil || len(questions) == 0 || len(questions) > maxClarificationQuestions {
+		return nil, true
+	}
+	params := requestUserInputParams{ThreadID: envelope.ThreadID, TurnID: envelope.TurnID, ItemID: envelope.Item.ID}
+	for i, q := range questions {
+		question := requestUserInputQuestion{ID: fmt.Sprintf("question-%d", i+1), Header: "Product question", Question: q.Title}
+		if len(q.Options) > maxClarificationOptions {
+			return nil, true
+		}
+		for _, option := range q.Options {
+			question.Options = append(question.Options, requestUserInputOption{Label: option, Description: option})
+		}
+		params.Questions = append(params.Questions, question)
+	}
+	normalized, err := json.Marshal(params)
+	if err != nil {
+		return nil, true
+	}
+	return normalized, true
 }

--- a/pkg/runner/harness/codex/clarification_test.go
+++ b/pkg/runner/harness/codex/clarification_test.go
@@ -18,8 +18,11 @@ package codex
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/faroshq/faros/pkg/runner/harness"
 )
 
 func TestParseClarificationRejectsSecretMalformedAndOversizedQuestions(t *testing.T) {
@@ -145,4 +148,41 @@ func cloneMap(input map[string]any) map[string]any {
 		}
 	}
 	return result
+}
+
+func TestAsyncNativeQuestionProducesBoundClarification(t *testing.T) {
+	payload := json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","item":{"type":"agentMessage","id":"question-call","phase":"final_answer","delivery":"async","text":"Choose a greeting","questions":[{"title":"Which greeting?","options":null}]},"completedAtMs":123}`)
+	var events []harness.Event
+	state := runState{sessionID: "thread-1", turnID: "turn-1", emit: func(e harness.Event) error { events = append(events, e); return nil }}
+	err := state.handle(wireMessage{Method: "item/completed", Params: payload})
+	var input *needsInputError
+	if !errors.As(err, &input) || input.clarification == nil {
+		t.Fatalf("question not recognized: %v", err)
+	}
+	if input.clarification.ID != stableClarificationID("thread-1", "turn-1", "question-call") || !strings.Contains(input.clarification.Text, "Which greeting?") {
+		t.Fatalf("incorrect clarification: %+v", input.clarification)
+	}
+	if len(events) != 1 || events[0].Clarification == nil {
+		t.Fatalf("missing structured event: %+v", events)
+	}
+	for _, data := range []json.RawMessage{
+		json.RawMessage(strings.Replace(string(payload), `"threadId":"thread-1"`, `"threadId":"foreign"`, 1)),
+		json.RawMessage(strings.Replace(string(payload), `"options":null`, `"options":null,"isSecret":true`, 1)),
+		json.RawMessage(strings.Replace(string(payload), `"Which greeting?"`, `""`, 1)),
+	} {
+		err = state.handle(wireMessage{Method: "item/completed", Params: data})
+		input = nil
+		if !errors.As(err, &input) || input.clarification != nil {
+			t.Fatalf("unsafe question accepted: %v", err)
+		}
+	}
+	for _, data := range []json.RawMessage{
+		json.RawMessage(`{"item":{"type":"agentMessage","text":"Which greeting?","delivery":"async","questions":null}}`),
+		json.RawMessage(strings.Replace(string(payload), `"delivery":"async"`, `"delivery":null`, 1)),
+		json.RawMessage(strings.Replace(string(payload), `"type":"agentMessage"`, `"type":"commandExecution"`, 1)),
+	} {
+		if _, matched := normalizeAsyncQuestion(data); matched {
+			t.Fatal("ordinary output promoted to a question")
+		}
+	}
 }

--- a/pkg/runner/harness/codex/codex.go
+++ b/pkg/runner/harness/codex/codex.go
@@ -746,6 +746,11 @@ func (s *runState) handle(msg wireMessage) error {
 	if msg.Method == "" {
 		return nil
 	}
+	if msg.Method == "item/completed" {
+		if payload, matched := normalizeAsyncQuestion(msg.Params); matched {
+			return s.handle(wireMessage{Method: "item/tool/requestUserInput", Params: payload})
+		}
+	}
 	if isRequestUserInput(msg.Method) {
 		clarification, clarificationErr := parseClarification(s.sessionID, s.turnID, msg.Params)
 		if clarificationErr != nil {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -154,6 +154,7 @@ func New(cfg Config, adapter harness.Adapter) (*Runner, error) {
 	verificationCapabilities := append([]string(nil), cfg.Verification...)
 	verificationCapabilities = appendUnique(verificationCapabilities, gitResultCapability)
 	verificationCapabilities = appendUnique(verificationCapabilities, clarificationCapability)
+	verificationCapabilities = appendUnique(verificationCapabilities, "cancel-unseen-v1")
 	if hasFetchRemote(cfg.Repositories) {
 		verificationCapabilities = appendUnique(verificationCapabilities, gitFetchCapability)
 	}
@@ -393,8 +394,9 @@ func (r *Runner) Inspect(_ context.Context, attemptID string) (Receipt, error) {
 	return receiptForResponse(attempt.Receipt), nil
 }
 
-// Cancel requests adapter cancellation. It returns while the attempt is in
-// cancelling; only adapter exit transitions it to cancelled.
+// Cancel requests adapter cancellation. Active attempts remain cancelling until
+// adapter exit. Unseen attempts receive a durable cancellation fence before
+// acknowledgement, so a delayed Start cannot launch them.
 func (r *Runner) Cancel(_ context.Context, request CancelRequest) (Receipt, error) {
 	if err := validateMutationIdentity(request.TaskID, request.AttemptID, request.AttemptEpoch, request.RequestID); err != nil {
 		return Receipt{}, protocolError(ErrorInvalidRequest, false, err.Error(), nil)
@@ -415,6 +417,9 @@ func (r *Runner) Cancel(_ context.Context, request CancelRequest) (Receipt, erro
 			return Receipt{}, protocolError(ErrorIdempotencyConflict, false, "request ID was already used with different content", &priorReceipt)
 		}
 		return r.receiptForAttemptLocked(prior.AttemptID)
+	}
+	if _, exists := r.state.Attempts[request.AttemptID]; !exists {
+		return r.cancelUnseenLocked(request, opKey, fingerprint)
 	}
 	attempt, err := r.attemptForMutationLocked(request.TaskID, request.AttemptID, request.AttemptEpoch)
 	if err != nil {


### PR DESCRIPTION
Codex can emit a native asynchronous product question as a completed agentMessage carrying structured questions. The runner previously treated that event as progress, leaving the task running while the agent waited for an answer. Recognize that explicit event shape through the existing bounded, session/turn/item-bound clarification parser; ordinary prose remains progress and malformed or foreign questions remain operator-held.

Also add `cancel-unseen-v1`: cancellation of an attempt absent from the runner journal persists a terminal fence before acknowledgement. Delayed starts cannot execute that attempt, including after restart. A failed write exposes neither a successful cancellation nor an Inspect receipt; existing active-attempt cancellation still waits for harness exit.

Validation: runner race tests, pinned formatter/lint (0 issues), and Darwin arm64/amd64 builds passed on current main. Regression cases cover cancellation replay/restart/write failure/identity mismatch and native async question recognition/rejection. Live Mac testing exercised unseen cancellation and same-attempt clarification/resume; the final review only adjusted cancellation receipt wording afterward. No private provider policy, fixture transcripts, or credentials are included.
