### PR TITLE
[AUTOMATED BOT PR] hub: bind org admins in every child workspace at the kcp layer (O-15)

### DIFF
--- a/pkg/hub/controllers/organization/controller.go
+++ b/pkg/hub/controllers/organization/controller.go
@@ -125,6 +125,11 @@ type WorkspaceProvisioner interface {
 	// rbacIdentity. Idempotent.
 	EnsureChildWorkspaceAdmin(ctx context.Context, orgUUID, wsUUID, rbacIdentity string) error
 
+	// ListChildTeamWorkspaces lists the Org's team workspaces (no
+	// infrastructure children). Used by the RBAC backfill to bind an
+	// org-scope admin into every child workspace (O-15).
+	ListChildTeamWorkspaces(ctx context.Context, orgUUID string) ([]string, error)
+
 	// EnsureChildWorkspaceDefaultMCPServer seeds the "default"
 	// MCPServer CR inside the child team Workspace so users have a
 	// working MCP endpoint out of the box. Idempotent.
@@ -832,20 +837,22 @@ func (r *Reconciler) reconcileWorkspace(ctx context.Context, org *tenancyv1alpha
 	}, true
 }
 
-// backfillWorkspaceAdmins walks the User's UMI workspace-scope entries
-// for the given org and ensures cluster-admin RBAC for the user's
-// rbacIdentity in each (excluding skipWsUUID, which the caller already
-// reconciled as Step H). Pre-PR fix the REST createWorkspace path
-// skipped EnsureChildWorkspaceAdmin entirely, leaving every
-// portal-created workspace without a faros-cluster-admin
-// ClusterRoleBinding — switching to one of them surfaced as a kcp
-// 403 once the workspace switcher actually retargeted the new cluster
-// in v0.0.63. This reconciler step self-heals that legacy state.
+// backfillWorkspaceAdmins walks the User's UMI and ensures cluster-admin
+// RBAC for the user's rbacIdentity wherever the rows say they belong:
+// every workspace-scope row, and every child team workspace of every org
+// where the user holds an org-scope admin row (O-15). The (orgUUID,
+// skipWsUUID) pair is excluded because the caller already reconciled it
+// as Step H.
+//
+// This is the self-healing path for legacy state (portal-created
+// workspaces once skipped the grant entirely; org-scope admin grants did
+// so until the REST handlers learned to bind them) and for users who were
+// granted membership before their first sign-in, when no rbacIdentity
+// existed to bind: the identity being set is what triggers this reconcile.
 //
 // Errors on individual workspaces are logged and skipped; one bad
-// workspace must not stall the whole Org reconcile. Idempotent —
-// EnsureChildWorkspaceAdmin handles the AlreadyExists / subject-rewrite
-// cases internally.
+// workspace must not stall the whole reconcile. Idempotent — the
+// bootstrapper keeps one binding per user, so re-granting is a no-op.
 func (r *Reconciler) backfillWorkspaceAdmins(ctx context.Context, user *tenancyv1alpha1.User, orgUUID, skipWsUUID string, logger logr.Logger) error {
 	var index tenancyv1alpha1.UserMembershipIndex
 	if err := r.client.Get(ctx, types.NamespacedName{Name: user.Name}, &index); err != nil {
@@ -854,17 +861,42 @@ func (r *Reconciler) backfillWorkspaceAdmins(ctx context.Context, user *tenancyv
 		}
 		return fmt.Errorf("loading UMI for workspace-admin backfill: %w", err)
 	}
-	for _, e := range index.Spec.Entries {
-		if e.OrgUUID != orgUUID || e.WorkspaceUUID == "" || e.WorkspaceUUID == skipWsUUID {
-			continue
+	done := map[string]map[string]bool{}
+	grant := func(org, ws string) {
+		if org == orgUUID && ws == skipWsUUID {
+			return
 		}
+		if done[org][ws] {
+			return
+		}
+		if done[org] == nil {
+			done[org] = map[string]bool{}
+		}
+		done[org][ws] = true
+		if err := r.provisioner.EnsureChildWorkspaceAdmin(ctx, org, ws, user.Spec.RBACIdentity); err != nil {
+			logger.Error(err, "Granting workspace-admin failed; will retry on next reconcile",
+				"orgUUID", org, "workspaceUUID", ws)
+		}
+	}
+	for _, e := range index.Spec.Entries {
 		if e.SoftDeletedAt != nil {
 			continue
 		}
-		if err := r.provisioner.EnsureChildWorkspaceAdmin(ctx, orgUUID, e.WorkspaceUUID, user.Spec.RBACIdentity); err != nil {
-			logger.Error(err, "Granting workspace-admin failed; will retry on next reconcile",
-				"workspaceUUID", e.WorkspaceUUID)
+		if e.WorkspaceUUID != "" {
+			grant(e.OrgUUID, e.WorkspaceUUID)
 			continue
+		}
+		if e.Role != tenancyv1alpha1.MembershipRoleAdmin {
+			continue
+		}
+		wss, err := r.provisioner.ListChildTeamWorkspaces(ctx, e.OrgUUID)
+		if err != nil {
+			logger.Error(err, "Listing child workspaces for org-admin backfill failed; will retry on next reconcile",
+				"orgUUID", e.OrgUUID)
+			continue
+		}
+		for _, ws := range wss {
+			grant(e.OrgUUID, ws)
 		}
 	}
 	return nil

--- a/pkg/hub/controllers/organization/controller_test.go
+++ b/pkg/hub/controllers/organization/controller_test.go
@@ -57,6 +57,14 @@ type fakeProvisioner struct {
 	// clusterHash is the value returned by GetChildWorkspaceClusterName.
 	// Defaults to a fixed test hash; tests can override.
 	clusterHash string
+	// teamWorkspaces is what ListChildTeamWorkspaces answers per org.
+	teamWorkspaces map[string][]string
+}
+
+func (f *fakeProvisioner) ListChildTeamWorkspaces(_ context.Context, orgUUID string) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.teamWorkspaces[orgUUID]...), nil
 }
 
 type membershipCall struct {
@@ -747,5 +755,55 @@ func hasCondition(conds []metav1.Condition, t string, status metav1.ConditionSta
 func TestOrgWorkspaceParentConstant(t *testing.T) {
 	if !strings.HasPrefix(orgWorkspaceParent, "root:faros:") {
 		t.Errorf("orgWorkspaceParent should live under root:faros, got %q", orgWorkspaceParent)
+	}
+}
+
+// TestReconciler_BackfillBindsOrgAdminInForeignOrgWorkspaces: an org-scope
+// admin row for another org binds the user in every one of that org's team
+// workspaces (O-15), and a workspace-scope row in another org binds that
+// workspace, once the user has an rbacIdentity to bind.
+func TestReconciler_BackfillBindsOrgAdminInForeignOrgWorkspaces(t *testing.T) {
+	scheme := newTestScheme(t)
+	user := newUser("erin", "Erin")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(user).
+		WithStatusSubresource(&tenancyv1alpha1.User{}, &tenancyv1alpha1.Organization{}, &tenancyv1alpha1.UserMembershipIndex{}).
+		Build()
+	prov := &fakeProvisioner{teamWorkspaces: map[string][]string{"org-x": {"ws-x1", "ws-x2"}}}
+	r := &Reconciler{client: c, provisioner: prov}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "erin"}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	var idx tenancyv1alpha1.UserMembershipIndex
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "erin"}, &idx); err != nil {
+		t.Fatalf("get UMI: %v", err)
+	}
+	idx.Spec.Entries = append(idx.Spec.Entries,
+		tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "org-x", Role: tenancyv1alpha1.MembershipRoleAdmin},
+		tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "org-y", Role: tenancyv1alpha1.MembershipRoleMember},
+		tenancyv1alpha1.MembershipIndexEntry{OrgUUID: "org-y", WorkspaceUUID: "ws-y1", Role: tenancyv1alpha1.MembershipRoleMember},
+	)
+	if err := c.Update(context.Background(), &idx); err != nil {
+		t.Fatalf("update UMI: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, call := range prov.AdminCalls() {
+		got[call.OrgUUID+"/"+call.WSUUID] = call.RBACIdentity == "rbac-erin"
+	}
+	for _, want := range []string{"org-x/ws-x1", "org-x/ws-x2", "org-y/ws-y1"} {
+		if !got[want] {
+			t.Errorf("expected EnsureChildWorkspaceAdmin for %s with rbac-erin; calls=%v", want, prov.AdminCalls())
+		}
+	}
+	// A plain org member in org-y gets no implicit workspace binding.
+	if got["org-y/ws-y2"] {
+		t.Error("member row bound a workspace it has no row for")
 	}
 }

