### PR TITLE
fix(linear): preserve edits and improve portal recovery

### DIFF
--- a/providers/linear/README.md
+++ b/providers/linear/README.md
@@ -43,8 +43,11 @@ KRM command path at `/mcp`; they require tenant bearer authentication and
    its Secret read claim.
 2. Create a Secret named `linear-api` with an `apiKey` entry in the Secret reference namespace (`default` unless specified), using your credential manager. Never put actual keys in Git.
 3. Apply [connection.yaml](examples/connection.yaml), replacing the allowed team
-   UUID. Use the portal's **Discover teams** command to find UUIDs accessible to
-   the key; an empty team list allows every team the key can access.
+   UUID. On the connection detail, **Discover permitted teams** lists teams
+   allowed by the current policy and lets you select them without copying UUIDs.
+   Ask a Linear administrator for UUIDs outside that scope. An empty API team
+   list allows every team the key can access; the portal requires an explicit
+   **Allow all teams accessible to this credential** choice.
 4. Submit an Operation through the portal, MCP, or Kubernetes API. Inspect
    `status.phase` and `status.result`; creation alone does not prove completion.
 
@@ -159,6 +162,12 @@ Resource details use `<collection>/detail/<name>`; issue details use
 Returning from an issue
 detail refreshes the cached collection while preserving its selected scope,
 query filter, and current page.
+
+Editing a search keeps the last applied results visible until **Search** is
+submitted; **Clear search** returns to the first unfiltered page. Refreshing an
+issue preserves unsaved field edits, with **Discard changes** restoring the
+latest fetched values. Leaving the detail page discards those edits, as the
+form explains. Comment progress and recovery appear beside the comment form.
 
 Build with `make build-linear-provider-portal` and verify behavior and types with
 `make test-linear-portal`. The portal still registers `faros-provider-linear` and

--- a/providers/linear/portal/src/components/ConnectionPolicy.vue
+++ b/providers/linear/portal/src/components/ConnectionPolicy.vue
@@ -8,6 +8,12 @@ const emit = defineEmits<{ saved: [Resource] }>();
 const teams = ref((props.resource.spec?.teams as { id: string }[] | undefined || []).map(t => t.id).join(', '));
 const allTeams = ref(!teams.value);
 const discovered = ref<Node[]>([]); const discovery = useTask(); const saveTask = useTask();
