### PR TITLE
[AUTOMATED BOT PR] skills(faros): CLI install guidance and in-repo plugin/Codex install

### DIFF
--- a/.agents/skills/faros
+++ b/.agents/skills/faros
@@ -1,0 +1,1 @@
+../../skills/faros

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "faros",
+  "owner": {
+    "name": "faroshq",
+    "url": "https://github.com/faroshq"
+  },
+  "metadata": {
+    "description": "Skills for using faros from Claude Code"
+  },
+  "plugins": [
+    {
+      "name": "faros",
+      "source": "./skills/faros",
+      "description": "Drive a faros hub as a user: faros CLI, orgs and workspaces, MCP, App Studio, infrastructure, hosted agents, edges.",
+      "category": "productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ skips them with a warning. `exec` needs a prior sync.
 | `providers/` | The providers listed above, each its own Go module |
 | `deploy/charts` | Helm charts for the hub and the agent |
 | `docs/` | Published docs and design documents |
+| `skills/faros` | Agent skill for using a hub from Claude Code, Codex or Cursor; the repo is a Claude Code plugin marketplace (`/plugin marketplace add faroshq/faros`) and ships it under `.agents/skills` for Codex ([install](skills/faros/README.md#install)) |
 
 ## Documentation
 

--- a/skills/faros/.claude-plugin/plugin.json
+++ b/skills/faros/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "faros",
+  "displayName": "faros",
+  "version": "0.1.0",
+  "description": "Drive a faros hub as a user: faros CLI, orgs and workspaces, MCP, App Studio, infrastructure, hosted agents, edges.",
+  "author": {
+    "name": "faroshq",
+    "url": "https://github.com/faroshq"
+  },
+  "homepage": "https://github.com/faroshq/faros/tree/main/skills/faros",
+  "repository": "https://github.com/faroshq/faros",
+  "license": "Apache-2.0",
+  "keywords": [
+    "faros",
+    "kcp",
+    "mcp",
+    "app-studio",
+    "kubernetes"
+  ]
+}

--- a/skills/faros/README.md
+++ b/skills/faros/README.md
@@ -27,23 +27,52 @@ published as a provider skill.
 
 ## Install
 
-Claude Code (per project; `.claude/` is gitignored in this repo, so link it):
+The skill is this directory: `SKILL.md` plus `references/`. Keep the two
+together; `SKILL.md` links into `references/`. Nothing is hosted anywhere
+else: every install path below reads this repository.
 
-```bash
-mkdir -p .claude/skills && ln -s ../../skills/faros .claude/skills/faros
-# or globally
-mkdir -p ~/.claude/skills && ln -s "$PWD/skills/faros" ~/.claude/skills/faros
+### Claude Code
+
+The repository is a plugin marketplace (`.claude-plugin/marketplace.json`)
+with one plugin, `faros`, whose root is this directory:
+
+```
+/plugin marketplace add faroshq/faros
+/plugin install faros@faros
 ```
 
-Codex: reference it from your `AGENTS.md`, or copy the directory into
-`~/.codex/skills/faros` if your Codex build loads skills from there.
+or from a shell, `claude plugin marketplace add faroshq/faros && claude plugin install faros@faros`.
+Update later with `/plugin update faros@faros`. To load it without the
+plugin system, copy the directory to `.claude/skills/faros` (one project) or
+`~/.claude/skills/faros` (every project); `.claude/` is gitignored here, so
+inside this repo use a symlink: `ln -s ../../skills/faros .claude/skills/faros`.
 
-Cursor and others: point a rule at `skills/faros/SKILL.md`, or paste it into
-the project instructions. The references are plain markdown.
+### Codex
 
-Inside App Studio: a project can ship it as
-`.agents/skills/faros/SKILL.md`; the references directory travels as
-package resources.
+Codex reads `.agents/skills/<name>/SKILL.md` at the repository root and
+`~/.agents/skills/<name>/SKILL.md` for the user. This repository ships
+`.agents/skills/faros` as a symlink to this directory, so Codex picks the
+skill up as soon as you open the repo. For another project or for every
+project:
+
+```bash
+git clone --depth 1 https://github.com/faroshq/faros /tmp/faros
+cp -r /tmp/faros/skills/faros .agents/skills/faros      # this project
+cp -r /tmp/faros/skills/faros ~/.agents/skills/faros    # all projects
+```
+
+Codex's bundled `$skill-installer` can also fetch it; give it
+`https://github.com/faroshq/faros/tree/main/skills/faros`.
+
+### Cursor and others
+
+Point a rule at `skills/faros/SKILL.md`, or paste it into the project
+instructions. The references are plain markdown.
+
+### Inside App Studio
+
+A project can ship it as `.agents/skills/faros/SKILL.md`; the references
+directory travels as package resources.
 
 ## Keeping it honest
 

--- a/skills/faros/SKILL.md
+++ b/skills/faros/SKILL.md
@@ -88,8 +88,40 @@ call. `MCP_TOKEN` is a long-lived ServiceAccount token.
 
 ## 2. Get connected
 
-Install: `kubectl krew index add faros https://github.com/faroshq/krew-index.git && kubectl krew install faros/faros`,
-`go install github.com/faroshq/faros/cmd/faros@latest`, or a release binary.
+**Check for the CLI first.** Everything below assumes `faros` is on `PATH`.
+`command not found: faros` (or `command -v faros` printing nothing) means it
+is not installed, not that the hub is down. Install it with the curl
+installer, which needs only `curl`, `tar` and `uname` and no sudo:
+
+```bash
+command -v faros >/dev/null || curl -fsSL https://downloads.faros.sh/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"       # the installer's default INSTALL_DIR; add to the shell profile too
+faros version
+```
+
+`FAROS_VERSION=vX.Y.Z` pins a release; `INSTALL_DIR=/usr/local/bin sudo -E sh`
+installs system-wide. Alternatives, when those tools are already present:
+`kubectl krew index add faros https://github.com/faroshq/krew-index.git && kubectl krew install faros/faros`
+(then `kubectl faros …` or `faros …`), `go install github.com/faroshq/faros/cmd/faros@latest`
+(Go 1.26+), or the release tarball `kubectl-faros_<Linux|Darwin>_<x86_64|aarch64|arm64>.tar.gz`
+from `https://github.com/faroshq/faros/releases`, which unpacks a binary
+named `kubectl-faros`: rename it to `faros`. Windows gets
+`kubectl-faros_Windows_<x86_64|arm64>.zip`; the installer script is Linux and macOS only.
+
+**No way to install anything.** The hub is plain HTTPS, so every CLI
+command has a curl equivalent once you hold a bearer; the CLI is only the
+convenient way to get one. On a static-token hub, `POST $HUB/auth/token-login`
+with `Authorization: Bearer <token>` and an empty body provisions your
+user and returns a kubeconfig (`.kubeconfig`, base64 in the JSON), and the same token is your
+`TOKEN` for every `fc` call. On an OIDC hub there is no browser-free login:
+ask someone with the CLI for a workspace service-account token
+(`POST …/serviceaccounts/{uuid}/tokens`, [references/access.md](references/access.md)
+section 6), which works on hub REST, kube REST and MCP, or for the
+workspace MCP connect token, which works on the MCP endpoint only and sees
+no org-owned provider tools. Org, workspace and cluster IDs then come from
+`GET $HUB/api/orgs` and `GET $HUB/api/orgs/$ORG/workspaces` instead of
+`faros env`.
+
 `faros login` writes a kubeconfig context `faros` pointing at
 `<hub>/clusters/<clusterName>`; OIDC logins cache tokens in
 `~/.config/faros/tokens/`. `faros use --org <o> --workspace <w>` switches

--- a/skills/faros/references/access.md
+++ b/skills/faros/references/access.md
@@ -5,7 +5,16 @@ Source citations are repo-relative paths in the faros repository.
 ## 1. CLI command tree
 
 Binary `faros`; krew installs `kubectl-faros`, so `kubectl faros <cmd>` is
-equivalent. Two global flags: `--kubeconfig <path>` (default `$KUBECONFIG`,
+equivalent. Install paths (source: `install.sh`, `.goreleaser.yml`):
+`curl -fsSL https://downloads.faros.sh/install.sh | sh` (latest GitHub
+release, or `FAROS_VERSION`; into `INSTALL_DIR`, default `~/.local/bin`;
+downloads from `downloads.faros.sh/cli/faros/<tag>/` and falls back to the
+GitHub release asset), krew from `github.com/faroshq/krew-index`,
+`go install github.com/faroshq/faros/cmd/faros@latest`, or the tarball
+`kubectl-faros_<OS>_<arch>.tar.gz` named after `uname -s`/`uname -m`
+(`Linux_x86_64`, `Linux_aarch64`, `Linux_ppc64le`, `Darwin_x86_64`,
+`Darwin_arm64`; Windows ships `.zip` for `x86_64` and `arm64`) with a `kubectl-faros_<version>_checksums.txt` beside it.
+`faros version` prints the build tag. Two global flags: `--kubeconfig <path>` (default `$KUBECONFIG`,
 else `~/.kube/config`) and `--insecure-skip-tls-verify`. `faros --help`
 groups commands (getting started, edges, organizations and access, developer
 workflow, agents/hub/dev); the generated per-command reference is

--- a/skills/faros/references/troubleshooting.md
+++ b/skills/faros/references/troubleshooting.md
@@ -8,6 +8,11 @@ Exact strings are in backticks; `…` marks elided detail.
 
 | Symptom | Cause | Fix |
 |---|---|---|
+| `command not found: faros` / `faros: not found` | The CLI is not installed; nothing to do with the hub | `curl -fsSL https://downloads.faros.sh/install.sh \| sh` (SKILL.md section 2); krew, `go install` or the release tarball otherwise |
+| Installer prints `Installed faros …` but `faros` still isn't found | `~/.local/bin` (the default `INSTALL_DIR`) is not on `PATH` | `export PATH="$HOME/.local/bin:$PATH"` in this shell and the profile, or reinstall with `INSTALL_DIR=/usr/local/bin sudo -E sh` |
+| Installer: `missing required tool: curl\|tar\|uname`, `unsupported OS: …`, `unsupported architecture: …` | The host lacks a prerequisite, or the script doesn't cover it (Linux and Darwin only; x86_64, aarch64/arm64, ppc64le) | Install the tool; on Windows unpack `kubectl-faros_Windows_<arch>.zip` from the releases page; otherwise skip the CLI and use raw REST with a token (SKILL.md section 2, "No way to install anything") |
+| Installer: `could not resolve latest release tag from GitHub` | `api.github.com` unreachable or rate-limited | Set `FAROS_VERSION=vX.Y.Z` so no lookup is needed |
+| `kubectl faros` works but `faros` doesn't (or vice versa) | krew installs the plugin as `kubectl-faros` only; the curl installer installs `faros` only | Either name runs the same binary; symlink one to the other if a script needs it |
 | `no hub configured` | No hub URL | `--hub-url` or `FAROS_HUB_URL` |
 | `no interactive terminal; pass --org and --workspace` | CI / no TTY | Pass both flags to `faros use` |
 | `… (token missing or expired; run 'faros login')` | 401 from the hub; OIDC token expired | `faros login`; re-run `eval "$(faros env)"` for a fresh `TOKEN` |


### PR DESCRIPTION
> **This pull request was prepared by an automated coding agent (Claude Code) on behalf of @mjudeikis. Review accordingly.**

## Summary

Two commits. The first fixes the skill's guidance for a machine with no `faros` binary; the second makes this repository the install point for the skill in Claude Code and Codex, with no separate hosting.

### 1. Cover installing the CLI and working without it

The skill assumed `faros` was on `PATH`; its only install guidance was one line (krew, `go install`, "or a release binary") and nothing in troubleshooting covered a missing CLI.

- **SKILL.md section 2** opens with a `command -v faros` check and the curl installer (`https://downloads.faros.sh/install.sh`; curl, tar, uname, no sudo), its `FAROS_VERSION` / `INSTALL_DIR` knobs and the `~/.local/bin` PATH follow-up. krew, `go install` (Go 1.26+) and the release tarballs are listed with exact asset names, including that the unpacked binary is `kubectl-faros` and Windows ships a `.zip`.
- **"No way to install anything"**: static-token hubs log in with `POST /auth/token-login` and curl; OIDC hubs have no browser-free login, so ask for a workspace service-account token (hub REST, kube REST, MCP) or the MCP connect token (MCP only, no org-owned provider tools); IDs come from `GET /api/orgs` and `GET /api/orgs/{org}/workspaces`.
- **references/access.md** records the install paths and archive naming from `install.sh` and `.goreleaser.yml`.
- **references/troubleshooting.md** gains rows for `command not found: faros`, the installer's own errors, "installed but not on PATH", the GitHub tag lookup failure, and `kubectl-faros` vs `faros`.

### 2. Install from this repo in Claude Code and Codex

- **Claude Code**: root `.claude-plugin/marketplace.json` declares one plugin, `faros`, rooted at `skills/faros`; `skills/faros/.claude-plugin/plugin.json` names it, and the `SKILL.md` at the plugin root loads as the single skill. Users run `/plugin marketplace add faroshq/faros` then `/plugin install faros@faros`.
- **Codex**: `.agents/skills/faros` is a symlink to `skills/faros`, the repo-scoped directory Codex discovers, so opening the repo is enough. Other projects copy the directory to `.agents/skills/` or `~/.agents/skills/`.
- `skills/faros/README.md` documents both paths plus Cursor and App Studio; the top-level README lists `skills/faros` in the repository layout.

## Verification

- `claude plugin validate --strict .` and `claude plugin validate --strict skills/faros` pass.
- Installed from the local checkout with `claude plugin marketplace add <path>` + `claude plugin install faros@faros`: one skill loaded, ~270 always-on tokens, ~13.8k on invoke. Uninstalled afterwards.
- `install.sh` URL returns 200; v0.1.29 release ships the named assets. Facts checked against `install.sh`, `.goreleaser.yml`, `pkg/cli/cmd/login.go`, `apis/tenancy/v1alpha1/types_auth.go`, and the current Codex skills docs for the `.agents/skills` paths.

## Test plan

- [ ] After merge: `/plugin marketplace add faroshq/faros` and `/plugin install faros@faros` from a clean machine.
- [ ] Open the repo in Codex and confirm the `faros` skill is listed.
- [ ] Follow the new section 2 of `SKILL.md` on a machine without `faros`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155GoXQsFECPYh9unBobpRq