--- a/pkg/hub/kcp/bootstrap.go
+++ b/pkg/hub/kcp/bootstrap.go
@@ -19,6 +19,8 @@ package kcp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"reflect"
 	"sort"
@@ -1152,6 +1154,35 @@ func (b *Bootstrapper) ListOrgMemberships(ctx context.Context, orgUUID string) (
 	return names, nil
 }
 
+// ListOrgMembershipRoles returns user name → role for every Membership in
+// the Organization workspace. Used to find the Org's admins when a child
+// workspace is created, so O-15 (org admin = implicit admin in every child
+// workspace) holds at the kcp RBAC layer too. Empty map if the Org
+// workspace has no Memberships or has been deleted.
+func (b *Bootstrapper) ListOrgMembershipRoles(ctx context.Context, orgUUID string) (map[string]string, error) {
+	if orgUUID == "" {
+		return nil, fmt.Errorf("ListOrgMembershipRoles: orgUUID is required")
+	}
+	orgConfig := configForPath(b.config, kcppaths.OrgPath(orgUUID))
+	orgClient, err := dynamic.NewForConfig(orgConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating org workspace client: %w", err)
+	}
+	list, err := orgClient.Resource(membershipGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("listing Memberships in org %s: %w", orgUUID, err)
+	}
+	roles := make(map[string]string, len(list.Items))
+	for i := range list.Items {
+		role, _, _ := unstructured.NestedString(list.Items[i].Object, "spec", "role")
+		roles[list.Items[i].GetName()] = role
+	}
+	return roles, nil
+}
+
 // mcpServerGVR is the tenant-workspace MCPServer resource (distributed via the
 // core.faros.sh APIExport). The in-core reconciler
 // (pkg/hub/controllers/mcpserver) provisions each server's identity.
@@ -1546,54 +1577,107 @@ func (b *Bootstrapper) EnsureWorkspaceAdmin(ctx context.Context, clusterName, rb
 	return ensureWorkspaceAdmin(ctx, tenantClient, rbacIdentity)
 }
 
+// RevokeWorkspaceAdmin removes the cluster-admin grant for rbacIdentity in
+// the workspace identified by clusterName. Idempotent on NotFound. Only the
+// caller's own per-user binding is touched; every other member keeps theirs.
+func (b *Bootstrapper) RevokeWorkspaceAdmin(ctx context.Context, clusterName, rbacIdentity string) error {
+	if clusterName == "" || rbacIdentity == "" {
+		return nil
+	}
+	tenantConfig := configForPath(b.config, clusterName)
+	tenantClient, err := dynamic.NewForConfig(tenantConfig)
+	if err != nil {
+		return fmt.Errorf("creating tenant client for %s: %w", clusterName, err)
+	}
+	return revokeWorkspaceAdmin(ctx, tenantClient, rbacIdentity)
+}
+
+// RevokeChildWorkspaceAdmin is RevokeWorkspaceAdmin with the canonical
+// child-workspace path. Idempotent.
+func (b *Bootstrapper) RevokeChildWorkspaceAdmin(ctx context.Context, orgUUID, wsUUID, rbacIdentity string) error {
+	if orgUUID == "" || wsUUID == "" {
+		return fmt.Errorf("RevokeChildWorkspaceAdmin: orgUUID and wsUUID are required")
+	}
+	return b.RevokeWorkspaceAdmin(ctx, childWorkspacePath(orgUUID, wsUUID), rbacIdentity)
+}
+
 var clusterRoleBindingGVR = schema.GroupVersionResource{
 	Group:    "rbac.authorization.k8s.io",
 	Version:  "v1",
 	Resource: "clusterrolebindings",
 }
 
