### PR TITLE
fix(tilt): rebuild Linear automatically on code changes

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1265,16 +1265,14 @@ local_resource(
     labels=['replicas'],
 )
 
-# Linear is opt-in while its external credential acceptance is pending.
+# Linear rebuilds automatically; registration and initialization remain opt-in.
 local_resource(
     'linear',
     cmd='make build-linear-provider',
     serve_cmd='make run-provider-linear',
-    deps=['providers/linear/main.go', 'providers/linear/init_cmd.go', 'providers/linear/assets.go',
-          'providers/linear/apis', 'providers/linear/internal', 'providers/linear/portal/src',
-          'providers/linear/portal/package.json', 'providers/linear/go.mod', 'providers/linear/go.sum'],
-    trigger_mode=TRIGGER_MODE_MANUAL,
-    auto_init=False,
+    deps=['providers/linear'],
+    ignore=['providers/linear/portal/node_modules', 'providers/linear/portal/dist'],
+    trigger_mode=TRIGGER_MODE_AUTO,
     labels=['providers-linear'],
 )
 local_resource(


### PR DESCRIPTION
Linear's Tilt resource required a manual trigger and watched only a subset of its build inputs. Enable automatic startup and rebuilds, and watch the full provider directory so backend, portal, and build-configuration changes trigger a rebuild. Exclude portal `node_modules` and `dist` to avoid rebuild loops. Registration and initialization remain manual.

Validation: the running Tilt instance loaded the new watch configuration. Touching `providers/linear/main.go` automatically triggered a successful rebuild, with both update and runtime status returning to `ok`. `git diff --check` passed.
