### PR TITLE
Add managed local runner installation and rollback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,8 @@ build-hub:
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BINDIR)/faros-hub ./cmd/faros-hub/
 
 test-runner: ## Run focused generic runner and harness tests
-	go test -count=1 ./pkg/runner/...
+	go test -count=1 ./pkg/runner/... ./cmd/faros-runner/...
+	python3 -m unittest discover -s hack/runner-install -p 'test_*.py'
 
 lint-runner: $(GOLANGCI_LINT) ## Lint the standalone runner and adapters
 	$(GOLANGCI_LINT) run ./pkg/runner/... ./cmd/faros-runner/...
@@ -2796,3 +2797,7 @@ fix-lint-linear-release: $(GOLANGCI_LINT)
 verify-linear-release: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run ./cmd/release
 	go test -count=1 ./cmd/release
+
+.PHONY: package-runner-darwin
+package-runner-darwin: build-runner-darwin ## Package Mac runner binaries and the local upgrade manager
+	python3 hack/runner-install/package.py $(BINDIR)

--- a/cmd/faros-runner/main.go
+++ b/cmd/faros-runner/main.go
@@ -19,12 +19,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"syscall"
 
 	"github.com/faroshq/faros/pkg/runner"
@@ -51,8 +53,10 @@ func main() {
 
 func run() (runErr error) {
 	var opts options
+	var showVersion bool
 	flags := flag.NewFlagSet("faros-runner", flag.ContinueOnError)
 	flags.SetOutput(os.Stderr)
+	flags.BoolVar(&showVersion, "version", false, "print build and protocol metadata as JSON, then exit")
 	flags.StringVar(&opts.config, "config", "", "path to the JSON runner enrollment/configuration file")
 	flags.StringVar(&opts.stateDir, "state-dir", "", "durable runner state directory")
 	flags.StringVar(&opts.listen, "listen", "", "loopback listen address (default 127.0.0.1:8787)")
@@ -63,6 +67,12 @@ func run() (runErr error) {
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		return err
 	}
+	if showVersion {
+		return json.NewEncoder(os.Stdout).Encode(map[string]string{
+			"version": version.Get(), "commit": version.GitCommit, "buildDate": version.BuildDate,
+			"protocolVersion": runner.ProtocolVersion, "os": runtime.GOOS, "arch": runtime.GOARCH,
+		})
+	}
 	if os.Geteuid() == 0 {
 		return errors.New("faros-runner must run as a non-root user")
 	}
@@ -70,6 +80,8 @@ func run() (runErr error) {
 	if err != nil {
 		return err
 	}
+	// Build identity is executable-owned, not enrollment configuration.
+	cfg.Version = version.Get()
 	if opts.stateDir != "" {
 		cfg.StateDir = opts.stateDir
 	}

--- a/docs/local-runner.md
+++ b/docs/local-runner.md
@@ -411,7 +411,7 @@ interruption, restart, and same-session resume evidence.
 loading enrollment, credentials, or Codex. The running capabilities response
 reports the executable's build version; enrollment cannot override it.
 
-`make package-runner-darwin` builds arm64/amd64 archives containing the binary,
+`make package-runner-darwin` builds plain arm64/amd64 tar archives containing the binary,
 manager, and `install.sh`, plus archive SHA-256 files. Verify the archive digest
 from your trusted distribution before extracting and running `sh install.sh`.
 This installs locally; it does not start the runner or enroll a worker.

--- a/docs/local-runner.md
+++ b/docs/local-runner.md
@@ -404,3 +404,54 @@ harness, Git-fetch, and local artifact contracts. They do not establish live
 GitHub publication or provide live Mac stage6B proof. Live acceptance still
 needs an actual enrolled host, approved local repository, start/observe path,
 interruption, restart, and same-session resume evidence.
+
+## Managed local installation and upgrades
+
+`faros-runner --version` prints JSON build, protocol, and host metadata without
+loading enrollment, credentials, or Codex. The running capabilities response
+reports the executable's build version; enrollment cannot override it.
+
+`make package-runner-darwin` builds arm64/amd64 archives containing the binary,
+manager, and `install.sh`, plus archive SHA-256 files. Verify the archive digest
+from your trusted distribution before extracting and running `sh install.sh`.
+This installs locally; it does not start the runner or enroll a worker.
+
+The Python 3 helper `hack/runner-install/manage.py` installs a **raw binary**
+from a trusted distribution with its separately verified SHA-256. It uses no
+network, never changes runner configuration, and retains the previous binary.
+Run it as your worker account, using the same install root for every command:
+
+```sh
+python3 manage.py install --binary ./faros-runner --sha256 EXPECTED_BINARY_SHA256
+python3 manage.py run -- --config /absolute/path/runner.json \
+  --codex-home /absolute/path/codex-home --version-pin YOUR_TESTED_CODEX_VERSION
+```
+
+Before upgrading, drain the Worker in its coordinating provider and wait until
+its current attempt has stopped. Stop the runner process, install the new binary
+with the same command, then launch with the same configuration and Codex home.
+Managed runs hold the install lock for their lifetime. For the first transition
+from a manually launched runner, stop that old process yourself. Keep the Edge
+agent running. Do not run the disposable fixture setup script on an existing
+worker: it writes fixture enrollment.
+
+Confirm the running version, runner identity, readiness, exact harness version,
+and required capabilities through the coordinating provider's published Edges
+Service client before undraining. Installation success and `--version` are
+local checks, not proof of live worker readiness. `status` inspects the selected
+binary while the manager is stopped.
+
+For a failed upgrade, keep the Worker drained, stop the runner, then:
+
+```sh
+python3 manage.py rollback
+python3 manage.py run -- --config /absolute/path/runner.json \
+  --codex-home /absolute/path/codex-home --version-pin YOUR_TESTED_CODEX_VERSION
+```
+
+Rollback switches only the executable. It does not roll back journals, harness
+sessions, credentials, or configuration. Only roll back across versions whose
+state formats were verified compatible; matching wire protocols alone does not
+prove this. If the upgraded runner wrote an incompatible state format, keep it
+stopped and recover from a tested backup instead. This helper does not install a
+launchd service or automatically retry failed jobs.

--- a/hack/runner-install/manage.py
+++ b/hack/runner-install/manage.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Faros Authors.
+"""Local, checksum-pinned runner installation. Never edits enrollment or state."""
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+import tempfile
+
+
+def metadata(binary):
+    result = subprocess.run([str(binary), '--version'], check=True,
+                            capture_output=True, text=True, timeout=10)
+    value = json.loads(result.stdout)
+    arch = {'aarch64': 'arm64', 'x86_64': 'amd64'}.get(platform.machine(), platform.machine())
+    if (value.get('protocolVersion') != 'runner/v1' or
+            value.get('os') != platform.system().lower() or value.get('arch') != arch):
+        raise ValueError('runner protocol or host architecture does not match')
+    if not value.get('version') or not value.get('commit'):
+        raise ValueError('runner build metadata is missing')
+    return value
+
+
+def digest(path):
+    with path.open('rb') as stream:
+        result = hashlib.sha256()
+        for block in iter(lambda: stream.read(1024 * 1024), b''):
+            result.update(block)
+        return result.hexdigest()
+
+
+def selected(root, state, field='current'):
+    sha = state.get(field, '')
+    if len(sha) != 64 or any(c not in '0123456789abcdef' for c in sha):
+        raise ValueError('no valid ' + field + ' installation')
+    binary = root / 'releases' / sha / 'faros-runner'
+    if digest(binary) != sha:
+        raise ValueError('installed binary checksum mismatch')
+    return binary
+
+
+def save(root, state):
+    fd, name = tempfile.mkstemp(dir=root, prefix='.selection-')
+    try:
+        with os.fdopen(fd, 'w') as stream:
+            json.dump(state, stream)
+            stream.write('\n')
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(name, root / 'selection.json')
+    finally:
+        Path(name).unlink(missing_ok=True)
+
+
+def install(root, state, source, expected):
+    if len(expected) != 64 or any(c not in '0123456789abcdef' for c in expected):
+        raise ValueError('provide the trusted SHA-256 of the binary')
+    releases = root / 'releases'
+    releases.mkdir(exist_ok=True)
+    fd, temporary = tempfile.mkstemp(dir=releases, prefix='.download-')
+    try:
+        with os.fdopen(fd, 'wb') as target, source.open('rb') as incoming:
+            for block in iter(lambda: incoming.read(1024 * 1024), b''):
+                target.write(block)
+            target.flush()
+            os.fsync(target.fileno())
+        binary = Path(temporary)
+        if digest(binary) != expected:
+            raise ValueError('binary checksum mismatch; current installation unchanged')
+        binary.chmod(0o700)
+        info = metadata(binary)
+        destination = releases / expected
+        destination.mkdir(exist_ok=True)
+        os.replace(binary, destination / 'faros-runner')
+        if state.get('current') != expected:
+            save(root, {'current': expected, 'previous': state.get('current')})
+        print(json.dumps(info))
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--root', type=Path, default=Path.home() / '.local/share/faros-runner')
+    commands = parser.add_subparsers(dest='command', required=True)
+    add = commands.add_parser('install')
+    add.add_argument('--binary', type=Path, required=True)
+    add.add_argument('--sha256', required=True)
+    commands.add_parser('status')
+    commands.add_parser('rollback')
+    run = commands.add_parser('run')
+    run.add_argument('arguments', nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    os.umask(0o077)
+    root = args.root.expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    with (root / '.lock').open('a') as lock:
+        # Held across exec: managed upgrades cannot race a running worker.
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        state_path = root / 'selection.json'
+        state = json.loads(state_path.read_text()) if state_path.exists() else {}
+        if args.command == 'install':
+            install(root, state, args.binary, args.sha256)
+        elif args.command == 'rollback':
+            metadata(selected(root, state, 'previous'))
+            save(root, {'current': state['previous'], 'previous': state['current']})
+            print('Previous binary selected. Start it with the same configuration.')
+        else:
+            binary = selected(root, state)
+            info = metadata(binary)
+            if args.command == 'status':
+                print(json.dumps({'binary': str(binary), **info}))
+            else:
+                arguments = args.arguments
+                if arguments[:1] == ['--']:
+                    arguments = arguments[1:]
+                os.set_inheritable(lock.fileno(), True)
+                os.execv(binary, [str(binary), *arguments])
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except BlockingIOError:
+        sys.exit('Runner manager is busy. Drain the worker and stop the managed runner before updating.')
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        sys.exit(str(error))

--- a/hack/runner-install/package.py
+++ b/hack/runner-install/package.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Faros Authors.
+"""Package already-built Darwin binaries without credentials or enrollment."""
+import hashlib
+import io
+from pathlib import Path
+import sys
+import tarfile
+
+bindir = Path(sys.argv[1] if len(sys.argv) > 1 else 'bin')
+source = Path(__file__).parent
+for arch in ('arm64', 'amd64'):
+    binary = bindir / ('faros-runner-darwin-' + arch)
+    sha = hashlib.sha256(binary.read_bytes()).hexdigest()
+    bundle = bindir / ('faros-runner-macos-' + arch + '.tar.gz')
+    installer = ('#!/bin/sh\nset -eu\n'
+                 'cd "$(dirname "$0")"\n'
+                 'exec python3 ./manage.py install --binary ./faros-runner --sha256 ' + sha + '\n')
+    with tarfile.open(bundle, 'w:gz') as archive:
+        archive.add(binary, arcname='faros-runner-install/faros-runner', recursive=False)
+        archive.add(source / 'manage.py', arcname='faros-runner-install/manage.py', recursive=False)
+        content = installer.encode()
+        info = tarfile.TarInfo('faros-runner-install/install.sh')
+        info.size, info.mode = len(content), 0o700
+        archive.addfile(info, io.BytesIO(content))
+    checksum = hashlib.sha256(bundle.read_bytes()).hexdigest()
+    bundle.with_suffix(bundle.suffix + '.sha256').write_text(checksum + '  ' + bundle.name + '\n')
+    print(bundle.name, checksum)

--- a/hack/runner-install/package.py
+++ b/hack/runner-install/package.py
@@ -12,11 +12,11 @@ source = Path(__file__).parent
 for arch in ('arm64', 'amd64'):
     binary = bindir / ('faros-runner-darwin-' + arch)
     sha = hashlib.sha256(binary.read_bytes()).hexdigest()
-    bundle = bindir / ('faros-runner-macos-' + arch + '.tar.gz')
+    bundle = bindir / ('faros-runner-macos-' + arch + '.tar')
     installer = ('#!/bin/sh\nset -eu\n'
                  'cd "$(dirname "$0")"\n'
                  'exec python3 ./manage.py install --binary ./faros-runner --sha256 ' + sha + '\n')
-    with tarfile.open(bundle, 'w:gz') as archive:
+    with tarfile.open(bundle, 'w') as archive:
         archive.add(binary, arcname='faros-runner-install/faros-runner', recursive=False)
         archive.add(source / 'manage.py', arcname='faros-runner-install/manage.py', recursive=False)
         content = installer.encode()

--- a/hack/runner-install/test_manage.py
+++ b/hack/runner-install/test_manage.py
@@ -93,5 +93,28 @@ class ManagerCLITest(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
 
 
+class PackageTest(unittest.TestCase):
+    def test_archives_contain_only_runner_manager_and_pinned_installer(self):
+        import subprocess
+        import sys
+        import tarfile
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for arch in ('arm64', 'amd64'):
+                (root / ('faros-runner-darwin-' + arch)).write_bytes(arch.encode())
+            subprocess.run([sys.executable, str(Path(__file__).with_name('package.py')), directory],
+                           check=True, capture_output=True)
+            for arch in ('arm64', 'amd64'):
+                archive = root / ('faros-runner-macos-' + arch + '.tar')
+                checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+                self.assertEqual(archive.with_suffix('.tar.sha256').read_text(), checksum + '  ' + archive.name + '\n')
+                with tarfile.open(archive, 'r:') as bundle:
+                    self.assertEqual(set(bundle.getnames()), {
+                        'faros-runner-install/faros-runner', 'faros-runner-install/manage.py',
+                        'faros-runner-install/install.sh'})
+                    script = bundle.extractfile('faros-runner-install/install.sh').read().decode()
+                    self.assertIn(hashlib.sha256(arch.encode()).hexdigest(), script)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/hack/runner-install/test_manage.py
+++ b/hack/runner-install/test_manage.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The Faros Authors.
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import platform
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location('manage', Path(__file__).with_name('manage.py'))
+manage = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(manage)
+
+
+class InstallTest(unittest.TestCase):
+    def test_upgrade_rejection_and_rollback_selection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            arch = {'x86_64': 'amd64', 'aarch64': 'arm64'}.get(platform.machine(), platform.machine())
+            def binary(name, protocol='runner/v1'):
+                data = {'version': name, 'commit': name, 'protocolVersion': protocol,
+                        'os': platform.system().lower(), 'arch': arch}
+                source = root / name
+                source.write_text('#!/bin/sh\ncat <<\'EOF\'\n' + json.dumps(data) + '\nEOF\n')
+                return source, hashlib.sha256(source.read_bytes()).hexdigest()
+            first, sha1 = binary('first')
+            manage.install(root, {}, first, sha1)
+            state = json.loads((root / 'selection.json').read_text())
+            second, sha2 = binary('second')
+            with self.assertRaisesRegex(ValueError, 'checksum mismatch'):
+                manage.install(root, state, second, '0' * 64)
+            bad, badsha = binary('bad', 'runner/v99')
+            with self.assertRaisesRegex(ValueError, 'protocol'):
+                manage.install(root, state, bad, badsha)
+            self.assertEqual(json.loads((root / 'selection.json').read_text()), state)
+            manage.install(root, state, second, sha2)
+            state = json.loads((root / 'selection.json').read_text())
+            self.assertEqual(state, {'current': sha2, 'previous': sha1})
+            self.assertEqual(manage.metadata(manage.selected(root, state, 'previous'))['version'], 'first')
+            import subprocess
+            import sys
+            subprocess.run([sys.executable, str(Path(__file__).with_name('manage.py')),
+                            '--root', directory, 'rollback'], check=True, capture_output=True)
+            rolled = json.loads((root / 'selection.json').read_text())
+            self.assertEqual(rolled, {'current': sha1, 'previous': sha2})
+            manage.selected(root, state).write_text('corrupted')
+            with self.assertRaisesRegex(ValueError, 'checksum'):
+                manage.selected(root, state)
+
+class ManagerCLITest(unittest.TestCase):
+    def test_lock_rejects_install_before_reading_binary(self):
+        import fcntl
+        import subprocess
+        import sys
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with (root / '.lock').open('a') as lock:
+                fcntl.flock(lock, fcntl.LOCK_EX)
+                result = subprocess.run([sys.executable, str(Path(__file__).with_name('manage.py')),
+                                         '--root', directory, 'install', '--binary', '/missing',
+                                         '--sha256', '0' * 64], capture_output=True, text=True)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn('manager is busy', result.stderr)
+                self.assertFalse((root / 'selection.json').exists())
+
+    def test_managed_run_holds_lock_across_exec(self):
+        import subprocess
+        import sys
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            arch = {'x86_64': 'amd64', 'aarch64': 'arm64'}.get(platform.machine(), platform.machine())
+            info = {'version': 'test', 'commit': 'test', 'protocolVersion': 'runner/v1',
+                    'os': platform.system().lower(), 'arch': arch}
+            binary = root / 'source'
+            binary.write_text('#!' + sys.executable + '\nimport sys,time\n'
+                              'if sys.argv[1:] == ["--version"]: print(' + repr(json.dumps(info)) + ')\n'
+                              'else:\n print("started", flush=True)\n time.sleep(20)\n')
+            sha = hashlib.sha256(binary.read_bytes()).hexdigest()
+            manage.install(root, {}, binary, sha)
+            command = [sys.executable, str(Path(__file__).with_name('manage.py')), '--root', directory]
+            child = subprocess.Popen(command + ['run'], stdout=subprocess.PIPE, text=True)
+            try:
+                import select
+                self.assertTrue(select.select([child.stdout], [], [], 5)[0], 'runner did not start')
+                self.assertEqual(child.stdout.readline().strip(), 'started')
+                result = subprocess.run(command + ['rollback'], capture_output=True, text=True)
+                self.assertIn('manager is busy', result.stderr)
+            finally:
+                child.terminate()
+                child.wait(timeout=5)
+                child.stdout.close()
+            result = subprocess.run(command + ['status'], capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Local Mac runner updates required replacing ad hoc preview binaries and offered no stable rollback command. Add a checksum-pinned, versioned local installer with an exec-held update lock, previous-binary rollback, executable-owned build metadata, and plain tar packages. Enrollment, credentials, and journals remain in their existing locations.

Validation: focused runner tests and lint; installer checksum, compatibility, rollback, lock, and archive-content tests; Darwin arm64/amd64 builds. Live Mac upgrade and published Edges discovery verified. Rollback is tested locally; a live Mac downgrade and launchd installation are outside this change.