-// ensureWorkspaceAdmin creates a cluster-admin ClusterRoleBinding for the given
-// rbacIdentity in the workspace targeted by tenantClient. Idempotent.
-// Uses the name "faros-user-admin" to avoid conflicting with the kcp-provisioned
-// "workspace-admin" binding.
-func ensureWorkspaceAdmin(ctx context.Context, tenantClient dynamic.Interface, rbacIdentity string) error {
-	wantSubjects := []interface{}{
-		map[string]interface{}{
-			"apiGroup": "rbac.authorization.k8s.io",
-			"kind":     "User",
-			"name":     rbacIdentity,
-		},
-	}
-	crb := &unstructured.Unstructured{
+// legacyWorkspaceAdminCRB is the single, shared cluster-admin binding the
+// hub used to keep per workspace. It held exactly one subject and every
+// grant overwrote it, so the last person granted was the only one with
+// kcp RBAC. ensureWorkspaceAdmin migrates it to per-user bindings on the
+// next grant or revoke in that workspace and then deletes it.
+const legacyWorkspaceAdminCRB = "faros-cluster-admin"
+
+// userAdminCRBPrefix prefixes the per-user cluster-admin bindings. The
+// suffix is a hash of the rbacIdentity: identities are emails, which are
+// not valid object names, and the hash keeps the name stable across the
+// identity's spelling while never colliding between users.
+const userAdminCRBPrefix = "faros-user-admin-"
+
+// userAdminCRBName returns the per-user cluster-admin binding name for an
+// rbacIdentity.
+func userAdminCRBName(rbacIdentity string) string {
+	sum := sha256.Sum256([]byte(rbacIdentity))
+	return userAdminCRBPrefix + hex.EncodeToString(sum[:])[:16]
+}
+
+func userAdminCRB(rbacIdentity string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "rbac.authorization.k8s.io/v1",
 			"kind":       "ClusterRoleBinding",
 			"metadata": map[string]interface{}{
-				"name": "faros-cluster-admin",
+				"name": userAdminCRBName(rbacIdentity),
+				"labels": map[string]interface{}{
+					"tenancy.faros.sh/managed-by": "hub",
+				},
+				"annotations": map[string]interface{}{
+					"tenancy.faros.sh/rbac-identity": rbacIdentity,
+				},
 			},
 			"roleRef": map[string]interface{}{
 				"apiGroup": "rbac.authorization.k8s.io",
 				"kind":     "ClusterRole",
 				"name":     "cluster-admin",
 			},
-			"subjects": wantSubjects,
+			"subjects": []interface{}{
+				map[string]interface{}{
+					"apiGroup": "rbac.authorization.k8s.io",
+					"kind":     "User",
+					"name":     rbacIdentity,
+				},
+			},
 		},
 	}
-	_, err := tenantClient.Resource(clusterRoleBindingGVR).Create(ctx, crb, metav1.CreateOptions{})
+}
+
+// ensureWorkspaceAdmin creates a per-user cluster-admin ClusterRoleBinding for
+// the given rbacIdentity in the workspace targeted by tenantClient. Grants are
+// additive: each member holds their own binding, so granting one user never
+// disturbs another's access. Idempotent.
+func ensureWorkspaceAdmin(ctx context.Context, tenantClient dynamic.Interface, rbacIdentity string) error {
+	if err := migrateLegacyWorkspaceAdmin(ctx, tenantClient); err != nil {
+		return err
+	}
+	want := userAdminCRB(rbacIdentity)
+	_, err := tenantClient.Resource(clusterRoleBindingGVR).Create(ctx, want, metav1.CreateOptions{})
 	if err == nil {
 		return nil
 	}
 	if !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("creating workspace-admin ClusterRoleBinding: %w", err)
 	}
-
-	// Reconcile subjects so legacy bindings (e.g. left over from the sub→email
-	// RBAC switch) get their subject rewritten to the current rbacIdentity
-	// instead of being silently stale.
-	existing, getErr := tenantClient.Resource(clusterRoleBindingGVR).Get(ctx, "faros-cluster-admin", metav1.GetOptions{})
+	existing, getErr := tenantClient.Resource(clusterRoleBindingGVR).Get(ctx, want.GetName(), metav1.GetOptions{})
 	if getErr != nil {
 		return fmt.Errorf("getting existing workspace-admin ClusterRoleBinding: %w", getErr)
 	}
+	wantSubjects, _, _ := unstructured.NestedSlice(want.Object, "subjects")
 	gotSubjects, _, _ := unstructured.NestedSlice(existing.Object, "subjects")
 	if reflect.DeepEqual(gotSubjects, wantSubjects) {
 		return nil
@@ -1603,6 +1687,52 @@ func ensureWorkspaceAdmin(ctx context.Context, tenantClient dynamic.Interface, r
 	}
 	if _, err := tenantClient.Resource(clusterRoleBindingGVR).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("updating workspace-admin ClusterRoleBinding: %w", err)
+	}
+	return nil
+}
+
+// revokeWorkspaceAdmin deletes the per-user cluster-admin binding for
+// rbacIdentity. The legacy shared binding is migrated first so a user who
+// only ever held access through it is revoked too. Idempotent on NotFound.
+func revokeWorkspaceAdmin(ctx context.Context, tenantClient dynamic.Interface, rbacIdentity string) error {
+	if err := migrateLegacyWorkspaceAdmin(ctx, tenantClient); err != nil {
+		return err
+	}
+	if err := tenantClient.Resource(clusterRoleBindingGVR).Delete(ctx, userAdminCRBName(rbacIdentity), metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting workspace-admin ClusterRoleBinding: %w", err)
+	}
+	return nil
+}
+
+// migrateLegacyWorkspaceAdmin converts the shared faros-cluster-admin
+// binding, when present, into one per-user binding per subject and deletes
+// it. Whoever held access through the shared binding keeps it. No-op once
+// the workspace is on per-user bindings.
+func migrateLegacyWorkspaceAdmin(ctx context.Context, tenantClient dynamic.Interface) error {
+	legacy, err := tenantClient.Resource(clusterRoleBindingGVR).Get(ctx, legacyWorkspaceAdminCRB, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("getting legacy workspace-admin ClusterRoleBinding: %w", err)
+	}
+	subjects, _, _ := unstructured.NestedSlice(legacy.Object, "subjects")
+	for _, s := range subjects {
+		m, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		kind, _ := m["kind"].(string)
+		name, _ := m["name"].(string)
+		if kind != "User" || name == "" {
+			continue
+		}
+		if _, err := tenantClient.Resource(clusterRoleBindingGVR).Create(ctx, userAdminCRB(name), metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("migrating legacy workspace-admin subject %q: %w", name, err)
+		}
+	}
+	if err := tenantClient.Resource(clusterRoleBindingGVR).Delete(ctx, legacyWorkspaceAdminCRB, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting legacy workspace-admin ClusterRoleBinding: %w", err)
 	}
 	return nil
 }

