### PR TITLE
fix(linear): refresh cached resources and preserve routed scope

### DIFF
--- a/providers/linear/README.md
+++ b/providers/linear/README.md
@@ -152,9 +152,15 @@ The Linear portal uses shared Vue PortalKit resource layouts with Connections,
 Issues, Operations, and Events sections. Connection and issue creation use
 dedicated routes; issue details expose updates and comments. Credentials remain
 Secret references, and pending or uncertain operations link to their detail page
-without replaying writes. Namespace-qualified links use
-`namespaces/<namespace>/<resource-route>` so opening a detail in a new tab retains
-its namespace. On a fresh load, bare provider routes use the default namespace.
+without replaying writes. Canonical collection routes use
+`<collection>/namespaces/<namespace>`; detail routes append `/detail/<name>`, or
+`/detail/<connection>/<id>` for issues. Creation uses
+`connections/namespaces/<namespace>/create` and
+`issues/namespaces/<namespace>/create`. Bare provider routes use the `default`
+namespace, while legacy namespace-first routes such as
+`namespaces/<namespace>/<collection>` remain supported. Returning from an issue
+detail refreshes the cached collection while preserving its selected scope,
+query filter, and current page.
 
 Build with `make build-linear-provider-portal` and verify behavior and types with
 `make test-linear-portal`. The portal still registers `faros-provider-linear` and

--- a/providers/linear/portal/src/Workspace.vue
+++ b/providers/linear/portal/src/Workspace.vue
@@ -2,7 +2,7 @@
 import { computed, onBeforeUnmount, provide, reactive, ref, watch } from 'vue';
 import { Plug, ListTodo, Activity, Radio } from 'lucide-vue-next';
 import type { FarosContext } from './api';
-import type { Route } from './routes';
+import { canonicalPath, type Route } from './routes';
 import { sessionKey } from './state';
 import Tabs from './portalkit/Tabs.vue';
 import ResourceBackLink from './portalkit/ResourceBackLink.vue';
@@ -20,7 +20,7 @@ const namespaceDraft = ref(namespace.value);
 const epoch = ref(0);
 let controller = new AbortController();
 const selection = reactive({ connection: '', team: '', query: '' });