+function selected(id: string) { return teams.value.split(',').map(t => t.trim()).includes(id); }
+function toggleTeam(id: string, checked: boolean) {
+  const ids = new Set(teams.value.split(',').map(t => t.trim()).filter(Boolean));
+  if (checked) ids.add(id); else ids.delete(id);
+  teams.value = [...ids].join(', ');
+}
 function discover() { void discovery.run(api => api.discover(props.resource.metadata.name, 'teams'), result => { discovered.value = result; }); }
 function save() {
   const ids = [...new Set(teams.value.split(',').map(t => t.trim()).filter(Boolean))];
@@ -19,11 +25,11 @@ function save() {
   <form class="linear-form" @submit.prevent="save">
     <TaskFeedback :task="saveTask.state" />
     <label for="policy-teams">Allowed team UUIDs<input id="policy-teams" v-model="teams" class="k-input" :disabled="saveTask.state.loading || allTeams" :required="!allTeams" aria-describedby="policy-help"></label>
-    <label class="linear-checkbox"><input v-model="allTeams" type="checkbox" :disabled="saveTask.state.loading">Allow all teams accessible to this credential</label>
+    <label class="k-checkbox-hit linear-checkbox"><input v-model="allTeams" class="k-checkbox" type="checkbox" :disabled="saveTask.state.loading">Allow all teams accessible to this credential</label>
     <p id="policy-help" class="linear-page-meta">Separate UUIDs with commas. Discovery respects the current policy; ask a Linear administrator for UUIDs outside that scope.</p>
     <div class="linear-actions"><button type="button" class="k-btn k-btn--ghost" :disabled="discovery.state.loading || saveTask.state.loading" @click="discover">Discover permitted teams</button><button class="k-btn k-btn--primary" :disabled="saveTask.state.loading || !resource.metadata.resourceVersion || (!allTeams && !teams.trim())">Save team policy</button></div>
     <TaskFeedback :task="discovery.state" />
-    <ul v-if="discovered.length"><li v-for="team in discovered" :key="team.id">{{ team.name || 'Unnamed team' }} · {{ team.id }}</li></ul>
+    <fieldset v-if="discovered.length" class="linear-team-options"><legend>Permitted teams</legend><p class="linear-page-meta">Select teams to include in the policy. Other manually entered UUIDs are kept.</p><label v-for="team in discovered" :key="team.id" class="k-checkbox-hit linear-checkbox"><input class="k-checkbox" type="checkbox" :checked="selected(team.id)" :disabled="allTeams || saveTask.state.loading" @change="toggleTeam(team.id, ($event.target as HTMLInputElement).checked)"><span>{{ team.name || 'Unnamed team' }}<span class="linear-page-meta"> · {{ team.id }}</span></span></label></fieldset>
     <p v-else-if="discovery.state.loaded" class="linear-notice">No teams are accessible under the current policy.</p>
   </form>
 </template>

--- a/providers/linear/portal/src/components/TaskFeedback.vue
+++ b/providers/linear/portal/src/components/TaskFeedback.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { useSession } from '../state';
 import { resourcePath } from '../routes';
-defineProps<{ task: { error: string; operationName: string; message: string; loading: boolean } }>();
+withDefaults(defineProps<{ task: { error: string; operationName: string; message: string; loading: boolean }; errorPresented?: boolean }>(), { errorPresented: false });
 const session = useSession();
 </script>
 <template>
-  <div v-if="task.error" class="linear-error" role="alert">
-    <p>{{ task.error }}</p>
+  <div v-if="task.error && (!errorPresented || task.operationName)" class="linear-error" :role="errorPresented ? undefined : 'alert'">
+    <p v-if="!errorPresented">{{ task.error }}</p>
     <a v-if="task.operationName" class="k-table-resource-link" :href="session.href(resourcePath('operations', task.operationName))" @click.prevent="session.navigate(resourcePath('operations', task.operationName))">Inspect operation</a>
   </div>
   <p v-if="task.message" class="linear-notice" role="status">{{ task.message }}</p>

--- a/providers/linear/portal/src/portal.regression.test.ts
+++ b/providers/linear/portal/src/portal.regression.test.ts
@@ -114,7 +114,7 @@ function fixture(initialConnections: Resource[] = [connection('linear')]) {
           return new Response('', { status: 503 });
         }
         if (spec.action === 'issues' && failIssueList) return new Response('', { status: 503 });
-        if (spec.action === 'updateIssue' && delayMutation) {
+        if (['updateIssue', 'addComment'].includes(spec.action) && delayMutation) {
           mutationReadStarted = true;
           return new Promise<Response>(resolve => { releaseMutationRead = () => resolve(Response.json({ ...operation, status: { phase: 'Succeeded', result: operationResult(operation) } })); });
         }
@@ -176,6 +176,88 @@ async function searchIssues(wrapper: VueWrapper, query = ''): Promise<void> {
 }
 
 describe('Linear canonical portal regressions', () => {
+  it('keeps comment progress, recovery and completion beside its composer', async () => {
+    const f = fixture();
+    const wrapper = await render({ ...f.ctx, subPath: 'issues/detail/linear/issue-1' });
+    f.delayNextMutation();
+    await wrapper.get('#issue-comment').setValue('Review this change');
+    const comments = wrapper.findAll('section').find(section => section.find('#issue-comment').exists())!;
+    const form = wrapper.findAll('form').find(item => item.find('#issue-comment').exists())!;
+    await form.trigger('submit'); await flushPromises();
+    expect(f.mutationReadStarted).toBe(true);
+    expect(form.text()).toContain('Adding…');
+    expect(wrapper.findAll('button').find(button => button.text() === 'Refresh')!.attributes()).toHaveProperty('disabled');
+    expect(wrapper.findAll('button').find(button => button.text() === 'Update issue')).toBeTruthy();
+    f.releaseMutation(); await flushPromises();
+    expect(comments.text()).toContain('Comment added.');
+    expect((wrapper.get('#issue-comment').element as HTMLTextAreaElement).value).toBe('');
+    expect(f.calls.filter(call => call.body?.spec?.action === 'addComment')).toHaveLength(1);
+  });
+
+  it('selects discovered policy teams while preserving manual IDs and announces a versioned save', async () => {
+    const f = fixture();
+    const conn = { ...connection('linear'), metadata: { name: 'linear', resourceVersion: '1' }, spec: { teams: [{ id: 'team' }, { id: 'manual' }] } };
+    let patched: any;
+    const fetch: FarosContext['fetch'] = async (input, init) => {
+      if (init?.method === 'PATCH') {
+        patched = JSON.parse(String(init.body));
+        return Response.json({ ...conn, metadata: { name: 'linear', resourceVersion: '2' }, spec: { ...conn.spec, ...patched.spec } });
+      }
+      if (String(input).endsWith('/connections/linear')) return Response.json(conn);
+      return f.ctx.fetch!(input, init);
+    };
+    const wrapper = await render({ ...f.ctx, fetch, subPath: 'connections/detail/linear' });
+    await clickText(wrapper, 'Discover permitted teams');
+    const checkbox = wrapper.get('fieldset input[type="checkbox"]');
+    expect((checkbox.element as HTMLInputElement).checked).toBe(true);
+    await checkbox.setValue(false);
+    expect((wrapper.get('#policy-teams').element as HTMLInputElement).value).toBe('manual');
+    await clickText(wrapper, 'Save team policy');
+    expect(patched).toEqual({ metadata: { resourceVersion: '1' }, spec: { teams: [{ id: 'manual' }] } });
+    expect(wrapper.text()).toContain('Team policy saved.');
+    expect((wrapper.get('#policy-teams').element as HTMLInputElement).value).toBe('manual');
+  });
+
+  it('preserves edits on refresh and allows explicitly discarding them without a write', async () => {
+    const f = fixture();
+    const wrapper = await render({ ...f.ctx, subPath: 'issues/detail/linear/issue-1' });
+    const original = (wrapper.get('#issue-title').element as HTMLInputElement).value;
+    await wrapper.get('#issue-title').setValue('Unsaved title');
+    await wrapper.get('#issue-description').setValue('Unsaved description');
+    await choose(wrapper, '#issue-state', 'Done');
+    await clickText(wrapper, 'Refresh');
+    expect((wrapper.get('#issue-title').element as HTMLInputElement).value).toBe('Unsaved title');
+    expect((wrapper.get('#issue-description').element as HTMLTextAreaElement).value).toBe('Unsaved description');
+    expect(wrapper.get('#issue-state').text()).toContain('Done');
+    expect(wrapper.text()).toContain('Unsaved changes.');
+    await clickText(wrapper, 'Discard changes');
+    expect((wrapper.get('#issue-title').element as HTMLInputElement).value).toBe(original);
+    expect(wrapper.get('#issue-state').text()).toContain('Keep current state');
+    expect(f.calls.filter(call => call.body?.spec?.action === 'updateIssue')).toHaveLength(0);
+  });
+
+  it('keeps applied search and pagination stable while editing, and clears search explicitly', async () => {
+    const f = fixture();
+    const wrapper = await render({ ...f.ctx, subPath: 'issues' });
+    await choose(wrapper, '#linear-connection', 'linear');
+    await choose(wrapper, '#linear-team', 'Engineering');
+    await searchIssues(wrapper, 'resource');
+    await wrapper.get('#linear-query').setValue('draft query');
+    expect(wrapper.text()).toContain('ENG-1');
+    expect(wrapper.text()).toContain('Search to apply your changes.');
+    await clickText(wrapper, 'Next');
+    expect(f.calls.filter(call => call.body?.spec?.action === 'issues').at(-1)?.body.spec).toMatchObject({ query: 'resource', after: 'next' });
+    await clickText(wrapper, 'Clear search');
+    expect((wrapper.get('#linear-query').element as HTMLInputElement).value).toBe('');
+    expect(f.calls.filter(call => call.body?.spec?.action === 'issues').at(-1)?.body.spec).toMatchObject({ query: '' });
+    expect(f.calls.filter(call => call.body?.spec?.action === 'issues').at(-1)?.body.spec).not.toHaveProperty('after');
+    f.failIssueList();
+    await searchIssues(wrapper, 'failed query');
+    await wrapper.get('#linear-query').setValue('not submitted');
+    await clickText(wrapper, 'Retry');
+    expect(f.calls.filter(call => call.body?.spec?.action === 'issues').at(-1)?.body.spec.query).toBe('failed query');
+  });
+
   it('uses workspace routes and treats reserved words as explicit resource identities', () => {
     for (const name of ['create', 'detail', 'namespaces', 'conn/name']) {
       expect(parseRoute(resourcePath('connections', name))).toEqual({ page: 'connections', name });

--- a/providers/linear/portal/src/style.css
+++ b/providers/linear/portal/src/style.css
@@ -35,4 +35,7 @@ faros-provider-linear .linear-comment-meta { display: flex; flex-wrap: wrap; ali
 faros-provider-linear .linear-comment-meta a { color: var(--color-accent); }
 faros-provider-linear .linear-history-summary { min-inline-size: min(260px, 65vw); display: grid; justify-items: start; gap: 6px; white-space: normal; }
 faros-provider-linear .linear-history-message { white-space: normal; overflow-wrap: anywhere; }
-faros-provider-linear .linear-checkbox { display: flex; align-items: center; gap: 8px; min-height: 44px; }
+faros-provider-linear .linear-checkbox { display: flex; align-items: center; gap: 8px; }
+faros-provider-linear .linear-team-options { border: 0; padding: 0; margin: 0; display: grid; gap: 8px; min-width: 0; }
+faros-provider-linear .linear-team-options legend { margin-bottom: 8px; font-size: 13px; font-weight: 600; }
+faros-provider-linear .linear-team-options span { overflow-wrap: anywhere; min-width: 0; }

--- a/providers/linear/portal/src/views/ConnectionCreateView.vue
+++ b/providers/linear/portal/src/views/ConnectionCreateView.vue
@@ -24,11 +24,13 @@ function submit() {
     <form class="k-create-surface k-create-surface--guided" @submit.prevent="submit">
       <div class="k-create-body k-create-body--guided">
       <div class="k-create-fields linear-form">
-        <label for="connection-name">Name<input id="connection-name" v-model="name" class="k-input" required maxlength="253" pattern="[a-z0-9]([-a-z0-9.]*[a-z0-9])?" :disabled="task.state.loading"></label>
-        <label for="connection-secret">Secret name<input id="connection-secret" v-model="secret" class="k-input" required :disabled="task.state.loading"></label>
-        <details><summary>Credential location</summary><label for="connection-secret-namespace">Secret namespace<input id="connection-secret-namespace" v-model="secretNamespace" class="k-input" required maxlength="63" pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?" :disabled="task.state.loading"></label></details>
+        <label for="connection-name">Name<input id="connection-name" v-model="name" class="k-input" required maxlength="253" pattern="[a-z0-9]([a-z0-9.\x2d]*[a-z0-9])?" aria-describedby="connection-name-help" :disabled="task.state.loading"></label>
+        <p id="connection-name-help" class="linear-page-meta">Choose a unique name, such as engineering. Use lowercase letters, numbers, dots or hyphens; start and end with a letter or number.</p>
+        <label for="connection-secret">Secret name<input id="connection-secret" v-model="secret" class="k-input" required aria-describedby="connection-secret-help" :disabled="task.state.loading"></label>
+        <p id="connection-secret-help" class="linear-page-meta">Enter the name of an existing Secret, such as linear-api, rather than the API key.</p>
+        <details><summary>Credential location</summary><label for="connection-secret-namespace">Secret namespace<input id="connection-secret-namespace" v-model="secretNamespace" class="k-input" required maxlength="63" pattern="[a-z0-9]([a-z0-9\x2d]*[a-z0-9])?" aria-describedby="connection-namespace-help" :disabled="task.state.loading"></label><p id="connection-namespace-help" class="linear-page-meta">Use the namespace containing the Secret. Lowercase letters, numbers and hyphens; start and end with a letter or number.</p></details>
         <label for="connection-teams">Allowed team UUIDs<input id="connection-teams" v-model="teams" class="k-input" aria-describedby="teams-help" :required="!allowAllTeams" :disabled="task.state.loading || allowAllTeams"></label>
-        <label class="linear-checkbox"><input v-model="allowAllTeams" type="checkbox" :disabled="task.state.loading">Allow all teams accessible to this credential</label>
+        <label class="k-checkbox-hit linear-checkbox"><input v-model="allowAllTeams" class="k-checkbox" type="checkbox" :disabled="task.state.loading">Allow all teams accessible to this credential</label>
         <p id="teams-help" class="linear-page-meta">Separate UUIDs with commas. Ask your Linear administrator for team UUIDs, or explicitly allow all teams available to this credential.</p>
       </div>
       <CreateGuidance title="Before connecting" :description="`Reference a Secret in ${secretNamespace} with an apiKey entry. Ask your workspace administrator to provision it using your authorized credential tooling; enter only its name here.`" :next-steps="['Faros will check the connection. Creating the resource does not mean it is ready yet.']" />

--- a/providers/linear/portal/src/views/IssueDetailView.vue
+++ b/providers/linear/portal/src/views/IssueDetailView.vue
@@ -8,10 +8,23 @@ import StatusBadge from '../portalkit/StatusBadge.vue';
 import IssueFields from '../components/IssueFields.vue';
 import TaskFeedback from '../components/TaskFeedback.vue';
 const props = defineProps<{ connection: string; id: string }>();
-const read = useTask(); const mutation = useTask(); const commentsRead = useTask();
+const read = useTask(); const mutation = useTask(); const commentsRead = useTask(); const commentTask = useTask();
+const busy = computed(() => mutation.state.loading || commentTask.state.loading);
 const issue = ref<Result>(); const comments = ref<Node[]>([]); const nextCursor = ref(''); const hasMore = ref(false);
 const title = ref(''); const description = ref(''); const stateID = ref(''); const body = ref('');
-function load() { if (mutation.state.loading) return; void read.run(api => api.operation(props.connection, { action: 'issue', issueID: props.id }), result => { issue.value = result; title.value = result.title || ''; description.value = result.description || ''; }); }
+function load() {
+  if (busy.value) return;
+  void read.run(api => api.operation(props.connection, { action: 'issue', issueID: props.id }), result => {
+    // Refresh the server snapshot without overwriting a local edit.
+    if (title.value === (issue.value?.title || '')) title.value = result.title || '';
+    if (description.value === (issue.value?.description || '')) description.value = result.description || '';
+    issue.value = result;
+  });
+}
+function discard() {
+  title.value = issue.value?.title || ''; description.value = issue.value?.description || ''; stateID.value = '';
+  mutation.reset();
+}
 function loadComments(more = false) {
   void commentsRead.run(api => api.operation(props.connection, { action: 'comments', issueID: props.id, first: 25, ...(more ? { after: nextCursor.value } : {}) }), result => {
     comments.value = more ? [...comments.value, ...(result.nodes || [])] : result.nodes || [];
@@ -24,7 +37,7 @@ const changedFields = computed(() => ({
   ...(stateID.value ? { stateID: stateID.value } : {}),
 }));
 function update() {
-  if (read.state.loading) return;
+  if (read.state.loading || busy.value) return;
   const fields = changedFields.value;
   if (!Object.keys(fields).length) return;
   void mutation.run(api => api.operation(props.connection, { action: 'updateIssue', issueID: props.id, ...fields }), result => {
@@ -33,32 +46,34 @@ function update() {
   });
 }
 function comment() {
-  if (!body.value.trim()) return;
-  void mutation.run(api => api.operation(props.connection, { action: 'addComment', issueID: props.id, body: body.value }), () => { body.value = ''; mutation.state.message = 'Comment added.'; commentsRead.cancel(); loadComments(); });
+  if (!body.value.trim() || read.state.loading || busy.value) return;
+  void commentTask.run(api => api.operation(props.connection, { action: 'addComment', issueID: props.id, body: body.value }), () => { body.value = ''; commentTask.state.message = 'Comment added.'; commentsRead.cancel(); loadComments(); });
 }
 function formatTime(value?: string) { const date = value ? new Date(value) : null; return date && !Number.isNaN(date.getTime()) ? date.toLocaleString() : 'Time unavailable'; }
 function sourceURL(value?: string) { try { const url = new URL(value || ''); return url.protocol === 'https:' && url.hostname === 'linear.app' ? url.href : undefined; } catch { return undefined; } }
 onMounted(load);
 </script>
 <template>
-  <ResourcePage :title="issue?.identifier || id" kind="Issue" :subtitle="issue?.title || ''" :loaded="read.state.loaded" :loading="read.state.loading" :error="read.state.error" :stale="read.state.loaded && !!read.state.error" :retryable="!mutation.state.loading" @retry="load">
-    <template #actions><button class="k-btn k-btn--ghost" :disabled="read.state.loading || mutation.state.loading" @click="load">Refresh</button></template>
+  <ResourcePage :title="issue?.identifier || id" kind="Issue" :subtitle="issue?.title || ''" :loaded="read.state.loaded" :loading="read.state.loading" :error="read.state.error" :stale="read.state.loaded && !!read.state.error" :retryable="!busy" @retry="load">
+    <template #actions><button class="k-btn k-btn--ghost" :disabled="read.state.loading || busy" @click="load">Refresh</button></template>
     <template #status><StatusBadge v-if="issue?.state?.name" :status="issue.state.name" /></template>
     <div class="linear-detail-content">
-    <TaskFeedback :task="mutation.state" />
     <ResourceSectionCard title="Details"><dl class="linear-facts"><div><dt>Connection</dt><dd>{{ connection }}</dd></div><div><dt>Team</dt><dd>{{ issue?.team?.name || issue?.team?.id || '—' }}</dd></div><div><dt>Issue ID</dt><dd>{{ id }}</dd></div><div><dt>Updated</dt><dd>{{ issue?.updatedAt || '—' }}</dd></div></dl><p class="linear-prose">{{ issue?.description || 'No description.' }}</p></ResourceSectionCard>
     <ResourceSectionCard title="Update issue" description="Edit the current values. Emptying Description removes it; unchanged fields are preserved.">
-      <form class="linear-form" @submit.prevent="update"><IssueFields v-model:title="title" v-model:description="description" v-model:stateID="stateID" :connection="connection" :team="issue?.team?.id || ''" updating :disabled="mutation.state.loading || read.state.loading" /><div class="linear-form-actions"><button class="k-btn k-btn--primary" :disabled="mutation.state.loading || read.state.loading || (!title.trim() || !Object.keys(changedFields).length)">{{ mutation.state.loading ? 'Submitting…' : 'Update issue' }}</button></div></form>
+      <TaskFeedback :task="mutation.state" />
+      <p v-if="Object.keys(changedFields).length" class="linear-notice" role="status">Unsaved changes. Refresh keeps your edits; leaving this page discards them.</p>
+      <form class="linear-form" @submit.prevent="update"><IssueFields v-model:title="title" v-model:description="description" v-model:stateID="stateID" :connection="connection" :team="issue?.team?.id || ''" updating :disabled="busy || read.state.loading" /><div class="linear-form-actions"><button v-if="Object.keys(changedFields).length" class="k-btn k-btn--ghost" type="button" :disabled="busy || read.state.loading" @click="discard">Discard changes</button><button class="k-btn k-btn--primary" :disabled="busy || read.state.loading || (!title.trim() || !Object.keys(changedFields).length)">{{ mutation.state.loading ? 'Submitting…' : 'Update issue' }}</button></div></form>
     </ResourceSectionCard>
     <ResourceSectionCard title="Comments">
-      <template #actions><button class="k-btn k-btn--ghost" :disabled="commentsRead.state.loading || mutation.state.loading" @click="loadComments()">{{ commentsRead.state.loading ? 'Loading…' : 'Read comments' }}</button></template>
+      <template #actions><button class="k-btn k-btn--ghost" :disabled="commentsRead.state.loading || busy" @click="loadComments()">{{ commentsRead.state.loading ? 'Loading…' : commentsRead.state.loaded ? 'Refresh comments' : 'Read comments' }}</button></template>
       <TaskFeedback :task="commentsRead.state" />
       <p v-if="!commentsRead.state.loaded" class="linear-notice">Read comments to load the conversation from Linear.</p><p v-else-if="!comments.length" class="linear-notice">No comments.</p>
       <ul v-else class="linear-comments"><li v-for="c in comments" :key="c.id" class="linear-prose"><div class="linear-comment-meta"><strong>{{ c.user?.displayName || c.user?.name || c.botActor?.name || (c.externalUser ? 'External user' : 'Unknown author') }}</strong><span v-if="c.botActor"> · Bot</span><span> · {{ formatTime(c.createdAt) }}</span><span v-if="c.editedAt"> · Edited {{ formatTime(c.editedAt) }}</span><a v-if="sourceURL(c.url)" :href="sourceURL(c.url)" target="_blank" rel="noopener noreferrer">View in Linear</a></div><p v-if="c.parentId" class="linear-page-meta">Reply to comment {{ c.parentId }}</p><p class="linear-prose">{{ c.body }}</p></li></ul>
       <button v-if="hasMore" class="k-btn k-btn--ghost" :disabled="commentsRead.state.loading || !nextCursor" @click="loadComments(true)">More comments</button>
-      <form class="linear-form" @submit.prevent="comment"><label for="issue-comment">Add comment<textarea id="issue-comment" v-model="body" class="k-input" required maxlength="16000" rows="3" :disabled="mutation.state.loading || read.state.loading" /></label><div class="linear-form-actions"><button class="k-btn k-btn--primary" :disabled="mutation.state.loading || !body.trim()">Add comment</button></div></form>
+      <TaskFeedback :task="commentTask.state" />
+      <form class="linear-form" @submit.prevent="comment"><label for="issue-comment">Add comment<textarea id="issue-comment" v-model="body" class="k-input" required maxlength="16000" rows="3" :disabled="busy || read.state.loading" /></label><div class="linear-form-actions"><button class="k-btn k-btn--primary" :disabled="busy || read.state.loading || !body.trim()">{{ commentTask.state.loading ? 'Adding…' : 'Add comment' }}</button></div></form>
     </ResourceSectionCard>
     </div>
   </ResourcePage>
-  <TaskFeedback v-if="read.state.operationName" :task="read.state" />
+  <TaskFeedback v-if="read.state.operationName" :task="read.state" error-presented />
 </template>

--- a/providers/linear/portal/src/views/IssuesView.vue
+++ b/providers/linear/portal/src/views/IssuesView.vue
@@ -8,18 +8,23 @@ import TaskFeedback from '../components/TaskFeedback.vue';
 import ResourceTable from '../portalkit/ResourceTable.vue';
 const session = useSession(); const read = useTask(); const issues = ref<Node[]>([]);
 const cursor = ref(''); const hasNext = ref(false); const cursors = ref<string[]>(['']); const index = ref(0);
+const activeQuery = ref('');
+let attemptedSearch = { page: 0, query: '' };
 const rows = computed(() => issues.value.map(i => ({ id: i.id, identifier: i.identifier || i.id, title: i.title, state: i.state?.name || '—', updated: i.updatedAt || '—' })));
 const columns = [{ key: 'identifier', label: 'Issue' }, { key: 'title', label: 'Title', primary: true }, { key: 'state', label: 'State' }, { key: 'updated', label: 'Updated' }];
-function search(page = 0) {
-  if (!session.selection.connection || !session.selection.team) return;
+function search(page = 0, query = activeQuery.value) {
+  if (read.state.loading || !session.selection.connection || !session.selection.team) return;
+  attemptedSearch = { page, query };
   const after = page === 0 ? '' : cursors.value[page];
-  void read.run(api => api.operation(session.selection.connection, { action: 'issues', teamID: session.selection.team, query: session.selection.query, first: 25, ...(after ? { after } : {}) }), result => {
+  void read.run(api => api.operation(session.selection.connection, { action: 'issues', teamID: session.selection.team, query, first: 25, ...(after ? { after } : {}) }), result => {
     issues.value = result.nodes || []; cursor.value = result.pageInfo?.endCursor || ''; hasNext.value = !!result.pageInfo?.hasNextPage;
-    index.value = page; if (!page) cursors.value = [''];
+    activeQuery.value = query; index.value = page; if (!page) cursors.value = [''];
   });
 }
 function next() { cursors.value[index.value + 1] = cursor.value; search(index.value + 1); }
-watch(() => [session.selection.connection, session.selection.team, session.selection.query], () => { read.reset(); issues.value = []; cursor.value = ''; hasNext.value = false; index.value = 0; cursors.value = ['']; }, { flush: 'sync' });
+function retry() { search(attemptedSearch.page, attemptedSearch.query); }
+function clearSearch() { session.selection.query = ''; search(0, ''); }
+watch(() => [session.selection.connection, session.selection.team], () => { read.reset(); issues.value = []; cursor.value = ''; hasNext.value = false; index.value = 0; cursors.value = ['']; activeQuery.value = ''; }, { flush: 'sync' });
 onActivated(() => {
   if (read.state.loaded && session.selection.connection && session.selection.team) search(index.value);
 });
@@ -29,9 +34,10 @@ function open(row: Record<string, unknown>) { session.navigate(issuePath(session
   <section class="linear-page">
     <header class="linear-page-head"><div><h2 class="linear-page-title">Issues</h2><p class="linear-page-meta">Browse and update issues in a connected Linear team.</p></div><button class="k-btn k-btn--primary" @click="session.navigate('issues/create')">Create issue</button></header>
     <IssueScope />
-    <form class="linear-fields" @submit.prevent="search()"><label for="linear-query">Title contains<input id="linear-query" v-model="session.selection.query" class="k-input" placeholder="Search issues…" maxlength="1000"></label><button class="k-btn k-btn--ghost" :disabled="read.state.loading || !session.selection.team || !session.selection.connection">{{ read.state.loading ? 'Searching…' : 'Search' }}</button></form>
-    <TaskFeedback :task="read.state" />
-    <ResourceTable v-if="read.state.loaded || read.state.loading || read.state.error" :columns="columns" :rows="rows" row-key="id" :loaded="read.state.loaded" :loading="read.state.loading" :error="read.state.error" :stale="read.state.loaded && !!read.state.error" retryable empty-text="No matching issues." aria-label="Linear issues" :row-aria-label="row => `Open issue ${row.identifier}`" @retry="search(index)" @row-click="open">
+    <form class="linear-fields" @submit.prevent="search(0, session.selection.query)"><label for="linear-query">Title contains<input id="linear-query" v-model="session.selection.query" class="k-input" placeholder="Search issues…" maxlength="1000"></label><button class="k-btn k-btn--ghost" :disabled="read.state.loading || !session.selection.team || !session.selection.connection">{{ read.state.loading ? 'Searching…' : 'Search' }}</button><button v-if="session.selection.query || activeQuery" type="button" class="k-btn k-btn--ghost" :disabled="read.state.loading || !session.selection.team || !session.selection.connection" @click="clearSearch">Clear search</button></form>
+    <p v-if="read.state.loaded && session.selection.query !== activeQuery" class="linear-notice" role="status">Showing {{ activeQuery ? `results for “${activeQuery}”` : 'all issues' }}. Search to apply your changes.</p>
+    <TaskFeedback :task="read.state" error-presented />
+    <ResourceTable v-if="read.state.loaded || read.state.loading || read.state.error" :columns="columns" :rows="rows" row-key="id" :loaded="read.state.loaded" :loading="read.state.loading" :error="read.state.error" :stale="read.state.loaded && !!read.state.error" retryable empty-text="No matching issues." aria-label="Linear issues" :row-aria-label="row => `Open issue ${row.identifier}`" @retry="retry" @row-click="open">
       <template #identifier="{ row }"><button class="k-btn k-btn--ghost k-table-resource-link" @click.stop="open(row)">{{ row.identifier }}</button></template>
     </ResourceTable>
     <p v-else class="linear-notice">Select a connection and team, then search for issues.</p>

--- a/providers/linear/portal/src/views/ResourceDetailView.vue
+++ b/providers/linear/portal/src/views/ResourceDetailView.vue
@@ -8,6 +8,8 @@ import ConnectionPolicy from '../components/ConnectionPolicy.vue';
 import StatusBadge from '../portalkit/StatusBadge.vue';
 const props = defineProps<{ kind: 'connections' | 'operations' | 'events'; name: string }>();
 const session = useSession(); const read = useTask(); const resource = ref<Resource>();
+const policyMessage = ref('');
+function policySaved(result: Resource) { resource.value = result; policyMessage.value = 'Team policy saved. Refresh the connection to check readiness.'; }
 const facts = computed(() => {
   const r = resource.value; if (!r) return [];
   const spec = r.spec || {};
@@ -29,7 +31,7 @@ onMounted(load);
     <template #status><StatusBadge v-if="resource && kind !== 'events'" :status="kind === 'connections' ? resource.status?.ready ? 'Ready' : 'Not ready' : resource.status?.phase || 'Pending'" /></template>
     <div class="linear-detail-content">
     <ResourceSectionCard title="Details"><dl class="linear-facts"><div v-for="[label, value] in facts" :key="label"><dt>{{ label }}</dt><dd>{{ value }}</dd></div></dl></ResourceSectionCard>
-    <ResourceSectionCard v-if="kind === 'connections' && resource" title="Team access"><ConnectionPolicy :key="resource.metadata.resourceVersion" :resource="resource" @saved="resource = $event" /></ResourceSectionCard>
+    <ResourceSectionCard v-if="kind === 'connections' && resource" title="Team access"><p v-if="policyMessage" class="linear-notice" role="status">{{ policyMessage }}</p><ConnectionPolicy :key="resource.metadata.resourceVersion" :resource="resource" @saved="policySaved" /></ResourceSectionCard>
     <button v-if="kind === 'connections' && session.draft.returnToIssue" class="k-btn k-btn--primary" @click="session.navigate('issues/create')">Return to issue draft</button>
     <ResourceSectionCard v-if="resource?.status?.result" title="Result"><pre class="linear-result">{{ JSON.stringify(resource.status.result, null, 2) }}</pre></ResourceSectionCard>
     </div>


### PR DESCRIPTION
## What changes

Refreshing an issue previously overwrote unsaved edits, and typing a search removed the current results before submission. Preserve local edits on refresh, provide explicit discard, and keep results and pagination tied to the applied query. Retry repeats the failed query even if the draft input has changed.

Move comment progress and recovery beside the composer; make discovered permitted teams selectable while retaining manually entered IDs and the explicit allow-all boundary. Preserve policy-save feedback across resource-version remounts, reuse PortalKit checkbox sizing, explain naming constraints, and fix HTML patterns that modern Chromium rejected. Update the provider README and add regression coverage.

## Validation

- Full Linear provider gate passed: code generation, build, lint, race tests, portal checks, and strict Helm lint. Used `GOFLAGS=-buildvcs=false` for an environment-specific Go/Git stamping failure.
- Final portal build/typecheck and 31 Vitest tests passed, along with the API script tests.
- `make verify-design-docs verify-portalkit verify-ui-conformance` passed using Node 24; conformance scanned 457 files with zero violations.
- Rendered fixture review covered 72 states across dark/light and 1440/390px using the compiled host CSS and fonts. Keyboard selection, route focus, policy selection, edit preservation/discard, search, issue creation/update, comments, and recovery passed. Browser-discovered pattern errors were fixed and nine final valid/invalid input checks passed without console/page errors. The final retry correction is covered by mounted tests.
- Independent Impeccable design assessment: **31/40 (Good)**, from a source-only baseline of 28/40; no unresolved provider P1/P2 finding in the reviewed scope.

## Limits

Browser coverage uses fixtures, not authenticated hub/Tilt or live Linear operations. This is not a comprehensive accessibility certification. Minor timestamp-formatting and duplicate-description presentation opportunities remain; shared Faros typography/palette choices were retained.