--- a/pkg/hub/kcp/workspaceadmin_test.go
+++ b/pkg/hub/kcp/workspaceadmin_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kcp
+
+import (
+	"context"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+func newCRBClient(t *testing.T) dynamic.Interface {
+	t.Helper()
+	return fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		clusterRoleBindingGVR: "ClusterRoleBindingList",
+	})
+}
+
+func crbSubjects(t *testing.T, c dynamic.Interface, name string) []string {
+	t.Helper()
+	got, err := c.Resource(clusterRoleBindingGVR).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get %s: %v", name, err)
+	}
+	subjects, _, _ := unstructured.NestedSlice(got.Object, "subjects")
+	var names []string
+	for _, s := range subjects {
+		names = append(names, s.(map[string]interface{})["name"].(string))
+	}
+	return names
+}
+
+func crbMissing(t *testing.T, c dynamic.Interface, name string) bool {
+	t.Helper()
+	_, err := c.Resource(clusterRoleBindingGVR).Get(context.Background(), name, metav1.GetOptions{})
+	return apierrors.IsNotFound(err)
+}
+
+// Regression: the hub used to keep one shared binding per workspace and
+// overwrite its only subject on every grant, so granting bob revoked alice.
+func TestEnsureWorkspaceAdmin_GrantsAreAdditive(t *testing.T) {
+	c := newCRBClient(t)
+	ctx := context.Background()
+	for _, id := range []string{"faros:alice@example.com", "faros:bob@example.com", "faros:alice@example.com"} {
+		if err := ensureWorkspaceAdmin(ctx, c, id); err != nil {
+			t.Fatalf("ensure %s: %v", id, err)
+		}
+	}
+	for _, id := range []string{"faros:alice@example.com", "faros:bob@example.com"} {
+		if got := crbSubjects(t, c, userAdminCRBName(id)); len(got) != 1 || got[0] != id {
+			t.Errorf("binding for %s: subjects %v", id, got)
+		}
+	}
+	if userAdminCRBName("faros:alice@example.com") == userAdminCRBName("faros:bob@example.com") {
+		t.Error("per-user binding names collide")
+	}
+}
+
+func TestEnsureWorkspaceAdmin_MigratesLegacySharedBinding(t *testing.T) {
+	c := newCRBClient(t)
+	ctx := context.Background()
+	legacy := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRoleBinding",
+		"metadata":   map[string]interface{}{"name": legacyWorkspaceAdminCRB},
+		"roleRef":    map[string]interface{}{"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "cluster-admin"},
+		"subjects": []interface{}{
+			map[string]interface{}{"apiGroup": "rbac.authorization.k8s.io", "kind": "User", "name": "faros:carol@example.com"},
+		},
+	}}
+	if _, err := c.Resource(clusterRoleBindingGVR).Create(ctx, legacy, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+	if err := ensureWorkspaceAdmin(ctx, c, "faros:dave@example.com"); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	// carol, who only held access through the shared binding, keeps it.
+	if got := crbSubjects(t, c, userAdminCRBName("faros:carol@example.com")); len(got) != 1 || got[0] != "faros:carol@example.com" {
+		t.Errorf("carol not migrated: %v", got)
+	}
+	if got := crbSubjects(t, c, userAdminCRBName("faros:dave@example.com")); len(got) != 1 || got[0] != "faros:dave@example.com" {
+		t.Errorf("dave not granted: %v", got)
+	}
+	if !crbMissing(t, c, legacyWorkspaceAdminCRB) {
+		t.Error("legacy shared binding still present")
+	}
+}
+
+func TestRevokeWorkspaceAdmin_OnlyTouchesThatUser(t *testing.T) {
+	c := newCRBClient(t)
+	ctx := context.Background()
+	for _, id := range []string{"faros:alice@example.com", "faros:bob@example.com"} {
+		if err := ensureWorkspaceAdmin(ctx, c, id); err != nil {
+			t.Fatalf("ensure %s: %v", id, err)
+		}
+	}
+	if err := revokeWorkspaceAdmin(ctx, c, "faros:bob@example.com"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if !crbMissing(t, c, userAdminCRBName("faros:bob@example.com")) {
+		t.Error("bob still bound")
+	}
+	if got := crbSubjects(t, c, userAdminCRBName("faros:alice@example.com")); len(got) != 1 {
+		t.Errorf("alice lost her binding: %v", got)
+	}
+	// Idempotent on NotFound.
+	if err := revokeWorkspaceAdmin(ctx, c, "faros:bob@example.com"); err != nil {
+		t.Errorf("second revoke: %v", err)
+	}
+}

--- a/pkg/hub/restapi/memberships.go
+++ b/pkg/hub/restapi/memberships.go
@@ -17,6 +17,7 @@ limitations under the License.
 package restapi
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -158,6 +159,16 @@ func (h *Handler) addOrgMembership(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
+	// An org admin is an implicit admin in every child workspace (O-15).
+	// The hub side of that is the UMI row above; the kcp side is a
+	// per-user binding in each child workspace, without which kcp 403s
+	// the moment they open one.
+	if role == tenancyv1alpha1.MembershipRoleAdmin {
+		if err := h.mgr.grantOrgAdminWorkspaceRBAC(r.Context(), orgUUID, target); err != nil {
+			writeError(w, err)
+			return
+		}
+	}
 	if isDelegated {
 		klog.FromContext(r.Context()).Info("Provider added organization member",
 			"provider", delegated.Provider, "providerOrg", delegated.ProviderOrgUUID,
@@ -203,6 +214,25 @@ func (h *Handler) patchOrgMembership(w http.ResponseWriter, r *http.Request) {
 	}); err != nil {
 		writeError(w, err)
 		return
+	}
+	// Keep kcp RBAC in the child workspaces in step with the role: a
+	// promotion binds the user everywhere (O-15), a demotion keeps only
+	// the workspaces they hold a workspace-scope row in.
+	target, err := h.mgr.userForRBAC(r.Context(), user)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if target != nil {
+		if req.Role == tenancyv1alpha1.MembershipRoleAdmin {
+			err = h.mgr.grantOrgAdminWorkspaceRBAC(r.Context(), orgUUID, target)
+		} else {
+			err = h.mgr.revokeOrgAdminWorkspaceRBAC(r.Context(), orgUUID, target)
+		}
+		if err != nil {
+			writeError(w, err)
+			return
+		}
 	}
 	writeJSON(w, http.StatusOK, MembershipView{User: user, Role: req.Role, OrgUUID: orgUUID})
 }
@@ -250,7 +280,23 @@ func (h *Handler) deleteOrgMembership(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// Drop the kcp bindings the remaining rows no longer justify. With
+	// cascade every workspace row is gone, so every binding goes.
+	if err := h.mgr.revokeOrgWorkspaceRBAC(r.Context(), orgUUID, user); err != nil {
+		writeError(w, err)
+		return
+	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// revokeOrgWorkspaceRBAC is revokeOrgAdminWorkspaceRBAC for a user named
+// in a route, tolerating a User CR that no longer exists.
+func (m *Manager) revokeOrgWorkspaceRBAC(ctx context.Context, orgUUID, userName string) error {
+	target, err := m.userForRBAC(ctx, userName)
+	if err != nil || target == nil {
+		return err
+	}
+	return m.revokeOrgAdminWorkspaceRBAC(ctx, orgUUID, target)
 }
 
 // selfLeaveOrg lets the caller remove themselves from an Org (O-12).
@@ -267,6 +313,10 @@ func (h *Handler) selfLeaveOrg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.mgr.removeUMIEntry(r.Context(), tc.User, orgUUID, ""); err != nil {
+		writeError(w, err)
+		return
+	}
+	if err := h.mgr.revokeOrgWorkspaceRBAC(r.Context(), orgUUID, tc.User); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -461,7 +511,21 @@ func (h *Handler) deleteWorkspaceMembership(w http.ResponseWriter, r *http.Reque
 		writeError(w, err)
 		return
 	}
+	if err := h.mgr.revokeMemberWorkspaceRBAC(r.Context(), tc.OrgUUID, tc.WorkspaceUUID, user); err != nil {
+		writeError(w, err)
+		return
+	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// revokeMemberWorkspaceRBAC is revokeWorkspaceRBAC for a user named in a
+// route, tolerating a User CR that no longer exists.
+func (m *Manager) revokeMemberWorkspaceRBAC(ctx context.Context, orgUUID, wsUUID, userName string) error {
+	target, err := m.userForRBAC(ctx, userName)
+	if err != nil || target == nil {
+		return err
+	}
+	return m.revokeWorkspaceRBAC(ctx, orgUUID, wsUUID, target)
 }
 
 // selfLeaveWorkspace lets the caller remove themselves.
@@ -471,6 +535,10 @@ func (h *Handler) selfLeaveWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.mgr.removeUMIEntry(r.Context(), tc.User, tc.OrgUUID, tc.WorkspaceUUID); err != nil {
+		writeError(w, err)
+		return
+	}
+	if err := h.mgr.revokeMemberWorkspaceRBAC(r.Context(), tc.OrgUUID, tc.WorkspaceUUID, tc.User); err != nil {
 		writeError(w, err)
 		return
 	}

--- a/pkg/hub/restapi/restapi.go
+++ b/pkg/hub/restapi/restapi.go
@@ -86,6 +86,14 @@ type WorkspaceOps interface {
 	// user's default workspace — every other workspace would 403 from
 	// the kcp proxy without this call.
 	EnsureChildWorkspaceAdmin(ctx context.Context, orgUUID, wsUUID, rbacIdentity string) error
+	// RevokeChildWorkspaceAdmin removes the rbacIdentity's cluster-admin
+	// binding from the child team Workspace. Grants are per user, so this
+	// never touches another member's access. Idempotent on NotFound.
+	RevokeChildWorkspaceAdmin(ctx context.Context, orgUUID, wsUUID, rbacIdentity string) error
+	// ListOrgMembershipRoles returns user name → role for every org-scope
+	// Membership CR. Used to bind the Org's admins into a new child
+	// workspace (O-15).
+	ListOrgMembershipRoles(ctx context.Context, orgUUID string) (map[string]string, error)
 	// ListChildTeamWorkspaces lists the Org's team workspaces, excluding
 	// infrastructure children such as the `providers` container for org-owned
 	// providers. Tenant-facing views must use this rather than the unfiltered

--- a/pkg/hub/restapi/restapi_test.go
+++ b/pkg/hub/restapi/restapi_test.go
@@ -357,6 +357,23 @@ func (f *fakeOps) EnsureChildWorkspaceAdmin(_ context.Context, orgUUID, wsUUID, 
 	return nil
 }
 
+func (f *fakeOps) RevokeChildWorkspaceAdmin(_ context.Context, orgUUID, wsUUID, rbacIdentity string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.workspaceAdmins[wsKey{orgUUID, wsUUID}], rbacIdentity)
+	return nil
+}
+
+func (f *fakeOps) ListOrgMembershipRoles(_ context.Context, orgUUID string) (map[string]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := map[string]string{}
+	for u, r := range f.orgMemberships[orgUUID] {
+		out[u] = r
+	}
+	return out, nil
+}
+
 // ===== test fixtures =====
 
 func newTestScheme(t *testing.T) *runtime.Scheme {

--- a/pkg/hub/restapi/workspace_rbac.go
+++ b/pkg/hub/restapi/workspace_rbac.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restapi
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
+)
+
+// Workspace kcp RBAC, kept in step with memberships.
+//
+// The UMI rows and Membership CRs are what the hub authorizes against; the
+// kcp proxy then forwards the caller's own token to the workspace's logical
+// cluster, where kcp RBAC needs a ClusterRoleBinding for the caller's
+// rbacIdentity. Every membership change that alters who may enter a
+// workspace therefore also has to alter the bindings there:
+//
+//   - a workspace-scope grant binds that user in that workspace;
+//   - an org-scope admin grant (add or promote) binds the user in every
+//     child workspace, per O-15 (org admin = implicit admin everywhere);
+//   - a new child workspace binds every current org admin;
+//   - a demotion or removal revokes the bindings the remaining rows no
+//     longer justify: an org admin keeps a workspace binding only where a
+//     workspace-scope row remains, and a workspace member keeps it only
+//     while they are also an org admin.
+//
+// Users who have not signed in yet have no rbacIdentity and are skipped;
+// the organization controller's backfill binds them at first sign-in.
+
+// grantOrgAdminWorkspaceRBAC binds the user as cluster-admin in every child
+// team workspace of the org. Idempotent.
+func (m *Manager) grantOrgAdminWorkspaceRBAC(ctx context.Context, orgUUID string, user *tenancyv1alpha1.User) error {
+	if user.Spec.RBACIdentity == "" {
+		return nil
+	}
+	wss, err := m.bootstrapper.ListChildTeamWorkspaces(ctx, orgUUID)
+	if err != nil {
+		return fmt.Errorf("listing child workspaces for org-admin grant: %w", err)
+	}
+	for _, ws := range wss {
+		if err := m.bootstrapper.EnsureChildWorkspaceAdmin(ctx, orgUUID, ws, user.Spec.RBACIdentity); err != nil {
+			return fmt.Errorf("granting org admin RBAC in workspace %s: %w", ws, err)
+		}
+	}
+	return nil
+}
+
+// revokeOrgAdminWorkspaceRBAC removes the user's cluster-admin binding from
+// every child team workspace where no workspace-scope UMI row keeps them a
+// member. Called after an org-scope demotion or removal, once the UMI has
+// been updated. Idempotent.
+func (m *Manager) revokeOrgAdminWorkspaceRBAC(ctx context.Context, orgUUID string, user *tenancyv1alpha1.User) error {
+	if user.Spec.RBACIdentity == "" {
+		return nil
+	}
+	keep := map[string]bool{}
+	if idx, err := m.client.UserMembershipIndices().Get(ctx, user.Name, metav1.GetOptions{}); err == nil {
+		for _, e := range idx.Spec.Entries {
+			if e.OrgUUID == orgUUID && e.WorkspaceUUID != "" {
+				keep[e.WorkspaceUUID] = true
+			}
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("loading UMI for org-admin revoke: %w", err)
+	}
+	wss, err := m.bootstrapper.ListChildTeamWorkspaces(ctx, orgUUID)
+	if err != nil {
+		return fmt.Errorf("listing child workspaces for org-admin revoke: %w", err)
+	}
+	for _, ws := range wss {
+		if keep[ws] {
+			continue
+		}
+		if err := m.bootstrapper.RevokeChildWorkspaceAdmin(ctx, orgUUID, ws, user.Spec.RBACIdentity); err != nil {
+			return fmt.Errorf("revoking org admin RBAC in workspace %s: %w", ws, err)
+		}
+	}
+	return nil
+}
+
+// revokeWorkspaceRBAC removes the user's cluster-admin binding from one
+// child workspace unless they are an org admin, who keeps implicit access
+// (O-15). Called after a workspace-scope removal. Idempotent.
+func (m *Manager) revokeWorkspaceRBAC(ctx context.Context, orgUUID, wsUUID string, user *tenancyv1alpha1.User) error {
+	if user.Spec.RBACIdentity == "" {
+		return nil
+	}
+	role, err := m.bootstrapper.GetOrgMembershipRole(ctx, orgUUID, user.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("reading org role for workspace revoke: %w", err)
+	}
+	if role == tenancyv1alpha1.MembershipRoleAdmin {
+		return nil
+	}
+	if err := m.bootstrapper.RevokeChildWorkspaceAdmin(ctx, orgUUID, wsUUID, user.Spec.RBACIdentity); err != nil {
+		return fmt.Errorf("revoking RBAC in workspace %s: %w", wsUUID, err)
+	}
+	return nil
+}
+
+// grantOrgAdminsWorkspaceRBAC binds every current org admin as cluster-admin
+// in one child workspace. Called when a workspace is created so O-15 holds
+// for admins who were added before the workspace existed. Idempotent.
+func (m *Manager) grantOrgAdminsWorkspaceRBAC(ctx context.Context, orgUUID, wsUUID string) error {
+	roles, err := m.bootstrapper.ListOrgMembershipRoles(ctx, orgUUID)
+	if err != nil {
+		return fmt.Errorf("listing org memberships for workspace RBAC: %w", err)
+	}
+	for userName, role := range roles {
+		if role != tenancyv1alpha1.MembershipRoleAdmin {
+			continue
+		}
+		user, err := m.client.Users().Get(ctx, userName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("loading org admin %s for workspace RBAC: %w", userName, err)
+		}
+		if user.Spec.RBACIdentity == "" {
+			continue
+		}
+		if err := m.bootstrapper.EnsureChildWorkspaceAdmin(ctx, orgUUID, wsUUID, user.Spec.RBACIdentity); err != nil {
+			return fmt.Errorf("granting org admin %s RBAC in workspace %s: %w", userName, wsUUID, err)
+		}
+	}
+	return nil
+}
+
+// userForRBAC loads the User CR named in a membership route. A missing
+// user yields nil so callers can skip the RBAC step: the membership rows
+// were already written or removed, and there is nothing to bind.
+func (m *Manager) userForRBAC(ctx context.Context, userName string) (*tenancyv1alpha1.User, error) {
+	user, err := m.client.Users().Get(ctx, userName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return user, nil
+}

--- a/pkg/hub/restapi/workspace_rbac_test.go
+++ b/pkg/hub/restapi/workspace_rbac_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2026 The Faros Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tenancyv1alpha1 "github.com/faroshq/faros/apis/tenancy/v1alpha1"
+)
+
+func rbacFixture(t *testing.T) (*Manager, *fakeOps) {
+	t.Helper()
+	org := &tenancyv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "org-a"},
+		Spec:       tenancyv1alpha1.OrganizationSpec{DisplayName: "A"},
+	}
+	bob := &tenancyv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "bob"},
+		Spec:       tenancyv1alpha1.UserSpec{Email: "bob@example.com", RBACIdentity: "faros:bob@example.com"},
+	}
+	carol := &tenancyv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "carol"},
+		Spec:       tenancyv1alpha1.UserSpec{Email: "carol@example.com", RBACIdentity: "faros:carol@example.com"},
+	}
+	alice := &tenancyv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice"},
+		Spec:       tenancyv1alpha1.UserSpec{Email: "alice@example.com", RBACIdentity: "faros:alice@example.com"},
+	}
+	mgr, ops, _ := newTestManager(t, org, alice, bob, carol)
+	for _, ws := range []string{"ws-1", "ws-2"} {
+		if err := ops.EnsureChildWorkspace(context.Background(), "org-a", ws); err != nil {
+			t.Fatalf("seed %s: %v", ws, err)
+		}
+	}
+	return mgr, ops
+}
+
+func doJSON(t *testing.T, method, url string, body any) int {
+	t.Helper()
+	var b []byte
+	if body != nil {
+		b, _ = json.Marshal(body)
+	}
+	req, _ := http.NewRequest(method, url, jsonBody(b))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		out, _ := io.ReadAll(resp.Body)
+		t.Logf("%s %s → %d: %s", method, url, resp.StatusCode, out)
+	}
+	return resp.StatusCode
+}
+
+func bound(ops *fakeOps, ws, identity string) bool {
+	ops.mu.Lock()
+	defer ops.mu.Unlock()
+	return ops.workspaceAdmins[wsKey{"org-a", ws}][identity]
+}
+
+// Regression for the org-admin 403: adding someone as org admin must bind
+// them in every child workspace, not only write the Membership CR + UMI
+// row (which is what the hub authorizes against, while kcp needs a CRB).
+func TestAddOrgMembership_AdminBindsEveryWorkspace(t *testing.T) {
+	mgr, ops := rbacFixture(t)
+	srv := newTestServer(t, mgr, adminTC("alice", "org-a", ""))
+	defer srv.Close()
+
+	if got := doJSON(t, http.MethodPost, srv.URL+"/api/orgs/org-a/memberships", MembershipAddRequest{User: "bob", Role: "admin"}); got != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201", got)
+	}
+	for _, ws := range []string{"ws-1", "ws-2"} {
+		if !bound(ops, ws, "faros:bob@example.com") {
+			t.Errorf("bob not bound in %s: %v", ws, ops.workspaceAdmins)
+		}
+	}
+	// A plain member gets nothing at the kcp layer until granted a workspace.
+	if got := doJSON(t, http.MethodPost, srv.URL+"/api/orgs/org-a/memberships", MembershipAddRequest{User: "carol", Role: "member"}); got != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201", got)
+	}
+	if bound(ops, "ws-1", "faros:carol@example.com") {
+		t.Error("member carol bound without a workspace grant")
+	}
+}
+
+func TestPatchOrgMembership_RoleChangesFollowIntoWorkspaces(t *testing.T) {
+	mgr, ops := rbacFixture(t)
+	_ = ops.EnsureOrgMembership(context.Background(), "org-a", "bob", "member")
+	srv := newTestServer(t, mgr, adminTC("alice", "org-a", ""))
+	defer srv.Close()
+
+	// bob is also an explicit member of ws-1.
+	wsSrv := newTestServer(t, mgr, adminTC("alice", "org-a", "ws-1"))
+	defer wsSrv.Close()
+	if got := doJSON(t, http.MethodPost, wsSrv.URL+"/api/orgs/org-a/workspaces/ws-1/memberships", MembershipAddRequest{User: "bob", Role: "member"}); got != http.StatusCreated {
+		t.Fatalf("workspace add: got %d", got)
+	}
+	if got := doJSON(t, http.MethodPatch, srv.URL+"/api/orgs/org-a/memberships/bob", MembershipPatchRequest{Role: "admin"}); got != http.StatusOK {
+		t.Fatalf("promote: got %d", got)
+	}
+	if !bound(ops, "ws-2", "faros:bob@example.com") {
+		t.Errorf("promotion did not bind bob in ws-2: %v", ops.workspaceAdmins)
+	}
+	if got := doJSON(t, http.MethodPatch, srv.URL+"/api/orgs/org-a/memberships/bob", MembershipPatchRequest{Role: "member"}); got != http.StatusOK {
+		t.Fatalf("demote: got %d", got)
+	}
+	if bound(ops, "ws-2", "faros:bob@example.com") {
+		t.Error("demotion left bob bound in ws-2")
+	}
+	if !bound(ops, "ws-1", "faros:bob@example.com") {
+		t.Error("demotion revoked bob's explicit ws-1 membership")
+	}
+}
+
+func TestDeleteOrgMembership_RevokesWorkspaces(t *testing.T) {
+	mgr, ops := rbacFixture(t)
+	srv := newTestServer(t, mgr, adminTC("alice", "org-a", ""))
+	defer srv.Close()
+	if got := doJSON(t, http.MethodPost, srv.URL+"/api/orgs/org-a/memberships", MembershipAddRequest{User: "bob", Role: "admin"}); got != http.StatusCreated {
+		t.Fatalf("add: got %d", got)
+	}
+	if got := doJSON(t, http.MethodDelete, srv.URL+"/api/orgs/org-a/memberships/bob?cascade=true", nil); got != http.StatusNoContent {
+		t.Fatalf("delete: got %d", got)
+	}
+	for _, ws := range []string{"ws-1", "ws-2"} {
+		if bound(ops, ws, "faros:bob@example.com") {
+			t.Errorf("bob still bound in %s after removal", ws)
+		}
+	}
+}
+
+func TestDeleteWorkspaceMembership_RevokesUnlessOrgAdmin(t *testing.T) {
+	mgr, ops := rbacFixture(t)
+	srv := newTestServer(t, mgr, adminTC("alice", "org-a", "ws-1"))
+	defer srv.Close()
+	for _, u := range []string{"bob", "carol"} {
+		if got := doJSON(t, http.MethodPost, srv.URL+"/api/orgs/org-a/workspaces/ws-1/memberships", MembershipAddRequest{User: u, Role: "member"}); got != http.StatusCreated {
+			t.Fatalf("add %s: got %d", u, got)
+		}
+	}
+	// carol is also an org admin; bob is a plain org member.
+	_ = ops.PatchOrgMembershipRole(context.Background(), "org-a", "carol", "admin")
+
+	for _, u := range []string{"bob", "carol"} {
+		if got := doJSON(t, http.MethodDelete, srv.URL+"/api/orgs/org-a/workspaces/ws-1/memberships/"+u, nil); got != http.StatusNoContent {
+			t.Fatalf("delete %s: got %d", u, got)
+		}
+	}
+	if bound(ops, "ws-1", "faros:bob@example.com") {
+		t.Error("bob still bound after workspace removal")
+	}
+	if !bound(ops, "ws-1", "faros:carol@example.com") {
+		t.Error("org admin carol lost her implicit workspace access")
+	}
+}
+
+func TestCreateWorkspace_BindsExistingOrgAdmins(t *testing.T) {
+	mgr, ops := rbacFixture(t)
+	_ = ops.EnsureOrgMembership(context.Background(), "org-a", "bob", "admin")
+	_ = ops.EnsureOrgMembership(context.Background(), "org-a", "carol", "member")
+	srv := newTestServer(t, mgr, adminTC("alice", "org-a", ""))
+	defer srv.Close()
+
+	b, _ := json.Marshal(CreateWorkspaceRequest{DisplayName: "platform"})
+	resp, err := http.Post(srv.URL+"/api/orgs/org-a/workspaces", "application/json", jsonBody(b))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	var view WorkspaceView
+	_ = json.NewDecoder(resp.Body).Decode(&view)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+	if !bound(ops, view.UUID, "faros:bob@example.com") {
+		t.Errorf("org admin bob not bound in new workspace: %v", ops.workspaceAdmins)
+	}
+	if bound(ops, view.UUID, "faros:carol@example.com") {
+		t.Error("org member carol bound in new workspace")
+	}
+}

