### PR TITLE
fix(linear): harden portal workflows and accessibility

### DIFF
--- a/docs/design/accessibility/interaction.md
+++ b/docs/design/accessibility/interaction.md
@@ -64,6 +64,11 @@ The current shared implementations demonstrate the contract:
   and `ConfirmDialog.vue` own complete names/roles, keyboard handling, and focus
   return for their respective rich controls. Use them instead of recreating
   partial ARIA behavior.
+- Provider route focus is owned by the host through `providerRouteFocus.ts`.
+  Opt-in providers announce `faros-route-ready` after rendering a destination;
+  Linear uses this contract. The host focuses a destination heading or restores
+  a still-mounted cached source control. This does not establish adoption by
+  other providers or authenticated host acceptance.
 - `ResourcePage.vue` exposes `aria-busy`, polite loading/refresh announcements,
   and an assertive initial error with a retry control. Its read-state contract
   is detailed in [resource reads](../patterns/resource-reads.md).

--- a/portal/src/pages/ProviderFrame.vue
+++ b/portal/src/pages/ProviderFrame.vue
@@ -15,10 +15,12 @@ import {
   invalidateProviderScript,
   loadProviderScript,
 } from '@/providers/providerScriptLoader'
+import { createProviderRouteFocus } from '@/providers/providerRouteFocus'
 import { createProviderContext } from '@/providers/providerContext'
 import { AlertCircle, Puzzle } from 'lucide-vue-next'
 import { useDelayedLoading } from '@/portalkit/useDelayedLoading'
 
+const routeFocus = createProviderRouteFocus()
 const routeContext = useRouteContextStore()
 const { scopePath } = useScopedNavigation()
 