-function scopedPath(path: string) { return `namespaces/${encodeURIComponent(namespace.value)}/${path}`; }
+function scopedPath(path: string) { return canonicalPath(namespace.value, path); }
 function navigate(path: string, replace = false) { root.value?.dispatchEvent(new CustomEvent('faros-navigate', { bubbles: true, detail: { path: scopedPath(path), ...(replace ? { replace: true } : {}) } })); }
 function href(path: string) {
   const current = window.location.pathname;
@@ -31,7 +31,11 @@ watch(namespace, () => {
   controller.abort(); controller = new AbortController(); epoch.value++;
   Object.assign(selection, { connection: '', team: '', query: '' });
 }, { flush: 'sync' });
-watch(() => props.route.namespace, value => { if (value) { namespace.value = value; namespaceDraft.value = value; } });
+watch(() => props.route.namespace, value => {
+  const nextNamespace = value || 'default';
+  if (nextNamespace !== namespace.value) namespace.value = nextNamespace;
+  namespaceDraft.value = nextNamespace;
+}, { flush: 'sync' });
 onBeforeUnmount(() => controller.abort());
 provide(sessionKey, { context: props.context, get namespace() { return namespace.value; }, get signal() { return AbortSignal.any([controller.signal, props.authoritySignal]); }, selection, navigate, href });
 const tabs = [{ id: 'connections', label: 'Connections', icon: Plug }, { id: 'issues', label: 'Issues', icon: ListTodo }, { id: 'operations', label: 'Operations', icon: Activity }, { id: 'events', label: 'Events', icon: Radio }];

--- a/providers/linear/portal/src/components/IssueScope.vue
+++ b/providers/linear/portal/src/components/IssueScope.vue
@@ -20,7 +20,11 @@ watch(() => session.selection.connection, (_, previous) => {
   discover();
 }, { immediate: true, flush: 'sync' });
 onMounted(load);
-onActivated(() => { if (!read.state.loaded) load(); if (!discovery.state.loaded) discover(); });
+onActivated(() => {
+  // Keep the refresh after activation hooks have re-enabled useTask's view
+  // guard. This also covers nested scopes restored by a cached IssuesView.
+  queueMicrotask(() => { load(); if (!discovery.state.loaded) discover(); });
+});
 </script>
 <template>
   <div class="linear-scope">

--- a/providers/linear/portal/src/portal.regression.test.ts
+++ b/providers/linear/portal/src/portal.regression.test.ts
@@ -1,0 +1,359 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import App from './App.vue';
+import type { FarosContext, Resource } from './api';
+import { canonicalPath, issuePath, parseRoute, resourcePath } from './routes';
+
+type Navigation = { path: string; replace: boolean };
+type Operation = { metadata: { name: string }; spec: Record<string, any> };
+
+const wrappers: VueWrapper[] = [];
+
+afterEach(() => {
+  wrappers.splice(0).forEach(wrapper => wrapper.unmount());
+  document.body.innerHTML = '';
+});
+
+const firstIssue = {
+  id: 'issue-1',
+  identifier: 'ENG-1',
+  title: 'Ship resource pages',
+  description: 'Original description',
+  team: { id: 'team', name: 'Engineering' },
+  state: { id: 'todo', name: 'Todo' },
+};
+
+const secondIssue = {
+  id: 'issue-2',
+  identifier: 'ENG-2',
+  title: 'Second resource',
+  description: 'Second description',
+  team: { id: 'team', name: 'Engineering' },
+  state: { id: 'todo', name: 'Todo' },
+};
+
+function connection(name: string): Resource {
+  return {
+    metadata: { name },
+    spec: { apiKeySecretRef: { name: `${name}-key` }, teams: [{ id: 'team' }] },
+    status: { ready: true },
+  };
+}
+
+function fixture(initialConnections: Resource[] = [connection('linear')]) {
+  const calls: { path: string; body?: any }[] = [];
+  const operations = new Map<string, Operation>();
+  let connections = [...initialConnections];
+  let issue = { ...firstIssue };
+  let pageTwoIssue = { ...secondIssue };
+  let issueList = [issue];
+  let failIssueRead = false;
+  let failIssueList = false;
+  let delayMutation = false;
+  let mutationReadStarted = false;
+  let releaseMutationRead: (() => void) | undefined;
+
+  function operationResult(operation: Operation): Record<string, unknown> {
+    const spec = operation.spec;
+    if (spec.action === 'teams') return { nodes: [{ id: 'team', name: 'Engineering', key: 'ENG' }] };
+    if (spec.action === 'states') return { nodes: [{ id: 'todo', name: 'Todo' }, { id: 'done', name: 'Done' }] };
+    if (spec.action === 'issues') {
+      if (failIssueList) return { __httpError: 503 };
+      if (spec.query === 'resource') {
+        return {
+          nodes: [spec.after ? pageTwoIssue : issue],
+          pageInfo: { hasNextPage: !spec.after, endCursor: spec.after ? '' : 'next' },
+        };
+      }
+      return { nodes: issueList, pageInfo: { hasNextPage: false, endCursor: '' } };
+    }
+    if (spec.action === 'issue') return spec.issueID === pageTwoIssue.id ? pageTwoIssue : issue;
+    if (spec.action === 'updateIssue') {
+      const updated = { ...(spec.issueID === pageTwoIssue.id ? pageTwoIssue : issue), ...(spec.title ? { title: spec.title } : {}) };
+      if (spec.issueID === pageTwoIssue.id) pageTwoIssue = updated;
+      else {
+        issue = updated;
+        issueList = issueList.map(candidate => candidate.id === updated.id ? updated : candidate);
+      }
+      return updated;
+    }
+    if (spec.action === 'createIssue') {
+      pageTwoIssue = { ...pageTwoIssue, id: 'issue-2', identifier: 'ENG-2', title: spec.title };
+      issueList = [...issueList, pageTwoIssue];
+      return pageTwoIssue;
+    }
+    if (spec.action === 'comments') return { nodes: [{ id: 'comment', body: 'Reviewed' }] };
+    return {};
+  }
+
+  const ctx: FarosContext = {
+    tenant: 'workspace',
+    user: { sub: 'reviewer' },
+    subPath: '',
+    fetch: async (input, init) => {
+      const path = String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      calls.push({ path, body });
+
+      if (body?.kind === 'Connection') {
+        const created = { ...body, status: { ready: true } } as Resource;
+        connections = [...connections, created];
+        return Response.json(created);
+      }
+      if (body?.kind === 'Operation') {
+        operations.set(body.metadata.name, body as Operation);
+        return Response.json(body);
+      }
+
+      const name = path.split('/').pop()!;
+      if (path.includes('/operations/')) {
+        const operation = operations.get(name)!;
+        const spec = operation.spec;
+        if (spec.action === 'issue' && failIssueRead) {
+          failIssueRead = false;
+          return new Response('', { status: 503 });
+        }
+        if (spec.action === 'issues' && failIssueList) return new Response('', { status: 503 });
+        if (spec.action === 'updateIssue' && delayMutation) {
+          mutationReadStarted = true;
+          return new Promise<Response>(resolve => { releaseMutationRead = () => resolve(Response.json({ ...operation, status: { phase: 'Succeeded', result: operationResult(operation) } })); });
+        }
+        const result = operationResult(operation);
+        if (result.__httpError) return new Response('', { status: Number(result.__httpError) });
+        return Response.json({ ...operation, status: { phase: 'Succeeded', result } });
+      }
+      if (path.includes('/connections?')) return Response.json({ items: connections });
+      if (path.includes('/connections/')) return Response.json(connections.find(item => item.metadata.name === name) || connection(name));
+      return Response.json({ items: [] });
+    },
+  };
+
+  return {
+    ctx,
+    calls,
+    failNextIssueRead: () => { failIssueRead = true; },
+    failIssueList: () => { failIssueList = true; },
+    delayNextMutation: () => { delayMutation = true; },
+    releaseMutation: () => { releaseMutationRead?.(); },
+    get mutationReadStarted() { return mutationReadStarted; },
+  };
+}
+
+async function render(ctx: FarosContext, navigations: Navigation[] = []): Promise<VueWrapper> {
+  const wrapper = mount(App, { props: { ctx }, attachTo: document.body });
+  wrappers.push(wrapper);
+  wrapper.element.addEventListener('faros-navigate', (event: Event) => {
+    const detail = (event as CustomEvent<{ path?: unknown; replace?: unknown }>).detail;
+    if (typeof detail?.path !== 'string') throw new Error('host navigation omitted path');
+    navigations.push({ path: detail.path, replace: detail.replace === true });
+    void wrapper.setProps({ ctx: { ...wrapper.props('ctx'), subPath: detail.path } });
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+async function clickText(wrapper: VueWrapper, text: string): Promise<void> {
+  const target = wrapper.findAll('button, a').find(candidate => candidate.text().trim() === text);
+  expect(target, `control ${text}`).toBeTruthy();
+  await target!.trigger('click');
+  await flushPromises();
+}
+
+async function choose(wrapper: VueWrapper, id: string, label: string): Promise<void> {
+  await wrapper.get(id).trigger('click');
+  await flushPromises();
+  const option = [...document.querySelectorAll('[role="option"]')]
+    .find(element => element.textContent?.includes(label));
+  expect(option, `option ${label}`).toBeTruthy();
+  (option as HTMLElement).click();
+  await flushPromises();
+}
+
+async function searchIssues(wrapper: VueWrapper, query = ''): Promise<void> {
+  if (query) await wrapper.get('#linear-query').setValue(query);
+  await wrapper.get('form.linear-fields').trigger('submit');
+  await flushPromises();
+}
+
+describe('Linear canonical portal regressions', () => {
+  it('parses canonical routes and keeps reserved create/detail names addressable', () => {
+    expect(parseRoute('connections/namespaces/default')).toMatchObject({ page: 'connections', namespace: 'default' });
+    expect(parseRoute('connections/namespaces/default/detail/create')).toMatchObject({ page: 'connections', namespace: 'default', name: 'create' });
+    expect(parseRoute('connections/namespaces/default/detail/detail')).toMatchObject({ page: 'connections', namespace: 'default', name: 'detail' });
+    expect(parseRoute('connections/namespaces/default/detail/namespaces')).toMatchObject({ page: 'connections', namespace: 'default', name: 'namespaces' });
+    expect(parseRoute('issues/namespaces/default/detail/create/detail')).toMatchObject({ page: 'issues', namespace: 'default', connection: 'create', name: 'detail' });
+    expect(parseRoute('issues/namespaces/default/detail/namespaces/issue-1')).toMatchObject({ page: 'issues', namespace: 'default', connection: 'namespaces', name: 'issue-1' });
+    expect(parseRoute('connections/namespaces/default/create')).toMatchObject({ page: 'connections', namespace: 'default', create: 'connection' });
+    expect(parseRoute('issues/namespaces/default/create')).toMatchObject({ page: 'issues', namespace: 'default', create: 'issue' });
+    expect(parseRoute('connections/namespaces')).toMatchObject({ page: 'connections', name: 'namespaces' });
+    // The three-segment form reserves `namespaces/<namespace>` for the
+    // canonical collection route; legacy issue identities use issuePath's
+    // explicit detail marker when the connection is named "namespaces".
+    expect(parseRoute('issues/namespaces/issue-1')).toMatchObject({ page: 'issues', namespace: 'issue-1' });
+    expect(parseRoute('issues/namespaces/eng-1')).toMatchObject({ page: 'issues', namespace: 'eng-1' });
+    expect(parseRoute(issuePath('namespaces', 'issue-1'))).toMatchObject({ page: 'issues', connection: 'namespaces', name: 'issue-1' });
+    expect(parseRoute('namespaces/default/connections')).toMatchObject({ page: 'connections', namespace: 'default' });
+    expect(parseRoute('connections')).toMatchObject({ page: 'connections' });
+    expect(canonicalPath('default', resourcePath('connections', 'namespaces')))
+      .toBe('connections/namespaces/default/detail/namespaces');
+    expect(canonicalPath('default', issuePath('namespaces', 'default')))
+      .toBe('issues/namespaces/default/detail/namespaces/default');
+  });
+
+  it('uses canonical host navigation for create, detail, issue detail, and Back', async () => {
+    const f = fixture();
+    const navigations: Navigation[] = [];
+    const wrapper = await render({ ...f.ctx, subPath: 'connections/namespaces/default' }, navigations);
+
+    await clickText(wrapper, 'Add connection');
+    expect(navigations.at(-1)).toEqual({ path: 'connections/namespaces/default/create', replace: false });
+    await wrapper.get('a.k-back-action').trigger('click');
+    await flushPromises();
+    expect(navigations.at(-1)).toEqual({ path: 'connections/namespaces/default', replace: false });
+
+    await clickText(wrapper, 'linear');
+    expect(navigations.at(-1)).toEqual({ path: 'connections/namespaces/default/detail/linear', replace: false });
+
+    await wrapper.setProps({ ctx: { ...f.ctx, subPath: 'issues/namespaces/default' } });
+    await flushPromises();
+    await choose(wrapper, '#linear-connection', 'linear');
+    await choose(wrapper, '#linear-team', 'Engineering');
+    await searchIssues(wrapper);
+    await clickText(wrapper, 'ENG-1');
+    expect(navigations.at(-1)).toEqual({ path: 'issues/namespaces/default/detail/linear/issue-1', replace: false });
+
+    await wrapper.get('a.k-back-action').trigger('click');
+    await flushPromises();
+    await clickText(wrapper, 'Create issue');
+    expect(navigations.at(-1)).toEqual({ path: 'issues/namespaces/default/create', replace: false });
+  });
+
+  it('refreshes the cached scope after creating a connection and browsing from its detail', async () => {
+    const f = fixture([]);
+    const wrapper = await render({ ...f.ctx, subPath: 'issues/namespaces/default' });
+
+    await clickText(wrapper, 'Add connection');
+    await wrapper.get('#connection-name').setValue('new-connection');
+    await wrapper.get('#connection-secret').setValue('new-secret');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+    await clickText(wrapper, 'Browse issues');
+
+    expect(wrapper.get('#linear-connection').text()).toContain('new-connection');
+    await wrapper.get('#linear-connection').trigger('click');
+    await flushPromises();
+    expect([...document.querySelectorAll('[role="option"]')].map(element => element.textContent?.trim()))
+      .toContain('new-connection');
+  });
+
+  it('refreshes cached issues while preserving the query and page after a detail update', async () => {
+    const f = fixture();
+    const wrapper = await render({ ...f.ctx, subPath: 'issues/namespaces/default' });
+    await choose(wrapper, '#linear-connection', 'linear');
+    await choose(wrapper, '#linear-team', 'Engineering');
+    await searchIssues(wrapper, 'resource');
+    await clickText(wrapper, 'Next');
+    await clickText(wrapper, 'ENG-2');
+    await wrapper.get('#issue-title').setValue('Updated title');
+    const updateForm = wrapper.findAll('form').find(form => form.find('#issue-title').exists());
+    expect(updateForm).toBeTruthy();
+    await updateForm!.trigger('submit');
+    await flushPromises();
+    await wrapper.get('a.k-back-action').trigger('click');
+    await flushPromises();
+
+    expect({
+      query: (wrapper.get('#linear-query').element as HTMLInputElement).value,
+      page: wrapper.text().match(/Page \d+/)?.[0],
+      title: wrapper.text().includes('Updated title'),
+      lastIssueRead: f.calls.filter(call => call.body?.spec?.action === 'issues').at(-1)?.body?.spec,
+    }).toMatchObject({
+      query: 'resource',
+      page: 'Page 2',
+      title: true,
+      lastIssueRead: expect.objectContaining({ after: 'next', query: 'resource' }),
+    });
+  });
+
+  it('refreshes cached issues after creation before returning from the new detail', async () => {
+    const f = fixture();
+    const wrapper = await render({ ...f.ctx, subPath: 'issues/namespaces/default' });
+    await choose(wrapper, '#linear-connection', 'linear');
+    await choose(wrapper, '#linear-team', 'Engineering');
+    await searchIssues(wrapper);
+    await clickText(wrapper, 'Create issue');
+    await wrapper.get('#issue-title').setValue('New issue');
+    await wrapper.get('form').trigger('submit');
+    await flushPromises();
+    await wrapper.get('a.k-back-action').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('ENG-2');
+    expect(wrapper.text()).toContain('New issue');
+  });
+
+  it('restores the default namespace and scope when host history returns to bare connections', async () => {
+    const f = fixture();
+    const navigations: Navigation[] = [];
+    const wrapper = await render({ ...f.ctx, subPath: 'connections' }, navigations);
+    expect((wrapper.get('#linear-namespace').element as HTMLInputElement).value).toBe('default');
+
+    await clickText(wrapper, 'Issues');
+    expect(navigations.at(-1)).toEqual({ path: 'issues/namespaces/default', replace: false });
+    await wrapper.get('#linear-namespace').setValue('team-a');
+    await wrapper.get('form.linear-namespace').trigger('submit');
+    await flushPromises();
+    expect(navigations.at(-1)).toEqual({ path: 'issues/namespaces/team-a', replace: true });
+
+    await wrapper.setProps({ ctx: { ...f.ctx, subPath: 'connections' } });
+    await flushPromises();
+    const connectionReads = f.calls.filter(call => call.path.includes('/connections?'));
+    expect({
+      namespace: (wrapper.get('#linear-namespace').element as HTMLInputElement).value,
+      path: connectionReads.at(-1)?.path,
+    }).toMatchObject({ namespace: 'default', path: expect.stringContaining('/namespaces/default/') });
+  });
+
+  it('keeps the last issue page visible when activation refresh fails', async () => {
+    const f = fixture();
+    const wrapper = await render({ ...f.ctx, subPath: 'issues/namespaces/default' });
+    await choose(wrapper, '#linear-connection', 'linear');
+    await choose(wrapper, '#linear-team', 'Engineering');
+    await searchIssues(wrapper);
+    f.failIssueList();
+
+    await clickText(wrapper, 'ENG-1');
+    await wrapper.get('a.k-back-action').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('ENG-1');
+    expect(wrapper.text()).toContain('503');
+    expect(wrapper.text()).toContain('Showing the last successful result.');
+  });
+
+  it('does not expose a detail Retry action that cannot run during a delayed mutation', async () => {
+    const f = fixture();
+    const wrapper = await render({ ...f.ctx, subPath: 'issues/namespaces/default/detail/linear/issue-1' });
+    f.failNextIssueRead();
+    await clickText(wrapper, 'Refresh');
+    expect(wrapper.find('.k-resource-page__retry').exists()).toBe(true);
+
+    f.delayNextMutation();
+    await wrapper.get('#issue-title').setValue('Retry-safe title');
+    const updateForm = wrapper.findAll('form').find(form => form.find('#issue-title').exists());
+    expect(updateForm).toBeTruthy();
+    await updateForm!.trigger('submit');
+    await flushPromises();
+    expect(f.mutationReadStarted).toBe(true);
+
+    expect(wrapper.find('.k-resource-page__retry').exists()).toBe(false);
+    f.releaseMutation();
+    await flushPromises();
+    const retry = wrapper.get('.k-resource-page__retry');
+    expect((retry.element as HTMLButtonElement).disabled).toBe(false);
+    const issueReadsBeforeRetry = f.calls.filter(call => call.body?.spec?.action === 'issue').length;
+    await retry.trigger('click');
+    await flushPromises();
+    expect(f.calls.filter(call => call.body?.spec?.action === 'issue').length).toBeGreaterThan(issueReadsBeforeRetry);
+  });
+});

--- a/providers/linear/portal/src/routes.ts
+++ b/providers/linear/portal/src/routes.ts
@@ -1,27 +1,100 @@
 export type Collection = 'connections' | 'issues' | 'operations' | 'events';
 export type Route = { page: Collection; name?: string; connection?: string; create?: 'connection' | 'issue'; invalid?: boolean; namespace?: string };
+
+const collections: Collection[] = ['connections', 'issues', 'operations', 'events'];
+const namespacePattern = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+function invalidRoute(): Route { return { page: 'connections', invalid: true }; }
+
+function decode(value: string): string {
+  return decodeURIComponent(value);
+}
+
+function encode(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function validNamespace(value: string): boolean {
+  return value.length <= 63 && namespacePattern.test(value);
+}
+
+function parseBareCollection(page: Collection, parts: string[]): Route {
+  if (!parts.length) return { page };
+  if (page === 'issues' && parts[0] === 'detail' && parts.length === 3) {
+    return { page, connection: decode(parts[1]), name: decode(parts[2]) };
+  }
+  if (page === 'issues' && parts.length === 2) {
+    return { page, connection: decode(parts[0]), name: decode(parts[1]) };
+  }
+  if (page !== 'issues' && parts.length === 1) return { page, name: decode(parts[0]) };
+  return invalidRoute();
+}
+
+function parseCanonicalCollection(page: Collection, namespace: string, parts: string[]): Route {
+  if (!parts.length) return { page, namespace };
+  if (parts.length === 1 && parts[0] === 'create' && (page === 'connections' || page === 'issues')) {
+    return { page, create: page === 'connections' ? 'connection' : 'issue', namespace };
+  }
+  if (parts[0] !== 'detail') return invalidRoute();
+  if (page === 'issues' && parts.length === 3) {
+    return { page, connection: decode(parts[1]), name: decode(parts[2]), namespace };
+  }
+  if (page !== 'issues' && parts.length === 2) {
+    return { page, name: decode(parts[1]), namespace };
+  }
+  return invalidRoute();
+}
+
+function parseCollection(parts: string[]): Route {
+  if (!collections.includes(parts[0] as Collection)) return invalidRoute();
+  const page = parts[0] as Collection;
+  if (parts[1] !== 'namespaces' || parts.length < 3) return parseBareCollection(page, parts.slice(1));
+  const namespace = decode(parts[2]);
+  if (!validNamespace(namespace)) return invalidRoute();
+  return parseCanonicalCollection(page, namespace, parts.slice(3));
+}
+
 export function parseRoute(value = ''): Route {
   const path = value.replace(/^\/+|\/+$/g, '');
   if (!path) return { page: 'connections' };
   const parts = path.split('/');
   if (parts[0] === 'namespaces' && parts.length >= 3) {
     try {
-      const namespace = decodeURIComponent(parts[1]);
-      if (!/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(namespace) || namespace.length > 63) return { page: 'connections', invalid: true };
-      return { ...parseRoute(parts.slice(2).join('/')), namespace };
+      const namespace = decode(parts[1]);
+      if (!validNamespace(namespace)) return invalidRoute();
+      const inner = parts.slice(2);
+      if (inner[0] === 'create' && inner.length === 2 && (inner[1] === 'connection' || inner[1] === 'issue')) {
+        return { page: inner[1] === 'connection' ? 'connections' : 'issues', create: inner[1], namespace };
+      }
+      if (!collections.includes(inner[0] as Collection)) return { ...invalidRoute(), namespace };
+      return { ...parseBareCollection(inner[0] as Collection, inner.slice(1)), namespace };
     } catch { return { page: 'connections', invalid: true }; }
   }
   try {
     if (parts[0] === 'create' && parts.length === 2 && (parts[1] === 'connection' || parts[1] === 'issue')) return { page: parts[1] === 'connection' ? 'connections' : 'issues', create: parts[1] };
-    if (['connections', 'issues', 'operations', 'events'].includes(parts[0])) {
-      const page = parts[0] as Collection;
-      if (parts.length === 1) return { page };
-      if (page === 'issues' && parts.length === 3) return { page, connection: decodeURIComponent(parts[1]), name: decodeURIComponent(parts[2]) };
-      if (page !== 'issues' && parts.length === 2) return { page, name: decodeURIComponent(parts[1]) };
-    }
+    return parseCollection(parts);
   } catch { /* Invalid escapes render the not-found state. */ }
-  return { page: 'connections', invalid: true };
+  return invalidRoute();
 }
-export const resourcePath = (page: Collection, name: string) => `${page}/${encodeURIComponent(name)}`;
-export const issuePath = (connection: string, id: string) => `issues/${encodeURIComponent(connection)}/${encodeURIComponent(id)}`;
+
+/** Serialize a parsed route using the collection-first, namespace-scoped URL contract. */
+export function routePath(route: Route, defaultNamespace = 'default'): string {
+  const namespace = route.namespace || defaultNamespace || 'default';
+  const prefix = `${route.page}/namespaces/${encode(namespace)}`;
+  if (route.create) return `${prefix}/create`;
+  if (!route.name) return prefix;
+  if (route.page === 'issues') return `${prefix}/detail/${encode(route.connection || '')}/${encode(route.name)}`;
+  return `${prefix}/detail/${encode(route.name)}`;
+}
+
+/** Convert a provider-relative route, including legacy aliases, to its canonical URL. */
+export function canonicalPath(namespace: string, value: string): string {
+  const route = parseRoute(value);
+  return routePath(route.invalid ? { page: 'connections' } : route, route.namespace || namespace);
+}
+
+export const resourcePath = (page: Collection, name: string) => `${page}/${encode(name)}`;
+// The explicit marker keeps a connection named "namespaces" unambiguous from
+// the canonical issues/namespaces/<namespace> collection route.
+export const issuePath = (connection: string, id: string) => `issues/detail/${encode(connection)}/${encode(id)}`;
 export const authorityKey = (ctx: import('./api').FarosContext | null) => JSON.stringify([ctx?.basePath, ctx?.tenant, ctx?.orgUUID, ctx?.workspaceUUID, ctx?.user?.sub || ctx?.user?.email]);

--- a/providers/linear/portal/src/views/IssueDetailView.vue
+++ b/providers/linear/portal/src/views/IssueDetailView.vue
@@ -34,7 +34,7 @@ function comment() {
 onMounted(load);
 </script>
 <template>
-  <ResourcePage :title="issue?.identifier || id" kind="Issue" :subtitle="issue?.title || ''" :loaded="read.state.loaded" :loading="read.state.loading" :error="read.state.error" :stale="read.state.loaded && !!read.state.error" retryable @retry="load">
+  <ResourcePage :title="issue?.identifier || id" kind="Issue" :subtitle="issue?.title || ''" :loaded="read.state.loaded" :loading="read.state.loading" :error="read.state.error" :stale="read.state.loaded && !!read.state.error" :retryable="!mutation.state.loading" @retry="load">
     <template #actions><button class="k-btn k-btn--ghost" :disabled="read.state.loading || mutation.state.loading" @click="load">Refresh</button></template>
     <template #status><StatusBadge v-if="issue?.state?.name" :status="issue.state.name" /></template>
     <div class="linear-detail-content">

--- a/providers/linear/portal/src/views/IssuesView.vue
+++ b/providers/linear/portal/src/views/IssuesView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, onActivated, ref, watch } from 'vue';
 import type { Node } from '../api';
 import { useSession, useTask } from '../state';
 import { issuePath } from '../routes';
@@ -20,6 +20,9 @@ function search(page = 0) {
 }
 function next() { cursors.value[index.value + 1] = cursor.value; search(index.value + 1); }
 watch(() => [session.selection.connection, session.selection.team, session.selection.query], () => { read.reset(); issues.value = []; cursor.value = ''; hasNext.value = false; index.value = 0; cursors.value = ['']; }, { flush: 'sync' });
+onActivated(() => {
+  if (read.state.loaded && session.selection.connection && session.selection.team) search(index.value);
+});
 function open(row: Record<string, unknown>) { session.navigate(issuePath(session.selection.connection, String(row.id))); }
 </script>
 <template>


### PR DESCRIPTION
Returning from Linear issue creation or editing could show cached connection options and outdated issue rows. Browser Back could also retain the previous namespace, and namespace-first URLs lost the host sidebar's active resource state.

Refresh cached connections and issue results on return while retaining issue filters and pagination. Restore the default namespace for bare routes, emit collection-first namespace URLs with explicit create/detail segments, and keep legacy namespace-first links readable. Hide Retry during issue mutations so it cannot become stuck waiting for a read that never starts.

Validation:
- `make test-linear-portal`: Vue typecheck, existing API test, and 18 Vitest tests passed, including eight regression scenarios.
- Portal build, design-doc, PortalKit parity, and UI-conformance gates passed (455 files, zero UI violations).
- Built-bundle fixture browser checks passed 52 scenarios across desktop/mobile and light/dark themes, including host navigation, namespace Back, creation/details, history, keyboard selection, long content, and failure states. No browser errors or page overflow.

Browser writes used fixtures and terminal operation results; these checks do not claim live Linear write verification.