--- a/pkg/hub/restapi/workspaces.go
+++ b/pkg/hub/restapi/workspaces.go
@@ -183,6 +183,12 @@ func (h *Handler) createWorkspace(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// Every org admin is an implicit admin here too (O-15); bind them now
+	// so the workspace is reachable for admins added before it existed.
+	if err := h.mgr.grantOrgAdminsWorkspaceRBAC(r.Context(), orgUUID, wsUUID); err != nil {
+		writeError(w, err)
+		return
+	}
 	if err := h.mgr.bootstrapper.EnsureChildWorkspaceDefaultMCPServer(r.Context(), orgUUID, wsUUID); err != nil {
 		writeError(w, err)
 		return


### PR DESCRIPTION
> **This pull request was prepared by an automated coding agent (Claude Code) on behalf of @mjudeikis. Review accordingly.**

## Problem

After #711 an org admin passes the hub's tenant middleware and the kcp proxy for any child workspace, but kcp itself still answers:

```
403: repositories.code.faros.sh is forbidden: User "faros:mangirdas@judeikis.lt" cannot list resource "repositories" in API group "code.faros.sh" at the cluster scope: access denied
```

Adding or promoting an org admin (`addOrgMembership`, `patchOrgMembership`) wrote only the Membership CR and the UserMembershipIndex row. Only workspace-scope grants, workspace creation and the personal-org bootstrap ever called `EnsureChildWorkspaceAdmin`, so no ClusterRoleBinding existed for the admin in the child workspace's logical cluster.

A second defect surfaced while tracing this: `ensureWorkspaceAdmin` kept one shared `faros-cluster-admin` binding per workspace and overwrote its single subject on every grant. In any workspace with more than one member, only the most recently granted person actually had kcp RBAC.

## Fix

- **Per-user bindings.** Each member gets `faros-user-admin-<sha256[:16]>` with their rbacIdentity as the only subject, so grants are additive. The legacy shared binding is migrated to per-user bindings and deleted the first time a grant or revoke touches that workspace; whoever held it keeps access.
- **Bootstrapper API.** New `RevokeChildWorkspaceAdmin` and `ListOrgMembershipRoles`.
- **Membership handlers keep kcp RBAC in step** (`pkg/hub/restapi/workspace_rbac.go`):
  - org-admin add or promote → bind in every child team workspace;
  - org-admin demote or org removal (incl. self-leave) → revoke where no workspace-scope row remains;
  - workspace member removal (incl. self-leave) → revoke unless the user is an org admin;
  - workspace create → bind every current org admin.
- **Organization controller backfill** now walks every UMI row, including org-scope admin rows in other orgs, so existing deployments self-heal on the next User reconcile and users invited before first sign-in get bound once their rbacIdentity exists.

## Tests

- `pkg/hub/kcp/workspaceadmin_test.go`: additive grants, legacy migration, revoke isolation.
- `pkg/hub/restapi/workspace_rbac_test.go`: every handler path above.
- `pkg/hub/controllers/organization/controller_test.go`: backfill across foreign orgs.
- `go test ./pkg/hub/... ./pkg/server/...`, gofmt and golangci-lint clean.

## Rollout note

The shared `faros-cluster-admin` binding is replaced lazily, on the first membership change in each workspace. Untouched workspaces keep working under the old binding until then. Not verified against console-dev in this session (expired CLI credential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