@@ -230,7 +232,10 @@ watch(
 // can clear its fragment while leaving subPath unchanged.
 watch(
   () => [theme.resolved, auth.token, auth.clusterName, tenant.orgUUID, tenant.workspaceUUID, props.subPath, router.currentRoute.value.hash] as const,
-  () => pushContext(),
+  () => {
+    if (elementRef.value) routeFocus.before(elementRef.value, props.subPath || '')
+    pushContext()
+  },
 )
 
 // Workspace/org switch: AppLayout keys its slot wrapper on auth.clusterName,
@@ -276,10 +281,12 @@ function isCurrentMount(generation: number, name: string): boolean {
 function bindMountEvents() {
   const mount = mountRef.value
   if (!mount || boundMount === mount) return
+  boundMount?.removeEventListener('faros-route-ready', onRouteReady)
   boundMount?.removeEventListener('faros-navigate', onNavigate)
   boundMount?.removeEventListener('faros-layout-change', onLayoutChange)
   boundMount?.removeEventListener('faros-provider-bootstrap-retry', onProviderBootstrapRetry)
   boundMount = mount
+  boundMount.addEventListener('faros-route-ready', onRouteReady)
   boundMount.addEventListener('faros-navigate', onNavigate)
   boundMount.addEventListener('faros-layout-change', onLayoutChange)
   boundMount.addEventListener('faros-provider-bootstrap-retry', onProviderBootstrapRetry)
@@ -289,7 +296,9 @@ function bindMountEvents() {
 // The explicit cleanup matters when access is revoked while the route
 // component itself remains mounted (for example, during a workspace switch).
 function clearMountedElement() {
+  routeFocus.clear()
   mountGeneration++
+  boundMount?.removeEventListener('faros-route-ready', onRouteReady)
   boundMount?.removeEventListener('faros-navigate', onNavigate)
   boundMount?.removeEventListener('faros-layout-change', onLayoutChange)
   boundMount?.removeEventListener('faros-provider-bootstrap-retry', onProviderBootstrapRetry)
@@ -312,6 +321,7 @@ function mountElement(name: string, generation?: number): boolean {
   const el = document.createElement(tagFor(name)) as HTMLElement
   mountRef.value.appendChild(el)
   elementRef.value = el
+  routeFocus.before(el, props.subPath || '')
   bindMountEvents()
   pushContext()
   return true
@@ -411,6 +421,11 @@ function pushContext() {
       scope: () => ({ token: auth.token, orgUUID: tenant.orgUUID, workspaceUUID: tenant.workspaceUUID }),
     },
   )
+}
+
+function onRouteReady(e: Event) {
+  const element = elementRef.value
+  if (element && element.contains(e.target as Node)) routeFocus.ready(element)
 }
 
 // Bubble faros-navigate CustomEvents up into Vue Router.

--- a/portal/src/providers/providerRouteFocus.ts
+++ b/portal/src/providers/providerRouteFocus.ts
@@ -1,0 +1,26 @@
+/** The host owns route focus; providers announce when their destination DOM exists. */
+export function createProviderRouteFocus() {
+  const sources = new Map<string, HTMLElement>();
+  let previousPath = '';
+  let previousRoot: HTMLElement | null = null;
+  return {
+    before(root: HTMLElement, path: string) {
+      if (previousRoot !== root) { sources.clear(); previousRoot = root; previousPath = path; return; }
+      if (path === previousPath) return;
+      const active = document.activeElement;
+      if (active instanceof HTMLElement && root.contains(active)) sources.set(previousPath, active);
+      previousPath = path;
+    },
+    ready(root: HTMLElement) {
+      if (root !== previousRoot) return;
+      // Never take focus away from a control the user reached while rendering.
+      if (document.activeElement !== document.body && root.contains(document.activeElement)) return;
+      const source = sources.get(previousPath);
+      const target = source?.isConnected && root.contains(source) ? source : root.querySelector<HTMLElement>('h1, h2');
+      if (!target) return;
+      if (!target.hasAttribute('tabindex') && /^H[12]$/.test(target.tagName)) target.tabIndex = -1;
+      target.focus({ preventScroll: !!source?.isConnected });
+    },
+    clear() { sources.clear(); previousRoot = null; previousPath = ''; },
+  };
+}

--- a/providers/linear/portal/src/Workspace.vue
+++ b/providers/linear/portal/src/Workspace.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, provide, reactive, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, provide, reactive, ref, watch } from 'vue';
 import { Plug, ListTodo, Activity, Radio } from 'lucide-vue-next';
 import type { FarosContext } from './api';
 import { canonicalPath, type Route } from './routes';
@@ -15,10 +15,15 @@ import IssueDetailView from './views/IssueDetailView.vue';
 import HistoryView from './views/HistoryView.vue';
 const props = defineProps<{ context: () => FarosContext; authoritySignal: AbortSignal; route: Route }>();
 const root = ref<HTMLElement>();
+watch(() => props.route, async () => {
+  await nextTick();
+  root.value?.dispatchEvent(new CustomEvent('faros-route-ready', { bubbles: true }));
+}, { flush: 'post', immediate: true });
 const namespace = ref(props.route.namespace || 'default');
 const namespaceDraft = ref(namespace.value);
 const epoch = ref(0);
 let controller = new AbortController();
+const draft = reactive({ title: '', description: '', stateID: '', returnToIssue: false });
 const selection = reactive({ connection: '', team: '', query: '' });
 function scopedPath(path: string) { return canonicalPath(namespace.value, path); }
 function navigate(path: string, replace = false) { root.value?.dispatchEvent(new CustomEvent('faros-navigate', { bubbles: true, detail: { path: scopedPath(path), ...(replace ? { replace: true } : {}) } })); }
@@ -29,6 +34,7 @@ function href(path: string) {
 }
 watch(namespace, () => {
   controller.abort(); controller = new AbortController(); epoch.value++;
+  Object.assign(draft, { title: '', description: '', stateID: '', returnToIssue: false });
   Object.assign(selection, { connection: '', team: '', query: '' });
 }, { flush: 'sync' });
 watch(() => props.route.namespace, value => {
@@ -37,7 +43,7 @@ watch(() => props.route.namespace, value => {
   namespaceDraft.value = nextNamespace;
 }, { flush: 'sync' });
 onBeforeUnmount(() => controller.abort());
-provide(sessionKey, { context: props.context, get namespace() { return namespace.value; }, get signal() { return AbortSignal.any([controller.signal, props.authoritySignal]); }, selection, navigate, href });
+provide(sessionKey, { context: props.context, get namespace() { return namespace.value; }, get signal() { return AbortSignal.any([controller.signal, props.authoritySignal]); }, draft, selection, navigate, href });
 const tabs = [{ id: 'connections', label: 'Connections', icon: Plug }, { id: 'issues', label: 'Issues', icon: ListTodo }, { id: 'operations', label: 'Operations', icon: Activity }, { id: 'events', label: 'Events', icon: Radio }];
 const collection = computed(() => !props.route.name && !props.route.create && !props.route.invalid);
 function changeNamespace() { namespace.value = namespaceDraft.value.trim() || 'default'; namespaceDraft.value = namespace.value; navigate(props.route.page, true); }

--- a/providers/linear/portal/src/api.behavior.test.ts
+++ b/providers/linear/portal/src/api.behavior.test.ts
@@ -38,3 +38,23 @@ it('stops polling on abort without replaying a write', async () => {
   await vi.advanceTimersByTimeAsync(0); controller.abort(); await vi.runAllTimersAsync();
   expect((await result).name).toBe('AbortError'); expect(posts).toBe(1);
 });
+
+it('recovers a lost connection response only when the exact named intent matches', async () => {
+  let posts = 0; const paths: string[] = [];
+  const api = client(async (input, init) => {
+    paths.push(String(input)); if (init?.method === 'POST') { posts++; throw new Error('lost response'); }
+    return Response.json({ metadata: { name: 'linear' }, spec: { apiKeySecretRef: { name: 'key', key: 'apiKey' }, teams: [{ id: 'one' }] } });
+  });
+  expect((await api.createConnection('linear', 'key', ['one'])).metadata.name).toBe('linear');
+  expect(posts).toBe(1); expect(paths[1]).toMatch(/connections\/linear$/);
+  await expect(api.createConnection('linear', 'different', ['one'])).rejects.toThrow('different settings');
+});
+it('bounds history reads to one page and preserves opaque cursors', async () => {
+  const paths: string[] = []; const api = client(async input => { paths.push(String(input)); return Response.json({ items: [], metadata: { continue: 'next' } }); });
+  await api.listPage('operations', 10, 'a/b+c'); expect(paths).toHaveLength(1); expect(paths[0]).toContain('limit=10&continue=a%2Fb%2Bc');
+});
+it('patches only team policy with a resource version concurrency fence', async () => {
+  let sent: RequestInit | undefined; const api = client(async (_input, init) => { sent = init; return Response.json({}); });
+  await api.updateTeams('linear', ['one'], '12'); expect(sent?.method).toBe('PATCH');
+  expect(JSON.parse(String(sent?.body))).toEqual({ metadata: { resourceVersion: '12' }, spec: { teams: [{ id: 'one' }] } });
+});

--- a/providers/linear/portal/src/api.ts
+++ b/providers/linear/portal/src/api.ts
@@ -4,23 +4,32 @@ export type FarosContext = ProviderFetchContext & {
   tenant?: string; theme?: string; subPath?: string; basePath?: string;
   orgUUID?: string; workspaceUUID?: string; user?: { sub?: string; email?: string };
 };
-export type Node = { id: string; name?: string; key?: string; identifier?: string; title?: string; description?: string; body?: string; url?: string; updatedAt?: string; team?: Node; state?: Node };
+export type Node = { id: string; name?: string; key?: string; identifier?: string; title?: string; description?: string; body?: string; createdAt?: string; editedAt?: string; parentId?: string; user?: { name?: string; displayName?: string }; botActor?: { name?: string; type?: string }; externalUser?: { id: string }; url?: string; updatedAt?: string; team?: Node; state?: Node };
 export type Result = Partial<Node> & { nodes?: Node[]; pageInfo?: { hasNextPage: boolean; endCursor: string } };
 export type Resource = {
-  metadata: { name: string; namespace?: string; creationTimestamp?: string };
+  metadata: { name: string; namespace?: string; resourceVersion?: string; creationTimestamp?: string };
   spec?: Record<string, unknown>;
   status?: { ready?: boolean; phase?: string; message?: string; checkedAt?: string; startedAt?: string; completedAt?: string; result?: Result };
 };
+export class RequestError extends Error {
+  constructor(public status: number) {
+    const guidance: Record<number, string> = { 400: 'Check the submitted fields.', 401: 'Sign in again, then retry.', 403: 'Ask your workspace administrator for access.', 404: 'The resource was not found. Refresh the collection.', 409: 'The resource already exists or has changed. Inspect it before retrying.', 410: 'This page expired. Refresh to start from the first page.', 422: 'Check the names and team UUIDs.', 429: 'Too many requests. Wait before retrying.' };
+    super(`Request failed (${status}). ${guidance[status] || 'The provider is unavailable. Retry when it is ready.'}`);
+  }
+}
+export class ConnectionError extends Error {
+  constructor(public connectionName: string, message: string) { super(message); }
+}
 export class OperationError extends Error {
   constructor(public operationName: string, message: string) { super(`${operationName}: ${message}`); }
 }
 export class API {
   constructor(private context: FarosContext, private namespace: string, private signal: AbortSignal) {}
-  async request(path: string, body?: unknown) {
+  async request(path: string, body?: unknown, method = body ? 'POST' : 'GET') {
     this.signal.throwIfAborted();
-    const response = await providerFetch(this.context)(path, { method: body ? 'POST' : 'GET', signal: this.signal, headers: body ? { 'Content-Type': 'application/json' } : undefined, body: body ? JSON.stringify(body) : undefined });
+    const response = await providerFetch(this.context)(path, { method, signal: this.signal, headers: body ? { 'Content-Type': method === 'PATCH' ? 'application/merge-patch+json' : 'application/json' } : undefined, body: body ? JSON.stringify(body) : undefined });
     this.signal.throwIfAborted();
-    if (!response.ok) throw new Error(`Request failed (${response.status}). Check workspace access and provider readiness.`);
+    if (!response.ok) throw new RequestError(response.status);
     const value = await response.json();
     this.signal.throwIfAborted();
     return value;
@@ -41,8 +50,27 @@ export class API {
     } while (cursor);
     return { items };
   }
-  createConnection(name: string, secret: string, teams: string[]): Promise<Resource> {
-    return this.request(this.path('connections'), { apiVersion: 'linear.providers.faros.sh/v1alpha1', kind: 'Connection', metadata: { name, namespace: this.namespace }, spec: { apiKeySecretRef: { name: secret, key: 'apiKey' }, teams: teams.map(id => ({ id })) } });
+  listPage(resource: string, limit = 10, cursor = ''): Promise<{ items: Resource[]; metadata?: { continue?: string } }> {
+    return this.request(this.path(resource) + `?limit=${limit}` + (cursor ? '&continue=' + encodeURIComponent(cursor) : ''));
+  }
+  updateTeams(name: string, teams: string[], resourceVersion: string): Promise<Resource> {
+    return this.request(this.path('connections', name), { metadata: { resourceVersion }, spec: { teams: teams.map(id => ({ id })) } }, 'PATCH');
+  }
+  async createConnection(name: string, secret: string, teams: string[]): Promise<Resource> {
+    const spec = { apiKeySecretRef: { name: secret, key: 'apiKey' }, teams: [...new Set(teams)].map(id => ({ id })) };
+    try {
+      return await this.request(this.path('connections'), { apiVersion: 'linear.providers.faros.sh/v1alpha1', kind: 'Connection', metadata: { name, namespace: this.namespace }, spec });
+    } catch (error) {
+      this.signal.throwIfAborted();
+      if (error instanceof RequestError && error.status < 500 && error.status !== 409) throw error;
+      let existing: Resource;
+      try { existing = await this.get('connections', name); }
+      catch { this.signal.throwIfAborted(); throw new ConnectionError(name, 'Creation outcome unknown. Inspect this connection before submitting again.'); }
+      const ref = existing.spec?.apiKeySecretRef as { name?: string; key?: string } | undefined;
+      const ids = (existing.spec?.teams as { id: string }[] | undefined || []).map(t => t.id).sort();
+      if (ref?.name === secret && (ref.key || 'apiKey') === 'apiKey' && JSON.stringify(ids) === JSON.stringify(spec.teams.map(t => t.id).sort())) return existing;
+      throw new ConnectionError(name, 'A connection with this name exists with different settings. Inspect it or choose another name.');
+    }
   }
   async discover(connection: string, action: 'teams' | 'states', teamID = ''): Promise<Node[]> {
     const nodes: Node[] = [];

--- a/providers/linear/portal/src/components/ConnectionPolicy.vue
+++ b/providers/linear/portal/src/components/ConnectionPolicy.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import type { Node, Resource } from '../api';
+import { useTask } from '../state';
+import TaskFeedback from './TaskFeedback.vue';
+const props = defineProps<{ resource: Resource }>();
+const emit = defineEmits<{ saved: [Resource] }>();
+const teams = ref((props.resource.spec?.teams as { id: string }[] | undefined || []).map(t => t.id).join(', '));
+const allTeams = ref(!teams.value);
+const discovered = ref<Node[]>([]); const discovery = useTask(); const saveTask = useTask();
+function discover() { void discovery.run(api => api.discover(props.resource.metadata.name, 'teams'), result => { discovered.value = result; }); }
+function save() {
+  const ids = [...new Set(teams.value.split(',').map(t => t.trim()).filter(Boolean))];
+  if (!allTeams.value && !ids.length) return;
+  void saveTask.run(api => api.updateTeams(props.resource.metadata.name, allTeams.value ? [] : ids, props.resource.metadata.resourceVersion!), result => { emit('saved', result); saveTask.state.message = 'Team policy saved. Refresh the connection to check readiness.'; });
+}
+</script>
+<template>
+  <form class="linear-form" @submit.prevent="save">
+    <TaskFeedback :task="saveTask.state" />
+    <label for="policy-teams">Allowed team UUIDs<input id="policy-teams" v-model="teams" class="k-input" :disabled="saveTask.state.loading || allTeams" :required="!allTeams" aria-describedby="policy-help"></label>
+    <label class="linear-checkbox"><input v-model="allTeams" type="checkbox" :disabled="saveTask.state.loading">Allow all teams accessible to this credential</label>
+    <p id="policy-help" class="linear-page-meta">Separate UUIDs with commas. Discovery respects the current policy; ask a Linear administrator for UUIDs outside that scope.</p>
+    <div class="linear-actions"><button type="button" class="k-btn k-btn--ghost" :disabled="discovery.state.loading || saveTask.state.loading" @click="discover">Discover permitted teams</button><button class="k-btn k-btn--primary" :disabled="saveTask.state.loading || !resource.metadata.resourceVersion || (!allTeams && !teams.trim())">Save team policy</button></div>
+    <TaskFeedback :task="discovery.state" />
+    <ul v-if="discovered.length"><li v-for="team in discovered" :key="team.id">{{ team.name || 'Unnamed team' }} · {{ team.id }}</li></ul>
+    <p v-else-if="discovery.state.loaded" class="linear-notice">No teams are accessible under the current policy.</p>
+  </form>
+</template>

--- a/providers/linear/portal/src/components/IssueFields.vue
+++ b/providers/linear/portal/src/components/IssueFields.vue
@@ -11,12 +11,12 @@ const stateID = defineModel<string>('stateID', { required: true });
 const task = useTask(); const states = ref<Node[]>([]);
 const options = computed(() => [{ value: '', label: props.updating ? 'Keep current state' : 'Default state' }, ...states.value.map(s => ({ value: s.id, label: s.name || s.id }))]);
 function load() { if (props.connection && props.team) void task.run(api => api.discover(props.connection, 'states', props.team), result => { states.value = result; }); }
-watch(() => [props.connection, props.team], () => { task.reset(); states.value = []; stateID.value = ''; load(); }, { immediate: true, flush: 'sync' });
+watch(() => [props.connection, props.team], (_, previous) => { task.reset(); states.value = []; if (previous) stateID.value = ''; load(); }, { immediate: true, flush: 'sync' });
 </script>
 <template>
   <label for="issue-title">Title<input id="issue-title" v-model="title" class="k-input" :required="!updating" maxlength="255" :disabled="disabled"></label>
   <label for="issue-description">Description<textarea id="issue-description" v-model="description" class="k-input" rows="5" maxlength="16000" :disabled="disabled" /></label>
-  <label for="issue-state">Workflow state<FormSelect id="issue-state" v-model="stateID" :options="options" :disabled="disabled || task.state.loading || !team" /></label>
+  <label id="issue-state-label" for="issue-state">Workflow state<FormSelect id="issue-state" labelledby="issue-state-label" v-model="stateID" :options="options" :disabled="disabled || task.state.loading || !team" /></label>
   <TaskFeedback :task="task.state" />
   <button v-if="task.state.error" class="k-btn k-btn--ghost" type="button" :disabled="disabled || task.state.loading" @click="load">Retry workflow states</button>
 </template>

--- a/providers/linear/portal/src/components/IssueScope.vue
+++ b/providers/linear/portal/src/components/IssueScope.vue
@@ -29,8 +29,8 @@ onActivated(() => {
 <template>
   <div class="linear-scope">
     <div class="linear-fields">
-      <label for="linear-connection">Connection<FormSelect id="linear-connection" v-model="session.selection.connection" :options="connectionOptions" placeholder="Select connection" :disabled="props.disabled || read.state.loading" /></label>
-      <label for="linear-team">Team<FormSelect id="linear-team" v-model="session.selection.team" :options="teamOptions" placeholder="Select team" :disabled="props.disabled || discovery.state.loading || !session.selection.connection" /></label>
+      <label id="linear-connection-label" for="linear-connection">Connection<FormSelect id="linear-connection" labelledby="linear-connection-label" v-model="session.selection.connection" :options="connectionOptions" placeholder="Select connection" :disabled="props.disabled || read.state.loading" /></label>
+      <label id="linear-team-label" for="linear-team">Team<FormSelect id="linear-team" labelledby="linear-team-label" v-model="session.selection.team" :options="teamOptions" placeholder="Select team" :disabled="props.disabled || discovery.state.loading || !session.selection.connection" /></label>
       <button class="k-btn k-btn--ghost" type="button" :disabled="props.disabled || discovery.state.loading || !session.selection.connection" @click="discover">{{ discovery.state.loading ? 'Discovering teams…' : 'Refresh teams' }}</button>
     </div>
     <TaskFeedback :task="read.state" /><button v-if="read.state.error" class="k-btn k-btn--ghost" type="button" @click="load">Retry connections</button>

--- a/providers/linear/portal/src/portal.behavior.test.ts
+++ b/providers/linear/portal/src/portal.behavior.test.ts
@@ -7,7 +7,7 @@ import type { FarosContext } from './api';
 
 const wrappers: VueWrapper[] = [];
 afterEach(() => { wrappers.splice(0).forEach(w => w.unmount()); document.body.innerHTML = ''; });
-const connection = { metadata: { name: 'linear' }, spec: { apiKeySecretRef: { name: 'linear-key' }, teams: [{ id: 'team' }] }, status: { ready: true } };
+const connection = { metadata: { name: 'linear', resourceVersion: '1' }, spec: { apiKeySecretRef: { name: 'linear-key' }, teams: [{ id: 'team' }] }, status: { ready: true } };
 const issue = { id: 'issue', identifier: 'ENG-1', title: 'Ship resource pages', description: '<script>not executable</script>', team: { id: 'team', name: 'Engineering' }, state: { id: 'todo', name: 'Todo' } };
 function fixture() {
   const calls: { path: string; body?: any }[] = [];
@@ -26,8 +26,8 @@ function fixture() {
       const result = s.action === 'teams' ? { nodes: [{ id: 'team', name: 'Engineering', key: 'ENG' }] }
         : s.action === 'states' ? { nodes: [{ id: 'done', name: 'Done' }] }
         : s.action === 'issues' ? { nodes: [s.after ? { ...issue, id: 'second', identifier: 'ENG-2' } : issue], pageInfo: { hasNextPage: !s.after, endCursor: 'next' } }
-        : s.action === 'comments' ? { nodes: [{ id: 'comment', body: 'Reviewed' }] }
-        : { ...issue, ...(s.title ? { title: s.title } : {}) };
+        : s.action === 'comments' ? { nodes: [{ id: 'comment', body: 'Reviewed', user: { displayName: 'Reviewer' }, createdAt: '2026-09-12T12:00:00Z', editedAt: '2026-09-12T13:00:00Z', parentId: 'parent', url: 'https://linear.app/team/issue/ENG-1#comment' }] }
+        : { ...issue, ...(s.title ? { title: s.title } : {}), ...(s.description !== undefined ? { description: s.description } : {}) };
       return Response.json({ ...op, status: { phase: uncertain ? 'Uncertain' : 'Succeeded', result, message: uncertain ? 'Check Linear before repeating' : '' } });
     }
     if (path.includes('/connections/')) return Response.json(connection);
@@ -111,4 +111,44 @@ describe('Linear resource journeys', () => {
     resolve(Response.json({ items: [{ metadata: { name: 'private-old-resource' } }] })); await flushPromises();
     expect(w.text()).not.toContain('private-old-resource'); expect(w.text()).toContain('Connect Linear');
   });
+});
+
+it('edits populated values, explicitly clears descriptions, and presents comment context', async () => {
+  const f = fixture(); const w = await render({ ...f.ctx, subPath: issuePath('linear', 'issue') });
+  expect((w.get('#issue-description').element as HTMLTextAreaElement).value).toBe(issue.description);
+  await w.get('#issue-description').setValue(''); await w.findAll('form')[0].trigger('submit'); await flushPromises();
+  const sent = f.calls.find(c => c.body?.spec.action === 'updateIssue')!.body.spec;
+  expect(sent.description).toBe(''); expect(sent).not.toHaveProperty('title');
+  expect(w.text()).toContain('No description.');
+  await click(w, 'Read comments'); expect(w.text()).toContain('Reviewer'); expect(w.text()).toContain('Edited'); expect(w.text()).toContain('Reply to comment parent');
+  expect(w.findAll('a').find(a => a.text() === 'View in Linear')!.attributes('rel')).toContain('noopener');
+});
+it('retains the issue draft across connection setup and fences it on namespace change', async () => {
+  const f = fixture(); const w = await render({ ...f.ctx, subPath: 'create/issue' });
+  await w.get('#issue-title').setValue('Draft to keep'); await w.get('#issue-description').setValue('Details to keep');
+  await w.setProps({ ctx: { ...f.ctx, subPath: 'create/connection' } }); await flushPromises();
+  await click(w, 'Return to issue draft');
+  expect((w.get('#issue-title').element as HTMLInputElement).value).toBe('Draft to keep');
+  expect((w.get('#issue-description').element as HTMLTextAreaElement).value).toBe('Details to keep');
+  await w.setProps({ ctx: { ...f.ctx, subPath: 'issues/namespaces/other/create' } }); await flushPromises();
+  expect((w.get('#issue-title').element as HTMLInputElement).value).toBe('');
+});
+
+it('does not interpret empty comma-separated team IDs as permission to allow all teams', async () => {
+  const f = fixture(); const w = await render({ ...f.ctx, subPath: 'create/connection' });
+  await w.get('#connection-name').setValue('scoped'); await w.get('#connection-secret').setValue('key'); await w.get('#connection-teams').setValue(' , , ');
+  await w.get('form').trigger('submit'); await flushPromises();
+  expect(f.calls.filter(c => c.body?.kind === 'Connection')).toHaveLength(0);
+});
+it('loads bounded history pages through shared navigation without eagerly following continuation', async () => {
+  const paths: string[] = [];
+  const w = await render({ tenant: 'workspace', subPath: 'operations', fetch: async input => {
+    const path = String(input); paths.push(path);
+    return Response.json({ items: [{ metadata: { name: path.includes('continue=') ? 'op-second' : 'op-first' }, status: { phase: 'Uncertain', message: 'Inspect before retrying' } }], metadata: { continue: path.includes('continue=') ? '' : 'next/cursor' } });
+  } });
+  expect(paths).toHaveLength(1); expect(paths[0]).toContain('limit=10'); expect(w.text()).toContain('op-first');
+  await w.get('button[aria-label="Next page"]').trigger('click'); await flushPromises();
+  expect(paths).toHaveLength(2); expect(paths[1]).toContain('continue=next%2Fcursor'); expect(w.text()).toContain('op-second');
+  await w.get('button[aria-label="Previous page"]').trigger('click'); await flushPromises();
+  expect(paths).toHaveLength(3); expect(paths[2]).not.toContain('continue='); expect(w.text()).toContain('op-first');
 });

--- a/providers/linear/portal/src/portal.regression.test.ts
+++ b/providers/linear/portal/src/portal.regression.test.ts
@@ -235,6 +235,7 @@ describe('Linear canonical portal regressions', () => {
     await clickText(wrapper, 'Add connection');
     await wrapper.get('#connection-name').setValue('new-connection');
     await wrapper.get('#connection-secret').setValue('new-secret');
+    await wrapper.get('#connection-teams').setValue('team');
     await wrapper.get('form').trigger('submit');
     await flushPromises();
     await clickText(wrapper, 'Browse issues');

--- a/providers/linear/portal/src/route-focus.test.ts
+++ b/providers/linear/portal/src/route-focus.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from 'vitest';
+import { createProviderRouteFocus } from '../../../../portal/src/providers/providerRouteFocus';
+it('the host focuses route headings, restores cached source controls and fences remounts', () => {
+  const focus = createProviderRouteFocus(); const root = document.createElement('div'); document.body.append(root);
+  root.innerHTML = '<button>Issue</button>'; const button = root.querySelector('button')!;
+  focus.before(root, 'issues'); button.focus(); focus.before(root, 'detail'); button.remove();
+  root.innerHTML = '<h1>Issue detail</h1>'; focus.ready(root); expect(document.activeElement).toBe(root.querySelector('h1'));
+  focus.before(root, 'issues'); root.replaceChildren(button); focus.ready(root); expect(document.activeElement).toBe(button);
+  focus.clear(); root.remove();
+});

--- a/providers/linear/portal/src/state.ts
+++ b/providers/linear/portal/src/state.ts
@@ -1,9 +1,10 @@
 import { inject, onActivated, onBeforeUnmount, onDeactivated, reactive, type InjectionKey } from 'vue';
-import { API, OperationError, type FarosContext } from './api';
+import { API, ConnectionError, OperationError, type FarosContext } from './api';
 export type Session = {
   context: () => FarosContext;
   namespace: string;
   signal: AbortSignal;
+  draft: { title: string; description: string; stateID: string; returnToIssue: boolean };
   selection: { connection: string; team: string; query: string };
   navigate: (path: string, replace?: boolean) => void;
   href: (path: string) => string;
@@ -13,7 +14,7 @@ export function useSession() { const session = inject(sessionKey); if (!session)
 /** Each view owns cancellation; the session also fences authority changes synchronously. */
 export function useTask() {
   const session = useSession();
-  const state = reactive({ loading: false, loaded: false, error: '', operationName: '', message: '' });
+  const state = reactive({ loading: false, loaded: false, error: '', operationName: '', connectionName: '', message: '' });
   let controller = new AbortController();
   let activeView = true;
   function cancel() { controller.abort(); controller = new AbortController(); state.loading = false; }
@@ -24,7 +25,7 @@ export function useTask() {
     if (!activeView || state.loading) return;
     const active = controller;
     const signal = AbortSignal.any([active.signal, session.signal]);
-    state.loading = true; state.error = ''; state.operationName = ''; state.message = '';
+    state.loading = true; state.error = ''; state.operationName = ''; state.connectionName = ''; state.message = '';
     try {
       const result = await work(new API(session.context(), session.namespace, signal));
       signal.throwIfAborted();
@@ -32,11 +33,12 @@ export function useTask() {
     } catch (error) {
       if (!signal.aborted) {
         state.error = error instanceof Error ? error.message : 'Request failed.';
+        if (error instanceof ConnectionError) state.connectionName = error.connectionName;
         if (error instanceof OperationError) state.operationName = error.operationName;
       }
     } finally { if (controller === active) state.loading = false; }
   }
-  function reset() { cancel(); state.loaded = false; state.error = ''; state.operationName = ''; state.message = ''; }
+  function reset() { cancel(); state.loaded = false; state.error = ''; state.operationName = ''; state.connectionName = ''; state.message = ''; }
   return { state, run, cancel, reset };
 }
 export function updateFields(title: string, description: string, stateID: string): Record<string, string> {

--- a/providers/linear/portal/src/style.css
+++ b/providers/linear/portal/src/style.css
@@ -32,3 +32,9 @@ faros-provider-linear .linear-sr-only { position: absolute; width: 1px; height: 
   faros-provider-linear .linear-page-head > .linear-actions { width: 100%; }
   faros-provider-linear .linear-fields > label { flex-basis: 100%; }
 }
+
+faros-provider-linear .linear-comment-meta { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; color: var(--color-text-secondary); }
+faros-provider-linear .linear-comment-meta a { color: var(--color-accent); }
+faros-provider-linear .linear-history-summary { min-inline-size: min(260px, 65vw); display: grid; justify-items: start; gap: 6px; white-space: normal; }
+faros-provider-linear .linear-history-message { white-space: normal; overflow-wrap: anywhere; }
+faros-provider-linear .linear-checkbox { display: flex; align-items: center; gap: 8px; min-height: 44px; }

--- a/providers/linear/portal/src/views/ConnectionCreateView.vue
+++ b/providers/linear/portal/src/views/ConnectionCreateView.vue
@@ -5,22 +5,32 @@ import { resourcePath } from '../routes';
 import CreateGuidance from '../portalkit/CreateGuidance.vue';
 import TaskFeedback from '../components/TaskFeedback.vue';
 const session = useSession(); const task = useTask();
-const name = ref(''); const secret = ref(''); const teams = ref('');
-function submit() { void task.run(api => api.createConnection(name.value.trim(), secret.value.trim(), teams.value.split(',').map(v => v.trim()).filter(Boolean)), result => session.navigate(resourcePath('connections', result.metadata.name), true)); }
+const name = ref(''); const secret = ref(''); const teams = ref(''); const allowAllTeams = ref(false);
+function submit() {
+  const teamIDs = teams.value.split(',').map(v => v.trim()).filter(Boolean);
+  if (!allowAllTeams.value && !teamIDs.length) return;
+  void task.run(api => api.createConnection(name.value.trim(), secret.value.trim(), allowAllTeams.value ? [] : teamIDs), result => {
+    session.selection.connection = result.metadata.name;
+    session.navigate(resourcePath('connections', result.metadata.name), true);
+  });
+}
 </script>
 <template>
   <section class="linear-page k-create-page">
     <header class="k-create-header"><h2 class="k-create-title">Add connection</h2><p class="k-create-description">Connect Linear in namespace {{ session.namespace }}.</p></header>
     <TaskFeedback :task="task.state" />
+    <a v-if="task.state.connectionName" :href="session.href(resourcePath('connections', task.state.connectionName))" @click.prevent="session.navigate(resourcePath('connections', task.state.connectionName))">Inspect connection {{ task.state.connectionName }}</a>
+    <p v-if="session.draft.returnToIssue" class="linear-notice">Your issue draft is kept while you set up this connection. <button type="button" class="k-btn k-btn--ghost" @click="session.navigate('create/issue')">Return to issue draft</button></p>
     <form class="k-create-surface k-create-surface--guided" @submit.prevent="submit">
       <div class="k-create-body k-create-body--guided">
       <div class="k-create-fields linear-form">
         <label for="connection-name">Name<input id="connection-name" v-model="name" class="k-input" required maxlength="253" pattern="[a-z0-9]([-a-z0-9.]*[a-z0-9])?" :disabled="task.state.loading"></label>
         <label for="connection-secret">Secret name<input id="connection-secret" v-model="secret" class="k-input" required :disabled="task.state.loading"></label>
-        <label for="connection-teams">Allowed team UUIDs<input id="connection-teams" v-model="teams" class="k-input" aria-describedby="teams-help" :disabled="task.state.loading"></label>
-        <p id="teams-help" class="linear-page-meta">Separate UUIDs with commas. Leave blank to allow all teams accessible to the credential.</p>
+        <label for="connection-teams">Allowed team UUIDs<input id="connection-teams" v-model="teams" class="k-input" aria-describedby="teams-help" :required="!allowAllTeams" :disabled="task.state.loading || allowAllTeams"></label>
+        <label class="linear-checkbox"><input v-model="allowAllTeams" type="checkbox" :disabled="task.state.loading">Allow all teams accessible to this credential</label>
+        <p id="teams-help" class="linear-page-meta">Separate UUIDs with commas. Ask your Linear administrator for team UUIDs, or explicitly allow all teams available to this credential.</p>
       </div>
-      <CreateGuidance title="Before connecting" :description="`Reference a Secret in ${session.namespace} with an apiKey entry. Keep the key in Credentials; enter only its name here.`" :next-steps="['Faros will check the connection. Creating the resource does not mean it is ready yet.']" />
+      <CreateGuidance title="Before connecting" :description="`Reference a Secret in ${session.namespace} with an apiKey entry. Ask your workspace administrator to provision it using your authorized credential tooling; enter only its name here.`" :next-steps="['Faros will check the connection. Creating the resource does not mean it is ready yet.']" />
       </div>
         <div class="k-create-actions"><button class="k-btn k-btn--ghost" type="button" :disabled="task.state.loading" @click="session.navigate('connections')">Cancel</button><button class="k-btn k-btn--primary" :disabled="task.state.loading">{{ task.state.loading ? 'Adding…' : 'Add connection' }}</button></div>
     </form>

--- a/providers/linear/portal/src/views/HistoryView.vue
+++ b/providers/linear/portal/src/views/HistoryView.vue
@@ -3,23 +3,35 @@ import { computed, onActivated, ref } from 'vue';
 import type { Resource } from '../api';
 import { useSession, useTask } from '../state';
 import { resourcePath } from '../routes';
+import type { ResourceTableChange } from '../portalkit/table';
 import ResourceTable from '../portalkit/ResourceTable.vue';
 import StatusBadge from '../portalkit/StatusBadge.vue';
 const props = defineProps<{ kind: 'operations' | 'events' }>();
 const session = useSession(); const read = useTask(); const resources = ref<Resource[]>([]);
+const page = ref(1); const pageSize = ref(10); const cursor = ref(''); const nextCursor = ref('');
+const lookup = ref(''); const activeLookup = ref('');
 const title = computed(() => props.kind === 'operations' ? 'Operations' : 'Events');
 const rows = computed(() => resources.value.map(r => ({ name: r.metadata.name, connection: r.spec?.connection || '—', action: r.spec?.action || '—', status: r.status?.phase || (props.kind === 'operations' ? 'Pending' : r.spec?.type || '—'), message: r.status?.message || r.spec?.issueID || r.spec?.entityID || '—', received: r.spec?.receivedAt || r.metadata.creationTimestamp || '—' })));
-const columns = computed(() => [{ key: 'name', label: 'Name' }, { key: 'connection', label: 'Connection' }, { key: 'action', label: 'Action' }, { key: 'status', label: props.kind === 'operations' ? 'Status' : 'Type' }, { key: 'message', label: props.kind === 'operations' ? 'Message' : 'Entity' }, { key: 'received', label: 'Created' }]);
-function load() { void read.run(api => api.list(props.kind), result => { resources.value = result.items; }); }
+const columns = [{ key: 'name', label: 'Summary', primary: true }, { key: 'connection', label: 'Connection' }, { key: 'action', label: 'Action' }, { key: 'received', label: 'Created' }];
+function load(targetPage = page.value, targetSize = pageSize.value, targetCursor = cursor.value, name = activeLookup.value) {
+  void read.run(async api => name ? { items: [await api.get(props.kind, name)], metadata: { continue: '' } } : api.listPage(props.kind, targetSize, targetCursor), result => {
+    resources.value = result.items; page.value = targetPage; pageSize.value = targetSize; cursor.value = targetCursor;
+    nextCursor.value = result.metadata?.continue || ''; activeLookup.value = name;
+  });
+}
+function change(event: ResourceTableChange) { load(event.page, event.pageSize, event.cursor || ''); }
+function find() { read.reset(); resources.value = []; load(1, pageSize.value, '', lookup.value.trim()); }
+function clear() { lookup.value = ''; find(); }
 function open(row: Record<string, unknown>) { session.navigate(resourcePath(props.kind, String(row.name))); }
-onActivated(load);
+onActivated(() => load());
 </script>
 <template>
   <section class="linear-page">
-    <header class="linear-page-head"><div><h2 class="linear-page-title">{{ title }}</h2><p class="linear-page-meta">{{ kind === 'operations' ? 'Inspect pending or uncertain operations before repeating a write.' : 'Verified notifications received from Linear.' }}</p></div><button class="k-btn k-btn--ghost" :disabled="read.state.loading" @click="load">Refresh</button></header>
-    <ResourceTable :columns="columns" :rows="rows" row-key="name" searchable :search-placeholder="`Search ${kind}…`" paginated :page-size="10" :loaded="read.state.loaded" :loading="read.state.loading" :error="read.state.error" :stale="read.state.loaded && !!read.state.error" retryable :empty-text="`No ${kind} yet.`" :aria-label="title" :row-aria-label="row => `Open ${row.name}`" @retry="load" @row-click="open">
-      <template #name="{ row }"><button class="k-btn k-btn--ghost k-table-resource-link" @click.stop="open(row)">{{ row.name }}</button></template>
-      <template #status="{ value }"><StatusBadge v-if="kind === 'operations'" :status="String(value)" /><span v-else>{{ value }}</span></template>
+    <header class="linear-page-head"><div><h2 class="linear-page-title">{{ title }}</h2><p class="linear-page-meta">{{ kind === 'operations' ? 'Inspect pending or uncertain operations before repeating a write.' : 'Verified notifications received from Linear.' }}</p></div><button class="k-btn k-btn--ghost" :disabled="read.state.loading" @click="load(1, pageSize, '')">Refresh</button></header>
+    <form class="linear-fields" @submit.prevent="find"><label for="history-name">Find by exact name<input id="history-name" v-model="lookup" class="k-input" placeholder="Resource name" :disabled="read.state.loading"></label><button class="k-btn k-btn--ghost" :disabled="read.state.loading || !lookup.trim()">Find</button><button v-if="activeLookup" type="button" class="k-btn k-btn--ghost" :disabled="read.state.loading" @click="clear">Show all</button></form>
+    <p class="linear-page-meta">Browse one page at a time, or find an exact resource name across all history. Full-text history search is not available.</p>
+    <ResourceTable :columns="columns" :rows="rows" row-key="name" pagination-mode="server" :page="page" :page-size="pageSize" :cursor="cursor || null" :page-info="{ hasNext: !!nextCursor, nextCursor: nextCursor || null }" :loaded="read.state.loaded" :loading="read.state.loading" :error="read.state.error" :stale="read.state.loaded && !!read.state.error" retryable :empty-text="`No ${kind} yet.`" :aria-label="title" :row-aria-label="row => `Open ${row.name}`" @change="change" @retry="load()" @row-click="open">
+      <template #name="{ row }"><div class="linear-history-summary"><StatusBadge v-if="kind === 'operations'" :status="String(row.status)" /><span v-else>{{ row.status }}</span><button class="k-btn k-btn--ghost k-table-resource-link" @click.stop="open(row)">{{ row.name }}</button><span class="linear-history-message">{{ row.message }}</span></div></template>
     </ResourceTable>
   </section>
 </template>

--- a/providers/linear/portal/src/views/IssueCreateView.vue
+++ b/providers/linear/portal/src/views/IssueCreateView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { toRefs } from 'vue';
 import { useSession, useTask, updateFields } from '../state';
 import { issuePath } from '../routes';
 import IssueScope from '../components/IssueScope.vue';
@@ -7,10 +7,12 @@ import IssueFields from '../components/IssueFields.vue';
 import TaskFeedback from '../components/TaskFeedback.vue';
 import CreateGuidance from '../portalkit/CreateGuidance.vue';
 const session = useSession(); const task = useTask();
-const title = ref(''); const description = ref(''); const stateID = ref('');
+const { title, description, stateID } = toRefs(session.draft);
+session.draft.returnToIssue = true;
 function submit() {
   if (!session.selection.connection || !session.selection.team || !title.value.trim()) return;
   void task.run(api => api.operation(session.selection.connection, { action: 'createIssue', teamID: session.selection.team, ...updateFields(title.value, description.value, stateID.value) }), result => {
+    Object.assign(session.draft, { title: '', description: '', stateID: '', returnToIssue: false });
     if (result.id) session.navigate(issuePath(session.selection.connection, result.id), true);
     else { task.state.message = 'Issue creation succeeded. Search Issues to locate the result.'; title.value = ''; description.value = ''; }
   });

--- a/providers/linear/portal/src/views/IssueDetailView.vue
+++ b/providers/linear/portal/src/views/IssueDetailView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import type { Node, Result } from '../api';
-import { useTask, updateFields } from '../state';
+import { useTask } from '../state';
 import ResourcePage from '../portalkit/ResourcePage.vue';
 import ResourceSectionCard from '../portalkit/ResourceSectionCard.vue';
 import StatusBadge from '../portalkit/StatusBadge.vue';
@@ -11,19 +11,24 @@ const props = defineProps<{ connection: string; id: string }>();
 const read = useTask(); const mutation = useTask(); const commentsRead = useTask();
 const issue = ref<Result>(); const comments = ref<Node[]>([]); const nextCursor = ref(''); const hasMore = ref(false);
 const title = ref(''); const description = ref(''); const stateID = ref(''); const body = ref('');
-function load() { if (mutation.state.loading) return; void read.run(api => api.operation(props.connection, { action: 'issue', issueID: props.id }), result => { issue.value = result; }); }
+function load() { if (mutation.state.loading) return; void read.run(api => api.operation(props.connection, { action: 'issue', issueID: props.id }), result => { issue.value = result; title.value = result.title || ''; description.value = result.description || ''; }); }
 function loadComments(more = false) {
   void commentsRead.run(api => api.operation(props.connection, { action: 'comments', issueID: props.id, first: 25, ...(more ? { after: nextCursor.value } : {}) }), result => {
     comments.value = more ? [...comments.value, ...(result.nodes || [])] : result.nodes || [];
     nextCursor.value = result.pageInfo?.endCursor || ''; hasMore.value = !!result.pageInfo?.hasNextPage;
   });
 }
+const changedFields = computed(() => ({
+  ...(title.value !== (issue.value?.title || '') ? { title: title.value } : {}),
+  ...(description.value !== (issue.value?.description || '') ? { description: description.value } : {}),
+  ...(stateID.value ? { stateID: stateID.value } : {}),
+}));
 function update() {
   if (read.state.loading) return;
-  const fields = updateFields(title.value, description.value, stateID.value);
+  const fields = changedFields.value;
   if (!Object.keys(fields).length) return;
   void mutation.run(api => api.operation(props.connection, { action: 'updateIssue', issueID: props.id, ...fields }), result => {
-    issue.value = { ...issue.value, ...result }; title.value = ''; description.value = ''; stateID.value = '';
+    issue.value = { ...issue.value, ...fields, ...result }; title.value = issue.value.title || ''; description.value = issue.value.description || ''; stateID.value = '';
     mutation.state.message = 'Issue updated.';
   });
 }
@@ -31,6 +36,8 @@ function comment() {
   if (!body.value.trim()) return;
   void mutation.run(api => api.operation(props.connection, { action: 'addComment', issueID: props.id, body: body.value }), () => { body.value = ''; mutation.state.message = 'Comment added.'; commentsRead.cancel(); loadComments(); });
 }
+function formatTime(value?: string) { const date = value ? new Date(value) : null; return date && !Number.isNaN(date.getTime()) ? date.toLocaleString() : 'Time unavailable'; }
+function sourceURL(value?: string) { try { const url = new URL(value || ''); return url.protocol === 'https:' && url.hostname === 'linear.app' ? url.href : undefined; } catch { return undefined; } }
 onMounted(load);
 </script>
 <template>
@@ -40,14 +47,14 @@ onMounted(load);
     <div class="linear-detail-content">
     <TaskFeedback :task="mutation.state" />
     <ResourceSectionCard title="Details"><dl class="linear-facts"><div><dt>Connection</dt><dd>{{ connection }}</dd></div><div><dt>Team</dt><dd>{{ issue?.team?.name || issue?.team?.id || '—' }}</dd></div><div><dt>Issue ID</dt><dd>{{ id }}</dd></div><div><dt>Updated</dt><dd>{{ issue?.updatedAt || '—' }}</dd></div></dl><p class="linear-prose">{{ issue?.description || 'No description.' }}</p></ResourceSectionCard>
-    <ResourceSectionCard title="Update issue" description="Leave fields blank to preserve their current values.">
-      <form class="linear-form" @submit.prevent="update"><IssueFields v-model:title="title" v-model:description="description" v-model:stateID="stateID" :connection="connection" :team="issue?.team?.id || ''" updating :disabled="mutation.state.loading || read.state.loading" /><div class="linear-form-actions"><button class="k-btn k-btn--primary" :disabled="mutation.state.loading || read.state.loading || (!title && !description && !stateID)">{{ mutation.state.loading ? 'Submitting…' : 'Update issue' }}</button></div></form>
+    <ResourceSectionCard title="Update issue" description="Edit the current values. Emptying Description removes it; unchanged fields are preserved.">
+      <form class="linear-form" @submit.prevent="update"><IssueFields v-model:title="title" v-model:description="description" v-model:stateID="stateID" :connection="connection" :team="issue?.team?.id || ''" updating :disabled="mutation.state.loading || read.state.loading" /><div class="linear-form-actions"><button class="k-btn k-btn--primary" :disabled="mutation.state.loading || read.state.loading || (!title.trim() || !Object.keys(changedFields).length)">{{ mutation.state.loading ? 'Submitting…' : 'Update issue' }}</button></div></form>
     </ResourceSectionCard>
     <ResourceSectionCard title="Comments">
       <template #actions><button class="k-btn k-btn--ghost" :disabled="commentsRead.state.loading || mutation.state.loading" @click="loadComments()">{{ commentsRead.state.loading ? 'Loading…' : 'Read comments' }}</button></template>
       <TaskFeedback :task="commentsRead.state" />
       <p v-if="!commentsRead.state.loaded" class="linear-notice">Read comments to load the conversation from Linear.</p><p v-else-if="!comments.length" class="linear-notice">No comments.</p>
-      <ul v-else class="linear-comments"><li v-for="c in comments" :key="c.id" class="linear-prose">{{ c.body }}</li></ul>
+      <ul v-else class="linear-comments"><li v-for="c in comments" :key="c.id" class="linear-prose"><div class="linear-comment-meta"><strong>{{ c.user?.displayName || c.user?.name || c.botActor?.name || (c.externalUser ? 'External user' : 'Unknown author') }}</strong><span v-if="c.botActor"> · Bot</span><span> · {{ formatTime(c.createdAt) }}</span><span v-if="c.editedAt"> · Edited {{ formatTime(c.editedAt) }}</span><a v-if="sourceURL(c.url)" :href="sourceURL(c.url)" target="_blank" rel="noopener noreferrer">View in Linear</a></div><p v-if="c.parentId" class="linear-page-meta">Reply to comment {{ c.parentId }}</p><p class="linear-prose">{{ c.body }}</p></li></ul>
       <button v-if="hasMore" class="k-btn k-btn--ghost" :disabled="commentsRead.state.loading || !nextCursor" @click="loadComments(true)">More comments</button>
       <form class="linear-form" @submit.prevent="comment"><label for="issue-comment">Add comment<textarea id="issue-comment" v-model="body" class="k-input" required maxlength="16000" rows="3" :disabled="mutation.state.loading || read.state.loading" /></label><div class="linear-form-actions"><button class="k-btn k-btn--primary" :disabled="mutation.state.loading || !body.trim()">Add comment</button></div></form>
     </ResourceSectionCard>

--- a/providers/linear/portal/src/views/IssuesView.vue
+++ b/providers/linear/portal/src/views/IssuesView.vue
@@ -9,7 +9,7 @@ import ResourceTable from '../portalkit/ResourceTable.vue';
 const session = useSession(); const read = useTask(); const issues = ref<Node[]>([]);
 const cursor = ref(''); const hasNext = ref(false); const cursors = ref<string[]>(['']); const index = ref(0);
 const rows = computed(() => issues.value.map(i => ({ id: i.id, identifier: i.identifier || i.id, title: i.title, state: i.state?.name || '—', updated: i.updatedAt || '—' })));
-const columns = [{ key: 'identifier', label: 'Issue' }, { key: 'title', label: 'Title' }, { key: 'state', label: 'State' }, { key: 'updated', label: 'Updated' }];
+const columns = [{ key: 'identifier', label: 'Issue' }, { key: 'title', label: 'Title', primary: true }, { key: 'state', label: 'State' }, { key: 'updated', label: 'Updated' }];
 function search(page = 0) {
   if (!session.selection.connection || !session.selection.team) return;
   const after = page === 0 ? '' : cursors.value[page];

--- a/providers/linear/portal/src/views/ResourceDetailView.vue
+++ b/providers/linear/portal/src/views/ResourceDetailView.vue
@@ -4,6 +4,7 @@ import type { Resource } from '../api';
 import { useSession, useTask } from '../state';
 import ResourcePage from '../portalkit/ResourcePage.vue';
 import ResourceSectionCard from '../portalkit/ResourceSectionCard.vue';
+import ConnectionPolicy from '../components/ConnectionPolicy.vue';
 import StatusBadge from '../portalkit/StatusBadge.vue';
 const props = defineProps<{ kind: 'connections' | 'operations' | 'events'; name: string }>();
 const session = useSession(); const read = useTask(); const resource = ref<Resource>();
@@ -28,6 +29,8 @@ onMounted(load);
     <template #status><StatusBadge v-if="resource && kind !== 'events'" :status="kind === 'connections' ? resource.status?.ready ? 'Ready' : 'Not ready' : resource.status?.phase || 'Pending'" /></template>
     <div class="linear-detail-content">
     <ResourceSectionCard title="Details"><dl class="linear-facts"><div v-for="[label, value] in facts" :key="label"><dt>{{ label }}</dt><dd>{{ value }}</dd></div></dl></ResourceSectionCard>
+    <ResourceSectionCard v-if="kind === 'connections' && resource" title="Team access"><ConnectionPolicy :key="resource.metadata.resourceVersion" :resource="resource" @saved="resource = $event" /></ResourceSectionCard>
+    <button v-if="kind === 'connections' && session.draft.returnToIssue" class="k-btn k-btn--primary" @click="session.navigate('create/issue')">Return to issue draft</button>
     <ResourceSectionCard v-if="resource?.status?.result" title="Result"><pre class="linear-result">{{ JSON.stringify(resource.status.result, null, 2) }}</pre></ResourceSectionCard>
     </div>
   </ResourcePage>


### PR DESCRIPTION
Linear's portal could not clear issue descriptions, lost drafts during prerequisite setup, and exposed insufficient context for accessible navigation and safe write recovery. This change fixes those flows while preserving the shared Faros UI.

- Associate selector names with visible labels; populate issue editors and submit changed fields, including empty descriptions.
- Retain workspace/namespace-scoped issue drafts through connection setup. Recover uncertain connection creation by reading the exact resource and comparing intent.
- Add version-fenced team-policy editing and scoped discovery. Require explicit consent for all-team access.
- Show comment authorship, timestamps, edit/parent context, and safe source links.
- Give issue titles the primary table width and keep operation status/recovery text visible on mobile.
- Load history through bounded server pagination. Exact-name lookup replaces the previous client-side full-text search; the UI states that limitation.
- Add host-owned, opt-in route focus management, with Linear announcing when destination content is rendered.

Validation: `make test-linear-portal` passes provider typechecking, adapter checks, and 26 behavioral tests. Linear production build and host typecheck pass. Design docs, PortalKit, and UI conformance gates pass; PortalKit used a temporary TypeScript loader for the local Node binary. The build reused installed dependencies with `--configLoader runner`. Impeccable's changed-composition scan found no issues. Fixture browser verification produced 56 desktop/mobile, light/dark captures with no page errors or document overflow; assertions cover labels, heading focus, bounded history reads, mobile recovery visibility, and 44px touch tabs.

Limits: no authenticated live Linear writes or full-host browser acceptance. Credential provisioning and team UUID discovery outside the current policy remain external prerequisites. Drafts are memory-only. The pre-existing collection-level Namespace field remains unchanged; its prominent placement is a follow-up UX concern.
